### PR TITLE
Change Coverity config to fix the analysis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,12 +56,12 @@ addons:
     # https://scan.coverity.com/travis_ci
     project:
       name: "JanusGraph/janusgraph"
-      version: "0.1.0-SNAPSHOT"
+      version: "0.2.0-SNAPSHOT"
       description: "Scalable, distributed graph database"
     notification_email: janusgraph-ci@googlegroups.com
     # For more info on `travis_wait`, see the docs:
     # https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
-    build_command: "travis_wait mvn clean package -B -DskipTests=true"
+    build_command: "mvn clean package -B -DskipTests=true"
     branch_pattern: coverity_scan
 
 install:


### PR DESCRIPTION
* Remove `travis_wait` because Coverity cannot find it:
  https://travis-ci.org/JanusGraph/janusgraph/jobs/236948159#L925
* Update version number to 0.2.0-SNAPSHOT for consistency with `pom.xml`

[skip ci] as we don't need to waste Travis cycles on this in the `master` branch
since this should only affect the `coverity_scan` branch, once we merge into it.