### PR TITLE
Add ability to await on multiple statuses

### DIFF
--- a/docs/basics.txt
+++ b/docs/basics.txt
@@ -887,8 +887,9 @@ location = mgmt.makePropertyKey('location').dataType(Geoshape.class).make()
 nameAndAge = mgmt.getGraphIndex('nameAndAge')
 mgmt.addIndexKey(nameAndAge, location)
 mgmt.commit()
-//Wait for the index to become available
-mgmt.awaitGraphIndexStatus(graph, 'nameAndAge').call()
+//Previously created property keys already have the status ENABLED, but
+//our newly created property key "location" needs to REGISTER so we wait for both statuses
+mgmt.awaitGraphIndexStatus(graph, 'nameAndAge').status(REGISTERED, ENABLED).call()
 //Reindex the existing data
 mgmt = graph.openManagement()
 mgmt.updateIndex(mgmt.getGraphIndex("nameAndAge"), SchemaAction.REINDEX).get()

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/AbstractIndexStatusReport.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/AbstractIndexStatusReport.java
@@ -1,0 +1,53 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.database.management;
+
+import org.janusgraph.core.schema.SchemaStatus;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public abstract class AbstractIndexStatusReport {
+    protected final boolean success;
+    protected final String indexName;
+    protected final List<SchemaStatus> targetStatuses;
+    protected final Duration elapsed;
+
+    public AbstractIndexStatusReport(boolean success, String indexName, List<SchemaStatus> targetStatuses, Duration elapsed) {
+        this.success = success;
+        this.indexName = indexName;
+        this.targetStatuses = targetStatuses;
+        this.elapsed = elapsed;
+    }
+
+    public boolean getSucceeded() {
+        return success;
+    }
+
+    public String getIndexName() {
+        return indexName;
+    }
+
+    public List<SchemaStatus> getTargetStatuses() {
+        return targetStatuses;
+    }
+
+    public Duration getElapsed() {
+        return elapsed;
+    }
+}
+

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/AbstractIndexStatusWatcher.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/AbstractIndexStatusWatcher.java
@@ -22,17 +22,23 @@ import org.janusgraph.core.schema.SchemaStatus;
 import java.time.Duration;
 import java.time.temporal.TemporalUnit;
 import java.util.concurrent.Callable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 
 public abstract class AbstractIndexStatusWatcher<R, S extends AbstractIndexStatusWatcher<R,S>> implements Callable<R> {
 
     protected JanusGraph g;
-    protected SchemaStatus status;
+    protected List<SchemaStatus> statuses;
     protected Duration timeout;
     protected Duration poll;
 
     public AbstractIndexStatusWatcher(JanusGraph g) {
         this.g = g;
-        this.status = SchemaStatus.REGISTERED;
+        this.statuses = new ArrayList<SchemaStatus>();
+        this.statuses.add(SchemaStatus.REGISTERED);
         this.timeout = Duration.ofSeconds(60L);
         this.poll = Duration.ofMillis(500L);
     }
@@ -40,16 +46,17 @@ public abstract class AbstractIndexStatusWatcher<R, S extends AbstractIndexStatu
     protected abstract S self();
 
     /**
-     * Set the target index status.  {@link #call()} will repeatedly
+     * Set the target index statuses.  {@link #call()} will repeatedly
      * poll the graph passed into this instance during construction to
      * see whether the index (also passed in during construction) has
-     * the supplied status.
+     * one of the the supplied statuses.
      *
-     * @param status
+     * @param statuses
      * @return
      */
-    public S status(SchemaStatus status) {
-        this.status = status;
+    public S status(SchemaStatus... statuses) {
+        this.statuses.clear();
+        this.statuses.addAll(Arrays.asList(statuses));
         return self();
     }
 
@@ -85,5 +92,5 @@ public abstract class AbstractIndexStatusWatcher<R, S extends AbstractIndexStatu
         this.poll = Duration.of(poll, pollUnit);
         return self();
     }
-
 }
+

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/GraphIndexStatusReport.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/GraphIndexStatusReport.java
@@ -14,41 +14,24 @@
 
 package org.janusgraph.graphdb.database.management;
 
-
 import org.janusgraph.core.schema.SchemaStatus;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
-public class GraphIndexStatusReport {
-    private final boolean success;
-    private final String indexName;
-    private final SchemaStatus targetStatus;
+public class GraphIndexStatusReport extends AbstractIndexStatusReport {
     private final Map<String, SchemaStatus> notConverged;
     private final Map<String, SchemaStatus> converged;
-    private final Duration elapsed;
 
-    public GraphIndexStatusReport(boolean success, String indexName, SchemaStatus targetStatus,
+    public GraphIndexStatusReport(boolean success, String indexName, List<SchemaStatus> targetStatuses,
                    Map<String, SchemaStatus> notConverged,
                    Map<String, SchemaStatus> converged, Duration elapsed) {
-        this.success = success;
-        this.indexName = indexName;
-        this.targetStatus = targetStatus;
+        super(success, indexName, targetStatuses, elapsed);
         this.notConverged = notConverged;
         this.converged = converged;
-        this.elapsed = elapsed;
-    }
-
-    public boolean getSucceeded() {
-        return success;
-    }
-
-    public String getIndexName() {
-        return indexName;
-    }
-
-    public SchemaStatus getTargetStatus() {
-        return targetStatus;
     }
 
     public Map<String, SchemaStatus> getNotConvergedKeys() {
@@ -59,19 +42,16 @@ public class GraphIndexStatusReport {
         return converged;
     }
 
-    public Duration getElapsed() {
-        return elapsed;
-    }
-
     @Override
     public String toString() {
         return "GraphIndexStatusReport[" +
                 "success=" + success +
                 ", indexName='" + indexName + '\'' +
-                ", targetStatus=" + targetStatus +
+                ", targetStatus=" + targetStatuses +
                 ", notConverged=" + notConverged +
                 ", converged=" + converged +
                 ", elapsed=" + elapsed +
                 ']';
     }
 }
+

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/RelationIndexStatusReport.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/RelationIndexStatusReport.java
@@ -18,32 +18,18 @@ package org.janusgraph.graphdb.database.management;
 import org.janusgraph.core.schema.SchemaStatus;
 
 import java.time.Duration;
+import java.util.List;
 
-public class RelationIndexStatusReport {
+public class RelationIndexStatusReport extends AbstractIndexStatusReport {
 
-    private final boolean succeeded;
-    private final String indexName;
     private final String relationTypeName;
     private final SchemaStatus actualStatus;
-    private final SchemaStatus targetStatus;
-    private final Duration elapsed;
 
-    public RelationIndexStatusReport(boolean succeeded, String indexName, String relationTypeName, SchemaStatus actualStatus,
-                                   SchemaStatus targetStatus, Duration elapsed) {
-        this.succeeded = succeeded;
-        this.indexName = indexName;
+    public RelationIndexStatusReport(boolean success, String indexName, String relationTypeName, SchemaStatus actualStatus,
+                                   List<SchemaStatus>targetStatuses, Duration elapsed) {
+        super(success, indexName, targetStatuses, elapsed);
         this.relationTypeName = relationTypeName;
         this.actualStatus = actualStatus;
-        this.targetStatus = targetStatus;
-        this.elapsed = elapsed;
-    }
-
-    public boolean getSucceeded() {
-        return succeeded;
-    }
-
-    public String getIndexName() {
-        return indexName;
     }
 
     public String getRelationTypeName() {
@@ -54,22 +40,14 @@ public class RelationIndexStatusReport {
         return actualStatus;
     }
 
-    public SchemaStatus getTargetStatus() {
-        return targetStatus;
-    }
-
-    public Duration getElapsed() {
-        return elapsed;
-    }
-
     @Override
     public String toString() {
         return "RelationIndexStatusReport[" +
-                "succeeded=" + succeeded +
+                "succeeded=" + success +
                 ", indexName='" + indexName + '\'' +
                 ", relationTypeName='" + relationTypeName + '\'' +
                 ", actualStatus=" + actualStatus +
-                ", targetStatus=" + targetStatus +
+                ", targetStatus=" + targetStatuses +
                 ", elapsed=" + elapsed +
                 ']';
     }

--- a/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrRunner.java
+++ b/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrRunner.java
@@ -27,7 +27,8 @@ public class SolrRunner {
     protected static final int NUM_SERVERS = 1;
     protected static final String[] COLLECTIONS = new String[] { "store1", "store2", "vertex", "edge", "namev", "namee",
             "composite", "psearch", "esearch", "vsearch", "mi", "mixed", "index1", "index2", "index3",
-            "ecategory", "vcategory", "pcategory", "theIndex", "vertices", "edges", "booleanIndex", "dateIndex", "instantIndex", "uuidIndex" };
+            "ecategory", "vcategory", "pcategory", "theIndex", "vertices", "edges", "booleanIndex", "dateIndex", "instantIndex", "uuidIndex",
+            "randomMixedIndex" };
 
     protected static final String[] KEY_FIELDS = new String[0];
 


### PR DESCRIPTION
This fixes the following bug for example:
If a user wants to update an index by adding a propertyKey to it, then
the existing propertyKeys will have status ENABLED, but the
IndexStatusWatcher will be looking for REGISTERED only, so the index update
is never completed.

Issues: #196

Signed-off-by: David Pitera <dpitera@us.ibm.com>