### PR TITLE
Use user.dir for ElasticsearchRunner default home

### DIFF
--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticsearchRunner.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticsearchRunner.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
  */
 public class ElasticsearchRunner extends DaemonRunner<ElasticsearchStatus> {
 
-    private static final String DEFAULT_HOME_DIR = ".";
+    private static final String DEFAULT_HOME_DIR = System.getProperty("user.dir");
 
     private final String homedir;
 


### PR DESCRIPTION
Fixes #235. Use of `.` for default home in ElasticsearchRunner causes problems when running embedded instances in some distributions. This updates to use `user.dir` system property instead.