### PR TITLE
Require additional modules for successful Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
+dist: trusty
 language: java
 sudo: false
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 cache:
   directories:
@@ -17,53 +18,37 @@ env:
     - ES_JAVA_OPTS="-Xms256m -Xmx512m"
 
   matrix:
-    - MODULE='berkeleyje'
-    - MODULE='cassandra'
-    - MODULE='es' ARGS='-DthreadCount=1'
-    - MODULE='es' ARGS='-DthreadCount=1 -Pelasticsearch2'
+    # sort modules by test time with quickest modules first
     - MODULE='hadoop-parent/janusgraph-hadoop-2'
-    - MODULE='hbase-parent/janusgraph-hbase-098'
-    - MODULE='hbase-parent/janusgraph-hbase-10'
-    - MODULE='lucene' ARGS='-DthreadCount=1'
-    - MODULE='solr' ARGS='-DthreadCount=1'
+    - MODULE='lucene'
+    - MODULE='solr'
+    - MODULE='es'
+    - MODULE='es' ARGS='-Pelasticsearch2'
+    - MODULE='es' ARGS='-Pelasticsearch2 -Dtest=**/Transport*'
+    - MODULE='berkeleyje'
     - MODULE='test'
+    - MODULE='cassandra' ARGS='-Dtest=**/diskstorage/cassandra/thrift/* -Dtest.skip.unordered=true'
+    - MODULE='cassandra' ARGS='-Dtest=**/diskstorage/cassandra/thrift/* -Dtest.skip.ordered=true -Dtest.skip.ssl=true -Dtest.skip.serial=true'
+    - MODULE='cassandra' ARGS='-Dtest=**/graphdb/thrift/* -Dtest.skip.unordered=true'
+    - MODULE='cassandra' ARGS='-Dtest=**/graphdb/thrift/* -Dtest.skip.ordered=true -Dtest.skip.ssl=true -Dtest.skip.serial=true'
+    - MODULE='cassandra' ARGS='-Dtest=**/diskstorage/cassandra/astyanax/*'
+    - MODULE='cassandra' ARGS='-Dtest=**/graphdb/astyanax/*'
+    - MODULE='cassandra' ARGS='-Dtest=**/diskstorage/cassandra/embedded/*'
+    - MODULE='cassandra' ARGS='-Dtest=***/cassandra/*,*/graphdb/embedded/*'
+    - MODULE='hbase-parent/janusgraph-hbase-10' ARGS='-Dtest=**/diskstorage/hbase/*'
+    - MODULE='hbase-parent/janusgraph-hbase-10' ARGS='-Dtest=**/graphdb/hbase/*'
+    - MODULE='hbase-parent/janusgraph-hbase-098' ARGS='-Dtest=**/diskstorage/hbase/*'
+    - MODULE='hbase-parent/janusgraph-hbase-098' ARGS='-Dtest=**/graphdb/hbase/*'
 
 matrix:
+  fast_finish: true
   # https://docs.travis-ci.com/user/customizing-the-build#Rows-that-are-Allowed-to-Fail
   allow_failures:
-    # Non-deterministic: can pass or fail, regardless of any relevant changes.
-    # https://travis-ci.org/JanusGraph/janusgraph/jobs/198165185
-    - env: MODULE='berkeleyje'
-
-    # Currently broken due to too many log statements (exceeds 4MB)
-    # https://travis-ci.org/JanusGraph/janusgraph/jobs/197472452
-    - env: MODULE='cassandra'
-
-    # Currently broken due to too many log statements (exceeds 4MB)
-    # https://travis-ci.org/JanusGraph/janusgraph/jobs/197472453
-    - env: MODULE='es' ARGS='-DthreadCount=1'
-    - env: MODULE='es' ARGS='-DthreadCount=1 -Pelasticsearch2'
-
-    # Currently broken due to too many log statements (exceeds 4MB)
-    # https://travis-ci.org/JanusGraph/janusgraph/jobs/197672947
-    - env: MODULE='hadoop-parent/janusgraph-hadoop-2'
-
-    # Currently broken due to timeout (runs longer than 50min)
-    # https://travis-ci.org/JanusGraph/janusgraph/jobs/197672951
-    - env: MODULE='hbase-parent/janusgraph-hbase-098'
-
-    # Currently broken due to timeout (runs longer than 50min)
-    # https://travis-ci.org/JanusGraph/janusgraph/jobs/197672952
-    - env: MODULE='hbase-parent/janusgraph-hbase-10'
-
-    # Currently broken due to too many log statements (exceeds 4MB)
-    # https://travis-ci.org/JanusGraph/janusgraph/jobs/197427609
-    - env: MODULE='solr' ARGS='-DthreadCount=1'
+    # Can fail due to timeout (runs longer than 50min)
+    - env: MODULE='hbase-parent/janusgraph-hbase-098' ARGS='-Dtest=**/diskstorage/hbase/*'
+    - env: MODULE='hbase-parent/janusgraph-hbase-098' ARGS='-Dtest=**/graphdb/hbase/*'
 
 addons:
-  apt:
-    packages:
-      - oracle-java8-installer
   coverity_scan:
     # Coverity config parameters described in detail:
     # https://scan.coverity.com/travis_ci
@@ -77,13 +62,17 @@ addons:
     build_command: "travis_wait mvn clean package -B -DskipTests=true"
     branch_pattern: coverity_scan
 
+install:
+  # Build and install current module and dependencies. Handle output timeouts and retry on error.
+  - travis_retry travis_wait mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl janusgraph-${MODULE} -am
+
 script:
   - if [[ "${COVERITY_SCAN_BRANCH}}" == 1 ]]; then
       echo "Skipping build/test on 'coverity_scan' branch.";
       exit 0;
     fi
-  - mvn install -DskipTests=true -B -pl janusgraph-${MODULE} -am
-  - mvn verify -pl janusgraph-${MODULE} ${ARGS}
+  # Build and test module. Handle output timeouts and retry with a clean build on error.
+  - travis_retry travis_wait 50 mvn clean verify -pl janusgraph-${MODULE} ${ARGS}
 
 # Syntax and more info: https://docs.travis-ci.com/user/notifications
 notifications:

--- a/janusgraph-berkeleyje/src/test/resources/log4j.properties
+++ b/janusgraph-berkeleyje/src/test/resources/log4j.properties
@@ -9,7 +9,8 @@ log4j.appender.A2.Threshold=ALL
 log4j.appender.A2.layout=org.apache.log4j.PatternLayout
 log4j.appender.A2.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
 
-log4j.rootLogger=WARN, A1, A2
+#log4j.rootLogger=INFO, A1, A2
+log4j.rootLogger=ERROR, A1
 
 #log4j.logger.org.apache.cassandra=INFO
 #log4j.logger.org.apache.hadoop=INFO

--- a/janusgraph-cassandra/src/test/resources/log4j.properties
+++ b/janusgraph-cassandra/src/test/resources/log4j.properties
@@ -1,21 +1,21 @@
 # A1 is a FileAppender.
 log4j.appender.A1=org.apache.log4j.FileAppender
 log4j.appender.A1.File=target/test.log
-log4j.appender.A1.Threshold=TRACE
+log4j.appender.A1.Threshold=ALL
 # A1 uses PatternLayout.
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
 
 # A2 is a ConsoleAppender.
 log4j.appender.A2=org.apache.log4j.ConsoleAppender
-log4j.appender.A2.Threshold=WARN
+log4j.appender.A2.Threshold=ALL
 # A2 uses PatternLayout.
 log4j.appender.A2.layout=org.apache.log4j.PatternLayout
 log4j.appender.A2.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
 
 # Set both appenders (A1 and A2) on the root logger.
-log4j.rootLogger=INFO, A1, A2
-#log4j.rootLogger=INFO, A1
+#log4j.rootLogger=INFO, A1, A2
+log4j.rootLogger=ERROR, A1
 
 # Restrict some of JanusGraph's dependencies to INFO and scarier.
 # These restrictions are useful when reducing the severity threshold

--- a/janusgraph-es/pom.xml
+++ b/janusgraph-es/pom.xml
@@ -218,7 +218,7 @@
                     <execution>
                         <id>default-test</id>
                         <configuration>
-                            <argLine>-Dtest.cassandra.confdir=${project.build.directory}/cassandra/conf/localhost-murmur -Dtest.cassandra.datadir=${project.build.directory}/cassandra/data/localhost-murmur</argLine>
+                            <argLine>${default.test.jvm.opts} -Dtest.cassandra.confdir=${project.build.directory}/cassandra/conf/localhost-murmur -Dtest.cassandra.datadir=${project.build.directory}/cassandra/data/localhost-murmur</argLine>
                             <excludes>
                                 <exclude>**/Transport*.java</exclude>
                             </excludes>
@@ -264,24 +264,6 @@
                 <elasticsearch.dist.version>${elasticsearch.version}</elasticsearch.dist.version>
                 <elasticsearch.groovy.inline>true</elasticsearch.groovy.inline>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <configuration combine.self="override">
-                                    <argLine>-Dtest.cassandra.confdir=${project.build.directory}/cassandra/conf/localhost-murmur -Dtest.cassandra.datadir=${project.build.directory}/cassandra/data/localhost-murmur</argLine>
-                                    <!-- Transport client tests cannot run in same JVM as REST client tests
-                                         due to required static setup in common base class. -->
-                                    <reuseForks>false</reuseForks>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
 
         <!-- Redeclare gpg-plugin at the bottom to ensure it runs after all the other packaging goals -->

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchSetup.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchSetup.java
@@ -105,7 +105,7 @@ public enum ElasticSearchSetup {
 
             TransportElasticSearchClient client = new TransportElasticSearchClient(tc);
             if (config.has(ElasticSearchIndex.BULK_REFRESH)) {
-                client.setBulkRefresh(config.get(ElasticSearchIndex.BULK_REFRESH).equals("true"));
+                client.setBulkRefresh(!"false".equals(config.get(ElasticSearchIndex.BULK_REFRESH)));
             }
             return new Connection(client);
         }

--- a/janusgraph-es/src/test/resources/log4j.properties
+++ b/janusgraph-es/src/test/resources/log4j.properties
@@ -1,19 +1,19 @@
 # A1 is set to be a FileAppender.
 log4j.appender.A1=org.apache.log4j.FileAppender
 log4j.appender.A1.File=target/test.log
-log4j.appender.A1.Threshold=TRACE
+log4j.appender.A1.Threshold=ALL
 # A1 uses PatternLayout.
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
 
 # A2 is a ConsoleAppender.
 log4j.appender.A2=org.apache.log4j.ConsoleAppender
-log4j.appender.A2.Threshold=ERROR
+log4j.appender.A2.Threshold=ALL
 # A2 uses PatternLayout.
 log4j.appender.A2.layout=org.apache.log4j.PatternLayout
 log4j.appender.A2.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
 
 # Set both appenders (A1 and A2) on the root logger.
-log4j.rootLogger=INFO, A1, A2
-#log4j.rootLogger=INFO, A1
+#log4j.rootLogger=INFO, A1, A2
+log4j.rootLogger=ERROR, A1
 

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/assembly/shared-resources/log4j.properties
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/assembly/shared-resources/log4j.properties
@@ -1,20 +1,21 @@
 # A1 is a FileAppender.
 log4j.appender.A1=org.apache.log4j.FileAppender
 log4j.appender.A1.File=target/test.log
-log4j.appender.A1.Threshold=DEBUG
+log4j.appender.A1.Threshold=ALL
 # A1 uses PatternLayout.
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
 
 # A2 is a ConsoleAppender.
 log4j.appender.A2=org.apache.log4j.ConsoleAppender
-log4j.appender.A2.Threshold=WARN
+log4j.appender.A2.Threshold=ALL
 # A2 uses PatternLayout.
 log4j.appender.A2.layout=org.apache.log4j.PatternLayout
 log4j.appender.A2.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
 
 # Set both appenders (A1 and A2) on the root logger.
-log4j.rootLogger=INFO, A1, A2
+#log4j.rootLogger=INFO, A1, A2
+log4j.rootLogger=ERROR, A1
 
 # Restrict some of JanusGraph's dependencies to INFO and scarier.
 # These restrictions are useful when reducing the severity threshold

--- a/janusgraph-hbase-parent/common/test/resources/log4j.properties
+++ b/janusgraph-hbase-parent/common/test/resources/log4j.properties
@@ -1,21 +1,21 @@
 # A1 is a FileAppender.
 log4j.appender.A1=org.apache.log4j.FileAppender
 log4j.appender.A1.File=target/test.log
-log4j.appender.A1.Threshold=TRACE
+log4j.appender.A1.Threshold=ALL
 # A1 uses PatternLayout.
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
 
 # A2 is a ConsoleAppender.
 log4j.appender.A2=org.apache.log4j.ConsoleAppender
-log4j.appender.A2.Threshold=WARN
+log4j.appender.A2.Threshold=ALL
 # A2 uses PatternLayout.
 log4j.appender.A2.layout=org.apache.log4j.PatternLayout
 log4j.appender.A2.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
 
 # Set both appenders (A1 and A2) on the root logger.
-log4j.rootLogger=INFO, A1, A2
-#log4j.rootLogger=INFO, A1
+#log4j.rootLogger=INFO, A1, A2
+log4j.rootLogger=ERROR, A1
 
 # Restrict some of JanusGraph's dependencies to INFO and scarier.
 # These restrictions are useful when reducing the severity threshold

--- a/janusgraph-lucene/src/test/resources/log4j.properties
+++ b/janusgraph-lucene/src/test/resources/log4j.properties
@@ -1,19 +1,19 @@
 # A1 is a FileAppender.
 log4j.appender.A1=org.apache.log4j.FileAppender
 log4j.appender.A1.File=target/test.log
-log4j.appender.A1.Threshold=TRACE
+log4j.appender.A1.Threshold=ALL
 # A1 uses PatternLayout.
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
 
 # A2 is a ConsoleAppender.
 log4j.appender.A2=org.apache.log4j.ConsoleAppender
-log4j.appender.A2.Threshold=WARN
+log4j.appender.A2.Threshold=ALL
 # A2 uses PatternLayout.
 log4j.appender.A2.layout=org.apache.log4j.PatternLayout
 log4j.appender.A2.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
 
 # Set both appenders (A1 and A2) on the root logger.
-log4j.rootLogger=INFO, A1, A2
-#log4j.rootLogger=INFO, A1
+#log4j.rootLogger=INFO, A1, A2
+log4j.rootLogger=ERROR, A1
 

--- a/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
+++ b/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
@@ -937,8 +937,8 @@ public class SolrIndex implements IndexProvider {
                for (Map.Entry<String, Slice> entry : slices.entrySet()) {
                     Map<String, Replica> shards = entry.getValue().getReplicasMap();
                     for (Map.Entry<String, Replica> shard : shards.entrySet()) {
-                        String state = shard.getValue().getStr(ZkStateReader.STATE_PROP);
-                        if ((state.equals(Replica.State.RECOVERING) || state.equals(Replica.State.DOWN))
+                        final String state = shard.getValue().getStr(ZkStateReader.STATE_PROP).toUpperCase();
+                        if ((Replica.State.RECOVERING.name().equals(state) || Replica.State.DOWN.name().equals(state))
                                 && clusterState.liveNodesContain(shard.getValue().getStr(
                                 ZkStateReader.NODE_NAME_PROP))) {
                             sawLiveRecovering = true;

--- a/janusgraph-solr/src/test/resources/log4j.properties
+++ b/janusgraph-solr/src/test/resources/log4j.properties
@@ -1,19 +1,19 @@
 # A1 is set to be a FileAppender.
 log4j.appender.A1=org.apache.log4j.FileAppender
 log4j.appender.A1.File=target/test.log
-log4j.appender.A1.Threshold=TRACE
+log4j.appender.A1.Threshold=ALL
 # A1 uses PatternLayout.
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
 
 # A2 is a ConsoleAppender.
 log4j.appender.A2=org.apache.log4j.ConsoleAppender
-log4j.appender.A2.Threshold=WARN
+log4j.appender.A2.Threshold=ALL
 # A2 uses PatternLayout.
 log4j.appender.A2.layout=org.apache.log4j.PatternLayout
 log4j.appender.A2.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
 
 # Set both appenders (A1 and A2) on the root logger.
-log4j.rootLogger=INFO, A1, A2
-#log4j.rootLogger=INFO, A1
+#log4j.rootLogger=INFO, A1, A2
+log4j.rootLogger=ERROR, A1
 


### PR DESCRIPTION
This PR makes a number of updates to improve test stability under Travis. All modules with the exception of hbase-098 now pass consistently and are required for a successful build. This should resolve #74 and may help mitigate the need for #5 and #18.

Testing consisted of monitoring 100 builds over the last week (see https://travis-ci.org/sjudeng/janusgraph/builds, builds <span>#</span>49-current). There were two unexpected build failures during that time. Other failures were the result of various build matrix experiments.

In the event of an isolated build failure committers can log in to Travis and restart the specific failed job. Based on the above testing this is estimated to be limited to 2% of builds. Should some module(s) begin failing more consistently we can mark them as optional again and investigate further.

More information:
* The following updates are included:
  * Use Travis Trusty build, which includes a more recent version of OpenJDK
  * Use OpenJDK instead of Oracle to avoid sporadic issues and performance/time cost associated with `oracle-java8-installer` installation
  * Limit logging to ERROR across all modules and use `travis_wait` to accommodate associated longer periods without output
  * Use `travis_retry` to provide better resilience against sporadic errors
  * (Bug fixes) Include `default.test.jvm.opts` when running janusgraph-es tests and fix logic in live recoveries check in janusgraph-solr
* HBase and Cassandra tests were split using existing package structure and skipTests properties. This avoided needing to specify specific test suite names in the Travis build matrix. As long as new test classes are added to existing packages they should get picked up automatically. Any new test packages would need to be added to existing/new test groups in the build matrix. Those submitting/reviewing PRs against HBase/Cassandra modules should ensure any new test classes are being run under Travis.