### PR TITLE
Issue 95: Adding first version of development process documentation.

### DIFF
--- a/docs/development.txt
+++ b/docs/development.txt
@@ -1,0 +1,82 @@
+[[development-process]]
+= JanusGraph Development Process
+
+The following sections describe the JanusGraph development process.
+
+
+[[development-decisions]]
+== Development Decisions
+
+Many development decisions will be made during the day-to-day work of JanusGraph contributors without any extra process overhead.
+However, for larger bodies of work and significant updates and additions, the following process shall be followed.
+Significant work may include, but is not limited to:
+
+* A major new feature or subproject, e.g., a new storage adapter
+* Incrementing the version of a core dependency such as a Apache TinkerPop
+* Addition or deprecation of a public API
+* Internal shared data structure or API change
+* Addition of a new major dependency
+
+For these sorts of changes, contributors will:
+
+* Create one or more issues in the GitHub issue tracker
+* Start a DISCUSS thread on the https://groups.google.com/forum/#!forum/janusgraph-dev[janusgraph-dev] list where the proposed change may be discussed by committers
+and other community members
+* When the proposer feels it appropriate, a VOTE shall be called
+* Two +1 votes are required for the change to be accepted
+
+[[branching]]
+== Branching
+
+For features that involve only one developer, developers will work in their own JanusGraph forks, managing their own branches, and submitting pull requests when ready. If multiple developers wish to collaborate on a feature,
+they may request that a feature branch be created in JanusGraph repository.  If the developers are not committers, a JanusGraph committer will be assigned as the shepherd for that branch.  The shepherd will be responsible for merging pull requests to that branch.
+
+=== Branch Naming Conventions
+
+All branch names hosted in the JanusGraph repository shall be prepended with `Issue_#_`.
+
+[[pull-requests]]
+== Pull Requests
+
+Most changes to JanusGraph must be reviewed before they are committed (RTC - review-then-commit).
+This workflow is performed using GitHub's pull request process. In instances where the committer deems the full process unnecessary, commit-then-review (CTR) may be employed.
+This should be used infrequently and only for extremely trivial changes.
+Changes of this sort may include:
+
+* Documentation typo or small documentation addition
+* Addition of a new test case
+
+Any commit that is made following CTR shall include the fact that it is a CTR in the commit comments.
+Community members who wish to review CTRs may subscribe to the https://groups.google.com/forum/#!forum/janusgraph-commits[JanusGraph commits] list so that they will see CTRs as they come through.
+If another committer responds with a -1, the commit should be rolled back and the formal RTC process should be followed.
+
+Users wishing to contribute to JanusGraph should fork the https://github.com/janusgraph/janusgraph[JanusGraph] repository and then submit pull requests using the GitHub pull request process.
+Every pull request must be associated with an existing issue.
+Be sure to include the relevant issue number in the title of your pull request and a description of what test suites were run to validate the pull request.
+
+Pull requests commit messages should clearly describe what work was accomplished.
+Intermediate work-in-progress commits should be squashed prior to pull request submittal.
+
+Pull requests must be reviewed before being merged.
+The JanusGraph project uses the https://help.github.com/articles/about-pull-request-reviews/[GitHub review process] to review pull requests.
+Non-committers are free, and encouraged to review pull requests.
+Their review will be non-binding, but can be taken into consideration and are still very valuable community input.
+The following rules apply to the voting process.
+
+* Two committer approvals are required to merge a pull request
+* One or more -1 votes within a change request will veto the pull request until the noted issue(s) are addressed and the -1 vote is withdrawn
+* Change requests will not be considered valid without an explanation
+
+[[release-policy]]
+== Release Policy
+
+Any JanusGraph committer may propose a release.
+To propose a release, simple start a new RELEASE thread on https://groups.google.com/forum/#!forum/janusgraph-dev[janusgraph-dev] proposing the new release and requesting feedback on what should be included in the release.
+After consensus is reached the release manager will perform the following tasks:
+
+* Create a release branch so that work may continue on `master`
+* Prepare the release artifacts
+* Call a vote to approve the release on https://groups.google.com/forum/#!forum/janusgraph-dev[janusgraph-dev]
+* Committers will be given 72 hours to review and vote on the release artifacts
+* Three +1 votes are required for a release to be approved
+* One or more -1 votes with explanation will veto the release until the noted issues are addressed and the -1 votes are withdrawn

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -15,4 +15,6 @@ include::advanced.txt[]
 
 include::internals.txt[]
 
+include::development.txt[]
+
 include::appendices.txt[]


### PR DESCRIPTION
Here is a first cut at developer process docs.  The release policy section is pretty sparse but I think we can expand this when we go through our first release process.  I imagine we'll also add explicit release steps and directions at that point also.  I'm not wed to any of these particular policies but I think they're a good start.  Specifically I'm curious if folks think we should allow CTR in limited cases like I've defined here.