### PR TITLE
Add fuzzy predicate on all mixed indexes backend

### DIFF
--- a/docs/searchpredicates.txt
+++ b/docs/searchpredicates.txt
@@ -22,9 +22,11 @@ The `Text` enum specifies the <<text-search, search operator>> used to query for
 ** `textContains`: is true if (at least) one word inside the text string matches the query string
 ** `textContainsPrefix`: is true if (at least) one word inside the text string begins with the query string
 ** `textContainsRegex`: is true if (at least) one word inside the text string matches the given regular expression
+** `textContainsFuzzy`: is true if (at least) one word inside the text string is similar to the query String (based on Levenshtein edit distance)
 * String search predicates which match against the entire string value
 ** `textPrefix`: if the string value starts with the given query string
 ** `textRegex`: if the string value matches the given regular expression in its entirety
+** `textFuzzy`: if the string value is similar to the given query string (based on Levenshtein edit distance)
 
 See <<text-search>> for more information about full-text and string search.
 
@@ -62,6 +64,8 @@ g.E().has("reason", textContains("loves")).has("reason", textContains("breezes")
 g.E().has("reason", textContainsPrefix("lov"))
 // or all edges which contain words that match the regular expression "br[ez]*s" in their entirety
 g.E().has("reason", textContainsRegex("br[ez]*s"))
+// or all edges which contain words similar to "love"
+g.E().has("reason", textContainsFuzzy("love"))
 // 5) Find all vertices older than a thousand years and named "saturn"
 g.V().has("age", gt(1000)).has("name", "saturn")
 

--- a/docs/textsearch.txt
+++ b/docs/textsearch.txt
@@ -31,12 +31,14 @@ When a string property is indexed as text, only full-text search predicates are 
 * `textContains`: is true if (at least) one word inside the text string matches the query string
 * `textContainsPrefix`: is true if (at least) one word inside the text string begins with the query string
 * `textContainsRegex`: is true if (at least) one word inside the text string matches the given regular expression
+* `textContainsFuzzy`: is true if (at least) one word inside the text string is similar to the query String (based on Levenshtein edit distance)
 
 [source, gremlin]
 import static org.janusgraph.core.attribute.Text.*
 g.V().has('booksummary', textContains('unicorns'))
 g.V().has('booksummary', textContainsPrefix('uni'))
 g.V().has('booksummary', textContainsRegex('.*corn.*'))
+g.V().has('booksummary', textContainsFuzzy('unicorn'))
 
 String search predicates (see below) may be used in queries, but those require filtering in memory which can be very costly.
 
@@ -58,6 +60,7 @@ When a string property is indexed as string, only the following predicates are s
 * `neq`: if the string is different than the query string
 * `textPrefix`: if the string value starts with the given query string
 * `textRegex`: if the string value matches the given regular expression in its entirety
+* `textFuzzy`: if the string value is similar to the given query string (based on Levenshtein edit distance)
 
 [source, gremlin]
 import static org.apache.tinkerpop.gremlin.process.traversal.P.*
@@ -66,6 +69,7 @@ g.V().has('bookname', eq('unicorns'))
 g.V().has('bookname', neq('unicorns'))
 g.V().has('bookname', textPrefix('uni'))
 g.V().has('bookname', textRegex('.*corn.*'))
+g.V().has('bookname', textFuzzy('unicorn'))
 
 Full-text search predicates may be used in queries, but those require filtering in memory which can be very costly.
 

--- a/janusgraph-core/pom.xml
+++ b/janusgraph-core/pom.xml
@@ -113,6 +113,18 @@
            <artifactId>noggit</artifactId>
            <version>0.6</version>
        </dependency>
+       <!-- We keep the gremlin version of org.apache.commons commons-lang3 -->
+       <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.0</version>
+            <exclusions>
+                 <exclusion>
+                      <groupId>org.apache.commons</groupId>
+                      <artifactId>commons-lang3</artifactId>
+                  </exclusion>
+             </exclusions>
+       </dependency>
     </dependencies>
     <build>
         <directory>${basedir}/target</directory>

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticSearchIndexTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticSearchIndexTest.java
@@ -89,9 +89,11 @@ public class ElasticSearchIndexTest extends IndexProviderTest {
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE), Text.CONTAINS));
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS_PREFIX));
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS_REGEX));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS_FUZZY));
         assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.REGEX));
         assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.STRING)), Text.CONTAINS));
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Text.PREFIX));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Text.FUZZY));
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Text.REGEX));
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.STRING)), Cmp.EQUAL));
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.STRING)), Cmp.NOT_EQUAL));

--- a/janusgraph-lucene/src/test/java/org/janusgraph/diskstorage/lucene/LuceneIndexTest.java
+++ b/janusgraph-lucene/src/test/java/org/janusgraph/diskstorage/lucene/LuceneIndexTest.java
@@ -82,6 +82,7 @@ public class LuceneIndexTest extends IndexProviderTest {
         // Same tests as above, except explicitly specifying TEXT instead of relying on DEFAULT
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS));
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS_PREFIX));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS_FUZZY));
         assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS_REGEX)); // TODO Not supported yet
         assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.REGEX));
         assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.PREFIX));
@@ -93,6 +94,7 @@ public class LuceneIndexTest extends IndexProviderTest {
         assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Text.CONTAINS_PREFIX));
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Text.REGEX));
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Text.PREFIX));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Text.FUZZY));
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Cmp.EQUAL));
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Cmp.NOT_EQUAL));
 

--- a/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
+++ b/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
@@ -581,6 +581,8 @@ public class SolrIndex implements IndexProvider {
                     return (key + ":\"" + escapeValue(value) + "\"");
                 } else if (janusgraphPredicate == Cmp.NOT_EQUAL) {
                     return ("-" + key + ":\"" + escapeValue(value) + "\"");
+                } else if (janusgraphPredicate == Text.FUZZY || janusgraphPredicate == Text.CONTAINS_FUZZY) {
+                    return (key + ":"+escapeValue(value)+"~");
                 } else {
                     throw new IllegalArgumentException("Relation is not supported for string value: " + janusgraphPredicate);
                 }
@@ -772,9 +774,9 @@ public class SolrIndex implements IndexProvider {
             switch(mapping) {
                 case DEFAULT:
                 case TEXT:
-                    return janusgraphPredicate == Text.CONTAINS || janusgraphPredicate == Text.CONTAINS_PREFIX || janusgraphPredicate == Text.CONTAINS_REGEX;
+                    return janusgraphPredicate == Text.CONTAINS || janusgraphPredicate == Text.CONTAINS_PREFIX || janusgraphPredicate == Text.CONTAINS_REGEX || janusgraphPredicate == Text.CONTAINS_FUZZY;
                 case STRING:
-                    return janusgraphPredicate == Cmp.EQUAL || janusgraphPredicate==Cmp.NOT_EQUAL || janusgraphPredicate==Text.REGEX || janusgraphPredicate==Text.PREFIX;
+                    return janusgraphPredicate == Cmp.EQUAL || janusgraphPredicate==Cmp.NOT_EQUAL || janusgraphPredicate==Text.REGEX || janusgraphPredicate==Text.PREFIX  || janusgraphPredicate == Text.FUZZY;
 //                case TEXTSTRING:
 //                    return (janusgraphPredicate instanceof Text) || janusgraphPredicate == Cmp.EQUAL || janusgraphPredicate==Cmp.NOT_EQUAL;
             }

--- a/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrIndexTest.java
+++ b/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrIndexTest.java
@@ -95,11 +95,13 @@ public class SolrIndexTest extends IndexProviderTest {
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE), Text.CONTAINS));
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.DEFAULT)), Text.CONTAINS_PREFIX));
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS_REGEX));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS_FUZZY));
         assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXTSTRING)), Text.REGEX));
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.TEXT)), Text.CONTAINS));
         assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.DEFAULT)), Text.PREFIX));
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Text.PREFIX));
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Text.REGEX));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Text.FUZZY));
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.STRING)), Cmp.EQUAL));
         assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.STRING)), Cmp.NOT_EQUAL));
         assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.TEXTSTRING)), Cmp.NOT_EQUAL));

--- a/janusgraph-test/src/main/java/org/janusgraph/diskstorage/indexing/IndexProviderTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/diskstorage/indexing/IndexProviderTest.java
@@ -204,6 +204,7 @@ public abstract class IndexProviderTest {
             assertEquals(0, tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "worl"))).size());
             assertEquals(1, tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "Tomorrow world"))).size());
             assertEquals(1, tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "WorLD HELLO"))).size());
+            assertEquals(1, tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS_FUZZY, "boby"))).size());
 
 
             //Ordering
@@ -246,6 +247,7 @@ public abstract class IndexProviderTest {
             assertEquals(3, tx.query(new IndexQuery(store, PredicateCondition.of(NAME, Cmp.NOT_EQUAL, "bob"))).size());
             assertEquals(1, tx.query(new IndexQuery(store, PredicateCondition.of(NAME, Text.PREFIX, "Tomorrow"))).size());
             assertEquals(0, tx.query(new IndexQuery(store, PredicateCondition.of(NAME, Text.PREFIX, "wor"))).size());
+            assertEquals(1, tx.query(new IndexQuery(store, PredicateCondition.of(NAME, Text.FUZZY, "Tomorow is the world"))).size());
             for (JanusGraphPredicate tp : new Text[]{Text.CONTAINS,Text.CONTAINS_PREFIX, Text.CONTAINS_REGEX}) {
                 try {
                     assertEquals(0, tx.query(new IndexQuery(store, PredicateCondition.of(NAME, tp, "tzubull"))).size());

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphIndexTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphIndexTest.java
@@ -1055,7 +1055,10 @@ public abstract class JanusGraphIndexTest extends JanusGraphBaseTest {
                 2, new boolean[]{true, true}, "mixed");
         evaluateQuery(tx.query().has("name", Text.PREFIX, "Middle"), ElementCategory.VERTEX,
                 1, new boolean[]{true, true}, "mixed");
-
+        evaluateQuery(tx.query().has("name", Text.FUZZY, "Long john Don"), ElementCategory.VERTEX,
+                1, new boolean[]{true, true}, "mixed");
+        evaluateQuery(tx.query().has("name", Text.CONTAINS_FUZZY, "Midle"), ElementCategory.VERTEX,
+                1, new boolean[]{true, true}, "mixed");
         for (Vertex u : tx.getVertices()) {
             String n = u.<String>value("name");
             if (n.endsWith("Don")) {

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/attribute/TextTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/attribute/TextTest.java
@@ -18,6 +18,9 @@ import org.janusgraph.core.attribute.Cmp;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
+
+import org.apache.commons.text.similarity.LevenshteinDistance;
+
 import static org.janusgraph.core.attribute.Text.*;
 
 /**
@@ -89,7 +92,40 @@ public class TextTest {
         assertTrue(REGEX.test(name, "(fu[ln]*y) (fu[ln]*y)"));
         assertFalse(REGEX.test(name, "(fu[l]*y) (fu[l]*y)"));
         assertTrue(REGEX.test(name, "(fu[l]*y) .*"));
+        
+        //FUZZY
+        String shortValue = "ah";
+        assertTrue(FUZZY.test(shortValue,"ah"));
+        assertFalse(FUZZY.test(shortValue,"ai"));
+        String mediumValue = "hop";
+        assertTrue(FUZZY.test(mediumValue,"hop"));
+        assertTrue(FUZZY.test(mediumValue,"hopp"));
+        assertTrue(FUZZY.test(mediumValue,"hap"));
+        assertFalse(FUZZY.test(mediumValue,"ha"));
+        assertFalse(FUZZY.test(mediumValue,"hoopp"));
+        String longValue = "surprises";
+        assertTrue(FUZZY.test(longValue,"surprises"));
+        assertTrue(FUZZY.test(longValue,"surpprises"));
+        assertTrue(FUZZY.test(longValue,"sutprises"));
+        assertTrue(FUZZY.test(longValue,"surprise"));
+        assertFalse(FUZZY.test(longValue,"surppirsses"));
 
+        //CONTAINS_FUZZY
+        //Short
+        assertTrue(CONTAINS_FUZZY.test(text,"is"));
+        assertFalse(CONTAINS_FUZZY.test(text,"si"));
+        //Medium
+        assertTrue(CONTAINS_FUZZY.test(text,"full"));
+        assertTrue(CONTAINS_FUZZY.test(text,"fully"));
+        assertTrue(CONTAINS_FUZZY.test(text,"ful"));
+        assertTrue(CONTAINS_FUZZY.test(text,"fill"));
+        assertFalse(CONTAINS_FUZZY.test(text,"fu"));
+        assertFalse(CONTAINS_FUZZY.test(text,"fullest"));
+        //Long
+        assertTrue(CONTAINS_FUZZY.test(text,"surprises"));
+        assertTrue(CONTAINS_FUZZY.test(text,"Surpprises"));
+        assertTrue(CONTAINS_FUZZY.test(text,"Sutrises"));
+        assertTrue(CONTAINS_FUZZY.test(text,"surprise"));
+        assertFalse(CONTAINS_FUZZY.test(text,"surppirsses"));
     }
-
 }


### PR DESCRIPTION
This adds fuzzy predicate (similarity based on Levenshtein edit distance) for all mixed indexes backend.
For the method evaluateRaw of the predicate, I use the same degree of similarity as ES : 
- 0 for strings of one or two characters
- 1 for strings of three, four or five characters
- 2 for strings of more than five characters

Issues : https://github.com/JanusGraph/janusgraph/issues/221
Signed-off-by: David Clement <david.clement90@laposte.net>