### PR TITLE
Added a basic Travis CI config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: java
+sudo: false
+
+cache:
+  directories:
+    - ${HOME}/.m2
+
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      script: mvn clean package -B -DskipTests=true
+
+    - os: osx
+      script: mvn clean package -B -DskipTests=true


### PR DESCRIPTION
This config only runs builds on Linux and OS X but does not run any tests. At
present, none of the subgroups of tests in JanusGraph (or even Titan) complete
within the 50min timeout that Travis enforces. The `pom.xml` config specifies at
timeout of 21600sec (6 hours), so we will need to create new groups/suites of
tests to break them into smaller sets that each will fit into the 50min limit,
as well as a set of smoke tests that will complete faster for the purposes of
code review.

In the meantime, we will get basic sanity checking for each PR, which will
remove some manual work from reviewers.