### PR TITLE
Ensure Log4j is used for testing

### DIFF
--- a/janusgraph-cassandra/pom.xml
+++ b/janusgraph-cassandra/pom.xml
@@ -67,7 +67,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.2</version>
         </dependency>
         <!-- End logging backends. -->
         <dependency>

--- a/janusgraph-es/pom.xml
+++ b/janusgraph-es/pom.xml
@@ -69,7 +69,7 @@
 
         <!-- Logging backends.
              Enforce a classpath ordering constraint to ensure log4j is used for logging.
-             See comment in titan-cassandra POM for more information. -->
+             See comment in janusgraph-cassandra POM for more information. -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>

--- a/janusgraph-es/pom.xml
+++ b/janusgraph-es/pom.xml
@@ -77,7 +77,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.2</version>
         </dependency>
         <!-- End logging backends. -->
     </dependencies>

--- a/janusgraph-es/pom.xml
+++ b/janusgraph-es/pom.xml
@@ -1,4 +1,3 @@
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -68,6 +67,19 @@
             <version>${antlr.version}</version>
         </dependency>
 
+        <!-- Logging backends.
+             Enforce a classpath ordering constraint to ensure log4j is used for logging.
+             See comment in titan-cassandra POM for more information. -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.1.2</version>
+        </dependency>
+        <!-- End logging backends. -->
     </dependencies>
     <build>
         <resources>

--- a/janusgraph-es/src/test/resources/log4j.properties
+++ b/janusgraph-es/src/test/resources/log4j.properties
@@ -1,16 +1,19 @@
 # A1 is set to be a FileAppender.
-log4j.appender.A1=org.apache.log4j.ConsoleAppender
-#log4j.appender.A1=org.apache.log4j.FileAppender
+log4j.appender.A1=org.apache.log4j.FileAppender
 log4j.appender.A1.File=target/test.log
 log4j.appender.A1.Threshold=TRACE
-
 # A1 uses PatternLayout.
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
-log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+log4j.appender.A1.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
 
-# Set root logger level to the designated level and its only appender to A1.
-log4j.rootLogger=INFO, A1
+# A2 is a ConsoleAppender.
+log4j.appender.A2=org.apache.log4j.ConsoleAppender
+log4j.appender.A2.Threshold=WARN
+# A2 uses PatternLayout.
+log4j.appender.A2.layout=org.apache.log4j.PatternLayout
+log4j.appender.A2.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
 
-log4j.logger.org.apache.cassandra=INFO
-log4j.logger.org.apache.hadoop=INFO
-log4j.logger.org.apache.zookeeper=INFO
+# Set both appenders (A1 and A2) on the root logger.
+log4j.rootLogger=INFO, A1, A2
+#log4j.rootLogger=INFO, A1
+

--- a/janusgraph-hadoop-parent/pom.xml
+++ b/janusgraph-hadoop-parent/pom.xml
@@ -153,7 +153,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.2</version>
         </dependency>
         <!-- End logging backends. -->
 

--- a/janusgraph-hadoop-parent/pom.xml
+++ b/janusgraph-hadoop-parent/pom.xml
@@ -142,11 +142,20 @@
             <artifactId>sesame-rio-turtle</artifactId>
         </dependency>
 
-        <!-- LOGGING -->
+        <!-- Logging backends.
+             Enforce a classpath ordering constraint to ensure slf4j-log4j12
+             binding appears on the classpath before logback-classic.
+             See comments in titan-cassandra/pom.xml for more information. -->
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.1.2</version>
+        </dependency>
+        <!-- End logging backends. -->
 
         <!-- TESTING -->
         <dependency>

--- a/janusgraph-hadoop-parent/pom.xml
+++ b/janusgraph-hadoop-parent/pom.xml
@@ -145,7 +145,7 @@
         <!-- Logging backends.
              Enforce a classpath ordering constraint to ensure slf4j-log4j12
              binding appears on the classpath before logback-classic.
-             See comments in titan-cassandra/pom.xml for more information. -->
+             See comments in janusgraph-cassandra/pom.xml for more information. -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>

--- a/janusgraph-hbase-parent/pom.xml
+++ b/janusgraph-hbase-parent/pom.xml
@@ -60,6 +60,10 @@
 
              These declarations could go away if HBase ever fully migrates
              to slf4j and removes its hard dependency on log4j.
+
+             Note, logback-classic is added explicitly to ensure slf4j-log4j12
+             binding appears on the classpath before logback-classic. See
+             comments in titan-cassandra/pom.xml for more information.
         -->
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -72,6 +76,11 @@
             <artifactId>log4j</artifactId>
             <optional>false</optional>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.1.2</version>
         </dependency>
     </dependencies>
     

--- a/janusgraph-hbase-parent/pom.xml
+++ b/janusgraph-hbase-parent/pom.xml
@@ -63,7 +63,7 @@
 
              Note, logback-classic is added explicitly to ensure slf4j-log4j12
              binding appears on the classpath before logback-classic. See
-             comments in titan-cassandra/pom.xml for more information.
+             comments in janusgraph-cassandra/pom.xml for more information.
         -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/janusgraph-hbase-parent/pom.xml
+++ b/janusgraph-hbase-parent/pom.xml
@@ -80,7 +80,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.2</version>
         </dependency>
     </dependencies>
     

--- a/janusgraph-lucene/src/test/resources/log4j.properties
+++ b/janusgraph-lucene/src/test/resources/log4j.properties
@@ -1,15 +1,19 @@
-# A1 is set to be a FileAppender.
-#log4j.appender.A1=org.apache.log4j.ConsoleAppender
+# A1 is a FileAppender.
 log4j.appender.A1=org.apache.log4j.FileAppender
 log4j.appender.A1.File=target/test.log
-
+log4j.appender.A1.Threshold=TRACE
 # A1 uses PatternLayout.
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
-log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+log4j.appender.A1.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
 
-# Set root logger level to the designated level and its only appender to A1.
-log4j.rootLogger=INFO, A1
+# A2 is a ConsoleAppender.
+log4j.appender.A2=org.apache.log4j.ConsoleAppender
+log4j.appender.A2.Threshold=WARN
+# A2 uses PatternLayout.
+log4j.appender.A2.layout=org.apache.log4j.PatternLayout
+log4j.appender.A2.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
 
-log4j.logger.org.apache.cassandra=INFO
-log4j.logger.org.apache.hadoop=INFO
-log4j.logger.org.apache.zookeeper=INFO
+# Set both appenders (A1 and A2) on the root logger.
+log4j.rootLogger=INFO, A1, A2
+#log4j.rootLogger=INFO, A1
+

--- a/janusgraph-solr/pom.xml
+++ b/janusgraph-solr/pom.xml
@@ -92,6 +92,20 @@
             <artifactId>jts</artifactId>
             <version>1.13</version>
         </dependency>
+        <!-- Logging backends.
+             Enforce a classpath ordering constraint to ensure slf4j-log4j12
+             binding appears on the classpath before logback-classic.
+             See comments in titan-cassandra/pom.xml for more information. -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.1.2</version>
+        </dependency>
+        <!-- End logging backends. -->
     </dependencies>
     <build>
         <directory>${basedir}/target</directory>

--- a/janusgraph-solr/pom.xml
+++ b/janusgraph-solr/pom.xml
@@ -95,7 +95,7 @@
         <!-- Logging backends.
              Enforce a classpath ordering constraint to ensure slf4j-log4j12
              binding appears on the classpath before logback-classic.
-             See comments in titan-cassandra/pom.xml for more information. -->
+             See comments in janusgraph-cassandra/pom.xml for more information. -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>

--- a/janusgraph-solr/pom.xml
+++ b/janusgraph-solr/pom.xml
@@ -103,7 +103,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.2</version>
         </dependency>
         <!-- End logging backends. -->
     </dependencies>

--- a/janusgraph-solr/src/test/resources/log4j.properties
+++ b/janusgraph-solr/src/test/resources/log4j.properties
@@ -1,15 +1,19 @@
 # A1 is set to be a FileAppender.
-#log4j.appender.A1=org.apache.log4j.ConsoleAppender
 log4j.appender.A1=org.apache.log4j.FileAppender
 log4j.appender.A1.File=target/test.log
-
+log4j.appender.A1.Threshold=TRACE
 # A1 uses PatternLayout.
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
-log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+log4j.appender.A1.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
 
-# Set root logger level to the designated level and its only appender to A1.
-log4j.rootLogger=INFO, A1
+# A2 is a ConsoleAppender.
+log4j.appender.A2=org.apache.log4j.ConsoleAppender
+log4j.appender.A2.Threshold=WARN
+# A2 uses PatternLayout.
+log4j.appender.A2.layout=org.apache.log4j.PatternLayout
+log4j.appender.A2.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
 
-log4j.logger.org.apache.cassandra=INFO
-log4j.logger.org.apache.hadoop=INFO
-log4j.logger.org.apache.zookeeper=INFO
+# Set both appenders (A1 and A2) on the root logger.
+log4j.rootLogger=INFO, A1, A2
+#log4j.rootLogger=INFO, A1
+

--- a/pom.xml
+++ b/pom.xml
@@ -618,6 +618,11 @@
                 <version>1.2.16</version>
             </dependency>
             <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.1.2</version>
+            </dependency>
+            <dependency>
                 <groupId>org.codehaus.jettison</groupId>
                 <artifactId>jettison</artifactId>
                 <version>1.3.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,13 @@
                         </excludes>
                         <excludedGroups>${test.excluded.groups}</excludedGroups>
                         <skip>${test.skip.default}</skip>
+                        <!-- Use log4j.properties from module test resources -->
+                        <systemProperties>
+                            <property>
+                                <name>log4j.configuration</name>
+                                <value>file:target/test-classes/log4j.properties</value>
+                            </property>
+                        </systemProperties>
                     </configuration>
                     <executions>
                         <execution>
@@ -279,6 +286,15 @@
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>2.15</version>
+                    <configuration>
+                        <!-- Use log4j.properties from module test resources -->
+                        <systemProperties>
+                            <property>
+                                <name>log4j.configuration</name>
+                                <value>file:target/test-classes/log4j.properties</value>
+                            </property>
+                        </systemProperties>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-site-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
                         <systemProperties>
                             <property>
                                 <name>log4j.configuration</name>
-                                <value>file:target/test-classes/log4j.properties</value>
+                                <value>file:${project.build.directory}/test-classes/log4j.properties</value>
                             </property>
                         </systemProperties>
                     </configuration>
@@ -279,6 +279,9 @@
                                     <exclude>**/*</exclude>
                                 </excludes> -->
                                 <skipTests>${test.skip.tp}</skipTests>
+                                <systemPropertyVariables>
+                                  <log4j.configuration>file:${project.build.directory}/test-classes/log4j.properties</log4j.configuration>
+                                </systemPropertyVariables>
                             </configuration>
                        </execution>
                     </executions>
@@ -291,7 +294,7 @@
                         <systemProperties>
                             <property>
                                 <name>log4j.configuration</name>
-                                <value>file:target/test-classes/log4j.properties</value>
+                                <value>file:${project.build.directory}/test-classes/log4j.properties</value>
                             </property>
                         </systemProperties>
                     </configuration>


### PR DESCRIPTION
Log4j should be used for testing but Logback is being used in some modules (janusgraph-es, janusgraph-hadoop, janusgraph-hbase and janusgraph-solr). In these cases the log4j.properties test resources are ignored and console logging is too verbose. In a standard test run (`mvn verify`) console logging exceeds 75M. With the fixes in this PR the logging output for the same run is about 3M.

Note the solution was already present in janusgraph-cassandra (see logging comment in [janusgraph-cassandra/pom.xml](https://github.com/JanusGraph/janusgraph/blob/fc48e9e680273ee62292126f55585b4f1a6d8294/janusgraph-cassandra/pom.xml#L44-L62)) and this PR just propagates that into the offending modules. More minor updates were to clean up some of the test log4j.properties files and ensure that these were used in relevant tests (e.g. `log4j.configuration` file).