### PR TITLE
AttributeSerializer conflict on HashMap data type for migrated Titan

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/serialize/StandardSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/serialize/StandardSerializer.java
@@ -138,6 +138,16 @@ public class StandardSerializer implements AttributeHandler, Serializer {
     public synchronized <V> void registerClass(int registrationNo, Class<V> datatype, AttributeSerializer<V> serializer) {
         Preconditions.checkArgument(registrationNo >= 0 && registrationNo < MAX_REGISTRATION_NO, "Registration number" +
                 " out of range [0,%s]: %s", MAX_REGISTRATION_NO, registrationNo);
+
+        if (datatype == HashMap.class) {
+            final Integer hashMapRegNo = registrations.inverse().get(normalizeDataType(HashMap.class));
+            if (hashMapRegNo != null) {
+            	// Remove the default HashMap serializer so we can replace it with the custom one
+            	registrations.remove(hashMapRegNo);
+            	handlers.remove(datatype);
+            }
+        }
+
         registerClassInternal(CLASS_REGISTRATION_OFFSET + registrationNo, datatype, serializer);
     }
 

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/serializer/SerializerTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/serializer/SerializerTest.java
@@ -234,6 +234,27 @@ public class SerializerTest extends SerializerTestCommon {
         assertFalse(b.hasRemaining());
 
     }
+    
+    @Test
+    public void customHashMapSerializeTest() {
+        serialize.registerClass(1,HashMap.class, new THashMapSerializer());
+        DataOutput out = serialize.getDataOutput(128);
+
+        final String property1 = "property1";
+        final String value1 = "value1";
+        HashMap<String, Object> hashMapIn = new HashMap<String, Object>();
+        hashMapIn.put(property1, value1);
+        out.writeObjectNotNull(hashMapIn);
+
+        ReadBuffer b = out.getStaticBuffer().asReadBuffer();
+        if (printStats) log.debug(bufferStats(b));
+        
+        HashMap<String, Object> hashMapOut = serialize.readObjectNotNull(b, HashMap.class);
+        assertNotNull(hashMapOut);
+        assertEquals(2, hashMapOut.size());
+        assertEquals(value1, hashMapOut.get(property1));
+        assertTrue(hashMapOut.containsKey(THashMapSerializer.class.getName())); // THashMapSerializer adds this
+    }
 
     private StaticBuffer getStringBuffer(String value) {
         DataOutput o = serialize.getDataOutput(value.length()+10);

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/serializer/attributes/THashMapSerializer.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/serializer/attributes/THashMapSerializer.java
@@ -1,0 +1,33 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.serializer.attributes;
+
+import java.util.HashMap;
+
+import org.janusgraph.diskstorage.ScanBuffer;
+import org.janusgraph.graphdb.database.serialize.attribute.SerializableSerializer;
+
+/**
+ * @author Scott McQuillan (scott.mcquillan@uk.ibm.com)
+ */
+public class THashMapSerializer extends SerializableSerializer<HashMap> {
+
+    @Override
+    public HashMap read(ScanBuffer buffer) {
+        HashMap hashMap = super.read(buffer);
+        hashMap.put(THashMapSerializer.class.getName(), null); // Unit test will check this got added
+        return hashMap;
+    }
+}


### PR DESCRIPTION
This it to fix Issue #306 which prevents the JanusGraph from starting from an existing TitanGraph if that graph had had a custom serializer registered.

The custom serializers are added `StandardSerializer.registerClass()`. At that point we’ll not have used the default HashMap serializer yet. So if we spot an attempt to add a custom one in this method then de-register the default one and then register the custom serializer as normal.

For the unit test I extended the SerializableSerializer class to add an extra property into the HashMap when its deserialized, then check for this property which would only be present if the custom serialiser had been used.