### PR TITLE
Cleanup some dependencies and implicit casts to make things cleaner in eclipse 

### DIFF
--- a/janusgraph-all/pom.xml
+++ b/janusgraph-all/pom.xml
@@ -49,6 +49,11 @@
             <version>${hbase098.core.version}-hadoop2</version>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>janusgraph-hadoop</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop2.version}</version>

--- a/janusgraph-all/pom.xml
+++ b/janusgraph-all/pom.xml
@@ -49,11 +49,6 @@
             <version>${hbase098.core.version}-hadoop2</version>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>janusgraph-hadoop</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop2.version}</version>

--- a/janusgraph-all/src/main/java/org/janusgraph/graphdb/tinkerpop/plugin/JanusGraphGremlinPlugin.java
+++ b/janusgraph-all/src/main/java/org/janusgraph/graphdb/tinkerpop/plugin/JanusGraphGremlinPlugin.java
@@ -24,7 +24,7 @@ import org.apache.tinkerpop.gremlin.groovy.plugin.GremlinPlugin;
 import org.apache.tinkerpop.gremlin.groovy.plugin.PluginAcceptor;
 
 import java.time.temporal.ChronoUnit;
-import java.util.HashSet;;
+import java.util.HashSet;
 import java.util.Set;
 
 /**

--- a/janusgraph-core/pom.xml
+++ b/janusgraph-core/pom.xml
@@ -116,15 +116,15 @@
         </testResources>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>gmaven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <version>1.5</version>
                 <executions>
                     <execution>
                         <goals>
                             <goal>generateStubs</goal>
                             <goal>compile</goal>
-                            <goal>generateTestStubs</goal>
+                            <goal>testGenerateStubs</goal>
                             <goal>testCompile</goal>
                         </goals>
                         <configuration>

--- a/janusgraph-core/pom.xml
+++ b/janusgraph-core/pom.xml
@@ -118,7 +118,7 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.5</version>
+                <version>${gmavenplus.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/job/IndexRepairJob.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/job/IndexRepairJob.java
@@ -136,8 +136,8 @@ public class IndexRepairJob extends IndexUpdateJob implements VertexScanJob {
                 EdgeSerializer edgeSerializer = writeTx.getEdgeSerializer();
                 List<Entry> additions = new ArrayList<>();
 
-                for (JanusGraphRelation relation : vertex.query().types(indexRelationTypeName).direction(Direction.OUT).relations()) {
-                    InternalRelation janusgraphRelation = (InternalRelation)relation;
+                for (Object relation : vertex.query().types(indexRelationTypeName).direction(Direction.OUT).relations()) {
+                    InternalRelation janusgraphRelation = (InternalRelation) relation;
                     for (int pos = 0; pos < janusgraphRelation.getArity(); pos++) {
                         if (!wrappedType.isUnidirected(Direction.BOTH) && !wrappedType.isUnidirected(EdgeDirection.fromPosition(pos)))
                             continue; //Directionality is not covered
@@ -166,8 +166,8 @@ public class IndexRepairJob extends IndexUpdateJob implements VertexScanJob {
                         break;
                     case EDGE:
                         elements = Lists.newArrayList();
-                        for (JanusGraphEdge e : addIndexSchemaConstraint(vertex.query().direction(Direction.OUT),indexType).edges()) {
-                            elements.add(e);
+                        for (Object e : addIndexSchemaConstraint(vertex.query().direction(Direction.OUT),indexType).edges()) {
+                            elements.add((JanusGraphEdge) e);
                         }
                         break;
                     default: throw new AssertionError("Unexpected category: " + indexType.getElement());

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/vertices/JanusGraphSchemaVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/vertices/JanusGraphSchemaVertex.java
@@ -138,7 +138,8 @@ public class JanusGraphSchemaVertex extends CacheVertex implements SchemaSource 
      * Resets the internal caches used to speed up lookups on this index type.
      * This is needed when the type gets modified in the {@link org.janusgraph.graphdb.database.management.ManagementSystem}.
      */
-    public void resetCache() {
+    @Override
+  public void resetCache() {
         name = null;
         definition=null;
         outRelations=null;
@@ -174,7 +175,7 @@ public class JanusGraphSchemaVertex extends CacheVertex implements SchemaSource 
     @Override
     public IndexType asIndexType() {
         Preconditions.checkArgument(getDefinition().containsKey(TypeDefinitionCategory.INTERNAL_INDEX),"Schema vertex is not a type vertex: [%s,%s]", longId(), name());
-        if (getDefinition().getValue(TypeDefinitionCategory.INTERNAL_INDEX)) {
+        if (getDefinition().<Boolean>getValue(TypeDefinitionCategory.INTERNAL_INDEX)) {
             return new CompositeIndexTypeWrapper(this);
         } else {
             return new MixedIndexTypeWrapper(this);

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/pom.xml
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/pom.xml
@@ -73,7 +73,7 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.5</version>
+                <version>${gmavenplus.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/pom.xml
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/pom.xml
@@ -71,8 +71,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>gmaven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <version>1.5</version>
                 <executions>
                     <execution>

--- a/janusgraph-test/pom.xml
+++ b/janusgraph-test/pom.xml
@@ -100,13 +100,13 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.2</version>
+                <version>1.5</version>
                 <executions>
                     <execution>
                         <goals>
                             <goal>addSources</goal>
                             <goal>addTestSources</goal>
-                            <goal>generateStubs</goal>
+                            <goal>testGenerateStubs</goal>
                             <goal>compile</goal>
                             <goal>testGenerateStubs</goal>
                             <goal>testCompile</goal>

--- a/janusgraph-test/pom.xml
+++ b/janusgraph-test/pom.xml
@@ -100,13 +100,13 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.5</version>
+                <version>${gmavenplus.version}</version>
                 <executions>
                     <execution>
                         <goals>
                             <goal>addSources</goal>
                             <goal>addTestSources</goal>
-                            <goal>testGenerateStubs</goal>
+                            <goal>generateStubs</goal>
                             <goal>compile</goal>
                             <goal>testGenerateStubs</goal>
                             <goal>testCompile</goal>

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphConcurrentTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphConcurrentTest.java
@@ -388,7 +388,8 @@ public abstract class JanusGraphConcurrentTest extends JanusGraphBaseTest {
                 // Make or break relType between two (possibly same) random nodes
                 JanusGraphVertex source = Iterables.<JanusGraphVertex>getOnlyElement(tx.query().has(idKey, 0).vertices());
                 JanusGraphVertex sink = Iterables.<JanusGraphVertex>getOnlyElement(tx.query().has(idKey, 1).vertices());
-                for (Edge r : source.query().direction(Direction.OUT).labels(elabel).edges()) {
+                for (Object o : source.query().direction(Direction.OUT).labels(elabel).edges()) {
+                    Edge r = (Edge) o;
                     if (getId(r.inVertex()) == getId(sink)) {
                         r.remove();
                         continue;
@@ -425,8 +426,8 @@ public abstract class JanusGraphConcurrentTest extends JanusGraphBaseTest {
 
             for (int i = 0; i < nodeTraversalCount; i++) {
                 assertCount(expectedEdges, v.query().labels(label2Traverse).direction(Direction.BOTH).edges());
-                for (JanusGraphEdge r : v.query().direction(Direction.OUT).labels(label2Traverse).edges()) {
-                    v = r.vertex(Direction.IN);
+                for (Object r : v.query().direction(Direction.OUT).labels(label2Traverse).edges()) {
+                    v = ((JanusGraphEdge) r).vertex(Direction.IN);
                 }
             }
         }

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphEventualGraphTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphEventualGraphTest.java
@@ -335,20 +335,21 @@ public abstract class JanusGraphEventualGraphTest extends JanusGraphBaseTest {
             assertEquals(2,pp.value());
         }
 
-        Edge e = getOnlyElement(v.query().direction(OUT).labels("es").edges());
+        Edge e = Iterables.<JanusGraphEdge>getOnlyElement(v.query().direction(OUT).labels("es").edges());
         assertEquals(wintx,e.<Integer>value("sig").intValue());
         assertNotEquals(rs[6].longId(),getId(e));
 
-        e = getOnlyElement(v.query().direction(OUT).labels("o2o").edges());
+        e = Iterables.<JanusGraphEdge>getOnlyElement(v.query().direction(OUT).labels("o2o").edges());
         assertEquals(wintx,e.<Integer>value("sig").intValue());
         assertEquals(rs[7].longId(), getId(e));
-        e = getOnlyElement(v.query().direction(OUT).labels("o2m").edges());
+        e = Iterables.<JanusGraphEdge>getOnlyElement(v.query().direction(OUT).labels("o2m").edges());
         assertEquals(wintx,e.<Integer>value("sig").intValue());
         assertNotEquals(rs[8].longId(),getId(e));
-        e = getOnlyElement(v.query().direction(OUT).labels("em").edges());
+        e = Iterables.<JanusGraphEdge>getOnlyElement(v.query().direction(OUT).labels("em").edges());
         assertEquals(wintx,e.<Integer>value("sig").intValue());
         assertEquals(rs[4].longId(), getId(e));
-        for (Edge ee : v.query().direction(OUT).labels("emf").edges()) {
+        for (Object o : v.query().direction(OUT).labels("emf").edges()) {
+            Edge ee = (Edge) o;
             assertNotEquals(rs[5].longId(),getId(ee));
             assertEquals(uid,ee.inVertex().id());
         }
@@ -374,19 +375,19 @@ public abstract class JanusGraphEventualGraphTest extends JanusGraphBaseTest {
             sign((JanusGraphVertexProperty)p,txid);
         }
 
-        Edge e = getOnlyElement(v.query().direction(OUT).labels("es").edges());
+        Edge e = Iterables.<JanusGraphEdge>getOnlyElement(v.query().direction(OUT).labels("es").edges());
         assertEquals(1,e.<Integer>value("sig").intValue());
         e.remove();
         sign(v.addEdge("es",u),txid);
-        e = getOnlyElement(v.query().direction(OUT).labels("o2o").edges());
+        e = Iterables.<JanusGraphEdge>getOnlyElement(v.query().direction(OUT).labels("o2o").edges());
         assertEquals(1,e.<Integer>value("sig").intValue());
         sign((JanusGraphEdge)e,txid);
-        e = getOnlyElement(v.query().direction(OUT).labels("o2m").edges());
+        e = Iterables.<JanusGraphEdge>getOnlyElement(v.query().direction(OUT).labels("o2m").edges());
         assertEquals(1,e.<Integer>value("sig").intValue());
         e.remove();
         sign(v.addEdge("o2m",u),txid);
         for (String label : new String[]{"em","emf"}) {
-            e = getOnlyElement(v.query().direction(OUT).labels(label).edges());
+            e = Iterables.<JanusGraphEdge>getOnlyElement(v.query().direction(OUT).labels(label).edges());
             assertEquals(1,e.<Integer>value("sig").intValue());
             sign((JanusGraphEdge)e,txid);
         }

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphOperationCountingTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphOperationCountingTest.java
@@ -121,6 +121,7 @@ public abstract class JanusGraphOperationCountingTest extends JanusGraphBaseTest
         testReadOperations(true);
     }
 
+    @SuppressWarnings("unchecked")
     public void testReadOperations(boolean cache) {
         metricsPrefix = "testReadOperations"+cache;
 
@@ -209,10 +210,10 @@ public abstract class JanusGraphOperationCountingTest extends JanusGraphBaseTest
         for (int i = 1; i <= 30; i++) {
             metricsPrefix = "op"+i+cache;
             tx = graph.buildTransaction().groupName(metricsPrefix).start();
-            v = getOnlyElement(tx.query().has("uid",1).vertices());
+            v = (JanusGraphVertex)getOnlyElement(tx.query().has("uid",1).vertices());
             assertEquals(1,v.<Integer>value("uid").intValue());
-            u = getOnlyElement(v.query().direction(Direction.BOTH).labels("knows").vertices());
-            e = getOnlyElement(u.query().direction(Direction.IN).labels("knows").edges());
+            u = (JanusGraphVertex)getOnlyElement(v.query().direction(Direction.BOTH).labels("knows").vertices());
+            e = (Edge)getOnlyElement(u.query().direction(Direction.IN).labels("knows").edges());
             assertEquals("juju",u.value("name"));
             assertEquals("edge",e.value("name"));
             tx.commit();
@@ -339,7 +340,7 @@ public abstract class JanusGraphOperationCountingTest extends JanusGraphBaseTest
         resetMetrics();
 
         tx = graph.buildTransaction().groupName(metricsPrefix).start();
-        v = Iterables.getOnlyElement(tx.query().has("uid", Cmp.EQUAL, "v1").vertices());
+        v = (JanusGraphVertex) Iterables.getOnlyElement(tx.query().has("uid", Cmp.EQUAL, "v1").vertices());
         assertEquals(25,v.property("age").value());
         tx.commit();
         verifyStoreMetrics(EDGESTORE_NAME, ImmutableMap.of(M_GET_SLICE,1l));
@@ -642,7 +643,7 @@ public abstract class JanusGraphOperationCountingTest extends JanusGraphBaseTest
         long start = System.nanoTime();
         JanusGraphVertex v = getV(graph,vid);
         for (int i=1; i<numV; i++) {
-            v = getOnlyElement(v.query().direction(Direction.OUT).labels("knows").vertices());
+            v = Iterables.<JanusGraphVertex>getOnlyElement(v.query().direction(Direction.OUT).labels("knows").vertices());
         }
         return ((System.nanoTime()-start)/1000000.0);
     }

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphPartitionGraphTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphPartitionGraphTest.java
@@ -83,7 +83,8 @@ public abstract class JanusGraphPartitionGraphTest extends JanusGraphBaseTest {
 
     private IDManager idManager;
 
-    @Before
+    @Override
+  @Before
     public void setUp() throws Exception {
         super.setUp();
         idManager = graph.getIDManager();
@@ -172,7 +173,7 @@ public abstract class JanusGraphPartitionGraphTest extends JanusGraphBaseTest {
             assertEquals(idManager.getCanonicalVertexId(gId), gId);
             JanusGraphVertex g = getV(tx, gId);
             final int canonicalPartition = getPartitionID(g);
-            assertEquals(g, (Vertex) getOnlyElement(tx.query().has("gid", i).vertices()));
+            assertEquals(g, getOnlyElement(tx.query().has("gid", i).vertices()));
             assertEquals(i, g.<Integer>value("gid").intValue());
             assertCount(names.size(), g.properties("name"));
 
@@ -374,7 +375,8 @@ public abstract class JanusGraphPartitionGraphTest extends JanusGraphBaseTest {
             assertCount(groupDegrees[i],g.query().direction(Direction.OUT).edges());
             assertCount(groupDegrees[i],g.query().direction(Direction.IN).edges());
             assertCount(groupDegrees[i]*2,g.query().edges());
-            for (JanusGraphVertex v : g.query().direction(Direction.IN).labels("member").vertices()) {
+            for (Object o : g.query().direction(Direction.IN).labels("member").vertices()) {
+                JanusGraphVertex v = (JanusGraphVertex) o;
                 int pid = getPartitionID(v);
                 partitionIds.add(pid);
                 assertEquals(g, getOnlyElement(v.query().direction(Direction.OUT).labels("member").vertices()));
@@ -476,7 +478,8 @@ public abstract class JanusGraphPartitionGraphTest extends JanusGraphBaseTest {
         for (int i=0;i<groupDegrees.length;i++) {
             JanusGraphVertex g = getOnlyVertex(tx.query().has("groupid","group"+i));
             int partitionId = -1;
-            for (JanusGraphVertex v : g.query().direction(Direction.IN).labels("member").vertices()) {
+            for (Object o : g.query().direction(Direction.IN).labels("member").vertices()) {
+                JanusGraphVertex v = (JanusGraphVertex) o;
                 if (partitionId<0) partitionId = getPartitionID(v);
                 assertEquals(partitionId,getPartitionID(v));
                 partitionIds.add(partitionId);

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphPartitionGraphTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphPartitionGraphTest.java
@@ -84,7 +84,7 @@ public abstract class JanusGraphPartitionGraphTest extends JanusGraphBaseTest {
     private IDManager idManager;
 
     @Override
-  @Before
+    @Before
     public void setUp() throws Exception {
         super.setUp();
         idManager = graph.getIDManager();

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphPerformanceMemoryTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphPerformanceMemoryTest.java
@@ -137,9 +137,9 @@ public abstract class JanusGraphPerformanceMemoryTest extends JanusGraphBaseTest
                         JanusGraphVertex v = getVertex(tx,"uid", random.nextInt(maxUID) + 1);
                         assertCount(2, v.properties());
                         int count = 0;
-                        for (JanusGraphEdge e : v.query().direction(Direction.BOTH).edges()) {
+                        for (Object e : v.query().direction(Direction.BOTH).edges()) {
                             count++;
-                            assertTrue(e.<Integer>value("time") >= 0);
+                            assertTrue(((JanusGraphEdge) e).<Integer>value("time") >= 0);
                         }
                         assertTrue(count <= 2);
 //                        if (t%(trials/10)==0) System.out.println(t);

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -278,8 +278,8 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertCount(numE, tx.query().edges());
 
         //tx.V().range(0,deleteV).remove();
-        for (JanusGraphVertex v : tx.query().limit(deleteV).vertices()) {
-            v.remove();
+        for (Object v : tx.query().limit(deleteV).vertices()) {
+            ((JanusGraphVertex) v).remove();
         }
 
         for (int i = 0; i < 10; i++) { //Repeated vertex counts
@@ -367,7 +367,8 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
 
             assertCount(connectOff.length + knowsOff.length, n.query().direction(Direction.OUT).edges());
             assertCount(2, n.properties());
-            for (JanusGraphEdge r : n.query().direction(Direction.OUT).labels("knows").edges()) {
+            for (Object o : n.query().direction(Direction.OUT).labels("knows").edges()) {
+                JanusGraphEdge r = (JanusGraphEdge) o;
                 JanusGraphVertex n2 = r.vertex(Direction.IN);
                 int idsum = ((Number) n.value("uid")).intValue() + ((Number) n2.value("uid")).intValue();
                 assertEquals(idsum, ((Number) r.value("uid")).intValue());
@@ -377,7 +378,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
             }
 
             Set edgeIds = new HashSet(10);
-            for (JanusGraphEdge r : n.query().direction(Direction.OUT).edges()) {
+            for (Object r : n.query().direction(Direction.OUT).edges()) {
                 edgeIds.add(((JanusGraphEdge) r).longId());
             }
             assertTrue(edgeIds + " vs " + nodeEdgeIds[i], edgeIds.equals(nodeEdgeIds[i]));
@@ -420,7 +421,8 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
      * Test the definition and inspection of various schema types and ensure their correct interpretation
      * within the graph
      */
-    @Test
+    @SuppressWarnings("unchecked")
+  @Test
     public void testSchemaTypes() {
         // ---------- PROPERTY KEYS ----------------
         //Normal single-valued property key
@@ -754,7 +756,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         JanusGraphEdge edge;
 
         // ######### INSPECTION & FAILURE ############
-        assertEquals(v, (Vertex) getOnlyElement(tx.query().has("uid", Cmp.EQUAL, "v1").vertices()));
+        assertEquals(v, getOnlyElement(tx.query().has("uid", Cmp.EQUAL, "v1").vertices()));
         v = getOnlyVertex(tx.query().has("uid", Cmp.EQUAL, "v1"));
         v12 = getOnlyVertex(tx.query().has("uid", Cmp.EQUAL, "v12"));
         v13 = getOnlyVertex(tx.query().has("uid", Cmp.EQUAL, "v13"));
@@ -785,18 +787,19 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertEquals(0.5, v.<Float>value("weight").doubleValue(), 0.00001);
         assertEquals("v1", v.value("uid"));
         assertCount(2, v.properties("name"));
-        for (JanusGraphVertexProperty<String> prop : v.query().labels("name").properties()) {
-            String nstr = prop.value();
+        for (Object prop : v.query().labels("name").properties()) {
+            String nstr = ((JanusGraphVertexProperty<String>) prop).value();
             assertTrue(nstr.equals("Bob") || nstr.equals("John"));
         }
         assertTrue(size(v.properties("value")) >= 3);
-        for (JanusGraphVertexProperty<Double> prop : v.query().labels("value").properties()) {
+        for (Object o : v.query().labels("value").properties()) {
+            JanusGraphVertexProperty<Double> prop = (JanusGraphVertexProperty<Double>) o;
             double prec = prop.value().doubleValue();
             assertEquals(prec * 2, prop.<Number>value("weight").doubleValue(), 0.00001);
         }
         //Ensure we can add additional values
         p = v.property("value", 44.4, "weight", 88.8);
-        assertEquals(v, (Vertex) getOnlyElement(tx.query().has("someid", Cmp.EQUAL, "Hello").vertices()));
+        assertEquals(v, getOnlyElement(tx.query().has("someid", Cmp.EQUAL, "Hello").vertices()));
 
         //------- EDGES -------
         try {
@@ -827,7 +830,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertCount(1, v12.query().direction(Direction.OUT).labels("parent").has("weight").edges());
         assertCount(1, v13.query().direction(Direction.OUT).labels("parent").has("weight").edges());
         assertEquals(v12, getOnlyElement(v.query().direction(Direction.OUT).labels("spouse").vertices()));
-        edge = getOnlyElement(v.query().direction(Direction.BOTH).labels("connect").edges());
+        edge = Iterables.<JanusGraphEdge>getOnlyElement(v.query().direction(Direction.BOTH).labels("connect").edges());
         assertEquals(1, edge.keys().size());
         assertEquals("e1", edge.value("uid"));
         try {
@@ -841,7 +844,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertCount(0, v13.query().direction(Direction.BOTH).labels("link").edges());
         //Assert we can add more friendships
         v.addEdge("friend", v12);
-        v2 = getOnlyElement(v12.query().direction(Direction.OUT).labels("connect").vertices());
+        v2 = Iterables.<JanusGraphVertex>getOnlyElement(v12.query().direction(Direction.OUT).labels("connect").vertices());
         assertEquals(v13, getOnlyElement(v2.query().direction(Direction.OUT).labels("link").vertices()));
 
         assertEquals(BaseVertexLabel.DEFAULT_VERTEXLABEL.name(), v.label());
@@ -885,18 +888,20 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertEquals(0.5, v.<Float>value("weight").doubleValue(), 0.00001);
         assertEquals("v1", v.value("uid"));
         assertCount(2, v.properties("name"));
-        for (JanusGraphVertexProperty<String> prop : v.query().labels("name").properties()) {
+        for (Object o : v.query().labels("name").properties()) {
+            JanusGraphVertexProperty<String> prop = (JanusGraphVertexProperty<String>) o;
             String nstr = prop.value();
             assertTrue(nstr.equals("Bob") || nstr.equals("John"));
         }
         assertTrue(Iterables.size(v.query().labels("value").properties()) >= 3);
-        for (JanusGraphVertexProperty<Double> prop : v.query().labels("value").properties()) {
+        for (Object o : v.query().labels("value").properties()) {
+            JanusGraphVertexProperty<Double> prop = (JanusGraphVertexProperty<Double>) o;
             double prec = prop.value().doubleValue();
             assertEquals(prec * 2, prop.<Number>value("weight").doubleValue(), 0.00001);
         }
         //Ensure we can add additional values
         p = v.property("value", 44.4, "weight", 88.8);
-        assertEquals(v, (Vertex) getOnlyElement(tx.query().has("someid", Cmp.EQUAL, "Hello").vertices()));
+        assertEquals(v, getOnlyElement(tx.query().has("someid", Cmp.EQUAL, "Hello").vertices()));
 
         //------- EDGES -------
         try {
@@ -927,7 +932,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertCount(1, v12.query().direction(Direction.OUT).labels("parent").has("weight").edges());
         assertCount(1, v13.query().direction(Direction.OUT).labels("parent").has("weight").edges());
         assertEquals(v12, getOnlyElement(v.query().direction(Direction.OUT).labels("spouse").vertices()));
-        edge = getOnlyElement(v.query().direction(Direction.BOTH).labels("connect").edges());
+        edge = Iterables.<JanusGraphEdge>getOnlyElement(v.query().direction(Direction.BOTH).labels("connect").edges());
         assertEquals(1, edge.keys().size());
         assertEquals("e1", edge.value("uid"));
         try {
@@ -941,7 +946,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertCount(0, v13.query().direction(Direction.BOTH).labels("link").edges());
         //Assert we can add more friendships
         v.addEdge("friend", v12);
-        v2 = getOnlyElement(v12.query().direction(Direction.OUT).labels("connect").vertices());
+        v2 = Iterables.<JanusGraphVertex>getOnlyElement(v12.query().direction(Direction.OUT).labels("connect").vertices());
         assertEquals(v13, getOnlyElement(v2.query().direction(Direction.OUT).labels("link").vertices()));
 
         assertEquals(BaseVertexLabel.DEFAULT_VERTEXLABEL.name(), v.label());
@@ -1085,8 +1090,8 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertEquals(shape, v.<Geoshape>value("geo"));
         assertEquals(10.12345, v.<Double>value("precise").doubleValue(), 0.000001);
         assertCount(3, v.properties("any"));
-        for (JanusGraphVertexProperty prop : v.query().labels("any").properties()) {
-            Object value = prop.value();
+        for (Object prop : v.query().labels("any").properties()) {
+            Object value = ((JanusGraphVertexProperty<?>) prop).value();
             if (value instanceof String) assertEquals("Hello", value);
             else if (value instanceof Long) assertEquals(10l, value);
             else if (value.getClass().isArray()) {
@@ -1106,8 +1111,8 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertEquals(shape, v.<Geoshape>value("geo"));
         assertEquals(10.12345, v.<Double>value("precise").doubleValue(), 0.000001);
         assertCount(3, v.properties("any"));
-        for (JanusGraphVertexProperty prop : v.query().labels("any").properties()) {
-            Object value = prop.value();
+        for (Object prop : v.query().labels("any").properties()) {
+            Object value = ((JanusGraphVertexProperty<?>) prop).value();
             if (value instanceof String) assertEquals("Hello", value);
             else if (value instanceof Long) assertEquals(10l, value);
             else if (value.getClass().isArray()) {
@@ -1230,7 +1235,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         v.addEdge("knows", v, "time", 11);
 
         newTx();
-        v = getOnlyElement(tx.query().has("time", 5).vertices());
+        v = Iterables.<JanusGraphVertex>getOnlyElement(tx.query().has("time", 5).vertices());
         assertNotNull(v);
         assertEquals("people", v.label());
         assertEquals(5, v.<Integer>value("time").intValue());
@@ -1280,7 +1285,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
 
         //VERIFY UPDATES IN TRANSACTION
         newTx();
-        v = getOnlyElement(tx.query().has("time", 5).vertices());
+        v = Iterables.<JanusGraphVertex>getOnlyElement(tx.query().has("time", 5).vertices());
         assertNotNull(v);
         assertEquals("person", v.label());
         assertEquals(5, v.<Integer>value("time").intValue());
@@ -1771,7 +1776,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         for (JanusGraphVertex v : new JanusGraphVertex[]{v1, v2, v3}) {
             assertCount(2, v.query().direction(Direction.BOTH).labels("knows").edges());
             assertCount(1, v.query().direction(Direction.OUT).labels("knows").edges());
-            JanusGraphEdge tmpE = getOnlyElement(v.query().direction(Direction.OUT).labels("knows").edges());
+            JanusGraphEdge tmpE = Iterables.<JanusGraphEdge>getOnlyElement(v.query().direction(Direction.OUT).labels("knows").edges());
             assertEquals(5, tmpE.<Integer>value("time") % 10);
         }
         e3.property("time", 35);
@@ -1780,8 +1785,8 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         v1.addEdge("friend", v2, "type", 0);
         graph.tx().commit();
         e4.property("type", 2);
-        JanusGraphEdge ef = getOnlyElement(v1.query().direction(Direction.OUT).labels("friend").edges());
-        assertEquals(ef, (Edge) getOnlyElement(graph.query().has("type", 0).edges()));
+        JanusGraphEdge ef = Iterables.<JanusGraphEdge>getOnlyElement(v1.query().direction(Direction.OUT).labels("friend").edges());
+        assertEquals(ef, getOnlyElement(graph.query().has("type", 0).edges()));
         ef.property("type", 1);
         graph.tx().commit();
 
@@ -1803,14 +1808,14 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         for (JanusGraphVertex v : new JanusGraphVertex[]{v1, v2, v3}) {
             assertCount(2, v.query().direction(Direction.BOTH).labels("knows").edges());
             assertCount(1, v.query().direction(Direction.OUT).labels("knows").edges());
-            assertEquals(5, getOnlyElement(v.query().direction(Direction.OUT).labels("knows").edges()).<Integer>value("time").intValue() % 10);
+            assertEquals(5, ((Edge) getOnlyElement(v.query().direction(Direction.OUT).labels("knows").edges())).<Integer>value("time").intValue() % 10);
         }
 
         graph.tx().commit();
 
         VertexProperty prop = v1.properties().next();
         assertTrue(getId(prop) > 0);
-        prop = (VertexProperty) ((Iterable) graph.multiQuery((JanusGraphVertex) v1).properties().values().iterator().next()).iterator().next();
+        prop = (VertexProperty) ((Iterable) graph.multiQuery(v1).properties().values().iterator().next()).iterator().next();
         assertTrue(getId(prop) > 0);
 
         assertEquals(45, e3.<Integer>value("time").intValue());
@@ -1822,7 +1827,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         for (JanusGraphVertex v : new JanusGraphVertex[]{v1, v2, v3}) {
             assertCount(2, v.query().direction(Direction.BOTH).labels("knows").edges());
             assertCount(1, v.query().direction(Direction.OUT).labels("knows").edges());
-            assertEquals(5, getOnlyElement(v.query().direction(Direction.OUT).labels("knows").edges()).<Integer>value("time").intValue() % 10);
+            assertEquals(5, ((Edge) getOnlyElement(v.query().direction(Direction.OUT).labels("knows").edges())).<Integer>value("time").intValue() % 10);
         }
 
         graph.tx().commit();
@@ -1861,12 +1866,12 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
 
         graph.tx().commit();
 
-        cartman = getOnlyElement(graph.query().has("name", "cartman").vertices());
+        cartman = Iterables.<JanusGraphVertex>getOnlyElement(graph.query().has("name", "cartman").vertices());
 
         graph.tx().commit();
 
         JanusGraphVertexProperty p = (JanusGraphVertexProperty) cartman.properties().next();
-        assertTrue(((Long) p.longId()) > 0);
+        assertTrue((p.longId()) > 0);
         graph.tx().commit();
     }
 
@@ -1916,18 +1921,18 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         v21.addEdge("link", v3);
         newTx();
         v21 = getV(tx, v21);
-        v3 = getOnlyElement(v21.query().direction(Direction.OUT).labels("link").vertices());
+        v3 = Iterables.<JanusGraphVertex>getOnlyElement(v21.query().direction(Direction.OUT).labels("link").vertices());
         assertFalse(v3.isRemoved());
         v3.remove();
         newTx();
         v21 = getV(tx, v21);
-        v3 = getOnlyElement(v21.query().direction(Direction.OUT).labels("link").vertices());
+        v3 = Iterables.<JanusGraphVertex>getOnlyElement(v21.query().direction(Direction.OUT).labels("link").vertices());
         assertFalse(v3.isRemoved());
         newTx();
 
         JanusGraphTransaction tx3 = graph.buildTransaction().checkInternalVertexExistence(true).start();
         v21 = getV(tx3, v21);
-        v3 = getOnlyElement(v21.query().direction(Direction.OUT).labels("link").vertices());
+        v3 = Iterables.<JanusGraphVertex>getOnlyElement(v21.query().direction(Direction.OUT).labels("link").vertices());
         assertTrue(v3.isRemoved());
         tx3.commit();
     }
@@ -1977,7 +1982,8 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         for (String prop : new String[]{foo, bar}) {
             int sum = 0;
             int index = values.size();
-            for (JanusGraphVertexProperty<String> p : v.query().labels(foo).properties()) {
+            for (Object o : v.query().labels(foo).properties()) {
+                JanusGraphVertexProperty<String> p = (JanusGraphVertexProperty<String>) o;
                 assertTrue(values.contains(p.value()));
                 int wint = p.value(weight);
                 sum += wint;
@@ -2287,10 +2293,10 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
          */
         long e1id = getId(e1);
         long e2id = getId(e2);
-        e1 = getOnlyElement(v1.query().direction(Direction.OUT).labels("connect").edges());
+        e1 = Iterables.<JanusGraphEdge>getOnlyElement(v1.query().direction(Direction.OUT).labels("connect").edges());
         assertEquals("e1", e1.value("name"));
         assertEquals(e1id, getId(e1));
-        e2 = getOnlyElement(v1.query().direction(Direction.OUT).labels("related").edges());
+        e2 = Iterables.<JanusGraphEdge>getOnlyElement(v1.query().direction(Direction.OUT).labels("related").edges());
         assertEquals("e2", e2.value("name"));
         assertEquals(e2id, getId(e2));
         //Update edges - one should simply update, the other fork
@@ -2300,10 +2306,10 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         newTx();
         v1 = getV(tx, v1);
 
-        e1 = getOnlyElement(v1.query().direction(Direction.OUT).labels("connect").edges());
+        e1 = Iterables.<JanusGraphEdge>getOnlyElement(v1.query().direction(Direction.OUT).labels("connect").edges());
         assertEquals("e1.2", e1.value("name"));
         assertEquals(e1id, getId(e1)); //should have same id
-        e2 = getOnlyElement(v1.query().direction(Direction.OUT).labels("related").edges());
+        e2 = Iterables.<JanusGraphEdge>getOnlyElement(v1.query().direction(Direction.OUT).labels("related").edges());
         assertEquals("e2.2", e2.value("name"));
         assertNotEquals(e2id, getId(e2)); //should have different id since forked
 
@@ -2493,6 +2499,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         final AtomicInteger txSuccess = new AtomicInteger(0);
         for (int i = 0; i < number; i++) {
             new Thread() {
+                @Override
                 public void run() {
                     awaitAllThreadsReady();
                     JanusGraphTransaction tx = graph.newTransaction();
@@ -2827,14 +2834,14 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
 
         newTx();
 
-        v = getOnlyElement(tx.query().has("name", "v").vertices());
+        v = Iterables.<JanusGraphVertex>getOnlyElement(tx.query().has("name", "v").vertices());
         assertNotNull(v);
         assertEquals(2, v.query().has("weight", 1.5).interval("time", 10, 30).limit(2).vertexIds().size());
         assertEquals(10, v.query().has("weight", 1.5).interval("time", 10, 30).vertexIds().size());
 
         newTx();
 
-        v = getOnlyElement(tx.query().has("name", "v").vertices());
+        v = Iterables.<JanusGraphVertex>getOnlyElement(tx.query().has("name", "v").vertices());
         assertNotNull(v);
         assertEquals(2, v.query().has("weight", 1.5).interval("time", 10, 30).limit(2).edgeCount());
         assertEquals(10, v.query().has("weight", 1.5).interval("time", 10, 30).edgeCount());
@@ -3150,10 +3157,12 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         //--------------
 
         //Update in transaction
-        for (JanusGraphVertexProperty<String> p : v.query().labels("name").properties()) {
+        for (Object o : v.query().labels("name").properties()) {
+            JanusGraphVertexProperty<String> p = (JanusGraphVertexProperty<String>) o;
             if (p.<Long>value("time") < (numV / 2)) p.remove();
         }
-        for (JanusGraphEdge e : v.query().direction(BOTH).edges()) {
+        for (Object o : v.query().direction(BOTH).edges()) {
+            JanusGraphEdge e = (JanusGraphEdge) o;
             if (e.<Long>value("time") < (numV / 2)) e.remove();
         }
         ns = new JanusGraphVertex[numV * 3 / 2];
@@ -3297,14 +3306,14 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         for (PropertyKey key : orderMap.keySet()) assertTrue(orders.containsKey(key));
 
         //Check subqueries
-        assertEquals(1, (Number) profiler.getAnnotation(QueryProfiler.NUMVERTICES_ANNOTATION));
+        assertEquals(Integer.valueOf(1), profiler.getAnnotation(QueryProfiler.NUMVERTICES_ANNOTATION));
         int subQueryCounter = 0;
         for (SimpleQueryProfiler subProfiler : profiler) {
             assertNotNull(subProfiler);
             if (subProfiler.getGroupName().equals(QueryProfiler.OPTIMIZATION)) continue;
             if (subQuerySpecs.length == 2) { //0=>fitted, 1=>ordered
-                assertEquals(subQuerySpecs[0], (Boolean) subProfiler.getAnnotation(QueryProfiler.FITTED_ANNOTATION));
-                assertEquals(subQuerySpecs[1], (Boolean) subProfiler.getAnnotation(QueryProfiler.ORDERED_ANNOTATION));
+                assertEquals(subQuerySpecs[0], subProfiler.getAnnotation(QueryProfiler.FITTED_ANNOTATION));
+                assertEquals(subQuerySpecs[1], subProfiler.getAnnotation(QueryProfiler.ORDERED_ANNOTATION));
             }
             //assertEquals(1,Iterables.size(subProfiler)); This only applies if a disk call is necessary
             subQueryCounter++;
@@ -3325,7 +3334,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertCount(numEdges, parentVertex.query().direction(Direction.OUT).edges());
 
         // Remove an edge.
-        parentVertex.query().direction(OUT).edges().iterator().next().remove();
+        ((Edge) parentVertex.query().direction(OUT).edges().iterator().next()).remove();
 
         // Check that getEdges returns one fewer.
         assertCount(numEdges - 1, parentVertex.query().direction(Direction.OUT).edges());
@@ -3616,7 +3625,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         tx2 = graph.buildTransaction().logIdentifier(userlogName).start();
         v1 = getV(tx2, v1id);
         assertEquals(111.1, v1.<Float>value("weight").doubleValue(), 0.01);
-        Edge e = getOnlyElement(v1.query().direction(Direction.OUT).labels("knows").edges());
+        Edge e = Iterables.<JanusGraphEdge>getOnlyElement(v1.query().direction(Direction.OUT).labels("knows").edges());
         assertFalse(e.property("weight").isPresent());
         e.property("weight", 44.4);
         tx2.commit();
@@ -4368,8 +4377,8 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         //Check subqueries
         SimpleQueryProfiler subp = Iterables.getOnlyElement(Iterables.filter(profiler, p -> !p.getGroupName().equals(QueryProfiler.OPTIMIZATION)));
         if (subQuerySpecs.length == 2) { //0=>fitted, 1=>ordered
-            assertEquals(subQuerySpecs[0], (Boolean) subp.getAnnotation(QueryProfiler.FITTED_ANNOTATION));
-            assertEquals(subQuerySpecs[1], (Boolean) subp.getAnnotation(QueryProfiler.ORDERED_ANNOTATION));
+            assertEquals(subQuerySpecs[0], subp.getAnnotation(QueryProfiler.FITTED_ANNOTATION));
+            assertEquals(subQuerySpecs[1], subp.getAnnotation(QueryProfiler.ORDERED_ANNOTATION));
         }
         Set<String> indexNames = new HashSet<>();
         int indexQueries = 0;
@@ -4482,22 +4491,22 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         JanusGraphVertex b = tx.addVertex(vt, user, fn, "bob");
         JanusGraphVertex v;
 
-        v = getOnlyElement(tx.query().has(vt, user).has(fn, bob).limit(1).vertices());
+        v = Iterables.<JanusGraphVertex>getOnlyElement(tx.query().has(vt, user).has(fn, bob).limit(1).vertices());
         assertEquals(bob, v.value(fn));
         assertEquals(user, v.value(vt));
 
-        v = getOnlyElement(tx.query().has(vt, user).has(fn, alice).limit(1).vertices());
+        v = Iterables.<JanusGraphVertex>getOnlyElement(tx.query().has(vt, user).has(fn, alice).limit(1).vertices());
         assertEquals(alice, v.value(fn));
         assertEquals(user, v.value(vt));
 
         tx.commit();
         tx = graph.newTransaction();
 
-        v = getOnlyElement(tx.query().has(vt, user).has(fn, bob).limit(1).vertices());
+        v = Iterables.<JanusGraphVertex>getOnlyElement(tx.query().has(vt, user).has(fn, bob).limit(1).vertices());
         assertEquals(bob, v.value(fn));
         assertEquals(user, v.value(vt));
 
-        v = getOnlyElement(tx.query().has(vt, user).has(fn, alice).limit(1).vertices());
+        v = Iterables.<JanusGraphVertex>getOnlyElement(tx.query().has(vt, user).has(fn, alice).limit(1).vertices());
         assertEquals(alice, v.value(fn));
         assertEquals(user, v.value(vt));
     }
@@ -4608,7 +4617,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
 
         v3 = getV(graph, v3);
         assertEquals(445, v3.<Integer>value("uid").intValue());
-        e = getOnlyElement(v3.query().direction(Direction.OUT).labels("knows").edges());
+        e = Iterables.<JanusGraphEdge>getOnlyElement(v3.query().direction(Direction.OUT).labels("knows").edges());
         assertEquals(111, e.<Integer>value("uid").intValue());
         assertEquals(e, getE(graph, e.id()));
         assertEquals(e, getE(graph, e.id().toString()));
@@ -4616,10 +4625,10 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         p.remove();
         v3.property("uid", 353);
 
-        e = getOnlyElement(v3.query().direction(Direction.OUT).labels("knows").edges());
+        e = Iterables.<JanusGraphEdge>getOnlyElement(v3.query().direction(Direction.OUT).labels("knows").edges());
         e.property("uid", 222);
 
-        e2 = getOnlyElement(v1.query().direction(Direction.OUT).labels("friend").edges());
+        e2 = Iterables.<JanusGraphEdge>getOnlyElement(v1.query().direction(Direction.OUT).labels("friend").edges());
         e2.property("uid", 1);
         e2.property("weight", 2.0);
 
@@ -4632,7 +4641,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         v3 = getV(graph, v3.id());
         assertEquals(353, v3.<Integer>value("uid").intValue());
 
-        e = getOnlyElement(v3.query().direction(Direction.OUT).labels("knows").edges());
+        e = Iterables.<JanusGraphEdge>getOnlyElement(v3.query().direction(Direction.OUT).labels("knows").edges());
         assertEquals(222, e.<Integer>value("uid").intValue());
     }
 
@@ -5101,14 +5110,14 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertEquals(Duration.ofDays(1), d);
 
         // get the edge via a vertex
-        e1 = getOnlyElement(v1.query().direction(Direction.OUT).labels("likes").edges());
+        e1 = Iterables.<JanusGraphEdge>getOnlyElement(v1.query().direction(Direction.OUT).labels("likes").edges());
         d = e1.value("~ttl");
         assertEquals(Duration.ofDays(1), d);
 
         // returned value of ^ttl is the total time to live since commit, not remaining time
         Thread.sleep(1001);
         graph.tx().rollback();
-        e1 = getOnlyElement(v1.query().direction(Direction.OUT).labels("likes").edges());
+        e1 = Iterables.<JanusGraphEdge>getOnlyElement(v1.query().direction(Direction.OUT).labels("likes").edges());
         d = e1.value("~ttl");
         assertEquals(Duration.ofDays(1), d);
 

--- a/janusgraph-test/src/main/java/org/janusgraph/olap/OLAPTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/olap/OLAPTest.java
@@ -55,6 +55,7 @@ public abstract class OLAPTest extends JanusGraphBaseTest {
     private static final Logger log =
             LoggerFactory.getLogger(OLAPTest.class);
 
+    @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();
@@ -188,7 +189,7 @@ public abstract class OLAPTest extends JanusGraphBaseTest {
         assertNull(getV(tx,v3id));
         v1 = getV(tx, v1id);
         assertNotNull(v1);
-        assertEquals(v3id,v1.query().direction(Direction.IN).labels("knows").vertices().iterator().next().longId());
+        assertEquals(v3id,((JanusGraphVertex) v1.query().direction(Direction.IN).labels("knows").vertices().iterator().next()).longId());
         tx.commit();
         mgmt.commit();
 
@@ -280,8 +281,8 @@ public abstract class OLAPTest extends JanusGraphBaseTest {
             for (JanusGraphVertex v : gview.query().vertices()) {
                 long degree2 = ((Integer)v.value(DegreeCounter.DEGREE)).longValue();
                 long actualDegree2 = 0;
-                for (JanusGraphVertex w : v.query().direction(Direction.OUT).vertices()) {
-                    actualDegree2 += Iterables.size(w.query().direction(Direction.OUT).vertices());
+                for (Object w : v.query().direction(Direction.OUT).vertices()) {
+                    actualDegree2 += Iterables.size(((JanusGraphVertex) w).query().direction(Direction.OUT).vertices());
                 }
                 assertEquals(actualDegree2,degree2);
             }

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/serializer/SerializerGraphConfiguration.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/serializer/SerializerGraphConfiguration.java
@@ -69,7 +69,7 @@ public class SerializerGraphConfiguration {
         tx.commit();
 
         tx = graph.newTransaction();
-        v = tx.query().has("time",5).vertices().iterator().next();
+        v = (JanusGraphVertex) tx.query().has("time",5).vertices().iterator().next();
         assertEquals(5,(int)v.value("time"));
         assertEquals(3, Iterators.size(v.properties("any")));
         tx.rollback();

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
         <jna.version>4.0.0</jna.version>
         <kuali.s3.wagon.version>1.1.20</kuali.s3.wagon.version>
         <jasper.version>5.5.23</jasper.version>
+        <gmavenplus.version>1.5</gmavenplus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <janusgraph.testdir>${project.build.directory}/janusgraph-test</janusgraph.testdir>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,6 @@
         <top.level.basedir>${basedir}</top.level.basedir>
         <compiler.source>1.8</compiler.source>
         <compiler.target>1.8</compiler.target>
-        <compiler.args />
         <test.excluded.groups>org.janusgraph.testcategory.MemoryTests,org.janusgraph.testcategory.PerformanceTests,org.janusgraph.testcategory.BrittleTests</test.excluded.groups>
     </properties>
     <modules>
@@ -219,10 +218,12 @@
                     <configuration>
                         <source>${compiler.source}</source>
                         <target>${compiler.target}</target>
-                        <compilerArgument>${compiler.args}</compilerArgument>
                         <compilerArguments>
                             <Xmaxerrs>500</Xmaxerrs>
                         </compilerArguments>
+                        <compilerArgs>
+                          <arg>-Xlint:unchecked</arg>
+                        </compilerArgs>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
This CL should change nothing, I've set up JanusGraph in eclipse and made some changes to make things saner.  For reference I'm using M2E to configure the project, no special settings.

* Switch to org.codehaus.gmavenplus version 1.5 for all gmaven plugins, there used to be a mix of gmaven and gmavenplus.  The latest version works nicely with M2E.
* Remove the janusgraph-hadoop project from the dependencies section of janusgraph-all/pom.xml as it's not a java project.
* Do explicit casts wherever eclipse was generating errors.
* A -Xlint:unchecked to compiler options so we get more warnings for this kind of thing.

Eclipse builds still aren't clean, theres errors from with the assembly plugin and something to do with packing output locations I haven't been able to track down yet.


