### PR TITLE
Clarifications to AUTHORS.txt and NOTICE.txt

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -11,8 +11,10 @@
 
 # Please keep the list sorted.
 
+Aurelius
 DataStax
 Dylan Bethune-Waddell <dylan.bethune.waddell@mail.utoronto.ca>
 Expero
 Google
+IBM
 Rafael Fernandes <luizrafael@gmail.com>

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,16 +1,19 @@
 ==============================================================
  JanusGraph: Distributed Graph Database
- Copyright 2012 and onwards Aurelius
+ Copyright 2012 and onwards JanusGraph Authors
 ==============================================================
 
-This product includes software developed by Aurelius (http://thinkaurelius.com/) and the following individuals:
+This product includes software developed by JanusGraph contributors listed
+in CONTRIBUTORS.txt; JanusGraph copyright holders are listed in AUTHORS.txt.
+
+This product is based on Titan, originally developed by Aurelius (acquired by
+DataStax) and the following individuals:
 
  * Matthias Broecheler
  * Dan LaRocque
  * Marko A. Rodriguez
  * Stephen Mallette
  * Pavel Yaskevich
- * Others as listed in CONTRIBUTORS.txt
 
 It also includes software from other open source projects including, but not limited to (check pom.xml for complete listing):
 


### PR DESCRIPTION
AUTHORS.txt
* For clarity, add Aurelius explicitly, even though DataStax acquisition implies
  that DataStax owns Aurelius IP
* Add IBM to the list of authors since we've had contributions from several
  IBM folks already

NOTICE.txt
* Update the copyright statement to include all JanusGraph copyright holders /
  authors
* Include reference to JanusGraph contributors
* Remove link to thinkaurelius.com as it redirects to DataStax and is thus not
  useful to learn about Aurelius; instead, mention that it was acquired by
  DataStax

This addresses issue #203
[skip ci]