### PR TITLE
Replace deprecated useMapperFromGraph in docs with ... [skip ci]

### DIFF
--- a/docs/basics.txt
+++ b/docs/basics.txt
@@ -669,7 +669,7 @@ scriptEngines: {
   gremlin-groovy: {
     scripts: [scripts/janusgraph.groovy]}}
 serializers:
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { useMapperFromGraph: graph }}
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}
 metrics: {
   slf4jReporter: {enabled: true, interval: 180000}}


### PR DESCRIPTION
`useMapperFromGraph` is deprecated and replaced by `ioRegistries`.  It isn't used in any other configuration file so let's update the docs to reflect that.