### PR TITLE
Change module versions to 0.1.0-SNAPSHOT.

### DIFF
--- a/janusgraph-all/pom.xml
+++ b/janusgraph-all/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-all</artifactId>

--- a/janusgraph-berkeleyje/pom.xml
+++ b/janusgraph-berkeleyje/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-berkeleyje</artifactId>

--- a/janusgraph-cassandra/pom.xml
+++ b/janusgraph-cassandra/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-cassandra</artifactId>

--- a/janusgraph-core/pom.xml
+++ b/janusgraph-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-core</artifactId>

--- a/janusgraph-dist/janusgraph-dist-hadoop-2/pom.xml
+++ b/janusgraph-dist/janusgraph-dist-hadoop-2/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-dist</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/janusgraph-dist/pom.xml
+++ b/janusgraph-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/janusgraph-doc/pom.xml
+++ b/janusgraph-doc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/janusgraph-es/pom.xml
+++ b/janusgraph-es/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-es</artifactId>

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-1/pom.xml
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-1/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hadoop-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hadoop-1</artifactId>

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-2/pom.xml
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-2/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hadoop-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hadoop-2</artifactId>

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/pom.xml
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hadoop-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hadoop-core</artifactId>

--- a/janusgraph-hadoop-parent/janusgraph-hadoop/pom.xml
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hadoop-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hadoop</artifactId>

--- a/janusgraph-hadoop-parent/pom.xml
+++ b/janusgraph-hadoop-parent/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hadoop-parent</artifactId>

--- a/janusgraph-hbase-parent/janusgraph-hbase-094/pom.xml
+++ b/janusgraph-hbase-parent/janusgraph-hbase-094/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hbase-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hbase-094</artifactId>

--- a/janusgraph-hbase-parent/janusgraph-hbase-096/pom.xml
+++ b/janusgraph-hbase-parent/janusgraph-hbase-096/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hbase-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hbase-096</artifactId>

--- a/janusgraph-hbase-parent/janusgraph-hbase-098/pom.xml
+++ b/janusgraph-hbase-parent/janusgraph-hbase-098/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hbase-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hbase-098</artifactId>

--- a/janusgraph-hbase-parent/janusgraph-hbase-10/pom.xml
+++ b/janusgraph-hbase-parent/janusgraph-hbase-10/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hbase-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hbase-10</artifactId>

--- a/janusgraph-hbase-parent/janusgraph-hbase-core/pom.xml
+++ b/janusgraph-hbase-parent/janusgraph-hbase-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hbase-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hbase-core</artifactId>

--- a/janusgraph-hbase-parent/janusgraph-hbase/pom.xml
+++ b/janusgraph-hbase-parent/janusgraph-hbase/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hbase-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hbase</artifactId>

--- a/janusgraph-hbase-parent/pom.xml
+++ b/janusgraph-hbase-parent/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hbase-parent</artifactId>

--- a/janusgraph-lucene/pom.xml
+++ b/janusgraph-lucene/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-lucene</artifactId>

--- a/janusgraph-solr/pom.xml
+++ b/janusgraph-solr/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-solr</artifactId>

--- a/janusgraph-test/pom.xml
+++ b/janusgraph-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <groupId>org.janusgraph</groupId>
     <artifactId>janusgraph</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <prerequisites>
         <maven>2.2.1</maven>


### PR DESCRIPTION
We forked Titan at the unreleased `titan11` branch where the version number was
1.1.0-SNAPSHOT, but given the amount of changes we are making and are likely to
make prior to the first release, we should inform our users that our code layout
and hence APIs are not yet stable (which a 1.x version signifies).

Once we have finalized changes, upgraded our dependencies, etc., we can upgrade
the version number to 1.0, but we cannot downgrade a release from a "stable" 1.x
down to a 0.x at any point.