### PR TITLE
Restore coverity_scan metadata tags in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,8 @@ addons:
     # https://scan.coverity.com/travis_ci
     project:
       name: "JanusGraph/janusgraph"
+      version: "0.2.0-SNAPSHOT"
+      description: "Scalable, distributed graph database"
     notification_email: janusgraph-ci@googlegroups.com
     build_command_prepend:
       - if ! [ -v COVERITY_ONLY ]; then


### PR DESCRIPTION
This restores metadata tags removed in #300. These tags are needed in Coverity dashboard (see [this comment](https://github.com/JanusGraph/janusgraph/pull/300#discussion_r121276345)).