### PR TITLE
Backward compatibility with Titan

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -15,3 +15,4 @@ DataStax
 Dylan Bethune-Waddell <dylan.bethune.waddell@mail.utoronto.ca>
 Expero
 Google
+Rafael Fernandes <luizrafael@gmail.com>

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -78,6 +78,7 @@ Peter Beaman <pbeaman@akiban.com>
 Petter Aas <aaspet@gmail.com> <petter.aas@fronter.com>
 Pieter <pieter@pieter-HP-EliteBook-8570w.(none)>
 PommeVerte <dylan.millikin@gmail.com>
+Rafael Fernandes <luizrafael@gmail.com>
 Ranger Tsao <cao.zhifu@gmail.com>
 Richard Doll <rdoll@care-view.com>
 Sebastian Good <sebastian@experoinc.com>

--- a/janusgraph-cassandra/src/test/java/org/janusgraph/graphdb/CassandraGraphTest.java
+++ b/janusgraph-cassandra/src/test/java/org/janusgraph/graphdb/CassandraGraphTest.java
@@ -14,19 +14,25 @@
 
 package org.janusgraph.graphdb;
 
+import static org.janusgraph.diskstorage.cassandra.AbstractCassandraStoreManager.CASSANDRA_KEYSPACE;
+import static org.janusgraph.diskstorage.cassandra.AbstractCassandraStoreManager.CASSANDRA_READ_CONSISTENCY;
+import static org.janusgraph.diskstorage.cassandra.AbstractCassandraStoreManager.CASSANDRA_WRITE_CONSISTENCY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.janusgraph.CassandraStorageSetup;
 import org.janusgraph.core.JanusGraphFactory;
 import org.janusgraph.diskstorage.cassandra.AbstractCassandraStoreManager;
 import org.janusgraph.diskstorage.configuration.ConfigElement;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.janusgraph.graphdb.configuration.JanusGraphConstants;
 import org.janusgraph.graphdb.database.StandardJanusGraph;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.janusgraph.diskstorage.cassandra.AbstractCassandraStoreManager.*;
 
 /**
  * @author Joshua Shinavier (http://fortytwo.net)
@@ -100,5 +106,29 @@ public abstract class CassandraGraphTest extends JanusGraphTest {
                 tx.getTxHandle().getBaseTransactionConfig().getCustomOptions()
                         .get(AbstractCassandraStoreManager.CASSANDRA_WRITE_CONSISTENCY));
         tx.rollback();
+    }
+    
+    @Test
+    public void testTitanGraphBackwardCompatibility() {
+        close();
+        WriteConfiguration wc = getConfiguration();
+        wc.set(ConfigElement.getPath(CASSANDRA_KEYSPACE), "titan");
+        wc.set(ConfigElement.getPath(GraphDatabaseConfiguration.TITAN_COMPATIBLE_VERSIONS), "x.x.x");
+        
+        assertNull(wc.get(ConfigElement.getPath(GraphDatabaseConfiguration.INITIAL_JANUSGRAPH_VERSION), 
+                            GraphDatabaseConfiguration.INITIAL_JANUSGRAPH_VERSION.getDatatype()));
+        
+        assertFalse(JanusGraphConstants.TITAN_COMPATIBLE_VERSIONS.contains(
+                            wc.get(ConfigElement.getPath(GraphDatabaseConfiguration.TITAN_COMPATIBLE_VERSIONS), 
+                                        GraphDatabaseConfiguration.TITAN_COMPATIBLE_VERSIONS.getDatatype())
+                ));
+
+        wc.set(ConfigElement.getPath(GraphDatabaseConfiguration.TITAN_COMPATIBLE_VERSIONS), "1.0.0");
+        assertTrue(JanusGraphConstants.TITAN_COMPATIBLE_VERSIONS.contains(
+                            wc.get(ConfigElement.getPath(GraphDatabaseConfiguration.TITAN_COMPATIBLE_VERSIONS), 
+                                        GraphDatabaseConfiguration.TITAN_COMPATIBLE_VERSIONS.getDatatype())
+                ));
+
+        graph = (StandardJanusGraph) JanusGraphFactory.open(wc);
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/JanusGraphConstants.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/JanusGraphConstants.java
@@ -14,14 +14,17 @@
 
 package org.janusgraph.graphdb.configuration;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-import org.janusgraph.core.JanusGraphFactory;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.janusgraph.core.JanusGraphFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Collection of constants used throughput the JanusGraph codebase.
@@ -41,6 +44,11 @@ public class JanusGraphConstants {
      * Past versions of JanusGraph with which the runtime version shares a compatible storage format
      */
     public static final List<String> COMPATIBLE_VERSIONS;
+
+    /**
+     * Past versions of Titan Graph with which the runtime version shares a compatible storage format
+     */
+    public static final List<String> TITAN_COMPATIBLE_VERSIONS;
 
     static {
 
@@ -67,12 +75,13 @@ public class JanusGraphConstants {
         }
 
         VERSION = props.getProperty("janusgraph.version");
-        ImmutableList.Builder<String> b = ImmutableList.builder();
-        for (String v : props.getProperty("janusgraph.compatible-versions", "").split(",")) {
-            v = v.trim();
-            if (!v.isEmpty()) b.add(v);
-        }
-        COMPATIBLE_VERSIONS = b.build();
+        COMPATIBLE_VERSIONS = getCompatibleVersions(props, "janusgraph.compatible-versions");
+        TITAN_COMPATIBLE_VERSIONS = getCompatibleVersions(props, "titan.compatible-versions");
     }
 
+    static List<String> getCompatibleVersions(Properties props, String key) {
+        ImmutableList.Builder<String> b = ImmutableList.builder();
+        b.addAll(Stream.of(props.getProperty(key, "").split(",")).map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toList()));
+        return b.build();
+    }
 }

--- a/janusgraph-core/src/main/resources/org/janusgraph/graphdb/configuration/janusgraph.internal.properties
+++ b/janusgraph-core/src/main/resources/org/janusgraph/graphdb/configuration/janusgraph.internal.properties
@@ -1,2 +1,3 @@
 janusgraph.version=${project.version}
 janusgraph.compatible-versions=${janusgraph.compatible.versions}
+titan.compatible-versions=${titan.compatible-versions}

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     </scm>
     <properties>
         <janusgraph.compatible.versions />
+        <titan.compatible-versions>1.0.0,1.1.0-SNAPSHOT</titan.compatible-versions>
         <tinkerpop.version>3.2.3</tinkerpop.version>
         <junit.version>4.12</junit.version>
         <mrunit.version>1.1.0</mrunit.version>


### PR DESCRIPTION
Implemented backward compatibility with titan and its previous versions compatible with JanusGraph's storage format.

Addresses issue #73.