### PR TITLE
Change "Saturn"'s Vertex label back to "titan" to be consistent with the documentation

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/example/GraphOfTheGodsFactory.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/example/GraphOfTheGodsFactory.java
@@ -91,7 +91,7 @@ public class GraphOfTheGodsFactory {
         mgmt.makeEdgeLabel("pet").make();
         mgmt.makeEdgeLabel("brother").make();
 
-        mgmt.makeVertexLabel("janusgraph").make();
+        mgmt.makeVertexLabel("titan").make();
         mgmt.makeVertexLabel("location").make();
         mgmt.makeVertexLabel("god").make();
         mgmt.makeVertexLabel("demigod").make();
@@ -103,7 +103,7 @@ public class GraphOfTheGodsFactory {
         JanusGraphTransaction tx = graph.newTransaction();
         // vertices
 
-        Vertex saturn = tx.addVertex(T.label, "janusgraph", "name", "saturn", "age", 10000);
+        Vertex saturn = tx.addVertex(T.label, "titan", "name", "saturn", "age", 10000);
         Vertex sky = tx.addVertex(T.label, "location", "name", "sky");
         Vertex sea = tx.addVertex(T.label, "location", "name", "sea");
         Vertex jupiter = tx.addVertex(T.label, "god", "name", "jupiter", "age", 5000);


### PR DESCRIPTION
Due to global find/replace the Vertex label was renamed
to janusgraph. Rename it back to "titan" to be
consistent with the example in the documentation

Signed-off-by: Simeon Monov <sdmonov@us.ibm.com>