### PR TITLE
Add repositories to enable dependency reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
         <compiler.source>1.8</compiler.source>
         <compiler.target>1.8</compiler.target>
         <test.excluded.groups>org.janusgraph.testcategory.MemoryTests,org.janusgraph.testcategory.PerformanceTests,org.janusgraph.testcategory.BrittleTests</test.excluded.groups>
+        <dependency.locations.enabled>false</dependency.locations.enabled>
     </properties>
     <modules>
         <module>janusgraph-core</module>
@@ -140,6 +141,35 @@
             </releases>
             <snapshots>
                 <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <!-- the repositories below are included here for `mvn project-info-reports:dependencies` -->
+        <repository>
+            <!-- for com.github.jeremyh:jBCrypt:jar -->
+            <id>jitpack.io</id>
+            <name>JitPack Package Repository</name>
+            <url>https://jitpack.io</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <!-- for com.sleepycat:je:jar -->
+            <id>oracleReleases</id>
+            <name>Oracle Released Java Packages</name>
+            <url>http://download.oracle.com/maven</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <!-- for org.restlet.jee:org.restlet:jar -->
+            <id>spring-releases</id>
+            <name>Spring Release Repository</name>
+            <url>http://repo.spring.io/libs-release-remote/</url>
+            <snapshots>
+                <enabled>false</enabled>
             </snapshots>
         </repository>
     </repositories>


### PR DESCRIPTION
https://github.com/JanusGraph/janusgraph/issues/132

Run `mvn project-info-reports:dependencies` to generate the reports. Takes around 4 minutes with `dependency.locations.enabled=false`. Results are found under `*/target/site/dependencies.html`.

I tracked down several of the undetermined ones:

* dom4j - BSD
  https://github.com/dom4j/dom4j/blob/dom4j_1_6_1/LICENSE.txt

* com.thoughtworks.paranamer:paranamer:2.6 - BSD
  https://github.com/paul-hammant/paranamer/blob/paranamer-parent-2.6/LICENSE.txt

* asm - BSD
  http://websvn.ow2.org/filedetails.php?repname=asm&path=%2Ftags%2FASM_3_1%2Fasm%2FLICENSE.txt

* commons-net:commons-net:1.4.1 - Apache
  https://github.com/apache/commons-net/blob/NET_1_4_1/LICENSE.txt

* javax.validation:validation-api:1.0.0.GA - Apache
  https://github.com/beanvalidation/beanvalidation-api/blob/1.0.0.GA/license.txt

* org.antlr:antlr:3.2 - BSD
  http://www.antlr3.org/license.html

* org.yaml:snakeyaml:1.11 - Apache
  https://bitbucket.org/asomov/snakeyaml/src/e5341219f4924ede78b1a077ea5a01ea778d38f0/LICENSE.txt?at=v1.11&fileviewer=file-view-default

* oro:oro:2.0.8 - Apache
  http://svn.apache.org/repos/asf/jakarta/oro/trunk/LICENSE

* commons-el:commons-el:1.0 - Apache
  http://svn.apache.org/repos/asf/commons/dormant/el/tags/EL_1_0/LICENSE.txt

* com.github.jeremyh:jBCrypt:jbcrypt-0.4 - ISC
  https://github.com/jeremyh/jBCrypt/blob/jbcrypt-0.4/LICENSE

* org.apache.zookeeper:zookeeper:3.4.6 - Apache

* org.apache.xbean:xbean-asm5-shaded:4.4 - Apache

* javax.servlet.jsp:jsp-api:2.1 - CDDL

* javax.servlet:servlet-api:2.5 - CDDL


These will need more review:

* org.acplt:oncrpc:1.0.7 - LGPL
* com.vividsolutions:jts:1.13 - LGPL

* com.github.stephenc.high-scale-lib:high-scale-lib:1.1.4 - Public Domain
* org.tukaani:xz:1.0 - Public Domain

* org.reflections:reflections:0.9.9-RC1 - WTFPL
