### PR TITLE
Implemented a new record reader to extract JanusGraph data from Cassa…

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -62,6 +62,7 @@ Joe Ferner <joe@fernsroth.com>
 Joshua Shinavier <josh@fortytwo.net>
 Justin Corpron <justin.corpron@justinc-677.glassdoor.local>
 Karthik Ramachandran <kramachandran@iqt.com>
+Kedar Mhaswade <kedar.mhaswade@gmail.com>
 ksenji <ksenji@ebay.com>
 Leifur Halldor Asgeirsson <leifurhauks@gmail.com>
 Mark McCraw <mark.mccraw@sas.com>

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -28,6 +28,7 @@ It also includes software from other open source projects including, but not lim
  * Apache Solr [http://lucene.apache.org/solr/]
  * Apache TinkerPop [http://tinkerpop.apache.org/]
  * Astyanax [https://github.com/Netflix/astyanax]
+ * DataStax Driver for Apache Cassandra  [https://github.com/datastax/java-driver]
  * EasyMock [http://easymock.org/]
  * Elasticsearch [https://www.elastic.co/]
  * Google Guava [https://github.com/google/guava]

--- a/TESTING.md
+++ b/TESTING.md
@@ -86,3 +86,12 @@ To run Elasicsearch tests using an embedded Elasticsearch Docker container, use 
 ```bash
 mvn clean install -pl janusgraph-es -Pes-docker
 ```
+
+### Running Hadoop tests with Cassandra-3 using CQL record reader (requires Docker)
+
+To run Hadoop tests with Cassandra-3 using the CQL record reader, start a Cassandra-3 Docker container and run tests with `-DskipCassandra3=false`. Note core HBase and Cassandra-2 Hadoop tests must be skipped when an external Cassandra instance is running.
+
+```bash
+docker run --name jg-cassandra -p 9160:9160 -p 9042:9042 -e CASSANDRA_START_RPC=true -d cassandra:3.10
+mvn clean install -pl :janusgraph-hadoop-2 -DskipHBase -DskipCassandra -DskipCassandra3=false
+```

--- a/janusgraph-cql/pom.xml
+++ b/janusgraph-cql/pom.xml
@@ -12,9 +12,7 @@
     <url>http://janusgraph.org</url>
 
     <properties>
-        <cassandra-driver.version>3.1.4</cassandra-driver.version>
         <vavr.version>0.9.0</vavr.version>
-
         <test.byteorderedpartitioner>byteorderedpartitioner</test.byteorderedpartitioner>
         <test.murmur>murmur</test.murmur>
         <test.murmur-ssl>murmur-ssl</test.murmur-ssl>

--- a/janusgraph-dist/src/assembly/static/conf/hadoop-graph/read-cassandra-3.properties
+++ b/janusgraph-dist/src/assembly/static/conf/hadoop-graph/read-cassandra-3.properties
@@ -1,0 +1,29 @@
+#
+# Hadoop Graph Configuration
+#
+gremlin.graph=org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph
+gremlin.hadoop.graphInputFormat=org.janusgraph.hadoop.formats.cassandra.Cassandra3InputFormat
+gremlin.hadoop.graphOutputFormat=org.apache.tinkerpop.gremlin.hadoop.structure.io.gryo.GryoOutputFormat
+
+gremlin.hadoop.jarsInDistributedCache=true
+gremlin.hadoop.inputLocation=none
+gremlin.hadoop.outputLocation=output
+
+#
+# JanusGraph Cassandra InputFormat configuration
+#
+janusgraphmr.ioformat.conf.storage.backend=cassandra
+janusgraphmr.ioformat.conf.storage.hostname=localhost
+janusgraphmr.ioformat.conf.storage.port=9160
+janusgraphmr.ioformat.conf.storage.cassandra.keyspace=janusgraph
+
+#
+# Apache Cassandra InputFormat configuration
+#
+cassandra.input.partitioner.class=org.apache.cassandra.dht.Murmur3Partitioner
+
+#
+# SparkGraphComputer Configuration
+#
+spark.master=local[4]
+spark.serializer=org.apache.spark.serializer.KryoSerializer

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cassandra/Cassandra3BinaryInputFormat.java
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cassandra/Cassandra3BinaryInputFormat.java
@@ -14,53 +14,18 @@
 
 package org.janusgraph.hadoop.formats.cassandra;
 
-import org.apache.cassandra.hadoop.ColumnFamilyInputFormat;
-import org.apache.cassandra.hadoop.ColumnFamilyRecordReader;
-import org.apache.cassandra.hadoop.ConfigHelper;
-import org.apache.cassandra.thrift.SlicePredicate;
-import org.apache.cassandra.thrift.SliceRange;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.InputSplit;
-import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.janusgraph.diskstorage.Entry;
 import org.janusgraph.diskstorage.StaticBuffer;
-import org.janusgraph.diskstorage.cassandra.AbstractCassandraStoreManager;
-import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
-import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
-import org.janusgraph.hadoop.config.JanusGraphHadoopConfiguration;
-import org.janusgraph.hadoop.formats.util.AbstractBinaryInputFormat;
-import org.janusgraph.hadoop.formats.util.input.JanusGraphHadoopSetupCommon;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
  * Wraps a ColumnFamilyInputFormat and converts CFIF's binary types to JanusGraph's binary types.
  */
-public class Cassandra3BinaryInputFormat extends AbstractBinaryInputFormat {
-
-    private static final Logger log = LoggerFactory.getLogger(Cassandra3BinaryInputFormat.class);
-
-    // Copied these private constants from Cassandra's ConfigHelper circa 2.0.9
-    private static final String INPUT_WIDEROWS_CONFIG = "cassandra.input.widerows";
-    private static final String RANGE_BATCH_SIZE_CONFIG = "cassandra.range.batch.size";
-
-    private final ColumnFamilyInputFormat columnFamilyInputFormat = new ColumnFamilyInputFormat();
-    private ColumnFamilyRecordReader columnFamilyRecordReader;
-    private RecordReader<StaticBuffer, Iterable<Entry>> janusgraphRecordReader;
-
-    public RecordReader<StaticBuffer, Iterable<Entry>> getRecordReader() {
-        return janusgraphRecordReader;
-    }
-
-    @Override
-    public List<InputSplit> getSplits(final JobContext jobContext) throws IOException, InterruptedException {
-        return this.columnFamilyInputFormat.getSplits(jobContext);
-    }
+public class Cassandra3BinaryInputFormat extends CassandraBinaryInputFormat {
 
     @Override
     public RecordReader<StaticBuffer, Iterable<Entry>> createRecordReader(final InputSplit inputSplit, final TaskAttemptContext taskAttemptContext)
@@ -69,39 +34,5 @@ public class Cassandra3BinaryInputFormat extends AbstractBinaryInputFormat {
         return janusgraphRecordReader;
     }
 
-    @Override
-    public void setConf(final Configuration config) {
-        super.setConf(config);
-
-        // Copy some JanusGraph configuration keys to the Hadoop Configuration keys used by Cassandra's ColumnFamilyInputFormat
-        ConfigHelper.setInputInitialAddress(config, janusgraphConf.get(GraphDatabaseConfiguration.STORAGE_HOSTS)[0]);
-        if (janusgraphConf.has(GraphDatabaseConfiguration.STORAGE_PORT))
-            ConfigHelper.setInputRpcPort(config, String.valueOf(janusgraphConf.get(GraphDatabaseConfiguration.STORAGE_PORT)));
-        if (janusgraphConf.has(GraphDatabaseConfiguration.AUTH_USERNAME))
-            ConfigHelper.setInputKeyspaceUserName(config, janusgraphConf.get(GraphDatabaseConfiguration.AUTH_USERNAME));
-        if (janusgraphConf.has(GraphDatabaseConfiguration.AUTH_PASSWORD))
-            ConfigHelper.setInputKeyspacePassword(config, janusgraphConf.get(GraphDatabaseConfiguration.AUTH_PASSWORD));
-
-        // Copy keyspace, force the CF setting to edgestore, honor widerows when set
-        final boolean wideRows = config.getBoolean(INPUT_WIDEROWS_CONFIG, false);
-        // Use the setInputColumnFamily overload that includes a widerows argument; using the overload without this argument forces it false
-        ConfigHelper.setInputColumnFamily(config, janusgraphConf.get(AbstractCassandraStoreManager.CASSANDRA_KEYSPACE),
-                mrConf.get(JanusGraphHadoopConfiguration.COLUMN_FAMILY_NAME), wideRows);
-        log.debug("Set keyspace: {}", janusgraphConf.get(AbstractCassandraStoreManager.CASSANDRA_KEYSPACE));
-
-        // Set the column slice bounds via Faunus's vertex query filter
-        final SlicePredicate predicate = new SlicePredicate();
-        final int rangeBatchSize = config.getInt(RANGE_BATCH_SIZE_CONFIG, Integer.MAX_VALUE);
-        predicate.setSlice_range(getSliceRange(JanusGraphHadoopSetupCommon.DEFAULT_SLICE_QUERY, rangeBatchSize)); // TODO stop slicing the whole row
-        ConfigHelper.setInputSlicePredicate(config, predicate);
-    }
-
-    private SliceRange getSliceRange(final SliceQuery slice, final int limit) {
-        final SliceRange sliceRange = new SliceRange();
-        sliceRange.setStart(slice.getSliceStart().asByteBuffer());
-        sliceRange.setFinish(slice.getSliceEnd().asByteBuffer());
-        sliceRange.setCount(Math.min(limit, slice.getLimit()));
-        return sliceRange;
-    }
 }
 

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cassandra/Cassandra3BinaryInputFormat.java
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cassandra/Cassandra3BinaryInputFormat.java
@@ -14,14 +14,6 @@
 
 package org.janusgraph.hadoop.formats.cassandra;
 
-import org.janusgraph.diskstorage.Entry;
-import org.janusgraph.diskstorage.StaticBuffer;
-import org.janusgraph.diskstorage.cassandra.AbstractCassandraStoreManager;
-import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
-import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
-import org.janusgraph.hadoop.config.JanusGraphHadoopConfiguration;
-import org.janusgraph.hadoop.formats.util.AbstractBinaryInputFormat;
-import org.janusgraph.hadoop.formats.util.input.JanusGraphHadoopSetupCommon;
 import org.apache.cassandra.hadoop.ColumnFamilyInputFormat;
 import org.apache.cassandra.hadoop.ColumnFamilyRecordReader;
 import org.apache.cassandra.hadoop.ConfigHelper;
@@ -32,6 +24,14 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.cassandra.AbstractCassandraStoreManager;
+import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.janusgraph.hadoop.config.JanusGraphHadoopConfiguration;
+import org.janusgraph.hadoop.formats.util.AbstractBinaryInputFormat;
+import org.janusgraph.hadoop.formats.util.input.JanusGraphHadoopSetupCommon;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,9 +41,9 @@ import java.util.List;
 /**
  * Wraps a ColumnFamilyInputFormat and converts CFIF's binary types to JanusGraph's binary types.
  */
-public class CassandraBinaryInputFormat extends AbstractBinaryInputFormat {
+public class Cassandra3BinaryInputFormat extends AbstractBinaryInputFormat {
 
-    private static final Logger log = LoggerFactory.getLogger(CassandraBinaryInputFormat.class);
+    private static final Logger log = LoggerFactory.getLogger(Cassandra3BinaryInputFormat.class);
 
     // Copied these private constants from Cassandra's ConfigHelper circa 2.0.9
     private static final String INPUT_WIDEROWS_CONFIG = "cassandra.input.widerows";
@@ -65,11 +65,7 @@ public class CassandraBinaryInputFormat extends AbstractBinaryInputFormat {
     @Override
     public RecordReader<StaticBuffer, Iterable<Entry>> createRecordReader(final InputSplit inputSplit, final TaskAttemptContext taskAttemptContext)
             throws IOException, InterruptedException {
-        // the default case, Cassandra 2.1.9
-        columnFamilyRecordReader =
-            (ColumnFamilyRecordReader) columnFamilyInputFormat.createRecordReader(inputSplit, taskAttemptContext);
-        janusgraphRecordReader =
-            new CassandraBinaryRecordReader(columnFamilyRecordReader);
+        janusgraphRecordReader = new CqlBridgeRecordReader(); // See issue 172
         return janusgraphRecordReader;
     }
 

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cassandra/Cassandra3InputFormat.java
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cassandra/Cassandra3InputFormat.java
@@ -1,0 +1,27 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.hadoop.formats.cassandra;
+
+import org.janusgraph.diskstorage.configuration.ConfigOption;
+import org.janusgraph.hadoop.formats.util.GiraphInputFormat;
+
+import static org.janusgraph.diskstorage.cassandra.AbstractCassandraStoreManager.*;
+
+public class Cassandra3InputFormat extends GiraphInputFormat {
+
+    public Cassandra3InputFormat() {
+        super(new Cassandra3BinaryInputFormat());
+    }
+}

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cassandra/CassandraBinaryInputFormat.java
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cassandra/CassandraBinaryInputFormat.java
@@ -51,7 +51,7 @@ public class CassandraBinaryInputFormat extends AbstractBinaryInputFormat {
 
     private final ColumnFamilyInputFormat columnFamilyInputFormat = new ColumnFamilyInputFormat();
     private ColumnFamilyRecordReader columnFamilyRecordReader;
-    private RecordReader<StaticBuffer, Iterable<Entry>> janusgraphRecordReader;
+    RecordReader<StaticBuffer, Iterable<Entry>> janusgraphRecordReader;
 
     public RecordReader<StaticBuffer, Iterable<Entry>> getRecordReader() {
         return janusgraphRecordReader;
@@ -65,7 +65,6 @@ public class CassandraBinaryInputFormat extends AbstractBinaryInputFormat {
     @Override
     public RecordReader<StaticBuffer, Iterable<Entry>> createRecordReader(final InputSplit inputSplit, final TaskAttemptContext taskAttemptContext)
             throws IOException, InterruptedException {
-        // the default case, Cassandra 2.1.9
         columnFamilyRecordReader =
             (ColumnFamilyRecordReader) columnFamilyInputFormat.createRecordReader(inputSplit, taskAttemptContext);
         janusgraphRecordReader =

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cassandra/CqlBridgeRecordReader.java
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cassandra/CqlBridgeRecordReader.java
@@ -1,18 +1,3 @@
-// Copyright 2017 JanusGraph Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// Brought in the following copyright header from Cassandra-3 GitHub Repo.
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cassandra/CqlBridgeRecordReader.java
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cassandra/CqlBridgeRecordReader.java
@@ -1,0 +1,391 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Brought in the following copyright header from Cassandra-3 GitHub Repo.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.janusgraph.hadoop.formats.cassandra;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ColumnMetadata;
+import com.datastax.driver.core.Metadata;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.SimpleStatement;
+import com.datastax.driver.core.TableMetadata;
+
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.hadoop.ColumnFamilySplit;
+import org.apache.cassandra.hadoop.ConfigHelper;
+import org.apache.cassandra.hadoop.HadoopCompat;
+import org.apache.cassandra.hadoop.cql3.CqlConfigHelper;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.classification.InterfaceStability.Unstable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.util.StaticArrayBuffer;
+import org.janusgraph.diskstorage.util.StaticArrayEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * <p> Background: The {@link org.apache.cassandra.hadoop.cql3.CqlRecordReader} class has changed
+ * significantly in Cassandra-3 from Cassandra-2. This class acts as a bridge between
+ * CqlRecordReader in Cassandra-2 to Cassandra-3. In essence, this class recreates CqlRecordReader
+ * from Cassandra-3 without referring to it (because otherwise we'd get functionality from
+ * CqlRecordReader on Cassandra-2 and we don't want it). </p>
+ *
+ * @see <a href="https://github.com/JanusGraph/janusgraph/issues/172">Issue 172</a>.
+ */
+@Unstable // Because it should go away with JanusGraph upgrading to Cassandra-3 for OLAP
+@Deprecated // Because this class should already be on its path to deprecation
+public class CqlBridgeRecordReader extends RecordReader<StaticBuffer, Iterable<Entry>> {
+
+    /* Implementation note: This is inspired by Cassandra-3's org/apache/cassandra/hadoop/cql3/CqlRecordReader.java */
+    private static final Logger log = LoggerFactory.getLogger(CqlBridgeRecordReader.class);
+
+    private ColumnFamilySplit split;
+    private DistinctKeyIterator distinctKeyIterator;
+    private int totalRowCount; // total number of rows to fetch
+    private String keyspace;
+    private String cfName;
+    private String cqlQuery;
+    private Cluster cluster;
+    private Session session;
+    private IPartitioner partitioner;
+    private String inputColumns;
+    private String userDefinedWhereClauses;
+
+    private List<String> partitionKeys = new ArrayList<>();
+
+    // partition keys -- key aliases
+    private LinkedHashMap<String, Boolean> partitionBoundColumns = Maps.newLinkedHashMap();
+    private int nativeProtocolVersion = 1;
+
+    // binary type mapping code from CassandraBinaryRecordReader
+    private KV currentKV;
+
+    CqlBridgeRecordReader() { //package private
+        super();
+    }
+
+    @Override
+    public void initialize(InputSplit split, TaskAttemptContext context) throws IOException {
+        this.split = (ColumnFamilySplit) split;
+        Configuration conf = HadoopCompat.getConfiguration(context);
+        totalRowCount = (this.split.getLength() < Long.MAX_VALUE)
+            ? (int) this.split.getLength()
+            : ConfigHelper.getInputSplitSize(conf);
+        cfName = ConfigHelper.getInputColumnFamily(conf);
+        keyspace = ConfigHelper.getInputKeyspace(conf);
+        partitioner = ConfigHelper.getInputPartitioner(conf);
+        inputColumns = CqlConfigHelper.getInputcolumns(conf);
+        userDefinedWhereClauses = CqlConfigHelper.getInputWhereClauses(conf);
+
+        try {
+            if (cluster != null) {
+                return;
+            }
+            // create a Cluster instance
+            String[] locations = split.getLocations();
+//            cluster = CqlConfigHelper.getInputCluster(locations, conf);
+            // disregard the conf as it brings some unforeseen issues.
+            cluster = Cluster.builder()
+                .addContactPoints(locations)
+                .build();
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to create cluster for table: " + cfName + ", in keyspace: " + keyspace, e);
+        }
+        // cluster should be represent to a valid cluster now
+        session = cluster.connect(quote(keyspace));
+        Preconditions.checkState(session != null, "Can't create connection session");
+        //get negotiated serialization protocol
+        nativeProtocolVersion = cluster.getConfiguration().getProtocolOptions().getProtocolVersion().toInt();
+
+        // If the user provides a CQL query then we will use it without validation
+        // otherwise we will fall back to building a query using the:
+        //   inputColumns
+        //   whereClauses
+        cqlQuery = CqlConfigHelper.getInputCql(conf);
+        // validate that the user hasn't tried to give us a custom query along with input columns
+        // and where clauses
+        if (StringUtils.isNotEmpty(cqlQuery) && (StringUtils.isNotEmpty(inputColumns) ||
+            StringUtils.isNotEmpty(userDefinedWhereClauses))) {
+            throw new AssertionError("Cannot define a custom query with input columns and / or where clauses");
+        }
+
+        if (StringUtils.isEmpty(cqlQuery)) {
+            cqlQuery = buildQuery();
+        }
+        log.trace("cqlQuery {}", cqlQuery);
+        distinctKeyIterator = new DistinctKeyIterator();
+        log.trace("created {}", distinctKeyIterator);
+    }
+
+    public void close() {
+        if (session != null) {
+            session.close();
+        }
+        if (cluster != null) {
+            cluster.close();
+        }
+    }
+
+    private static class KV {
+        private final StaticArrayBuffer key;
+        private ArrayList<Entry> entries;
+
+        KV(StaticArrayBuffer key) {
+            this.key = key;
+        }
+
+        void addEntries(Collection<Entry> toAdd) {
+            if (entries == null) {
+                entries = new ArrayList<>(toAdd.size());
+            }
+            entries.addAll(toAdd);
+        }
+    }
+
+    @Override
+    public StaticBuffer getCurrentKey() {
+        return currentKV.key;
+    }
+
+    @Override
+    public Iterable<Entry> getCurrentValue() throws IOException {
+        return currentKV.entries;
+    }
+
+    public float getProgress() {
+        if (!distinctKeyIterator.hasNext()) {
+            return 1.0F;
+        }
+
+        // the progress is likely to be reported slightly off the actual but close enough
+        float progress = ((float) distinctKeyIterator.totalRead / totalRowCount);
+        return progress > 1.0F ? 1.0F : progress;
+    }
+
+    public boolean nextKeyValue() throws IOException {
+        final Map<StaticArrayBuffer, Map<StaticBuffer, StaticBuffer>> kv = distinctKeyIterator.next();
+        if (kv == null) {
+            return false;
+        }
+        final Map.Entry<StaticArrayBuffer, Map<StaticBuffer, StaticBuffer>> onlyEntry = Iterables.getOnlyElement(kv.entrySet());
+        final KV newKV = new KV(onlyEntry.getKey());
+        final Map<StaticBuffer, StaticBuffer> v = onlyEntry.getValue();
+        final List<Entry> entries = v.keySet()
+                .stream()
+                .map(column -> StaticArrayEntry.of(column, v.get(column)))
+                .collect(toList());
+        newKV.addEntries(entries);
+        currentKV = newKV;
+        return true;
+    }
+
+    /**
+     * Return native version protocol of the cluster connection
+     *
+     * @return serialization protocol version.
+     */
+    public int getNativeProtocolVersion() {
+        return nativeProtocolVersion;
+    }
+
+    /**
+     * A non-static nested class that represents an iterator for distinct keys based on the
+     * row iterator from DataStax driver. In the usual case, more than one row will be associated
+     * with a single key in JanusGraph's use of Cassandra.
+     */
+    private class DistinctKeyIterator implements Iterator<Map<StaticArrayBuffer, Map<StaticBuffer, StaticBuffer>>> {
+        public static final String KEY = "key";
+        public static final String COLUMN_NAME = "column1";
+        public static final String VALUE = "value";
+        private final Iterator<Row> rowIterator;
+        long totalRead;
+        Row previousRow = null;
+        DistinctKeyIterator() {
+            AbstractType type = partitioner.getTokenValidator();
+            Object startToken = type.compose(type.fromString(split.getStartToken()));
+            Object endToken = type.compose(type.fromString(split.getEndToken()));
+            SimpleStatement statement = new SimpleStatement(cqlQuery, startToken, endToken);
+            rowIterator = session.execute(statement).iterator();
+            for (ColumnMetadata meta : cluster.getMetadata().getKeyspace(quote(keyspace)).getTable(quote(cfName)).getPartitionKey()) {
+                partitionBoundColumns.put(meta.getName(), Boolean.TRUE);
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            return rowIterator.hasNext();
+        }
+
+        /**
+         * <p>
+         *     Implements the <i>business logic</i> of the outer class. Refer to {@linkplain CqlBridgeRecordReader}.
+         * Relies on the {@linkplain Iterator} of {@linkplain Row} to get a map of rows that correspond
+         * to the same key.
+         * </p>
+         * <p>
+         *     Note: This is not a general purpose iterator. There is no provision of {@linkplain java.util.ConcurrentModificationException}
+         *     while iterating using this iterator.
+         * </p>
+         * @return the next element in the iteration of distinct keys, returns <code>null</code> to indicate
+         * end of iteration
+         */
+        @Override
+        public Map<StaticArrayBuffer, Map<StaticBuffer, StaticBuffer>> next() {
+            if (! rowIterator.hasNext()) {
+                return null; // null means no more data
+            }
+            Map<StaticArrayBuffer, Map<StaticBuffer, StaticBuffer>> kcvs = new HashMap<>(); // key -> (column1 -> value)
+            Row row;
+            if (previousRow == null) {
+                row = rowIterator.next(); // just the first time, should succeed
+            } else {
+                row = previousRow;
+            }
+            StaticArrayBuffer key = StaticArrayBuffer.of(row.getBytesUnsafe(KEY));
+            StaticBuffer column1 = StaticArrayBuffer.of(row.getBytesUnsafe(COLUMN_NAME));
+            StaticBuffer value = StaticArrayBuffer.of(row.getBytesUnsafe(VALUE));
+            Map<StaticBuffer, StaticBuffer> cvs = new HashMap<>();
+            cvs.put(column1, value);
+            kcvs.put(key, cvs);
+            while (rowIterator.hasNext()) {
+                Row nextRow = rowIterator.next();
+                StaticArrayBuffer nextKey = StaticArrayBuffer.of(nextRow.getBytesUnsafe(KEY));
+                if (! key.equals(nextKey)) {
+                    previousRow = nextRow;
+                    break;
+                }
+                StaticBuffer nextColumn = StaticArrayBuffer.of(nextRow.getBytesUnsafe(COLUMN_NAME));
+                StaticBuffer nextValue = StaticArrayBuffer.of(nextRow.getBytesUnsafe(VALUE));
+                cvs.put(nextColumn, nextValue);
+                totalRead++;
+            }
+            return kcvs;
+        }
+    }
+    /**
+     * Build a query for the reader of the form:
+     *
+     * SELECT * FROM ks>cf token(pk1,...pkn)>? AND token(pk1,...pkn)<=? [AND user where clauses]
+     * [ALLOW FILTERING]
+     */
+    private String buildQuery() {
+        fetchKeys();
+
+        List<String> columns = getSelectColumns();
+        String selectColumnList = columns.size() == 0 ? "*" : makeColumnList(columns);
+        String partitionKeyList = makeColumnList(partitionKeys);
+
+        return String.format("SELECT %s FROM %s.%s WHERE token(%s)>? AND token(%s)<=?" + getAdditionalWhereClauses(),
+            selectColumnList, quote(keyspace), quote(cfName), partitionKeyList, partitionKeyList);
+    }
+
+    private String getAdditionalWhereClauses() {
+        String whereClause = "";
+        if (StringUtils.isNotEmpty(userDefinedWhereClauses)) {
+            whereClause += " AND " + userDefinedWhereClauses;
+        }
+        if (StringUtils.isNotEmpty(userDefinedWhereClauses)) {
+            whereClause += " ALLOW FILTERING";
+        }
+        return whereClause;
+    }
+
+    private List<String> getSelectColumns() {
+        List<String> selectColumns = new ArrayList<>();
+
+        if (StringUtils.isNotEmpty(inputColumns)) {
+            // We must select all the partition keys plus any other columns the user wants
+            selectColumns.addAll(partitionKeys);
+            for (String column : Splitter.on(',').split(inputColumns)) {
+                if (!partitionKeys.contains(column)) {
+                    selectColumns.add(column);
+                }
+            }
+        }
+        return selectColumns;
+    }
+
+    private String makeColumnList(Collection<String> columns) {
+        return Joiner.on(',').join(Iterables.transform(columns, new Function<String, String>() {
+            public String apply(String column) {
+                return quote(column);
+            }
+        }));
+    }
+
+    private void fetchKeys() {
+        // get CF meta data
+        TableMetadata tableMetadata = session.getCluster()
+            .getMetadata()
+            .getKeyspace(Metadata.quote(keyspace))
+            .getTable(Metadata.quote(cfName));
+        if (tableMetadata == null) {
+            throw new RuntimeException("No table metadata found for " + keyspace + "." + cfName);
+        }
+        //Here we assume that tableMetadata.getPartitionKey() always
+        //returns the list of columns in order of component_index
+        for (ColumnMetadata partitionKey : tableMetadata.getPartitionKey()) {
+            partitionKeys.add(partitionKey.getName());
+        }
+    }
+
+    private String quote(String identifier) {
+        return "\"" + identifier.replaceAll("\"", "\"\"") + "\"";
+    }
+
+}

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/test/java/org/janusgraph/hadoop/Cassandra3InputFormatIT.java
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/test/java/org/janusgraph/hadoop/Cassandra3InputFormatIT.java
@@ -19,33 +19,21 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 import org.janusgraph.CassandraStorageSetup;
 import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
-import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.tinkerpop.gremlin.structure.util.GraphFactory;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
-public class CassandraInputFormatIT extends AbstractInputFormatIT {
+public class Cassandra3InputFormatIT extends CassandraInputFormatIT {
 
     protected PropertiesConfiguration getGraphConfiguration() throws ConfigurationException, IOException {
-        final PropertiesConfiguration config = new PropertiesConfiguration("target/test-classes/cassandra-read.properties");
-        Path baseOutDir = Paths.get((String) config.getProperty("gremlin.hadoop.outputLocation"));
-        baseOutDir.toFile().mkdirs();
-        String outDir = Files.createTempDirectory(baseOutDir, null).toAbsolutePath().toString();
-        config.setProperty("gremlin.hadoop.outputLocation", outDir);
+        final PropertiesConfiguration config = super.getGraphConfiguration();
+        config.setProperty("gremlin.hadoop.graphInputFormat", "org.janusgraph.hadoop.formats.cassandra.Cassandra3InputFormat");
         return config;
-    }
-
-    protected Graph getGraph() throws ConfigurationException, IOException {
-        return GraphFactory.open(getGraphConfiguration());
     }
 
     @Override
     public WriteConfiguration getConfiguration() {
-        String className = getClass().getSimpleName();
-        ModifiableConfiguration mc = CassandraStorageSetup.getEmbeddedConfiguration(className);
+        String className = CassandraInputFormatIT.class.getSimpleName();
+        ModifiableConfiguration mc = CassandraStorageSetup.getCassandraThriftConfiguration(className);
         return mc.getConfiguration();
     }
 }

--- a/janusgraph-hadoop-parent/pom.xml
+++ b/janusgraph-hadoop-parent/pom.xml
@@ -14,6 +14,9 @@
     <properties>
         <top.level.basedir>${project.parent.basedir}</top.level.basedir>
         <skipCassandra>${skipTests}</skipCassandra>
+        <!-- Cassandra-3 testing requires an external Cassandra instance. 
+             See TESTING.md for more information. -->
+        <skipCassandra3>true</skipCassandra3>
         <skipHBase>${skipTests}</skipHBase>
         <skipPipeline>${skipTests}</skipPipeline>
     </properties>
@@ -322,10 +325,29 @@
                                 <includes>
                                     <include>**/*Cassandra*IT.java</include>
                                 </includes>
+                                <excludes>
+                                    <exclude>**/*Cassandra3*IT.java</exclude>
+                                </excludes>
                                 <skipTests>${skipCassandra}</skipTests>
                                 <reuseForks>false</reuseForks>
                                 <summaryFile>target/failsafe-reports/failsafe-janusgraph-cassandra.xml</summaryFile>
                                 <argLine>-Dtest.cassandra.confdir=${project.build.directory}/cassandra/conf/localhost-murmur -Dtest.cassandra.datadir=${project.build.directory}/cassandra/data/localhost-murmur</argLine>
+                            </configuration>
+                        </execution>
+                        <!-- Cassandra-3 testing requires an external Cassandra instance. 
+                        See TESTING.md for more information. -->
+                        <execution>
+                            <id>janusgraph-cassandra3-test</id>
+                            <goals>
+                                <goal>integration-test</goal>
+                            </goals>
+                            <configuration>
+                                <includes>
+                                    <include>**/*Cassandra3*IT.java</include>
+                                </includes>
+                                <skipTests>${skipCassandra3}</skipTests>
+                                <reuseForks>false</reuseForks>
+                                <summaryFile>target/failsafe-reports/failsafe-janusgraph-cassandra3.xml</summaryFile>
                             </configuration>
                         </execution>
                         <execution>

--- a/janusgraph-hadoop-parent/pom.xml
+++ b/janusgraph-hadoop-parent/pom.xml
@@ -156,6 +156,12 @@
             <artifactId>sesame-rio-turtle</artifactId>
         </dependency>
 
+        <!-- Required for Cassandra-3 connectivity, see issue 172 -->
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+            <version>${cassandra-driver.version}</version>
+        </dependency>
         <!-- Logging backends.
              Enforce a classpath ordering constraint to ensure slf4j-log4j12
              binding appears on the classpath before logback-classic.

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
         <compiler.target>1.8</compiler.target>
         <test.excluded.groups>org.janusgraph.testcategory.MemoryTests,org.janusgraph.testcategory.PerformanceTests,org.janusgraph.testcategory.BrittleTests</test.excluded.groups>
         <dependency.locations.enabled>false</dependency.locations.enabled>
+        <cassandra-driver.version>3.1.4</cassandra-driver.version>
     </properties>
     <modules>
         <module>janusgraph-codepipelines-ci</module>


### PR DESCRIPTION
…ndra-3.

Summary:
The new reader and key iterator are inspired by Cassandra-3's CqlRecordReader.
Preparing for a PR upstream. Tested thoroughly on local C-3 instance on OLAP
path via SparkGraphComputer.

Note that the way I am plugging in
the Reader is by keeping the Cassandra-2 path unaffected. Only when the system
property "use.cassandra.3" is defined, this code path gets exercised.
To embed JG as a library in a JVM, I resorted to using a system property
instead of a different InputFormat. So, right now, we have a single InputFormat
for both Cassandra-2 and Cassandra-3, although it behaves differently based
on the backend.

Tested locally on Cassandra-3 per instructions from Ted Wilmes (see the
issue-172 page).

Signed-off-by: Kedar Mhaswade (kedar@uber.com)