### PR TITLE
Support deserializing points stored in legacy graphs

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/io/graphson/JanusGraphSONModule.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/io/graphson/JanusGraphSONModule.java
@@ -50,10 +50,10 @@ public class JanusGraphSONModule extends TinkerPopJacksonModule {
     private JanusGraphSONModule() {
         super("janusgraph");
         addSerializer(RelationIdentifier.class, new RelationIdentifierSerializer());
-        addSerializer(Geoshape.class, new Geoshape.GeoshapeGsonSerializer());
+        addSerializer(Geoshape.class, new Geoshape.GeoshapeGsonSerializerV1d0());
 
         addDeserializer(RelationIdentifier.class, new RelationIdentifierDeserializer());
-        addDeserializer(Geoshape.class, new Geoshape.GeoshapeGsonDeserializer());
+        addDeserializer(Geoshape.class, new Geoshape.GeoshapeGsonDeserializerV1d0());
     }
 
     private static final JanusGraphSONModule INSTANCE = new JanusGraphSONModule();

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestElasticSearchClient.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestElasticSearchClient.java
@@ -54,7 +54,7 @@ public class RestElasticSearchClient implements ElasticSearchClient {
     private static final ObjectWriter mapWriter;
     static {
         final SimpleModule module = new SimpleModule();
-        module.addSerializer(new Geoshape.GeoshapeGsonSerializer());
+        module.addSerializer(new Geoshape.GeoshapeGsonSerializerV1d0());
         mapper = new ObjectMapper();
         mapper.registerModule(module);
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/attribute/GeoshapeTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/attribute/GeoshapeTest.java
@@ -334,7 +334,7 @@ public class GeoshapeTest {
     @Test
     public void testGeoJsonSerialization() throws IOException {
         SimpleModule module = new SimpleModule();
-        module.addSerializer(new Geoshape.GeoshapeGsonSerializer());
+        module.addSerializer(new Geoshape.GeoshapeGsonSerializerV1d0());
         final ObjectMapper om = new ObjectMapper();
         om.registerModule(module);
         JtsSpatialContext context = (JtsSpatialContext) Geoshape.getSpatialContext();

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/serializer/SerializerTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/serializer/SerializerTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import org.janusgraph.core.attribute.*;
 import org.janusgraph.diskstorage.ReadBuffer;
 import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.graphdb.database.idhandling.VariableLong;
 import org.janusgraph.graphdb.database.serialize.DataOutput;
 import org.janusgraph.graphdb.database.serialize.attribute.*;
 import org.janusgraph.graphdb.serializer.attributes.*;
@@ -373,6 +374,24 @@ public class SerializerTest extends SerializerTestCommon {
         }
 
 
+    }
+
+    @Test
+    public void testLegacyPointSerialization() {
+        Geoshape geo = Geoshape.point(0.5, 2.5);
+        DataOutput out = serialize.getDataOutput(128);
+
+        int length = geo.size();
+        VariableLong.writePositive(out,length);
+        for (int i = 0; i < 2; i++) {
+            for (int j = 0; j < length; j++) {
+                Geoshape.Point point = geo.getPoint(j);
+                out.putFloat((float) (i==0 ? geo.getPoint(j).getLatitude() : geo.getPoint(j).getLongitude()));
+            }
+        }
+
+        ReadBuffer b = out.getStaticBuffer().asReadBuffer();
+        assertEquals(geo, serialize.readObjectNotNull(b, Geoshape.class));
     }
 
     private static class SerialEntry {


### PR DESCRIPTION
These updates allow Geoshape points stored in legacy (pre-0.2) graphs and Kryo files to be deserialized. Also adds support for Geoshape serialization using GraphSON 2.0.

Fixes #374