### PR TITLE
Support disabling QUORUM calls for system queries

### DIFF
--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
@@ -59,6 +59,12 @@ public interface CQLConfigOptions {
             ConfigOption.Type.MASKABLE,
             CQLStoreManager.CONSISTENCY_QUORUM);
 
+    public static final ConfigOption<Boolean> ONLY_USE_LOCAL_CONSISTENCY_FOR_SYSTEM_OPERATIONS =
+        new ConfigOption<Boolean>(CQL_NS, "only-use-local-consistency-for-system-operations",
+            "True to prevent any system queries from using QUORUM consistency " +
+                "and always use LOCAL_QUORUM instead",
+            ConfigOption.Type.MASKABLE, false);
+
     // The number of statements in a batch
     public static final ConfigOption<Integer> BATCH_STATEMENT_SIZE = new ConfigOption<>(
             CQL_NS,

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
@@ -22,6 +22,7 @@ import static io.vavr.API.Match;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.ATOMIC_BATCH_MUTATE;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.BATCH_STATEMENT_SIZE;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CLUSTER_NAME;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.ONLY_USE_LOCAL_CONSISTENCY_FOR_SYSTEM_OPERATIONS;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.KEYSPACE;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.LOCAL_DATACENTER;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.PROTOCOL_VERSION;
@@ -154,11 +155,13 @@ public class CQLStoreManager extends DistributedStoreManager implements KeyColum
                 .set(WRITE_CONSISTENCY, CONSISTENCY_LOCAL_QUORUM)
                 .set(METRICS_PREFIX, METRICS_SYSTEM_PREFIX_DEFAULT);
 
+        final Boolean onlyUseLocalConsistency = configuration.get(ONLY_USE_LOCAL_CONSISTENCY_FOR_SYSTEM_OPERATIONS);
+
         final StandardStoreFeatures.Builder fb = new StandardStoreFeatures.Builder();
 
         fb.batchMutation(true).distributed(true);
         fb.timestamps(true).cellTTL(true);
-        fb.keyConsistent(global, local);
+        fb.keyConsistent((onlyUseLocalConsistency ? local : global), local);
         fb.optimisticLocking(true);
         fb.multiQuery(false);
 


### PR DESCRIPTION
Add a configuration flag to the Cassandra CQL backend to disable system operations from issuing global queries. If set, this flag will result in all system queries using the local consistency, LOCAL_QUORUM.

Addresses issue: https://github.com/JanusGraph/janusgraph/issues/347

Reviewers: dbolcion, vigneshg, suganyar

Reviewed By: vigneshg

Subscribers: dbolcion, jenkins

Differential Revision: https://code.uberinternal.com/D948839

Signed-off-by: Alain Rodriguez <alain@uber.com>