### PR TITLE
Update Maven packaging to fix Eclipse dependency issue

### DIFF
--- a/janusgraph-hadoop-parent/janusgraph-hadoop/pom.xml
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop/pom.xml
@@ -7,7 +7,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hadoop</artifactId>
-    <packaging>pom</packaging>
     <name>JanusGraph-Hadoop: Universal binary</name>
     <url>http://janusgraph.org</url>
 


### PR DESCRIPTION
Signed-off-by: Chin Huang <chhuang@us.ibm.com>

The current packaging=pom for janusgraph-hadoop is causing an
Eclipse dependency error for the janusgraph-all project. I removed
the packaging line from pom.xml so the default type of jar is used.
It results in that the Eclipse Import will create a java project for
janusgraph-hadoop.