### PR TITLE
Added email notifications.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,8 @@ matrix:
 
     - os: osx
       script: mvn clean package -B -DskipTests=true
+
+# Syntax and more info: https://docs.travis-ci.com/user/notifications
+notifications:
+  email:
+    - janusgraph-ci@googlegroups.com

--- a/TESTING.md
+++ b/TESTING.md
@@ -11,6 +11,13 @@ JanusGraph runs all tests using JUnit.  To compile, package, and run the default
 
 JanusGraph has a specialty tests, disabled by default, intended to generate basic performance metrics or stress its cache structures under memory pressure.  The next section describes how JanusGraph's tests are internally categorized and the Maven options that enabled/disable test categories.
 
+### Continuous Integration
+
+JanusGraph runs continuous integration via Travis; see the [dashboard](https://travis-ci.org/JanusGraph/janusgraph) for current status.
+
+Travis sends emails on test failures and status transitions (to/from failure) to
+[janusgraph-ci@googlegroups.com](https://groups.google.com/forum/#!forum/janusgraph-ci) mailing list.
+
 ### JUnit Test Categories
 
 All of JanusGraph's tests are written for JUnit.  JanusGraph's JUnit tests are annotated with the following [JUnit Categories](https://github.com/junit-team/junit/wiki/Categories):
@@ -28,7 +35,7 @@ All of JanusGraph's tests are written for JUnit.  JanusGraph's JUnit tests are a
 
 **Maven Property** above is a boolean-valued pom.xml property that skips the associated test category when true and executes the associated test category when false.  The default values defined in pom.xml can be overridden on the command-line in the ordinary Maven way, e.g. `mvn -Dtest.skip.mem=false test`.
 
-*Implementation Note.*  The Maven property naming pattern "test.skip.x=boolean" is needlessly verbose, a cardinal sin for command line options.  A more concise alternative would be "test.x" with the boolean sense negated.  However, this complicates the pom.xml configuration for the Surefire plugin since it precludes direct use of the Surefire plugin's `<skip>` configuration tag, as in `<skip>${test.skip.perf}</skip>`.  There doesn't seem to be a straightforward way to negate a boolean or otherwise make this easy, at least without resorting to profiles or a custom plugin, though I might be missing something.  Also, the mold is arguably already set by Surefire's "maven.test.skip" property, though that has slightly different interpretation semantics than the properties above.    
+*Implementation Note.*  The Maven property naming pattern "test.skip.x=boolean" is needlessly verbose, a cardinal sin for command line options.  A more concise alternative would be "test.x" with the boolean sense negated.  However, this complicates the pom.xml configuration for the Surefire plugin since it precludes direct use of the Surefire plugin's `<skip>` configuration tag, as in `<skip>${test.skip.perf}</skip>`.  There doesn't seem to be a straightforward way to negate a boolean or otherwise make this easy, at least without resorting to profiles or a custom plugin, though I might be missing something.  Also, the mold is arguably already set by Surefire's "maven.test.skip" property, though that has slightly different interpretation semantics than the properties above.
 
 ### Running a Single Test via Maven
 


### PR DESCRIPTION
In case folks want to follow Travis CI build/test notifications, we can have them sent to this list (which I've already created). Travis also has integrations with Slack and other mediums, but we first need to decide on Slack vs. Gitter vs. other channel before spending the time to integrate with those; this can be useful for anyone who wants to subscribe to these notifications via email or browse via web UI.