### PR TITLE
Automatically run tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,49 @@
 language: java
 sudo: false
 
+jdk:
+  - oraclejdk8
+
 cache:
   directories:
     - ${HOME}/.m2
 
 env:
   global:
-   # This is the encrypted COVERITY_SCAN_TOKEN, created via the
-   # `travis encrypt` command using the project repo's public key.
-   - secure: "v5ixqTeb74y0vRuPcDbe3C28GDDYvqyEXA2dt+9UVU6GG7WpnmpkBf05gI1dIhp51lBhwx9WSlFBtzho+KdCBmNY/CzBRhVHe/lCQYK9Hb6uGPvuwBvC0WjJgJXsVrLFjppeRhcf+OAweVQ3uw2RPMDRvKIVMUcO1BTFjjJl6REJXNUdzGS57MtH2mmRyOEz250EwgqUELZvcOytG7fNrjMJKVK2nSsoxi0BqZIpItTWPWWeQ1wi1FplJ18A2qtD+MPfAGNSB+/a+r0Av+VCT2eGl06ZyZAzP3q/vG5IYjQ3AJsSPqcZUt4ms+2us1+kwuzXIILjzZmcfImu29+y/thndU5E5b2v+nZ4H69CUCc5OmKW2RwozLNmBIUhO0n+35va/J7FiPIqm3pwxCz5vWA3YTHDADxnIYe7+9uY/+dOK/AvP5fyu7u07vuF3liKNBdrX7ylP3kYc7FXGmYl8wCZv31iy1yTtndQ9qKef7bo8lM9Cdh39KyowrygH+Um7pr9gqf2S9jn99nQ3bib32fBWgBkLpJRwhZYHPUupZjZfgu/9woby0DuriuHZKMqZd7QUawYz6wXGlhzu78x5Tohlj1pGBwHYdcJ/Tm3PiEpyH4aYQLffkjGHJAcCW5tO8QbB0qrLYWC8xVMWuFz1TpSBRXOqVYdBfIa2UZDtOU="
+    # This is the encrypted COVERITY_SCAN_TOKEN, created via the
+    # `travis encrypt` command using the project repo's public key.
+    - secure: "v5ixqTeb74y0vRuPcDbe3C28GDDYvqyEXA2dt+9UVU6GG7WpnmpkBf05gI1dIhp51lBhwx9WSlFBtzho+KdCBmNY/CzBRhVHe/lCQYK9Hb6uGPvuwBvC0WjJgJXsVrLFjppeRhcf+OAweVQ3uw2RPMDRvKIVMUcO1BTFjjJl6REJXNUdzGS57MtH2mmRyOEz250EwgqUELZvcOytG7fNrjMJKVK2nSsoxi0BqZIpItTWPWWeQ1wi1FplJ18A2qtD+MPfAGNSB+/a+r0Av+VCT2eGl06ZyZAzP3q/vG5IYjQ3AJsSPqcZUt4ms+2us1+kwuzXIILjzZmcfImu29+y/thndU5E5b2v+nZ4H69CUCc5OmKW2RwozLNmBIUhO0n+35va/J7FiPIqm3pwxCz5vWA3YTHDADxnIYe7+9uY/+dOK/AvP5fyu7u07vuF3liKNBdrX7ylP3kYc7FXGmYl8wCZv31iy1yTtndQ9qKef7bo8lM9Cdh39KyowrygH+Um7pr9gqf2S9jn99nQ3bib32fBWgBkLpJRwhZYHPUupZjZfgu/9woby0DuriuHZKMqZd7QUawYz6wXGlhzu78x5Tohlj1pGBwHYdcJ/Tm3PiEpyH4aYQLffkjGHJAcCW5tO8QbB0qrLYWC8xVMWuFz1TpSBRXOqVYdBfIa2UZDtOU="
+
+  matrix:
+    - MODULE='berkeleyje'
+
+    # Currently broken due to too many log statements (exceeds 4MB)
+    # https://travis-ci.org/JanusGraph/janusgraph/jobs/197472452
+    # - MODULE='cassandra'
+
+    # Currently broken due to too many log statements (exceeds 4MB)
+    # https://travis-ci.org/JanusGraph/janusgraph/jobs/197472453
+    # - MODULE='es' ARGS='-DthreadCount=1'
+
+    # Currently broken due to too many log statements (exceeds 4MB)
+    # https://travis-ci.org/JanusGraph/janusgraph/jobs/197672947
+    # - MODULE='hadoop-parent/janusgraph-hadoop-2'
+
+    # Currently broken due to timeout (runs longer than 50min)
+    # https://travis-ci.org/JanusGraph/janusgraph/jobs/197672951
+    # - MODULE='hbase-parent/janusgraph-hbase-098'
+
+    # Currently broken due to timeout (runs longer than 50min)
+    # https://travis-ci.org/JanusGraph/janusgraph/jobs/197672952
+    # - MODULE='hbase-parent/janusgraph-hbase-10'
+
+    - MODULE='lucene' ARGS='-DthreadCount=1'
+
+    # Currently broken due to too many log statements (exceeds 4MB)
+    # https://travis-ci.org/JanusGraph/janusgraph/jobs/197427609
+    # - MODULE='solr' ARGS='-DthreadCount=1'
+
+    - MODULE='test'
 
 addons:
   apt:
@@ -31,24 +65,20 @@ branches:
     - master
     - coverity_scan
 
+script:
+  - if [[ "${COVERITY_SCAN_BRANCH}}" == 1 ]]; then
+      echo "Skipping build/test on 'coverity_scan' branch.";
+      exit 0;
+    fi
+  - mvn install -DskipTests=true -B -pl janusgraph-${MODULE} -am
+  - mvn verify -pl janusgraph-${MODULE} ${ARGS}
+
 matrix:
   include:
     - os: linux
       dist: trusty
-      script:
-        - if [[ "${COVERITY_SCAN_BRANCH}}" == 1 ]]; then
-            echo "Skipping build/test on 'coverity_scan' branch.";
-            exit 0;
-          fi
-        - mvn clean package -B -DskipTests=true
 
     - os: osx
-      script:
-        - if [[ "${COVERITY_SCAN_BRANCH}}" == 1 ]]; then
-            echo "Skipping build/test on 'coverity_scan' branch.";
-            exit 0;
-          fi
-        - mvn clean package -B -DskipTests=true
 
 # Syntax and more info: https://docs.travis-ci.com/user/notifications
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,13 +73,6 @@ script:
   - mvn install -DskipTests=true -B -pl janusgraph-${MODULE} -am
   - mvn verify -pl janusgraph-${MODULE} ${ARGS}
 
-matrix:
-  include:
-    - os: linux
-      dist: trusty
-
-    - os: osx
-
 # Syntax and more info: https://docs.travis-ci.com/user/notifications
 notifications:
   email:


### PR DESCRIPTION
Factored out the build and test steps to be able to easily parameterize them
using environment variables in both Linux and OS X.

Starting by testing just the `janusgraph-solr` and `janusgraph-test` modules.