### PR TITLE
Can use external ES mapping instead of push mapping

### DIFF
--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchClient.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchClient.java
@@ -36,6 +36,8 @@ public interface ElasticSearchClient extends Closeable {
 
     void createMapping(String indexName, String typeName, XContentBuilder mapping) throws IOException;
 
+    Map getMapping(String indexName, String typeName) throws IOException;
+
     void deleteIndex(String indexName) throws IOException;
 
     void bulkRequest(List<ElasticSearchMutation> requests) throws IOException;

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/TransportElasticSearchClient.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/TransportElasticSearchClient.java
@@ -18,6 +18,8 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsResponse;
+import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
+import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.bulk.BulkItemResponse;
@@ -94,7 +96,13 @@ public class TransportElasticSearchClient implements ElasticSearchClient {
 
     @Override
     public void createMapping(String indexName, String typeName, XContentBuilder mapping) throws IOException {
-            client.admin().indices().preparePutMapping(indexName).setType(typeName).setSource(mapping).execute().actionGet();
+        client.admin().indices().preparePutMapping(indexName).setType(typeName).setSource(mapping).execute().actionGet();
+    }
+
+    @Override
+    public Map getMapping(String indexName, String typeName) throws IOException {
+        GetMappingsResponse response = client.admin().indices().getMappings(new GetMappingsRequest().indices(indexName.toLowerCase()).types(typeName)).actionGet();
+        return (Map)response.getMappings().get(indexName.toLowerCase()).get(typeName).getSourceAsMap().get("properties");
     }
 
     @Override

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestElasticSearchClient.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestElasticSearchClient.java
@@ -157,6 +157,15 @@ public class RestElasticSearchClient implements ElasticSearchClient {
     }
 
     @Override
+    public Map getMapping(String indexName, String typeName) throws IOException{
+        Response response = performRequest("GET", "/" + indexName.toLowerCase() + "/_mapping/"+typeName, null);
+        try (final InputStream inputStream = response.getEntity().getContent()) {
+            Map<String, RestIndexMappings> settings = mapper.readValue(inputStream, new TypeReference<Map<String, RestIndexMappings>>() {});
+            return settings.get(indexName).getMappings().get(typeName).getProperties();
+        }
+    }
+
+    @Override
     public void deleteIndex(String indexName) throws IOException {
         try {
             performRequest("DELETE", "/" + indexName, null);

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestIndexMappings.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestIndexMappings.java
@@ -1,0 +1,48 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.es.rest;
+
+import java.util.Map;
+
+/**
+ * Serialization of Elasticsearch index mapping.
+ *
+ * @author David Clement (davidclement90@laposte.net)
+ */
+public class RestIndexMappings {
+
+    private Map<String, RestIndexMapping> mappings;
+
+    public Map<String, RestIndexMapping> getMappings() {
+        return mappings;
+    }
+
+    public void setMappings(Map<String, RestIndexMapping> mappings){
+        this.mappings = mappings;
+    }
+
+    public static class RestIndexMapping {
+
+        private Map<String, Object> properties;
+
+        public Map<String, Object> getProperties() {
+            return properties;
+        }
+
+        public void setProperties(Map<String, Object> properties) {
+            this.properties = properties;
+        }
+    }
+}

--- a/janusgraph-es/src/test/resources/mapping.json
+++ b/janusgraph-es/src/test/resources/mapping.json
@@ -1,0 +1,46 @@
+{
+  "mappings": {
+    "test_mapping": {
+      "properties": {
+        "boundary": {
+          "type": "geo_shape",
+          "tree": "quadtree",
+          "tree_levels": 20,
+          "distance_error_pct": 0.025
+        },
+        "date": {
+          "type": "date"
+        },
+        "location": {
+          "type": "geo_point"
+        },
+        "name": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "phone_list": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "phone_set": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "text": {
+          "type": "string"
+        },
+        "time": {
+          "type": "long"
+        }
+      }
+    }
+  },
+  "settings": {
+    "index": {
+      "number_of_shards": "5",
+      "max_result_window": "2147483647",
+      "number_of_replicas": "1"
+    }
+  }
+}
+

--- a/janusgraph-es/src/test/resources/template.json
+++ b/janusgraph-es/src/test/resources/template.json
@@ -1,0 +1,47 @@
+{
+  "template": "janusgraph*",
+  "mappings": {
+    "test_mapping": {
+      "properties": {
+        "boundary": {
+          "type": "geo_shape",
+          "tree": "quadtree",
+          "tree_levels": 20,
+          "distance_error_pct": 0.025
+        },
+        "date": {
+          "type": "date"
+        },
+        "location": {
+          "type": "geo_point"
+        },
+        "name": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "phone_list": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "phone_set": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "text": {
+          "type": "string"
+        },
+        "time": {
+          "type": "long"
+        }
+      }
+    }
+  },
+  "settings": {
+    "index": {
+      "number_of_shards": "5",
+      "max_result_window": "2147483647",
+      "number_of_replicas": "1"
+    }
+  }
+}
+


### PR DESCRIPTION
This adds the possibility to use external mapping in order to use custom ES mapping.
If you set USE_EXTERNAL_MAPPINGS to true, JanusGraph will check if the mapping is good instead of push it.
Whitout this adds, even if I push a mapping JanusGraph will update it during register phase. 
This feature will allows to manage mapping directly in Kibana and not with ES_CREATE_EXTRAS_NS properties or to set for example a property with are declare in JanusGraph as String to IP, or use copy-to ES feature.

Issue : https://github.com/JanusGraph/janusgraph/issues/222
Signed-off-by: David Clement <david.clement90@laposte.net>