### PR TITLE
Issue 182: Enable Travis CI on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,11 +73,6 @@ addons:
     build_command: "travis_wait mvn clean package -B -DskipTests=true"
     branch_pattern: coverity_scan
 
-branches:
-  only:
-    - master
-    - coverity_scan
-
 script:
   - if [[ "${COVERITY_SCAN_BRANCH}}" == 1 ]]; then
       echo "Skipping build/test on 'coverity_scan' branch.";


### PR DESCRIPTION
Resolves #182 by removing the branch safelist from .travis.yml so that all branches are tested under Travis. If at a later time some branches do need to be excluded this could be revisited, possibly [using regular expressions](https://docs.travis-ci.com/user/customizing-the-build#Using-regular-expressions) instead of specific branch names.