### PR TITLE
Fix IllegalAccessError for Iterators.emptyIterator() when using Guava >= 20.0

### DIFF
--- a/janusgraph-cassandra/src/main/java/org/janusgraph/diskstorage/cassandra/thrift/CassandraThriftKeyColumnValueStore.java
+++ b/janusgraph-cassandra/src/main/java/org/janusgraph/diskstorage/cassandra/thrift/CassandraThriftKeyColumnValueStore.java
@@ -406,7 +406,7 @@ public class CassandraThriftKeyColumnValueStore implements KeyColumnValueStore {
 
             this.seenEnd = false;
             this.isClosed = false;
-            this.ksIter = Iterators.emptyIterator();
+            this.ksIter = Collections.emptyIterator();
             this.mostRecentRow = null;
             this.omitEndToken = omitEndToken;
         }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/QueryProcessor.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/QueryProcessor.java
@@ -63,7 +63,7 @@ public class QueryProcessor<Q extends ElementQuery<R, B>, R extends JanusGraphEl
     @Override
     public Iterator<R> iterator() {
         if (query.isEmpty())
-            return Iterators.emptyIterator();
+            return Collections.emptyIterator();
 
         return new ResultSetIterator(getUnfoldedIterator(),(query.hasLimit()) ? query.getLimit() : Query.NO_LIMIT);
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/EmptyVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/EmptyVertex.java
@@ -27,6 +27,7 @@ import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.janusgraph.util.datastructures.Retriever;
 import org.apache.tinkerpop.gremlin.structure.*;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -112,12 +113,12 @@ public class EmptyVertex implements InternalVertex {
 
     @Override
     public Iterator<Edge> edges(Direction direction, String... edgeLabels) {
-        return Iterators.emptyIterator();
+        return Collections.emptyIterator();
     }
 
     @Override
     public Iterator<Vertex> vertices(Direction direction, String... edgeLabels) {
-        return Iterators.emptyIterator();
+        return Collections.emptyIterator();
     }
 
     @Override
@@ -162,7 +163,7 @@ public class EmptyVertex implements InternalVertex {
 
     @Override
     public <V> Iterator<VertexProperty<V>> properties(String... propertyKeys) {
-        return Iterators.emptyIterator();
+        return Collections.emptyIterator();
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/AllEdgesIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/AllEdgesIterator.java
@@ -20,6 +20,7 @@ import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -37,7 +38,7 @@ public class AllEdgesIterator implements Iterator<Edge> {
     private final Set<? extends Vertex> vertices;
     private final Iterator<? extends Vertex> vertexIter;
 
-    private Iterator<Edge> currentEdges = Iterators.emptyIterator();
+    private Iterator<Edge> currentEdges = Collections.emptyIterator();
 
     private Edge next;
 

--- a/janusgraph-core/src/main/java/org/janusgraph/util/datastructures/IterablesUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/util/datastructures/IterablesUtil.java
@@ -34,7 +34,7 @@ public class IterablesUtil {
 
             @Override
             public Iterator<O> iterator() {
-                return Iterators.emptyIterator();
+                return Collections.emptyIterator();
             }
 
         };


### PR DESCRIPTION
Since Guava 20.0, Iterators.emptyIterator() is no longer public, resulting in an IllegalAccessError when trying to use various traversal iteration steps which call it.  Per the deprecation notice in the documentation for Guava 19.0 (https://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Iterators.html#emptyIterator()), this commit replaces all occurrences of Iterators.emptyIterator() with Collections.emptyIterator().

Signed-off-by: Mike Sager <mike@mikesager.name>