### PR TITLE
Avoid timeouts due to no output with `travis_wait`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,9 @@ addons:
       version: "0.1.0-SNAPSHOT"
       description: "Scalable, distributed graph database"
     notification_email: janusgraph-ci@googlegroups.com
-    build_command: "mvn clean package -B -DskipTests=true"
+    # For more info on `travis_wait`, see the docs:
+    # https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
+    build_command: "travis_wait mvn clean package -B -DskipTests=true"
     branch_pattern: coverity_scan
 
 branches:


### PR DESCRIPTION
The last line of the output of a recently-failed Travis job:
https://travis-ci.org/JanusGraph/janusgraph/jobs/195761554
tells us that our build is being terminated due to no output for 10 minutes.

The output also tells us to look at the following documentation:
https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
which suggests that using `travis_wait` command for silent long-running commands
will print out a line of output every minute for 20 minutes, such that Travis
does not automatically end the build if there's no output for 10 minutes.

If we need more time, per the docs, we can extend it by adding a number to the
command, e.g.,

```
travis_wait 30 mvn clean package [...]
```

-----

@hsaputra – the only way to test this is to submit a PR to `master`, then fast-forward merge into `coverity_scan` (the alternative is to push to `coverity_scan` directly, but I prefer to keep `master` as the authoritative, and `coverity_scan` as trailing `master` rather than the other way around).

As you can see from the above Travis CI link, Coverity is now running, just timing out due to no output, so we're making good progress.