### PR TITLE
Migrate from javaslang to vavr for CQL backend

### DIFF
--- a/janusgraph-cql/pom.xml
+++ b/janusgraph-cql/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <cassandra-driver.version>3.1.4</cassandra-driver.version>
-        <javaslang.version>2.0.5</javaslang.version>
+        <vavr.version>0.9.0</vavr.version>
 
         <test.byteorderedpartitioner>byteorderedpartitioner</test.byteorderedpartitioner>
         <test.murmur>murmur</test.murmur>
@@ -40,9 +40,9 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.javaslang</groupId>
-            <artifactId>javaslang</artifactId>
-            <version>${javaslang.version}</version>
+            <groupId>io.vavr</groupId>
+            <artifactId>vavr</artifactId>
+            <version>${vavr.version}</version>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLColValGetter.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLColValGetter.java
@@ -20,7 +20,7 @@ import org.janusgraph.diskstorage.util.StaticArrayEntry.GetColVal;
 
 import com.datastax.driver.core.Row;
 
-import javaslang.Tuple3;
+import io.vavr.Tuple3;
 
 class CQLColValGetter implements GetColVal<Tuple3<StaticBuffer, StaticBuffer, Row>, StaticBuffer> {
 

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLResultSetKeyIterator.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLResultSetKeyIterator.java
@@ -28,9 +28,9 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.google.common.collect.AbstractIterator;
 
-import javaslang.Tuple;
-import javaslang.Tuple3;
-import javaslang.collection.Iterator;
+import io.vavr.Tuple;
+import io.vavr.Tuple3;
+import io.vavr.collection.Iterator;
 
 /**
  * {@link SliceQuery} iterator that handles CQL result sets that may have more

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
@@ -16,9 +16,9 @@ package org.janusgraph.diskstorage.cql;
 
 import static com.datastax.driver.core.schemabuilder.SchemaBuilder.createKeyspace;
 import static com.datastax.driver.core.schemabuilder.SchemaBuilder.dropKeyspace;
-import static javaslang.API.$;
-import static javaslang.API.Case;
-import static javaslang.API.Match;
+import static io.vavr.API.$;
+import static io.vavr.API.Case;
+import static io.vavr.API.Match;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.ATOMIC_BATCH_MUTATE;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.BATCH_STATEMENT_SIZE;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CLUSTER_NAME;
@@ -91,13 +91,13 @@ import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.TokenAwarePolicy;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
-import javaslang.Tuple;
-import javaslang.collection.Array;
-import javaslang.collection.HashMap;
-import javaslang.collection.Iterator;
-import javaslang.collection.Seq;
-import javaslang.concurrent.Future;
-import javaslang.control.Option;
+import io.vavr.Tuple;
+import io.vavr.collection.Array;
+import io.vavr.collection.HashMap;
+import io.vavr.collection.Iterator;
+import io.vavr.collection.Seq;
+import io.vavr.concurrent.Future;
+import io.vavr.control.Option;
 
 /**
  * This class creates {@see CQLKeyColumnValueStore}s and handles Cassandra-backed allocation of vertex IDs for JanusGraph (when so

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLResultSetKeyIteratorTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLResultSetKeyIteratorTest.java
@@ -34,12 +34,12 @@ import org.junit.Test;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 
-import javaslang.Function1;
-import javaslang.Tuple;
-import javaslang.Tuple2;
-import javaslang.collection.Array;
-import javaslang.collection.Iterator;
-import javaslang.collection.Seq;
+import io.vavr.Function1;
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
+import io.vavr.collection.Array;
+import io.vavr.collection.Iterator;
+import io.vavr.collection.Seq;
 
 public class CQLResultSetKeyIteratorTest {
 


### PR DESCRIPTION
Now that the CQL backend is merged, please find the requested PR migrating from the "javaslang" library to the renamed (and upgraded) "vavr" library.