### PR TITLE
Support testing Thrift and CQL with ScyllaDB

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -70,3 +70,11 @@ Monitor container logs and wait until the setup container exits (message will be
 ```bash
 mvn clean install -pl janusgraph-solr -Dindex.search.solr.zookeeper-url=localhost:2181
 ```
+
+### Running Thrift/CQL tests with ScyllaDB (requires Docker)
+
+To run Thrift or CQL tests with the [ScyllaDB](http://www.scylladb.com/) backend, ensure Docker is running and run tests under the `scylladb-test` Maven profile.
+
+```bash
+mvn clean install -pl janusgraph-cql -Pscylladb-test
+```

--- a/janusgraph-cassandra/pom.xml
+++ b/janusgraph-cassandra/pom.xml
@@ -384,16 +384,105 @@
     </build>
 
     <profiles>
-      <profile>
-	<id>coverage</id>
-	<activation>
-	  <activeByDefault>false</activeByDefault>
-	</activation>
-
-	<properties>
-	  <test.extra.jvm.opts>${jacoco.opts} -javaagent:${basedir}/target/jamm-${jamm.version}.jar</test.extra.jvm.opts>
-	</properties>
-      </profile>
+        <profile>
+	          <id>coverage</id>
+	          <activation>
+	              <activeByDefault>false</activeByDefault>
+	          </activation>
+	          <properties>
+	              <test.extra.jvm.opts>${jacoco.opts} -javaagent:${basedir}/target/jamm-${jamm.version}.jar</test.extra.jvm.opts>
+	          </properties>
+        </profile>
+        <profile>
+            <!-- Run Thrift tests with ScyllaDB (requires Docker) -->
+            <id>scylladb-test</id>
+            <properties>
+                <!-- Tests are run under failsafe so skip them under surefire -->
+                <test.skip.ordered>true</test.skip.ordered>
+                <test.skip.unordered>true</test.skip.unordered>
+                <test.skip.ssl>true</test.skip.ssl>
+                <test.skip.serial>true</test.skip.serial>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skipITs>false</skipITs>
+                            <includes>
+                                <include>**/org/janusgraph/diskstorage/cassandra/thrift/*.java</include>
+                                <include>**/org/janusgraph/graphdb/thrift/*.java</include>
+                            </includes>
+                            <!-- Exclude default (performance/memory) tests. Also exclude SSL tests (fail under Scylla) -->
+                            <excludedGroups>${test.excluded.groups},org.janusgraph.testcategory.CassandraSSLTests</excludedGroups>
+                            <systemProperties>
+                                <!-- Run tests against the containerized Scylla test server -->
+                                <property>
+                                    <name>storage.hostname</name>
+                                    <value>0.0.0.0</value>
+                                </property>
+                            </systemProperties>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <version>0.18.1</version>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <alias>scylladb</alias>
+                                    <name>scylladb/scylla:${scylladb.version}</name>
+                                    <run>
+                                        <!-- Limit to two CPUs -->
+                                        <cmd>--smp 2</cmd>
+                                        <!-- Expose Thrift and CQL ports -->
+                                        <ports>
+                                            <port>9160:9160</port>
+                                            <port>9042:9042</port>
+                                        </ports>
+                                        <wait>
+                                            <tcp>
+                                                <ports>
+                                                    <port>9160</port>
+                                                    <port>9042</port>
+                                                </ports>
+                                            </tcp>
+                                            <time>60000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>docker-start</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>docker-stop</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                    <goal>remove</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>
 

--- a/janusgraph-cassandra/src/test/java/org/janusgraph/CassandraStorageSetup.java
+++ b/janusgraph-cassandra/src/test/java/org/janusgraph/CassandraStorageSetup.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import org.janusgraph.diskstorage.cassandra.AbstractCassandraStoreManager;
 
 import org.janusgraph.diskstorage.cassandra.utils.CassandraDaemonWrapper;
+import org.janusgraph.diskstorage.configuration.ConfigElement;
 import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
 
@@ -38,6 +39,7 @@ public class CassandraStorageSetup {
 
     public static final String CONFDIR_SYSPROP = "test.cassandra.confdir";
     public static final String DATADIR_SYSPROP = "test.cassandra.datadir";
+    public static final String HOSTNAME = System.getProperty(ConfigElement.getPath(STORAGE_HOSTS));
 
     private static volatile Paths paths;
 
@@ -59,6 +61,7 @@ public class CassandraStorageSetup {
         config.set(PAGE_SIZE,500);
         config.set(CONNECTION_TIMEOUT, Duration.ofSeconds(60L));
         config.set(STORAGE_BACKEND, backend);
+        if (HOSTNAME != null) config.set(STORAGE_HOSTS, new String[]{HOSTNAME});
         return config;
     }
 
@@ -124,7 +127,9 @@ public class CassandraStorageSetup {
      * from logging statements.
      */
     public static void startCleanEmbedded() {
-        startCleanEmbedded(getPaths());
+        if (HOSTNAME == null) {
+            startCleanEmbedded(getPaths());
+        }
     }
 
     /*
@@ -144,7 +149,7 @@ public class CassandraStorageSetup {
 
     private static ModifiableConfiguration enableSSL(ModifiableConfiguration mc) {
         mc.set(AbstractCassandraStoreManager.SSL_ENABLED, true);
-        mc.set(STORAGE_HOSTS, new String[]{ "localhost" });
+        mc.set(STORAGE_HOSTS, new String[] {HOSTNAME != null ? HOSTNAME : "127.0.0.1"});
         mc.set(AbstractCassandraStoreManager.SSL_TRUSTSTORE_LOCATION,
                 Joiner.on(File.separator).join("target", "cassandra", "conf", "localhost-murmur-ssl", "test.truststore"));
         mc.set(AbstractCassandraStoreManager.SSL_TRUSTSTORE_PASSWORD, "cassandra");

--- a/janusgraph-cassandra/src/test/java/org/janusgraph/diskstorage/cassandra/thrift/ThriftDistributedStoreManagerTest.java
+++ b/janusgraph-cassandra/src/test/java/org/janusgraph/diskstorage/cassandra/thrift/ThriftDistributedStoreManagerTest.java
@@ -14,13 +14,18 @@
 
 package org.janusgraph.diskstorage.cassandra.thrift;
 
+import org.janusgraph.CassandraStorageSetup;
 import org.janusgraph.diskstorage.BackendException;
+import org.janusgraph.diskstorage.DistributedStoreManagerTest;
+import org.janusgraph.diskstorage.common.DistributedStoreManager.Deployment;
+import org.janusgraph.testcategory.OrderedKeyStoreTests;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
-import org.janusgraph.CassandraStorageSetup;
-import org.janusgraph.diskstorage.DistributedStoreManagerTest;
+import static org.junit.Assert.assertEquals;
 
 public class ThriftDistributedStoreManagerTest extends DistributedStoreManagerTest<CassandraThriftStoreManager> {
 
@@ -40,5 +45,13 @@ public class ThriftDistributedStoreManagerTest extends DistributedStoreManagerTe
     public void tearDown() throws BackendException {
         if (null != manager)
             manager.close();
+    }
+
+    @Override
+    @Test
+    @Category({ OrderedKeyStoreTests.class })
+    public void testGetDeployment() {
+        final Deployment deployment = CassandraStorageSetup.HOSTNAME == null ? Deployment.LOCAL : Deployment.REMOTE;
+        assertEquals(deployment, manager.getDeployment());
     }
 }

--- a/janusgraph-cql/pom.xml
+++ b/janusgraph-cql/pom.xml
@@ -311,4 +311,96 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <!-- Run Thrift tests with ScyllaDB (requires Docker) -->
+            <id>scylladb-test</id>
+            <properties>
+                <!-- Tests are run under failsafe so skip them under surefire -->
+                <test.skip.byteorderedpartitioner>true</test.skip.byteorderedpartitioner>
+                <test.skip.murmur>true</test.skip.murmur>
+                <test.skip.murmur-serial>true</test.skip.murmur-serial>
+                <test.skip.murmur-ssl>true</test.skip.murmur-ssl>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skipITs>false</skipITs>
+                            <includes>
+                                <include>**/org/janusgraph/diskstorage/cql/*.java</include>
+                                <include>**/org/janusgraph/graphdb/cql/*.java</include>
+                            </includes>
+                            <!-- Exclude default (performance/memory) tests. Also exclude SSL tests (fail under Scylla) -->
+                            <excludedGroups>${test.excluded.groups},org.janusgraph.testcategory.CassandraSSLTests</excludedGroups>
+                            <systemProperties>
+                                <!-- Run tests against the containerized Scylla test server -->
+                                <property>
+                                    <name>storage.hostname</name>
+                                    <value>0.0.0.0</value>
+                                </property>
+                            </systemProperties>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <version>0.18.1</version>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <alias>scylladb</alias>
+                                    <name>scylladb/scylla:${scylladb.version}</name>
+                                    <run>
+                                        <!-- Limit to two CPUs -->
+                                        <cmd>--smp 2</cmd>
+                                        <!-- Expose Thrift and CQL ports -->
+                                        <ports>
+                                            <port>9160:9160</port>
+                                            <port>9042:9042</port>
+                                        </ports>
+                                        <wait>
+                                            <tcp>
+                                                <ports>
+                                                    <port>9160</port>
+                                                    <port>9042</port>
+                                                </ports>
+                                            </tcp>
+                                            <time>60000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>docker-start</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>docker-stop</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                    <goal>remove</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLDistributedStoreManagerTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLDistributedStoreManagerTest.java
@@ -16,9 +16,15 @@ package org.janusgraph.diskstorage.cql;
 
 import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.DistributedStoreManagerTest;
+import org.janusgraph.diskstorage.common.DistributedStoreManager.Deployment;
+import org.janusgraph.testcategory.OrderedKeyStoreTests;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.assertEquals;
 
 public class CQLDistributedStoreManagerTest extends DistributedStoreManagerTest<CQLStoreManager> {
 
@@ -37,5 +43,13 @@ public class CQLDistributedStoreManagerTest extends DistributedStoreManagerTest<
     public void tearDown() throws BackendException {
         if (null != manager)
             manager.close();
+    }
+
+    @Override
+    @Test
+    @Category({ OrderedKeyStoreTests.class })
+    public void testGetDeployment() {
+        final Deployment deployment = CassandraStorageSetup.HOSTNAME == null ? Deployment.LOCAL : Deployment.REMOTE;
+        assertEquals(deployment, manager.getDeployment());
     }
 }

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLSSLStoreTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLSSLStoreTest.java
@@ -28,7 +28,7 @@ public class CQLSSLStoreTest extends CQLStoreTest {
 
     @BeforeClass
     public static void startCassandra() {
-        startCleanEmbedded(true);
+        startCleanEmbedded();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <hbase098.version>${hbase098.core.version}-hadoop2</hbase098.version>
         <hbase100.core.version>1.2.4</hbase100.core.version>
         <hbase100.version>${hbase100.core.version}</hbase100.version>
+        <scylladb.version>1.7.1</scylladb.version>
         <jackson1.version>1.9.2</jackson1.version>
         <jackson2.version>2.6.6</jackson2.version>
         <lucene-solr.version>6.6.0</lucene-solr.version>


### PR DESCRIPTION
Related issue is #53. A new Maven profile, disabled by default, allows running Thrift and CQL tests using the ScyllaDB storage backend. This PR just adds support for running the tests but does not resolve the associated test failures/errors (see #53 for more information).