### PR TITLE
Use larger id block size and avoid deprecated methods.

### DIFF
--- a/janusgraph-test/src/main/java/org/janusgraph/blueprints/AbstractJanusGraphComputerProvider.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/blueprints/AbstractJanusGraphComputerProvider.java
@@ -32,20 +32,17 @@ public abstract class AbstractJanusGraphComputerProvider extends AbstractJanusGr
 
     @Override
     public GraphTraversalSource traversal(final Graph graph) {
-        return GraphTraversalSource.build().engine(ComputerTraversalEngine.build().computer(FulgoraGraphComputer.class)).create(graph);
+        return new GraphTraversalSource(graph).withComputer(FulgoraGraphComputer.class);
     }
 
     @Override
     public GraphTraversalSource traversal(final Graph graph, final TraversalStrategy... strategies) {
-        final GraphTraversalSource.Builder builder = GraphTraversalSource.build().engine(ComputerTraversalEngine.build().computer(FulgoraGraphComputer.class));
-        Stream.of(strategies).forEach(builder::with);
-        return builder.create(graph);
+        return new GraphTraversalSource(graph).withComputer(FulgoraGraphComputer.class).withStrategies(strategies);
     }
 
     @Override
     public ModifiableConfiguration getJanusGraphConfiguration(String graphName, Class<?> test, String testMethodName) {
         return GraphDatabaseConfiguration.buildGraphConfiguration()
-                .set(GraphDatabaseConfiguration.IDS_BLOCK_SIZE,1)
                 .set(SimpleBulkPlacementStrategy.CONCURRENT_PARTITIONS,1)
                 .set(GraphDatabaseConfiguration.CLUSTER_MAX_PARTITIONS, 2)
                 .set(GraphDatabaseConfiguration.IDAUTHORITY_CAV_BITS,0);


### PR DESCRIPTION
I now use the default block size here. I think we need to opt-out of some tests still
Signed-off-by: Alexander Patrikalakis <amcp@amazon.co.jp>