### PR TITLE
Add signatures for value-based type defaults

### DIFF
--- a/docs/basics.txt
+++ b/docs/basics.txt
@@ -245,9 +245,7 @@ JanusGraph natively supports the following data types.
 |Long			|long value
 |Float			|4 byte floating point number
 |Double			|8 byte floating point number
-|Decimal		|Number with 3 decimal digits
-|Precision		|Number with 6 decimal digits
-|Date           |Date
+|Date                   |Date
 |Geoshape		|Geographic shape like point, circle or box
 |UUID   		|UUID
 |=====
@@ -1007,7 +1005,7 @@ Hence, the `battlesByLocationAndTime` index can speed up the first two but not t
 Multiple vertex-centric indexes can be built for the same edge label in order to support different constraint traversals. JanusGraph's query optimizer attempts to pick the most efficient index for any given traversal. Vertex-centric indexes only support equality and range/interval constraints.
 
 [NOTE]
-The property keys used in a vertex-centric index must have an explicitly defined data type (i.e. _not_ `Object.class`) which supports a native sort order. If the data type are floating point numbers, JanusGraph's custom `Decimal` or `Precision` data types must be used which have a fixed number of decimals.
+The property keys used in a vertex-centric index must have an explicitly defined data type (i.e. _not_ `Object.class`) which supports a native sort order.
 
 If the vertex-centric index is built against an edge label that is defined in the same management transaction, the index will be immediately available for querying. If the edge label has already been in use, building a vertex-centric index against it requires the execution of a <<reindex, reindex procedure>> to ensure that the index contains all previously added edges. Until the reindex procedure has completed, the index will not be available.
 
@@ -1406,9 +1404,6 @@ When defining unique types with <<eventual-consistency, locking enabled>> (i.e. 
 
 Such exceptions are to be expected, since JanusGraph cannot know how to recover from a transactional state where an earlier read value has been modified by another transaction since this may invalidate the state of the transaction. In most cases it is sufficient to simply re-run the transaction. If locking exceptions are very frequent, try to analyze and remove the source of congestion.
 
-=== Floating point numbers in Vertex-centric Indices
-
-JanusGraph does not allow property keys with `Double` or `Float` data type to be part of a vertex centric index because their serialization does not support index creation. Use custom, fixed-digit data types `Decimal` (3 decimal digits) or `Precision (6 decimal digits) instead.
 
 === Ghost Vertices
 

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/DefaultSchemaMaker.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/DefaultSchemaMaker.java
@@ -62,6 +62,18 @@ public interface DefaultSchemaMaker {
     }
 
     /**
+     * Creates a new property key with default settings against the provided {@link PropertyKeyMaker} and value.
+     *
+     * @param factory PropertyKeyMaker through which the property key is created
+     * @param value the value of the property. The default implementation does not use this parameter.
+     * @return A new property key
+     * @throws IllegalArgumentException if the name is already in use or if other configured values are invalid.
+     */
+    public default PropertyKey makePropertyKey(PropertyKeyMaker factory, Object value) {
+         return makePropertyKey(factory);
+    }
+
+    /**
      * Creates a new vertex label with the default settings against the provided {@link VertexLabelMaker}.
      *
      * @param factory VertexLabelMaker through which the vertex label is created

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/SchemaInspector.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/SchemaInspector.java
@@ -67,6 +67,25 @@ public interface SchemaInspector {
      */
     public PropertyKey getOrCreatePropertyKey(String name);
 
+
+    /**
+     * Returns the property key with the given name. If automatic type making is enabled, it will make the property key
+     * using the configured default type maker if a key with the given name does not exist.
+     *
+     * The default implementation simply calls the {@link #getOrCreatePropertyKey(String name) getOrCreatePropertyKey} method
+     *
+     * @param name name of the property key to return
+     * @param value the value of the property key. This param is not used by the default
+     * implementaion
+     * @return the property key with the given name
+     * @throws IllegalArgumentException if a property key with the given name does not exist or if the
+     *                                  type with the given name is not a property key
+     * @see PropertyKey
+     */
+    public default PropertyKey getOrCreatePropertyKey(String name, Object value) {
+       return getOrCreatePropertyKey(name);
+    }
+
     /**
      * Returns the property key with the given name. If it does not exist, NULL is returned
      *

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphDefaultSchemaMaker.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphDefaultSchemaMaker.java
@@ -14,8 +14,14 @@
 
 package org.janusgraph.graphdb.tinkerpop;
 
-import org.janusgraph.core.*;
+import org.janusgraph.core.attribute.Geoshape;
+import org.janusgraph.core.Cardinality;
+import org.janusgraph.core.PropertyKey;
 import org.janusgraph.core.schema.DefaultSchemaMaker;
+import org.janusgraph.core.schema.PropertyKeyMaker;
+
+import java.util.Date;
+import java.util.UUID;
 
 /**
  * {@link org.janusgraph.core.schema.DefaultSchemaMaker} implementation for Blueprints graphs
@@ -34,9 +40,45 @@ public class JanusGraphDefaultSchemaMaker implements DefaultSchemaMaker {
         return Cardinality.SINGLE;
     }
 
+    @Override
+    public PropertyKey makePropertyKey(PropertyKeyMaker factory, Object value) {
+        String name = factory.getName();
+        Class klass = determineClass(value);
+        return factory.cardinality(defaultPropertyCardinality(name)).dataType(klass).make();
+    }
 
     @Override
     public boolean ignoreUndefinedQueryTypes() {
         return true;
+    }
+
+    protected Class determineClass(Object value) {
+        if (value instanceof String) {
+            return String.class;
+        } else if (value instanceof Character) {
+            return Character.class;
+        } else if (value instanceof Boolean) {
+            return Boolean.class;
+        } else if (value instanceof Byte) {
+            return Byte.class;
+        } else if (value instanceof Short) {
+            return Short.class;
+        } else if (value instanceof Integer) {
+            return Integer.class;
+        } else if (value instanceof Long) {
+            return Long.class;
+        } else if (value instanceof Float) {
+            return Float.class;
+        } else if (value instanceof Double) {
+            return Double.class;
+        } else if (value instanceof Date) {
+            return Date.class;
+        } else if (value instanceof Geoshape) {
+            return Geoshape.class;
+        } else if (value instanceof UUID) {
+            return UUID.class;
+        } else {
+            return Object.class;
+        }
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -928,6 +928,17 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
     }
 
     @Override
+    public PropertyKey getOrCreatePropertyKey(String name, Object value) {
+        RelationType et = getRelationType(name);
+        if (et == null) {
+            return config.getAutoSchemaMaker().makePropertyKey(makePropertyKey(name), value);
+        } else if (et.isPropertyKey()) {
+            return (PropertyKey) et;
+        } else
+            throw new IllegalArgumentException("The type of given name is not a key: " + name);
+    }
+
+    @Override
     public PropertyKey getOrCreatePropertyKey(String name) {
         RelationType et = getRelationType(name);
         if (et == null) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/AbstractVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/AbstractVertex.java
@@ -145,14 +145,14 @@ public abstract class AbstractVertex extends AbstractElement implements Internal
 	 */
 
     public<V> JanusGraphVertexProperty<V> property(final String key, final V value, final Object... keyValues) {
-        JanusGraphVertexProperty<V> p = tx().addProperty(it(), tx().getOrCreatePropertyKey(key), value);
+        JanusGraphVertexProperty<V> p = tx().addProperty(it(), tx().getOrCreatePropertyKey(key, value), value);
         ElementHelper.attachProperties(p,keyValues);
         return p;
     }
 
     @Override
     public <V> JanusGraphVertexProperty<V> property(final VertexProperty.Cardinality cardinality, final String key, final V value, final Object... keyValues) {
-        JanusGraphVertexProperty<V> p = tx().addProperty(cardinality, it(), tx().getOrCreatePropertyKey(key), value);
+        JanusGraphVertexProperty<V> p = tx().addProperty(cardinality, it(), tx().getOrCreatePropertyKey(key, value), value);
         ElementHelper.attachProperties(p,keyValues);
         return p;
     }

--- a/janusgraph-test/pom.xml
+++ b/janusgraph-test/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
-            <version>3.1</version>
+            <version>3.4</version>
         </dependency>
 
 

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/tinkerpop/JanusGraphDefaultSchemaMakerTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/tinkerpop/JanusGraphDefaultSchemaMakerTest.java
@@ -1,0 +1,79 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop;
+
+import static org.easymock.EasyMock.expect;
+
+import org.easymock.EasyMockSupport;
+import org.junit.Test;
+
+import org.janusgraph.core.attribute.Geoshape;
+import org.janusgraph.core.Cardinality;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.PropertyKeyMaker;
+import org.janusgraph.core.schema.DefaultSchemaMaker;
+
+import java.util.Date;
+import java.util.UUID;
+
+public class JanusGraphDefaultSchemaMakerTest extends EasyMockSupport {
+
+  @Test
+  public void testMakePropertyKey() {
+      PropertyKeyMaker pkm = mockPropertyKeyMaker();
+      DefaultSchemaMaker schemaMaker = JanusGraphDefaultSchemaMaker.INSTANCE;
+      byte b = 100;
+      short s = 10000;
+      schemaMaker.makePropertyKey(pkm, "Foo");
+      schemaMaker.makePropertyKey(pkm, 'f');
+      schemaMaker.makePropertyKey(pkm, true);
+      schemaMaker.makePropertyKey(pkm, b);
+      schemaMaker.makePropertyKey(pkm, s);
+      schemaMaker.makePropertyKey(pkm, 100);
+      schemaMaker.makePropertyKey(pkm, 100L);
+      schemaMaker.makePropertyKey(pkm, 100.0f);
+      schemaMaker.makePropertyKey(pkm, 1.23e2);
+      schemaMaker.makePropertyKey(pkm, new Date());
+      schemaMaker.makePropertyKey(pkm, Geoshape.point(42.3601f, 71.0589f));
+      schemaMaker.makePropertyKey(pkm, UUID.randomUUID());
+      schemaMaker.makePropertyKey(pkm, new Object());
+
+      verifyAll();
+  }
+
+  private PropertyKeyMaker mockPropertyKeyMaker() {
+      PropertyKeyMaker propertyKeyMaker = createMock(PropertyKeyMaker.class);
+      PropertyKey pk = createMock(PropertyKey.class);
+      expect(propertyKeyMaker.make()).andReturn(pk).anyTimes();
+      expect(propertyKeyMaker.getName()).andReturn("Quux").anyTimes();
+      expect(propertyKeyMaker.cardinality(Cardinality.SINGLE)).andReturn(propertyKeyMaker).anyTimes();
+      expect(propertyKeyMaker.dataType(String.class)).andReturn(propertyKeyMaker);
+      expect(propertyKeyMaker.dataType(Character.class)).andReturn(propertyKeyMaker);
+      expect(propertyKeyMaker.dataType(Boolean.class)).andReturn(propertyKeyMaker);
+      expect(propertyKeyMaker.dataType(Byte.class)).andReturn(propertyKeyMaker);
+      expect(propertyKeyMaker.dataType(Short.class)).andReturn(propertyKeyMaker);
+      expect(propertyKeyMaker.dataType(Integer.class)).andReturn(propertyKeyMaker);
+      expect(propertyKeyMaker.dataType(Long.class)).andReturn(propertyKeyMaker);
+      expect(propertyKeyMaker.dataType(Float.class)).andReturn(propertyKeyMaker);
+      expect(propertyKeyMaker.dataType(Double.class)).andReturn(propertyKeyMaker);
+      expect(propertyKeyMaker.dataType(Date.class)).andReturn(propertyKeyMaker);
+      expect(propertyKeyMaker.dataType(Geoshape.class)).andReturn(propertyKeyMaker);
+      expect(propertyKeyMaker.dataType(UUID.class)).andReturn(propertyKeyMaker);
+      expect(propertyKeyMaker.dataType(Object.class)).andReturn(propertyKeyMaker);
+      replayAll();
+      return propertyKeyMaker;
+  }
+
+}

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTxTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTxTest.java
@@ -1,0 +1,110 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.janusgraph.graphdb.transaction;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.isA;
+import static org.easymock.EasyMock.notNull;
+import static org.easymock.EasyMock.replay;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.easymock.EasyMockSupport;
+import org.junit.Test;
+
+import org.janusgraph.core.RelationType;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.DefaultSchemaMaker;
+import org.janusgraph.core.schema.PropertyKeyMaker;
+import org.janusgraph.diskstorage.util.time.TimestampProvider;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.janusgraph.graphdb.database.StandardJanusGraph;
+import org.janusgraph.graphdb.database.serialize.Serializer;
+import org.janusgraph.graphdb.database.EdgeSerializer;
+import org.janusgraph.graphdb.database.IndexSerializer;
+import org.janusgraph.graphdb.idmanagement.IDManager;
+
+public class StandardJanusGraphTxTest extends EasyMockSupport {
+
+    @Test
+    public void testGetOrCreatePropertyKey() {
+        StandardJanusGraphTx tx = createTxWithMockedInternals();
+        tx.getOrCreatePropertyKey("Foo", "Bar");
+        Exception e = null;
+        try {
+            tx.getOrCreatePropertyKey("Baz", "Quuz");
+        } catch (IllegalArgumentException ex) {
+            e = ex;
+        }
+        tx.getOrCreatePropertyKey("Qux", "Quux");
+        assertNotNull("getOrCreatePropertyKey should throw an Exception when the relationType is not a PropertyKey", e);
+        verifyAll();
+    }
+
+
+    private StandardJanusGraphTx createTxWithMockedInternals() {
+        StandardJanusGraph mockGraph = createMock(StandardJanusGraph.class);
+        TransactionConfiguration txConfig = createMock(TransactionConfiguration.class);
+        GraphDatabaseConfiguration gdbConfig = createMock(GraphDatabaseConfiguration.class);
+        TimestampProvider tsProvider = createMock(TimestampProvider.class);
+        Serializer mockSerializer = createMock(Serializer.class);
+        EdgeSerializer mockEdgeSerializer = createMock(EdgeSerializer.class);
+        IndexSerializer mockIndexSerializer = createMock(IndexSerializer.class);
+        RelationType relationType = createMock(RelationType.class);
+        IDManager idManager = createMock(IDManager.class);
+        PropertyKey propertyKey = createMock(PropertyKey.class);
+        DefaultSchemaMaker defaultSchemaMaker = createMock(DefaultSchemaMaker.class);
+
+        expect(mockGraph.getConfiguration()).andReturn(gdbConfig);
+        expect(mockGraph.isOpen()).andReturn(true).anyTimes();
+        expect(mockGraph.getDataSerializer()).andReturn(mockSerializer);
+        expect(mockGraph.getEdgeSerializer()).andReturn(mockEdgeSerializer);
+        expect(mockGraph.getIndexSerializer()).andReturn(mockIndexSerializer);
+        expect(mockGraph.getIDManager()).andReturn(idManager);
+
+        expect(gdbConfig.getTimestampProvider()).andReturn(tsProvider);
+
+        expect(txConfig.isSingleThreaded()).andReturn(true);
+        expect(txConfig.hasPreloadedData()).andReturn(false);
+        expect(txConfig.hasVerifyExternalVertexExistence()).andReturn(false);
+        expect(txConfig.hasVerifyInternalVertexExistence()).andReturn(false);
+        expect(txConfig.getVertexCacheSize()).andReturn(6);
+        expect(txConfig.isReadOnly()).andReturn(true);
+        expect(txConfig.getDirtyVertexSize()).andReturn(2);
+        expect(txConfig.getIndexCacheWeight()).andReturn(2l);
+        expect(txConfig.getGroupName()).andReturn(null);
+        expect(txConfig.getAutoSchemaMaker()).andReturn(defaultSchemaMaker);
+
+        expect(defaultSchemaMaker.makePropertyKey(isA(PropertyKeyMaker.class), notNull())).andReturn(propertyKey);
+
+        expect(relationType.isPropertyKey()).andReturn(false);
+
+        expect(propertyKey.isPropertyKey()).andReturn(true);
+
+        replayAll();
+
+        StandardJanusGraphTx partialMock = createMockBuilder(StandardJanusGraphTx.class)
+           .withConstructor(mockGraph, txConfig)
+           .addMockedMethod("getRelationType")
+           .createMock();
+
+        expect(partialMock.getRelationType("Foo")).andReturn(null);
+        expect(partialMock.getRelationType("Qux")).andReturn(propertyKey);
+        expect(partialMock.getRelationType("Baz")).andReturn(relationType);
+
+        replay(partialMock);
+        return partialMock;
+
+    }
+}


### PR DESCRIPTION
The previous implementation only provided property key names to
DefaultSchemaMaker instances, which limits users' ability to customize
behavior. This changeset also passes the property key value down to the
DefaultSchemaMaker, allowing more fine-grained analysis and potentially
better decisions around default types. A base implementation has been
added to the JanusGraphDefaultSchemaMaker.

Signed-off-by: Keith Lohnes <krlohnes@us.ibm.com>