### PR TITLE
Added a badge for Coverity Scan [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ can support thousands of concurrent users, complex traversals, and analytic grap
 [![Build Status][travis-shield]][travis-link]
 [![Maven][maven-shield]][maven-link]
 [![Javadoc][javadoc-shield]][javadoc-link]
+[![Coverity Scan][coverity-shield]][coverity-link]
 [![Gitter][gitter-shield]][gitter-link]
 [![Stack Overflow][stackoverflow-shield]][stackoverflow-link]
 
@@ -17,6 +18,8 @@ can support thousands of concurrent users, complex traversals, and analytic grap
 [maven-link]: https://search.maven.org/#search%7Cga%7C1%7Corg.janusgraph
 [javadoc-shield]: https://javadoc.io/badge/org.janusgraph/janusgraph-core.svg?color=blue
 [javadoc-link]: https://javadoc.io/doc/org.janusgraph/janusgraph-core
+[coverity-shield]: https://img.shields.io/coverity/scan/janusgraph-janusgraph.svg
+[coverity-link]: https://scan.coverity.com/projects/janusgraph-janusgraph
 [gitter-shield]: https://img.shields.io/gitter/room/janusgraph/janusgraph.svg
 [gitter-link]: https://gitter.im/janusgraph/janusgraph
 [stackoverflow-shield]: https://img.shields.io/badge/stackoverflow-janusgraph-blue.svg


### PR DESCRIPTION
The first build was submitted manually, because it does not (yet) work via
Travis CI; the scan results can be seen at
https://scan.coverity.com/projects/janusgraph-janusgraph

Making further progress on issue https://github.com/JanusGraph/janusgraph/issues/9; now we need to start addressing the issues Coverity found, perhaps in decreasing order of severity.

If you don't have access to the Coverity dashboard and would like it, please contact me or apply via Coverity dashboard (and let me know). You can login to Coverity with your GitHub account.