### PR TITLE
Issue 171: Exclude TraversalInterruptionTest in BerkeleyJanusGraphProcessTest

### DIFF
--- a/janusgraph-berkeleyje/src/test/java/org/janusgraph/blueprints/process/BerkeleyJanusGraphProcessTest.java
+++ b/janusgraph-berkeleyje/src/test/java/org/janusgraph/blueprints/process/BerkeleyJanusGraphProcessTest.java
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
  */
-@RunWith(ProcessStandardSuite.class)
+@RunWith(BerkeleyProcessStandardSuite.class)
 @GraphProviderClass(provider = BerkeleyGraphProvider.class, graph = JanusGraph.class)
 public class BerkeleyJanusGraphProcessTest {
 }

--- a/janusgraph-berkeleyje/src/test/java/org/janusgraph/blueprints/process/BerkeleyProcessStandardSuite.java
+++ b/janusgraph-berkeleyje/src/test/java/org/janusgraph/blueprints/process/BerkeleyProcessStandardSuite.java
@@ -1,0 +1,44 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.blueprints.process;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.tinkerpop.gremlin.process.ProcessStandardSuite;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalInterruptionTest;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.RunnerBuilder;
+
+import java.lang.reflect.Field;
+
+/**
+ * Custom TinkerPop {@link ProcessStandardSuite} that excludes {@link TraversalInterruptionTest} for compatibility with
+ * BerkeleyDB JE, which does not support thread interrupts.
+ */
+public class BerkeleyProcessStandardSuite extends ProcessStandardSuite {
+
+    public BerkeleyProcessStandardSuite(final Class<?> klass, final RunnerBuilder builder) throws InitializationError {
+        super(klass, builder, getTestList());
+    }
+
+    private static final Class<?>[] getTestList() throws InitializationError {
+        try {
+            final Field field = ProcessStandardSuite.class.getDeclaredField("allTests");
+            field.setAccessible(true);
+            return (Class<?>[]) ArrayUtils.removeElement((Class<?>[]) field.get(null), TraversalInterruptionTest.class);
+        } catch (ReflectiveOperationException e) {
+            throw new InitializationError("Unable to create test list");
+        }
+    }
+}


### PR DESCRIPTION
This PR resolves #171 by using a custom `ProcessStandardSuite` implementation to skip the `TraversalInterruptionTest` in that module.

All remaining tests are passing with this update.

```
$ mvn clean install -DskipTests=true -Dtest.skip.tp=false -pl janusgraph-berkeleyje
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 3:18:13.432s
[INFO] Finished at: Sat Apr 01 00:57:43 UTC 2017
[INFO] Final Memory: 26M/510M
[INFO] ------------------------------------------------------------------------

$ mvn clean install -pl janusgraph-berkeleyje
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 9:02.101s
[INFO] Finished at: Sat Apr 01 01:48:08 UTC 2017
[INFO] Final Memory: 33M/534M
[INFO] ------------------------------------------------------------------------
```