### PR TITLE
Add Seeq to the list of JanusGraph users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ CLAs and best practices for working with GitHub.
 The following users have deployed JanusGraph in production.
 
 * [FiNC](https://finc.com)
+* [Seeq](https://seeq.com)


### PR DESCRIPTION
Thanks to @sharpau for confirmation that Seeq has deployed JanusGraph and permission to use the name here.

See also https://github.com/JanusGraph/janusgraph.org/pull/11 for the website update.