### PR TITLE
AttributeSerializer conflict on HashMap data type for migrated Titan Graph

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/serialize/StandardSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/serialize/StandardSerializer.java
@@ -138,6 +138,14 @@ public class StandardSerializer implements AttributeHandler, Serializer {
     public synchronized <V> void registerClass(int registrationNo, Class<V> datatype, AttributeSerializer<V> serializer) {
         Preconditions.checkArgument(registrationNo >= 0 && registrationNo < MAX_REGISTRATION_NO, "Registration number" +
                 " out of range [0,%s]: %s", MAX_REGISTRATION_NO, registrationNo);
+
+        if (datatype == HashMap.class)
+        {
+            Integer hashMapRegNo = registrations.inverse().get(normalizeDataType(HashMap.class));
+            registrations.remove(hashMapRegNo);
+            handlers.remove(datatype);
+        }
+
         registerClassInternal(CLASS_REGISTRATION_OFFSET + registrationNo, datatype, serializer);
     }
 

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/serializer/CustomHashMapSerializer.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/serializer/CustomHashMapSerializer.java
@@ -1,0 +1,82 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.serializer;
+
+import org.janusgraph.core.*;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.janusgraph.graphdb.database.StandardJanusGraph;
+import org.janusgraph.graphdb.serializer.attributes.*;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+
+/**
+ *  @author Scott McQuillan (scott.mcquillan@uk.ibm.com)
+ */
+public class CustomHashMapSerializer {
+
+	StandardJanusGraph graph;
+
+    @Before
+    public void initialize() {
+        ModifiableConfiguration config = GraphDatabaseConfiguration.buildGraphConfiguration();
+        config.set(GraphDatabaseConfiguration.STORAGE_BACKEND,"inmemory");
+        config.set(GraphDatabaseConfiguration.CUSTOM_ATTRIBUTE_CLASS, HashMap.class.getName(), "attribute1");
+        config.set(GraphDatabaseConfiguration.CUSTOM_SERIALIZER_CLASS, THashMapSerializer.class.getName(), "attribute1");
+        
+        graph = (StandardJanusGraph) JanusGraphFactory.open(config);
+    }
+
+    @After
+    public void shutdown() {
+        graph.close();
+    }
+
+    @Test
+    public void testCustomHashMapSerialization() {
+        JanusGraphManagement mgmt = graph.openManagement();
+        PropertyKey time = mgmt.makePropertyKey("time").dataType(Integer.class).make();
+        mgmt.makePropertyKey("hashMap").cardinality(Cardinality.SINGLE).dataType(HashMap.class).make();
+        mgmt.buildIndex("byTime",Vertex.class).addKey(time).buildCompositeIndex();
+        mgmt.makeVertexLabel("person").make();
+        mgmt.commit();
+
+        HashMap<String, Object> hashMapIn = new HashMap<String, Object>();
+        hashMapIn.put("property1", "value1");
+        
+        JanusGraphTransaction tx = graph.newTransaction();
+        JanusGraphVertex v = tx.addVertex("person");
+        v.property("time", 5);
+        v.property("hashMap", hashMapIn);
+        tx.commit();
+
+        tx = graph.newTransaction();
+        v = (JanusGraphVertex) tx.query().has("time",5).vertices().iterator().next();
+        assertEquals(5,(int)v.value("time"));
+        
+        HashMap<String, Object> hashMapOut = v.<HashMap<String, Object>>property("hashMap").orElse(null);
+        assertNotNull(hashMapOut);
+        assertEquals(2, hashMapOut.size());
+        assertEquals("value1", hashMapOut.get("property1"));
+        assertTrue(hashMapOut.containsKey(THashMapSerializer.class.getName())); // THashMapSerializer adds this
+
+        tx.rollback();
+    }
+}

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/serializer/attributes/THashMapSerializer.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/serializer/attributes/THashMapSerializer.java
@@ -1,0 +1,33 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.serializer.attributes;
+
+import java.util.HashMap;
+
+import org.janusgraph.diskstorage.ScanBuffer;
+import org.janusgraph.graphdb.database.serialize.attribute.SerializableSerializer;
+
+/**
+ * @author Scott McQuillan (scott.mcquillan@uk.ibm.com)
+ */
+public class THashMapSerializer extends SerializableSerializer<HashMap<String, ?>> {
+
+    @Override
+    public HashMap<String, ?> read(ScanBuffer buffer) {
+        HashMap<String, ?> hashMap = super.read(buffer);
+        hashMap.put(THashMapSerializer.class.getName(), null); // Unit test will check this got added
+        return hashMap;
+    }
+}


### PR DESCRIPTION
This it to fix Issue #306 which prevents the JanusGraph from starting from an existing TitanGraph if that graph had had a custom serializer registered. 

The custom serializers are added  `StandardSerializer.registerClass()`. At that point we’ll not have used the default HashMap serializer yet. So if we spot an attempt to add a custom one in this method then de-register the default one and then register the custom serializer as normal.

For the unit test I extended the SerializableSerializer class to add an extra property into the HashMap when its deserialized, then check for this property which would only be present if the custom serialiser had been used.