### PR TITLE
Documentation and error message enhancements for GraphOfTheGodsFactory with no index backend configured

### DIFF
--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -190,6 +190,16 @@ gremlin> GraphOfTheGodsFactory.load(graph)
 gremlin> g = graph.traversal()
 ==>graphtraversalsource[standardjanusgraph[cassandrathrift:[127.0.0.1]], standard]
 
+You may also use the `conf/janusgraph-cassandra.properties`, `conf/janusgraph-berkeleyje.properties`, or `conf/janusgraph-hbase.properties` configuration files to open a graph without an indexing backend configured. In such cases, you will need to use the `GraphOfTheGodsFactory.loadWithoutMixedIndex()` method to load the _Graph of the Gods_ so that it doesn't attempt to make use of an indexing backend.
+
+[source, gremlin]
+gremlin> graph = JanusGraphFactory.open('conf/janusgraph-cassandra.properties')
+==>standardjanusgraph[cassandrathrift:[127.0.0.1]]
+gremlin> GraphOfTheGodsFactory.loadWithoutMixedIndex(graph, true)
+==>null
+gremlin> g = graph.traversal()
+==>graphtraversalsource[standardjanusgraph[cassandrathrift:[127.0.0.1]], standard]
+
 === Global Graph Indices
 
 The typical pattern for accessing data in a graph database is to first locate the entry point into the graph using a graph index. That entry point is an element (or set of elements) -- i.e. a vertex or edge. From the entry elements, a Gremlin path description describes how to traverse to other elements in the graph via the explicit graph structure.

--- a/janusgraph-core/src/main/java/org/janusgraph/example/GraphOfTheGodsFactory.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/example/GraphOfTheGodsFactory.java
@@ -14,6 +14,7 @@
 
 package org.janusgraph.example;
 
+import com.google.common.base.Preconditions;
 import org.janusgraph.core.EdgeLabel;
 import org.janusgraph.core.Multiplicity;
 import org.janusgraph.core.PropertyKey;
@@ -24,6 +25,7 @@ import org.janusgraph.core.attribute.Geoshape;
 import org.janusgraph.core.schema.ConsistencyModifier;
 import org.janusgraph.core.schema.JanusGraphIndex;
 import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.graphdb.database.StandardJanusGraph;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
@@ -40,6 +42,10 @@ import java.io.File;
 public class GraphOfTheGodsFactory {
 
     public static final String INDEX_NAME = "search";
+    private static final String ERR_NO_INDEXING_BACKEND = 
+            "The indexing backend with name \"%s\" is not defined. Specify an existing indexing backend or " +
+            "use GraphOfTheGodsFactory.loadWithoutMixedIndex(graph,true) to load without the use of an " +
+            "indexing backend.";
 
     public static JanusGraph create(final String directory) {
         JanusGraphFactory.Builder config = JanusGraphFactory.build();
@@ -60,7 +66,15 @@ public class GraphOfTheGodsFactory {
         load(graph, INDEX_NAME, true);
     }
 
+    private static boolean mixedIndexNullOrExists(StandardJanusGraph graph, String indexName) {
+        return indexName == null || graph.getIndexSerializer().containsIndex(indexName) == true;
+    }
+
     public static void load(final JanusGraph graph, String mixedIndexName, boolean uniqueNameCompositeIndex) {
+        if (graph instanceof StandardJanusGraph) {
+            Preconditions.checkState(mixedIndexNullOrExists((StandardJanusGraph)graph, mixedIndexName), 
+                    ERR_NO_INDEXING_BACKEND, mixedIndexName);
+        }
 
         //Create Schema
         JanusGraphManagement mgmt = graph.openManagement();

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -1304,6 +1304,17 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
     }
 
     @Test
+    public void testGotGLoadWithoutIndexBackendException() {
+        try {
+            GraphOfTheGodsFactory.load(graph);
+            fail("Expected an exception to be thrown indicating improper index backend configuration");
+        } catch (IllegalStateException ex) {
+            assertTrue("An exception asking the user to use loadWithoutMixedIndex was expected",
+                    ex.getMessage().contains("loadWithoutMixedIndex"));
+        }
+    }
+
+    @Test
     public void testGotGIndexRemoval() throws InterruptedException, ExecutionException {
         clopen(option(LOG_SEND_DELAY, MANAGEMENT_LOG), Duration.ZERO,
                 option(KCVSLog.LOG_READ_LAG_TIME, MANAGEMENT_LOG), Duration.ofMillis(50),


### PR DESCRIPTION
This changeset updates the getting-started documentation to indicate that a user must use the `loadWithoutMixedIndex` method when using a JanusGraph configuration without an indexing backend.  It also updates the "load" method to throw an exception when it's told to use mixed indexes, but an indexing backend isn't configured.

Issue: #298