### PR TITLE
Incorrect Cassandra keyspace regex for non-alphanumeric-underscore characters

### DIFF
--- a/janusgraph-cassandra/src/test/java/org/janusgraph/CassandraStorageSetup.java
+++ b/janusgraph-cassandra/src/test/java/org/janusgraph/CassandraStorageSetup.java
@@ -137,7 +137,7 @@ public class CassandraStorageSetup {
         Preconditions.checkNotNull(raw);
         Preconditions.checkArgument(0 < raw.length());
 
-        if (48 < raw.length() || raw.matches("[^a-zA-Z_]")) {
+        if (48 < raw.length() || raw.matches("^.*[^a-zA-Z0-9_].*$")) {
             return "strhash" + String.valueOf(Math.abs(raw.hashCode()));
         } else {
             return raw;


### PR DESCRIPTION
Regex to detect if Cassandra keyspace name contains non-alphanumeric-underscore characters is incorrect. This causes test failures in `janusgraph-solr` tests with the following error.

```
InvalidRequestException(why:Keyspace name must not be empty, more than 48 characters long, or contain non-alphanumeric-underscore characters (got "org.janusgraph.diskstorage.solr.ThriftSolrTest"))
```

This wasn't a problem previously because `com.thinkaurelius.titan`-based keyspace names had lengths longer than max length of 48, so they'd be updated based on that constraint, but `org.janusgraph`-based names can have lengths less than 48.