### PR TITLE
Remove ssl.enabled=false element from gremlin server yaml

### DIFF
--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server.yaml
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server.yaml
@@ -36,5 +36,4 @@ maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
 writeBufferLowWaterMark: 32768
 writeBufferHighWaterMark: 65536
-ssl: {
-  enabled: false}
+


### PR DESCRIPTION
Fixes #245 by removing the ssl property. With this update Gremlin Server starts up properly. But note TinkerPop 3.2.4 [gremlin-server.yaml](https://github.com/apache/tinkerpop/blob/3.2.4/gremlin-server/conf/gremlin-server.yaml) does have this element defined so this might not be the correct solution.