### PR TITLE
Make optimisticLocking a StoreFeature. Silence noisy kcvslog test.

### DIFF
--- a/janusgraph-berkeleyje/src/main/java/org/janusgraph/diskstorage/berkeleyje/BerkeleyJEStoreManager.java
+++ b/janusgraph-berkeleyje/src/main/java/org/janusgraph/diskstorage/berkeleyje/BerkeleyJEStoreManager.java
@@ -90,6 +90,7 @@ public class BerkeleyJEStoreManager extends LocalStoreManager implements Ordered
                     .scanTxConfig(GraphDatabaseConfiguration.buildGraphConfiguration()
                             .set(ISOLATION_LEVEL, IsolationLevel.READ_UNCOMMITTED.toString()))
                     .supportsInterruption(false)
+                    .optimisticLocking(false)
                     .build();
 
 //        features = new StoreFeatures();

--- a/janusgraph-berkeleyje/src/test/java/org/janusgraph/graphdb/berkeleyje/BerkeleyGraphTest.java
+++ b/janusgraph-berkeleyje/src/test/java/org/janusgraph/graphdb/berkeleyje/BerkeleyGraphTest.java
@@ -74,11 +74,6 @@ public class BerkeleyGraphTest extends JanusGraphTest {
     }
 
     @Override
-    protected boolean isLockingOptimistic() {
-        return false;
-    }
-
-    @Override
     public void testConcurrentConsistencyEnforcement() {
         //Do nothing TODO: Figure out why this is failing in BerkeleyDB!!
     }

--- a/janusgraph-berkeleyje/src/test/java/org/janusgraph/graphdb/berkeleyje/BerkeleyOperationCountingTest.java
+++ b/janusgraph-berkeleyje/src/test/java/org/janusgraph/graphdb/berkeleyje/BerkeleyOperationCountingTest.java
@@ -25,9 +25,4 @@ public class BerkeleyOperationCountingTest extends JanusGraphOperationCountingTe
         return BerkeleyStorageSetup.getBerkeleyJEGraphConfiguration();
     }
 
-    @Override
-    public boolean storeUsesConsistentKeyLocker() {
-        return false;
-    }
-
 }

--- a/janusgraph-cassandra/src/main/java/org/janusgraph/diskstorage/cassandra/AbstractCassandraStoreManager.java
+++ b/janusgraph-cassandra/src/main/java/org/janusgraph/diskstorage/cassandra/AbstractCassandraStoreManager.java
@@ -272,6 +272,7 @@ public abstract class AbstractCassandraStoreManager extends DistributedStoreMana
             fb.batchMutation(true).distributed(true);
             fb.timestamps(true).cellTTL(true);
             fb.keyConsistent(global, local);
+            fb.optimisticLocking(true);
 
             boolean keyOrdered;
 

--- a/janusgraph-cassandra/src/test/java/org/janusgraph/graphdb/CassandraGraphTest.java
+++ b/janusgraph-cassandra/src/test/java/org/janusgraph/graphdb/CassandraGraphTest.java
@@ -38,11 +38,6 @@ public abstract class CassandraGraphTest extends JanusGraphTest {
         CassandraStorageSetup.startCleanEmbedded();
     }
 
-    @Override
-    protected boolean isLockingOptimistic() {
-        return true;
-    }
-
     @Test
     public void testHasTTL() throws Exception {
         assertTrue(features.hasCellTTL());

--- a/janusgraph-cassandra/src/test/java/org/janusgraph/graphdb/thrift/ThriftGraphCacheTest.java
+++ b/janusgraph-cassandra/src/test/java/org/janusgraph/graphdb/thrift/ThriftGraphCacheTest.java
@@ -32,11 +32,4 @@ public class ThriftGraphCacheTest extends JanusGraphTest {
     public static void beforeClass() {
         CassandraStorageSetup.startCleanEmbedded();
     }
-
-
-
-    @Override
-    protected boolean isLockingOptimistic() {
-        return true;
-    }
 }

--- a/janusgraph-cassandra/src/test/java/org/janusgraph/graphdb/thrift/ThriftOperationCountingTest.java
+++ b/janusgraph-cassandra/src/test/java/org/janusgraph/graphdb/thrift/ThriftOperationCountingTest.java
@@ -31,9 +31,4 @@ public class ThriftOperationCountingTest extends JanusGraphOperationCountingTest
         return CassandraStorageSetup.getCassandraThriftGraphConfiguration(getClass().getSimpleName());
     }
 
-    @Override
-    public boolean storeUsesConsistentKeyLocker() {
-        return true;
-    }
-
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/StandardStoreFeatures.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/StandardStoreFeatures.java
@@ -42,6 +42,7 @@ public class StandardStoreFeatures implements StoreFeatures {
     private final Configuration localKeyConsistentTxConfig;
     private final Configuration scanTxConfig;
     private final boolean supportsInterruption;
+    private final boolean optimisticLocking;
 
     @Override
     public boolean hasScan() {
@@ -147,6 +148,11 @@ public class StandardStoreFeatures implements StoreFeatures {
         return supportsInterruption;
     }
 
+    @Override
+    public boolean hasOptimisticLocking() {
+        return optimisticLocking;
+    }
+
     /**
      * The only way to instantiate {@link StandardStoreFeatures}.
      */
@@ -172,6 +178,7 @@ public class StandardStoreFeatures implements StoreFeatures {
         private Configuration localKeyConsistentTxConfig;
         private Configuration scanTxConfig;
         private boolean supportsInterruption = true;
+        private boolean optimisticLocking;
 
         /**
          * Construct a Builder with everything disabled/unsupported/false/null.
@@ -203,6 +210,12 @@ public class StandardStoreFeatures implements StoreFeatures {
             }
             scanTxConfig(template.getScanTxConfig());
             supportsInterruption(template.supportsInterruption());
+            optimisticLocking(template.hasOptimisticLocking());
+        }
+
+        public Builder optimisticLocking(boolean b) {
+            optimisticLocking = b;
+            return this;
         }
 
         public Builder unorderedScan(boolean b) {
@@ -317,7 +330,7 @@ public class StandardStoreFeatures implements StoreFeatures {
                     timestamps, preferredTimestamps, cellLevelTTL,
                     storeLevelTTL, visibility, supportsPersist,
                     keyConsistentTxConfig,
-                    localKeyConsistentTxConfig, scanTxConfig, supportsInterruption);
+                    localKeyConsistentTxConfig, scanTxConfig, supportsInterruption, optimisticLocking);
         }
     }
 
@@ -330,7 +343,7 @@ public class StandardStoreFeatures implements StoreFeatures {
             boolean visibility, boolean supportsPersist,
             Configuration keyConsistentTxConfig,
             Configuration localKeyConsistentTxConfig,
-            Configuration scanTxConfig, boolean supportsInterruption) {
+            Configuration scanTxConfig, boolean supportsInterruption, boolean optimisticLocking) {
         this.unorderedScan = unorderedScan;
         this.orderedScan = orderedScan;
         this.multiQuery = multiQuery;
@@ -351,5 +364,6 @@ public class StandardStoreFeatures implements StoreFeatures {
         this.localKeyConsistentTxConfig = localKeyConsistentTxConfig;
         this.scanTxConfig = scanTxConfig;
         this.supportsInterruption = supportsInterruption;
+        this.optimisticLocking = optimisticLocking;
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/StoreFeatures.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/StoreFeatures.java
@@ -30,58 +30,58 @@ public interface StoreFeatures {
      * Equivalent to calling {@link #hasUnorderedScan()} {@code ||}
      * {@link #hasOrderedScan()}.
      */
-    public boolean hasScan();
+    boolean hasScan();
 
     /**
      * Whether this storage backend supports global key scans via
      * {@link KeyColumnValueStore#getKeys(SliceQuery, StoreTransaction)}.
      */
-    public boolean hasUnorderedScan();
+    boolean hasUnorderedScan();
 
     /**
      * Whether this storage backend supports global key scans via
      * {@link KeyColumnValueStore#getKeys(KeyRangeQuery, StoreTransaction)}.
      */
-    public boolean hasOrderedScan();
+    boolean hasOrderedScan();
 
     /**
      * Whether this storage backend supports query operations on multiple keys
      * via
      * {@link KeyColumnValueStore#getSlice(java.util.List, SliceQuery, StoreTransaction)}
      */
-    public boolean hasMultiQuery();
+    boolean hasMultiQuery();
 
     /**
      * Whether this store supports locking via
      * {@link KeyColumnValueStore#acquireLock(org.janusgraph.diskstorage.StaticBuffer, org.janusgraph.diskstorage.StaticBuffer, org.janusgraph.diskstorage.StaticBuffer, StoreTransaction)}
      *
      */
-    public boolean hasLocking();
+    boolean hasLocking();
 
     /**
      * Whether this storage backend supports batch mutations via
      * {@link KeyColumnValueStoreManager#mutateMany(java.util.Map, StoreTransaction)}.
      *
      */
-    public boolean hasBatchMutation();
+    boolean hasBatchMutation();
 
     /**
      * Whether this storage backend preserves key locality. This affects JanusGraph's
      * use of vertex ID partitioning.
      *
      */
-    public boolean isKeyOrdered();
+    boolean isKeyOrdered();
 
     /**
      * Whether this storage backend writes and reads data from more than one
      * machine.
      */
-    public boolean isDistributed();
+    boolean isDistributed();
 
     /**
      * Whether this storage backend's transactions support isolation.
      */
-    public boolean hasTxIsolation();
+    boolean hasTxIsolation();
 
     /**
      * Whether this storage backend has a (possibly improper) subset of the
@@ -92,7 +92,7 @@ public interface StoreFeatures {
      * return a valid list as described in that method.  If this is false, that
      * method will not be invoked.
      */
-    public boolean hasLocalKeyPartition();
+    boolean hasLocalKeyPartition();
 
     /**
      * Whether this storage backend provides strong consistency within each
@@ -103,7 +103,7 @@ public interface StoreFeatures {
      *
      * @return true if the backend supports key-level strong consistency
      */
-    public boolean isKeyConsistent();
+    boolean isKeyConsistent();
 
     /**
      * Returns true if column-value entries in this storage backend are annotated with a timestamp,
@@ -111,7 +111,7 @@ public interface StoreFeatures {
      *
      * @return
      */
-    public boolean hasTimestamps();
+    boolean hasTimestamps();
 
     /**
      * If this storage backend supports one particular type of data
@@ -125,7 +125,7 @@ public interface StoreFeatures {
      *
      * @return null or a Timestamps enum value
      */
-    public TimestampProviders getPreferredTimestamps();
+    TimestampProviders getPreferredTimestamps();
 
     /**
      * Returns true if this storage backend support time-to-live (TTL) settings for column-value entries. If such a value
@@ -136,7 +136,7 @@ public interface StoreFeatures {
      *
      * @return true if the storage backend supports cell-level TTL, else false
      */
-    public boolean hasCellTTL();
+    boolean hasCellTTL();
 
     /**
      * Returns true if this storage backend supports time-to-live (TTL) settings on a per-store basis. That means, that
@@ -146,7 +146,7 @@ public interface StoreFeatures {
      *
      * @return true if the storage backend supports store-level TTL, else false
      */
-    public boolean hasStoreTTL();
+    boolean hasStoreTTL();
 
     /**
      * Returns true if this storage backend supports entry-level visibility by attaching a visibility or authentication
@@ -154,13 +154,13 @@ public interface StoreFeatures {
      *
      * @return
      */
-    public boolean hasVisibility();
+    boolean hasVisibility();
 
     /**
      * Whether the backend supports data persistence. Return false if the backend is in-memory only.
      * @return
      */
-    public boolean supportsPersistence();
+    boolean supportsPersistence();
 
     /**
      * Get a transaction configuration that enforces key consistency. This
@@ -169,7 +169,7 @@ public interface StoreFeatures {
      *
      * @return a key-consistent tx config
      */
-    public Configuration getKeyConsistentTxConfig();
+    Configuration getKeyConsistentTxConfig();
 
     /**
      * Get a transaction configuration that enforces local key consistency.
@@ -185,7 +185,7 @@ public interface StoreFeatures {
      *
      * @return a locally (or globally) key-consistent tx config
      */
-    public Configuration getLocalKeyConsistentTxConfig();
+    Configuration getLocalKeyConsistentTxConfig();
 
 
     /**
@@ -197,12 +197,20 @@ public interface StoreFeatures {
      *
      * @return a transaction configuration suitable for scanjob data reading
      */
-    public Configuration getScanTxConfig();
+    Configuration getScanTxConfig();
 
 
     /**
      * Whether calls to this manager and its stores may be safely interrupted
      * without leaving the underlying system in an inconsistent state.
      */
-    public boolean supportsInterruption();
+    boolean supportsInterruption();
+
+    /**
+     * Whether the store will commit pending mutations optimistically and make other pending changes
+     * to the same cells fail on tx.commit() (true) or will fail pending mutations pessimistically on tx.commit()
+     * if other parallel transactions have already marked the relevant cells dirty.
+     * @return
+     */
+    boolean hasOptimisticLocking();
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/inmemory/InMemoryStoreManager.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/inmemory/InMemoryStoreManager.java
@@ -53,6 +53,7 @@ public class InMemoryStoreManager implements KeyColumnValueStoreManager {
             .unorderedScan(true)
             .keyOrdered(true)
             .persists(false)
+            .optimisticLocking(true)
             .keyConsistent(GraphDatabaseConfiguration.buildGraphConfiguration())
             .build();
 

--- a/janusgraph-hbase-parent/janusgraph-hbase-core/src/main/java/org/janusgraph/diskstorage/hbase/HBaseStoreManager.java
+++ b/janusgraph-hbase-parent/janusgraph-hbase-core/src/main/java/org/janusgraph/diskstorage/hbase/HBaseStoreManager.java
@@ -390,7 +390,7 @@ public class HBaseStoreManager extends DistributedStoreManager implements KeyCol
                 .orderedScan(true).unorderedScan(true).batchMutation(true)
                 .multiQuery(true).distributed(true).keyOrdered(true).storeTTL(true)
                 .timestamps(true).preferredTimestamps(PREFERRED_TIMESTAMPS)
-                .keyConsistent(c);
+                .optimisticLocking(true).keyConsistent(c);
 
         try {
             fb.localKeyPartition(getDeployment() == Deployment.LOCAL);

--- a/janusgraph-hbase-parent/janusgraph-hbase-core/src/test/java/org/janusgraph/graphdb/hbase/HBaseGraphTest.java
+++ b/janusgraph-hbase-parent/janusgraph-hbase-core/src/test/java/org/janusgraph/graphdb/hbase/HBaseGraphTest.java
@@ -42,9 +42,4 @@ public class HBaseGraphTest extends JanusGraphTest {
         return HBaseStorageSetup.getHBaseGraphConfiguration();
     }
 
-    @Override
-    protected boolean isLockingOptimistic() {
-        return true;
-    }
-
 }

--- a/janusgraph-hbase-parent/janusgraph-hbase-core/src/test/java/org/janusgraph/graphdb/hbase/HBaseOperationCountingTest.java
+++ b/janusgraph-hbase-parent/janusgraph-hbase-core/src/test/java/org/janusgraph/graphdb/hbase/HBaseOperationCountingTest.java
@@ -47,11 +47,6 @@ public class HBaseOperationCountingTest extends JanusGraphOperationCountingTest 
     }
 
     @Override
-    public boolean storeUsesConsistentKeyLocker() {
-        return true;
-    }
-
-    @Override
     public void testCacheConcurrency() throws InterruptedException {
         //Don't run this test;
     }

--- a/janusgraph-test/src/main/java/org/janusgraph/diskstorage/LockKeyColumnValueStoreTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/diskstorage/LockKeyColumnValueStoreTest.java
@@ -80,7 +80,7 @@ public abstract class LockKeyColumnValueStoreTest extends AbstractKCVSTest {
 
     private StaticBuffer k, c1, c2, v1, v2;
 
-    private final String concreteClassName;
+    protected final String concreteClassName;
 
     public LockKeyColumnValueStoreTest() {
         concreteClassName = getClass().getSimpleName();

--- a/janusgraph-test/src/main/java/org/janusgraph/diskstorage/log/LogTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/diskstorage/log/LogTest.java
@@ -347,7 +347,7 @@ public abstract class LogTest {
             StaticBuffer content = message.getContent();
             assertEquals(8,content.length());
             long value = content.getLong(0);
-            log.info("Read log value {} by senderid \"{}\"", value, message.getSenderId());
+            log.debug("Read log value {} by senderid \"{}\"", value, message.getSenderId());
             if (expectIncreasingValues) {
                 assertTrue("Message out of order or duplicated: " + lastMessageValue + " preceded " + value, lastMessageValue<value);
                 lastMessageValue = value;

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphConcurrentTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphConcurrentTest.java
@@ -304,7 +304,11 @@ public abstract class JanusGraphConcurrentTest extends JanusGraphBaseTest {
      */
     @Test
     public void testStandardIndexVertexPropertyReads() throws InterruptedException, ExecutionException {
-        final int propCount = THREAD_COUNT * 5;
+        testStandardIndexVertexPropertyReadsLogic(THREAD_COUNT);
+    }
+
+    protected void testStandardIndexVertexPropertyReadsLogic(int numThreads) throws InterruptedException, ExecutionException {
+        final int propCount = numThreads * 5;
         final int vertexCount = 1 * 1000;
         // Create props with standard indexes
         log.info("Creating types");

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphOperationCountingTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphOperationCountingTest.java
@@ -69,7 +69,9 @@ public abstract class JanusGraphOperationCountingTest extends JanusGraphBaseTest
 
     public abstract WriteConfiguration getBaseConfiguration();
 
-    public abstract boolean storeUsesConsistentKeyLocker();
+    public final boolean storeUsesConsistentKeyLocker() {
+        return !this.features.hasLocking();
+    }
 
     @Override
     public WriteConfiguration getConfiguration() {

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -168,7 +168,9 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
 
     private Logger log = LoggerFactory.getLogger(JanusGraphTest.class);
 
-    protected abstract boolean isLockingOptimistic();
+    final boolean isLockingOptimistic() {
+        return features.hasOptimisticLocking();
+    }
 
   /* ==================================================================================
                             INDEXING

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/inmemory/InMemoryGraphTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/inmemory/InMemoryGraphTest.java
@@ -99,9 +99,4 @@ public class InMemoryGraphTest extends JanusGraphTest {
     @Override
     public void testIndexUpdateSyncWithMultipleInstances() {}
 
-    @Override
-    protected boolean isLockingOptimistic() {
-        return true;
-    }
-
 }


### PR DESCRIPTION
These changes are a rework of something I tried to do two years ago but did not make it in Titan before the end of 2015. Contains an extremely minor refactoring of tests so that the DynamoDB Storage Backend can change some parameters. Also promotes optimisticLocking to a StoreFeature, as that is where it belongs.

Signed-off-by: Alexander Patrikalakis <amcp@amazon.co.jp>