### PR TITLE
Add Uber as a production JanusGraph user [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,4 @@ The following users have deployed JanusGraph in production.
 * [CELUM](https://www.celum.com/) - [use case and system architecture](https://www.celum.com/en/graph-driven-and-reactive-architecture)
 * [FiNC](https://finc.com)
 * [Seeq](https://seeq.com)
+* [Uber](https://uber.com)


### PR DESCRIPTION
Courtesy to use the company name courtesy of @tunaygur.

Also, note that we don't yet have permission to feature Uber's logo on http://janusgraph.org so there's no corresponding PR on that repo to add it.