### PR TITLE
Static cluster/session management in CQL backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,10 @@ env:
     - MODULE='hbase-parent/janusgraph-hbase-10' ARGS='-Dtest=**/graphdb/hbase/*'
     - MODULE='hbase-parent/janusgraph-hbase-098' ARGS='-Dtest=**/diskstorage/hbase/*'
     - MODULE='hbase-parent/janusgraph-hbase-098' ARGS='-Dtest=**/graphdb/hbase/*'
-    - MODULE='cql'
+    - MODULE='cql' ARGS='-Dtest=**/diskstorage/cql/* -Dtest.skip.murmur=true'
+    - MODULE='cql' ARGS='-Dtest=**/diskstorage/cql/* -Dtest.skip.byteorderedpartitioner=true -Dtest.skip.murmur-serial=true -Dtest.skip.murmur-ssl=true'
+    - MODULE='cql' ARGS='-Dtest=**/graphdb/cql/* -Dtest.skip.murmur=true'
+    - MODULE='cql' ARGS='-Dtest=**/graphdb/cql/* -Dtest.skip.byteorderedpartitioner=true -Dtest.skip.murmur-serial=true -Dtest.skip.murmur-ssl=true'
     - COVERITY_ONLY=true
 
 matrix:
@@ -56,7 +59,10 @@ matrix:
     - env: MODULE='cassandra' ARGS='-Dtest=**/graphdb/thrift/* -Dtest.skip.unordered=true -Dtest.skip.ssl=true -Dtest.skip.serial=true'
     - env: MODULE='cassandra' ARGS='-Dtest=**/graphdb/thrift/* -Dtest.skip.ordered=true -Dtest.skip.ssl=true -Dtest.skip.serial=true'
     - env: MODULE='cassandra' ARGS='-Dtest=**/graphdb/thrift/* -Dtest.skip.unordered=true -Dtest.skip.ordered=true'
-    - env: MODULE='cql'
+    - env: MODULE='cql' ARGS='-Dtest=**/diskstorage/cql/* -Dtest.skip.murmur=true'
+    - env: MODULE='cql' ARGS='-Dtest=**/diskstorage/cql/* -Dtest.skip.byteorderedpartitioner=true -Dtest.skip.murmur-serial=true -Dtest.skip.murmur-ssl=true'
+    - env: MODULE='cql' ARGS='-Dtest=**/graphdb/cql/* -Dtest.skip.murmur=true'
+    - env: MODULE='cql' ARGS='-Dtest=**/graphdb/cql/* -Dtest.skip.byteorderedpartitioner=true -Dtest.skip.murmur-serial=true -Dtest.skip.murmur-ssl=true'
 
 addons:
   coverity_scan:

--- a/janusgraph-cql/pom.xml
+++ b/janusgraph-cql/pom.xml
@@ -191,10 +191,9 @@
                     <argLine>${test.jvm.opts}</argLine>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
-                    <parallel>classes</parallel>
-                    <perCoreThreadCount>true</perCoreThreadCount>
-                    <threadCount>2</threadCount>
-                    <runOrder>random</runOrder>
+                    <parallel>none</parallel>
+                    <perCoreThreadCount>false</perCoreThreadCount>
+                    <threadCount>1</threadCount>
                     <systemPropertyVariables>
                         <log4j.configuration>file:${project.build.testOutputDirectory}/log4j.properties</log4j.configuration>
                     </systemPropertyVariables>

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLDistributedStoreManagerTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLDistributedStoreManagerTest.java
@@ -35,7 +35,7 @@ public class CQLDistributedStoreManagerTest extends DistributedStoreManagerTest<
 
     @Before
     public void setUp() throws BackendException {
-        manager = new CQLStoreManager(CassandraStorageSetup.getCQLConfiguration(this.getClass().getSimpleName()));
+        manager = new CachingCQLStoreManager(CassandraStorageSetup.getCQLConfiguration(this.getClass().getSimpleName()));
         store = manager.openDatabase("distributedcf");
     }
 

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLIDAuthorityTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLIDAuthorityTest.java
@@ -39,7 +39,7 @@ public class CQLIDAuthorityTest extends IDAuthorityTest {
     }
 
     private CQLStoreManager openStorageManager(final Configuration c) throws BackendException {
-        return new CQLStoreManager(c);
+        return new CachingCQLStoreManager(c);
     }
 
     @Override

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLLockStoreTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLLockStoreTest.java
@@ -34,7 +34,7 @@ public class CQLLockStoreTest extends LockKeyColumnValueStoreTest {
     }
 
     private CQLStoreManager openStorageManager(final Configuration c) throws BackendException {
-        return new CQLStoreManager(c);
+        return new CachingCQLStoreManager(c);
     }
 
     @Override

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLLogTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLLogTest.java
@@ -37,7 +37,7 @@ public class CQLLogTest extends KCVSLogTest {
     }
 
     private CQLStoreManager openStorageManager(final Configuration c) throws BackendException {
-        return new CQLStoreManager(c);
+        return new CachingCQLStoreManager(c);
     }
 
     @Override

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLMultiWriteStoreTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLMultiWriteStoreTest.java
@@ -34,7 +34,7 @@ public class CQLMultiWriteStoreTest extends MultiWriteKeyColumnValueStoreTest {
     }
 
     private CQLStoreManager openStorageManager(final Configuration c) throws BackendException {
-        return new CQLStoreManager(c);
+        return new CachingCQLStoreManager(c);
     }
 
     @Override

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLSSLStoreTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLSSLStoreTest.java
@@ -37,7 +37,7 @@ public class CQLSSLStoreTest extends CQLStoreTest {
     }
 
     private CQLStoreManager openStorageManager(final Configuration c) throws BackendException {
-        return new CQLStoreManager(c);
+        return new CachingCQLStoreManager(c);
     }
 
     @Override

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLStoreTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLStoreTest.java
@@ -53,7 +53,7 @@ public class CQLStoreTest extends KeyColumnValueStoreTest {
     }
 
     private CQLStoreManager openStorageManager(final Configuration c) throws BackendException {
-        return new CQLStoreManager(c);
+        return new CachingCQLStoreManager(c);
     }
 
     @Override

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CachingCQLStoreManager.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CachingCQLStoreManager.java
@@ -1,0 +1,42 @@
+package org.janusgraph.diskstorage.cql;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import org.janusgraph.diskstorage.BackendException;
+import org.janusgraph.diskstorage.PermanentBackendException;
+import org.janusgraph.diskstorage.configuration.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CachingCQLStoreManager extends CQLStoreManager {
+
+    private static Cluster cluster;
+    private static Map<String,Session> sessions = new HashMap<>();
+
+    public CachingCQLStoreManager(final Configuration configuration) throws BackendException {
+        super(configuration);
+    }
+
+    @Override
+    Cluster initializeCluster() throws PermanentBackendException {
+        if (cluster == null || cluster.isClosed()) {
+            cluster = super.initializeCluster();
+        }
+        return cluster;
+    }
+
+    @Override
+    Session initializeSession(final String keyspaceName) {
+        if (!sessions.containsKey(keyspaceName)) {
+            sessions.put(keyspaceName, super.initializeSession(keyspaceName));
+        }
+        return sessions.get(keyspaceName);
+    }
+
+    @Override
+    public void close() {
+        this.executorService.shutdownNow();
+    }
+
+}

--- a/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLGraphIterativeTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLGraphIterativeTest.java
@@ -17,7 +17,7 @@ package org.janusgraph.graphdb.cql;
 import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.configuration.BasicConfiguration;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
-import org.janusgraph.diskstorage.cql.CQLStoreManager;
+import org.janusgraph.diskstorage.cql.CachingCQLStoreManager;
 import org.janusgraph.diskstorage.cql.CassandraStorageSetup;
 import org.janusgraph.diskstorage.keycolumnvalue.KeyColumnValueStoreManager;
 import org.janusgraph.graphdb.JanusGraphIterativeBenchmark;
@@ -33,7 +33,7 @@ public class CQLGraphIterativeTest extends JanusGraphIterativeBenchmark {
 
     @Override
     public KeyColumnValueStoreManager openStorageManager() throws BackendException {
-        return new CQLStoreManager(new BasicConfiguration(GraphDatabaseConfiguration.ROOT_NS,getConfiguration(), BasicConfiguration.Restriction.NONE));
+        return new CachingCQLStoreManager(new BasicConfiguration(GraphDatabaseConfiguration.ROOT_NS,getConfiguration(), BasicConfiguration.Restriction.NONE));
     }
 
 

--- a/janusgraph-cql/src/test/resources/log4j.properties
+++ b/janusgraph-cql/src/test/resources/log4j.properties
@@ -1,15 +1,16 @@
-log4j.appender.FILE=org.apache.log4j.FileAppender
-log4j.appender.FILE.File=${project.build.directory}/test.log
-log4j.appender.FILE.Threshold=TRACE
-log4j.appender.FILE.layout=org.apache.log4j.PatternLayout
-log4j.appender.FILE.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%20.20t] %-5p %30.30c: %m%n
+log4j.appender.A1=org.apache.log4j.FileAppender
+log4j.appender.A1.File=${project.build.directory}/test.log
+log4j.appender.A1.Threshold=ALL
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%20.20t] %-5p %30.30c: %m%n
 
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.Threshold=INFO
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%20.20t] %-5p %30.30c: %m%n
+log4j.appender.A2=org.apache.log4j.ConsoleAppender
+log4j.appender.A2.Threshold=ALL
+log4j.appender.A2.layout=org.apache.log4j.PatternLayout
+log4j.appender.A2.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%20.20t] %-5p %30.30c: %m%n
 
-log4j.rootLogger=INFO,FILE,CONSOLE
+#log4j.rootLogger=INFO, A1, A2
+log4j.rootLogger=ERROR, A1
 
 log4j.logger.org.apache.cassandra=WARN
 log4j.logger.com.datastax.driver=WARN


### PR DESCRIPTION
Makes the following updates to fix #383. With these updates the full (default+TinkerPop) test suite runtime for the CQL module is decreased from 15.1 hours to 3.3 hours.

* A single static cluster instance and a single static session per keyspace managed in CQLStoreManager.
* Truncate tables instead of drop keyspace in CQLStoreManager.clearStorage(). There was an issue with test failures when switching to truncation that was resolved by deleting the commitlog directory prior to starting embedded test instance in CassandraStorageSetup.
* Test parallelism was removed to resolve test failures associated with the above updates and for consistency with test executions in other modules.
* Minor updates to split Travis build matrix for CQL tests and reduce logging (also renamed logging appender names for consistency with other modules).