### PR TITLE
Issue 398 - CQL storage adapter doesn't work with default configs and bundled Cassandra

### DIFF
--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
@@ -207,11 +207,10 @@ public class CQLStoreManager extends DistributedStoreManager implements KeyColum
                 .addContactPointsWithPorts(contactPoints)
                 .withClusterName(configuration.get(CLUSTER_NAME));
 
-        if (configuration.get(PROTOCOL_VERSION) == 0) {
-            builder.withProtocolVersion(ProtocolVersion.NEWEST_SUPPORTED);
-        } else {
+        if (configuration.get(PROTOCOL_VERSION) != 0) {
             builder.withProtocolVersion(ProtocolVersion.fromInt(configuration.get(PROTOCOL_VERSION)));
         }
+
         if (configuration.has(AUTH_USERNAME) && configuration.has(AUTH_PASSWORD)) {
             builder.withCredentials(configuration.get(AUTH_USERNAME), configuration.get(AUTH_PASSWORD));
         }

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CassandraStorageSetup.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CassandraStorageSetup.java
@@ -105,8 +105,6 @@ public class CassandraStorageSetup {
         config.set(PAGE_SIZE, 500);
         config.set(CONNECTION_TIMEOUT, Duration.ofSeconds(60L));
         config.set(STORAGE_BACKEND, "cql");
-        // Set to 3 because we have a 2.1.9 database that only supports version 3, if we let it negotiate then there are spurious errors.
-        config.set(PROTOCOL_VERSION, 3);
         if (HOSTNAME != null) config.set(STORAGE_HOSTS, new String[]{HOSTNAME});
         return config;
     }


### PR DESCRIPTION
If no protocol is specified, the CQL driver no longer defaults to the highest driver
protocol version. Instead, the driver will negotiate with Cassandra and select the
highest mutually supported protocol version.