### PR TITLE
UpdateTriggerStatus from Set -> List

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementLogger.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementLogger.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -105,7 +106,7 @@ public class ManagementLogger implements MessageReader {
     }
 
     public void sendCacheEviction(Set<JanusGraphSchemaVertex> updatedTypes,
-                                             Set<Callable<Boolean>> updatedTypeTriggers,
+                                             List<Callable<Boolean>> updatedTypeTriggers,
                                              Set<String> openInstances) {
         Preconditions.checkArgument(!openInstances.isEmpty());
         long evictionId = evictionTriggerCounter.incrementAndGet();
@@ -124,11 +125,11 @@ public class ManagementLogger implements MessageReader {
     private class EvictionTrigger {
 
         final long evictionId;
-        final Set<Callable<Boolean>> updatedTypeTriggers;
+        final List<Callable<Boolean>> updatedTypeTriggers;
         final ImmutableSet<String> openInstances;
         final AtomicInteger ackCounter;
 
-        private EvictionTrigger(long evictionId, Set<Callable<Boolean>> updatedTypeTriggers, Set<String> openInstances) {
+        private EvictionTrigger(long evictionId, List<Callable<Boolean>> updatedTypeTriggers, Set<String> openInstances) {
             this.evictionId = evictionId;
             this.updatedTypeTriggers = updatedTypeTriggers;
             this.openInstances = ImmutableSet.copyOf(openInstances);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
@@ -106,6 +106,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -140,7 +142,7 @@ public class ManagementSystem implements JanusGraphManagement {
     private final StandardJanusGraphTx transaction;
 
     private final Set<JanusGraphSchemaVertex> updatedTypes;
-    private final Set<Callable<Boolean>> updatedTypeTriggers;
+    private final List<Callable<Boolean>> updatedTypeTriggers;
 
     private final Instant txStartTime;
     private boolean graphShutdownRequired;
@@ -160,7 +162,7 @@ public class ManagementSystem implements JanusGraphManagement {
         this.userConfig = new UserModifiableConfiguration(modifyConfig, configVerifier);
 
         this.updatedTypes = new HashSet<JanusGraphSchemaVertex>();
-        this.updatedTypeTriggers = new HashSet<Callable<Boolean>>();
+        this.updatedTypeTriggers = new ArrayList<Callable<Boolean>>();
         this.graphShutdownRequired = false;
 
         this.transaction = (StandardJanusGraphTx) graph.buildTransaction().disableBatchLoading().start();
@@ -870,8 +872,6 @@ public class ManagementSystem implements JanusGraphManagement {
     }
 
     private void setUpdateTrigger(Callable<Boolean> trigger) {
-        //Make sure the most current is the one set
-        if (updatedTypeTriggers.contains(trigger)) updatedTypeTriggers.remove(trigger);
         updatedTypeTriggers.add(trigger);
     }
 


### PR DESCRIPTION
Previously, we were seeing new index creations on the same graph act as
if they were equal to previous triggers. Thus, the previous but
not finished updateStatusTriggers were being removed from the SET and
getting stuck in INSTALLED. In this change, we have done two things:
1. Change the datastructure housing the updateStatusTriggers from a Set
to a List.
2. Remove the code that removes any updateStatusTriggers from the data
structure.

These changes ensure all index creations on a given graph fulfill their
INSTALLing.

Issues: #195

Signed-off-by: David Pitera <dpitera@us.ibm.com>