### PR TITLE
0.1 release prep

### DIFF
--- a/CHANGELOG.asc
+++ b/CHANGELOG.asc
@@ -3,8 +3,8 @@
 Release Notes
 -------------
 
-Version 0.1.0 (TBD)
-~~~~~~~~~~~~~~~~~~~
+Version 0.1.0 (Release Date: April 11, 2017)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [source, m2]
 <dependency>

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -3,8 +3,8 @@
 Release Notes
 -------------
 
-Version 0.1.0 (TBD)
-~~~~~~~~~~~~~~~~~~~
+Version 0.1.0 (Release Date: April 11, 2017) 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [source, m2]
 <dependency>

--- a/janusgraph-all/pom.xml
+++ b/janusgraph-all/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-all</artifactId>

--- a/janusgraph-all/pom.xml
+++ b/janusgraph-all/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-all</artifactId>

--- a/janusgraph-berkeleyje/pom.xml
+++ b/janusgraph-berkeleyje/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-berkeleyje</artifactId>

--- a/janusgraph-berkeleyje/pom.xml
+++ b/janusgraph-berkeleyje/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-berkeleyje</artifactId>

--- a/janusgraph-cassandra/pom.xml
+++ b/janusgraph-cassandra/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-cassandra</artifactId>

--- a/janusgraph-cassandra/pom.xml
+++ b/janusgraph-cassandra/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-cassandra</artifactId>

--- a/janusgraph-core/pom.xml
+++ b/janusgraph-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-core</artifactId>

--- a/janusgraph-core/pom.xml
+++ b/janusgraph-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-core</artifactId>

--- a/janusgraph-dist/janusgraph-dist-hadoop-2/pom.xml
+++ b/janusgraph-dist/janusgraph-dist-hadoop-2/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-dist</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/janusgraph-dist/janusgraph-dist-hadoop-2/pom.xml
+++ b/janusgraph-dist/janusgraph-dist-hadoop-2/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-dist</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/janusgraph-dist/pom.xml
+++ b/janusgraph-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/janusgraph-dist/pom.xml
+++ b/janusgraph-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/janusgraph-doc/pom.xml
+++ b/janusgraph-doc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/janusgraph-doc/pom.xml
+++ b/janusgraph-doc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/janusgraph-es/pom.xml
+++ b/janusgraph-es/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-es</artifactId>

--- a/janusgraph-es/pom.xml
+++ b/janusgraph-es/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-es</artifactId>

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-2/pom.xml
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-2/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hadoop-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hadoop-2</artifactId>

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-2/pom.xml
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-2/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hadoop-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hadoop-2</artifactId>

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/pom.xml
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hadoop-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hadoop-core</artifactId>

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/pom.xml
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hadoop-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hadoop-core</artifactId>

--- a/janusgraph-hadoop-parent/janusgraph-hadoop/pom.xml
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hadoop-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hadoop</artifactId>

--- a/janusgraph-hadoop-parent/janusgraph-hadoop/pom.xml
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hadoop-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hadoop</artifactId>

--- a/janusgraph-hadoop-parent/pom.xml
+++ b/janusgraph-hadoop-parent/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hadoop-parent</artifactId>

--- a/janusgraph-hadoop-parent/pom.xml
+++ b/janusgraph-hadoop-parent/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hadoop-parent</artifactId>

--- a/janusgraph-hbase-parent/janusgraph-hbase-098/pom.xml
+++ b/janusgraph-hbase-parent/janusgraph-hbase-098/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hbase-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hbase-098</artifactId>

--- a/janusgraph-hbase-parent/janusgraph-hbase-098/pom.xml
+++ b/janusgraph-hbase-parent/janusgraph-hbase-098/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hbase-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hbase-098</artifactId>

--- a/janusgraph-hbase-parent/janusgraph-hbase-10/pom.xml
+++ b/janusgraph-hbase-parent/janusgraph-hbase-10/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hbase-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hbase-10</artifactId>

--- a/janusgraph-hbase-parent/janusgraph-hbase-10/pom.xml
+++ b/janusgraph-hbase-parent/janusgraph-hbase-10/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hbase-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hbase-10</artifactId>

--- a/janusgraph-hbase-parent/janusgraph-hbase-core/pom.xml
+++ b/janusgraph-hbase-parent/janusgraph-hbase-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hbase-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hbase-core</artifactId>

--- a/janusgraph-hbase-parent/janusgraph-hbase-core/pom.xml
+++ b/janusgraph-hbase-parent/janusgraph-hbase-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hbase-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hbase-core</artifactId>

--- a/janusgraph-hbase-parent/janusgraph-hbase/pom.xml
+++ b/janusgraph-hbase-parent/janusgraph-hbase/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hbase-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hbase</artifactId>

--- a/janusgraph-hbase-parent/janusgraph-hbase/pom.xml
+++ b/janusgraph-hbase-parent/janusgraph-hbase/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph-hbase-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hbase</artifactId>

--- a/janusgraph-hbase-parent/pom.xml
+++ b/janusgraph-hbase-parent/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hbase-parent</artifactId>

--- a/janusgraph-hbase-parent/pom.xml
+++ b/janusgraph-hbase-parent/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-hbase-parent</artifactId>

--- a/janusgraph-lucene/pom.xml
+++ b/janusgraph-lucene/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-lucene</artifactId>

--- a/janusgraph-lucene/pom.xml
+++ b/janusgraph-lucene/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-lucene</artifactId>

--- a/janusgraph-solr/pom.xml
+++ b/janusgraph-solr/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-solr</artifactId>

--- a/janusgraph-solr/pom.xml
+++ b/janusgraph-solr/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-solr</artifactId>

--- a/janusgraph-test/pom.xml
+++ b/janusgraph-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-test</artifactId>

--- a/janusgraph-test/pom.xml
+++ b/janusgraph-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.janusgraph</groupId>
         <artifactId>janusgraph</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>janusgraph-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <groupId>org.janusgraph</groupId>
     <artifactId>janusgraph</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.0</version>
     <packaging>pom</packaging>
     <prerequisites>
         <maven>2.2.1</maven>
@@ -60,7 +60,7 @@
         <connection>scm:git:git@github.com:JanusGraph/janusgraph.git</connection>
         <developerConnection>scm:git:git@github.com:JanusGraph/janusgraph.git</developerConnection>
         <url>git@github.com:JanusGraph/janusgraph.git</url>
-        <tag>HEAD</tag>
+        <tag>v0.1.0-rc2</tag>
     </scm>
     <properties>
         <janusgraph.compatible.versions />

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <groupId>org.janusgraph</groupId>
     <artifactId>janusgraph</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <prerequisites>
         <maven>2.2.1</maven>
@@ -60,7 +60,7 @@
         <connection>scm:git:git@github.com:JanusGraph/janusgraph.git</connection>
         <developerConnection>scm:git:git@github.com:JanusGraph/janusgraph.git</developerConnection>
         <url>git@github.com:JanusGraph/janusgraph.git</url>
-        <tag>v0.1.0-rc2</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <janusgraph.compatible.versions />


### PR DESCRIPTION
* Release date set in change logs
* mvn release:prepare run which bumped version 0.1.0, committed, tagged, and then bumped to the new dev version 0.1.1-SNAPSHOT and committed