### PR TITLE
Issue 173: Update to TinkerPop 3.2.4

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/CacheVertexProperty.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/CacheVertexProperty.java
@@ -133,7 +133,7 @@ public class CacheVertexProperty extends AbstractVertexProperty {
 
     @Override
     public void remove() {
-        if (!tx().isRemovedRelation(super.longId())) {
+        if (!tx().isRemovedRelation(super.longId()) && !tx().getConfiguration().isReadOnly()) {
             tx().removeRelation(this);
         }// else throw InvalidElementException.removedException(this);
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphStep.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphStep.java
@@ -78,7 +78,7 @@ public class JanusGraphStep<S, E extends Element> extends GraphStep<S, E> implem
 
     @Override
     public void addAll(Iterable<HasContainer> has) {
-        Iterables.addAll(hasContainers, has);
+        HasStepFolder.splitAndP(hasContainers, has);
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphVertexStep.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphVertexStep.java
@@ -137,7 +137,7 @@ public class JanusGraphVertexStep<E extends Element> extends VertexStep<E> imple
 
     @Override
     public void addAll(Iterable<HasContainer> has) {
-        Iterables.addAll(hasContainers, has);
+        HasStepFolder.splitAndP(hasContainers, has);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <properties>
         <janusgraph.compatible.versions />
         <titan.compatible-versions>1.0.0,1.1.0-SNAPSHOT</titan.compatible-versions>
-        <tinkerpop.version>3.2.3</tinkerpop.version>
+        <tinkerpop.version>3.2.4</tinkerpop.version>
         <junit.version>4.12</junit.version>
         <mrunit.version>1.1.0</mrunit.version>
         <cassandra.version>2.1.9</cassandra.version>
@@ -315,6 +315,7 @@
                                 <systemPropertyVariables>
                                   <build.dir>${project.build.directory}</build.dir>
                                   <log4j.configuration>file:${project.build.directory}/test-classes/log4j.properties</log4j.configuration>
+                                  <is.testing>true</is.testing>
                                 </systemPropertyVariables>
                             </configuration>
                        </execution>


### PR DESCRIPTION
Resolves #173. Tested default and TinkerPop tests in two groups covering all modules except hbase-098.

`mvn verify -Dtest.skip.tp=false -pl janusgraph-test,janusgraph-berkeleyje,janusgraph-cassandra`
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 19:16:02.759s
[INFO] Finished at: Wed Apr 12 23:05:13 UTC 2017
[INFO] Final Memory: 34M/873M
[INFO] ------------------------------------------------------------------------
```

`mvn verify -Dtest.skip.tp=false -rf :janusgraph-hbase-10`
```
INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 19:43:18.469s
[INFO] Finished at: Wed Apr 12 23:32:26 UTC 2017
[INFO] Final Memory: 125M/1520M
[INFO] ------------------------------------------------------------------------
```