### PR TITLE
Paginate column access in AstyanaxStore

### DIFF
--- a/janusgraph-cassandra/src/main/java/org/janusgraph/diskstorage/cassandra/astyanax/AstyanaxStoreManager.java
+++ b/janusgraph-cassandra/src/main/java/org/janusgraph/diskstorage/cassandra/astyanax/AstyanaxStoreManager.java
@@ -126,6 +126,15 @@ public class AstyanaxStoreManager extends AbstractCassandraStoreManager {
             ConfigOption.Type.MASKABLE, 3);
 
     /**
+     * The page size for Cassandra read operations.
+     * <p/>
+     */
+    public static final ConfigOption<Integer> READ_PAGE_SIZE =
+            new ConfigOption<Integer>(ASTYANAX_NS, "read-page-size",
+            "The page size for Cassandra read operations",
+            ConfigOption.Type.MASKABLE, Integer.class, 4096);
+
+    /**
      * How Astyanax discovers Cassandra cluster nodes. This must be one of the
      * values of the Astyanax NodeDiscoveryType enum.
      * <p/>
@@ -270,6 +279,7 @@ public class AstyanaxStoreManager extends AbstractCassandraStoreManager {
 
     private final RetryPolicy retryPolicy;
 
+    final int readPageSize;
     private final int retryDelaySlice;
     private final int retryMaxDelaySlice;
     private final int retrySuspendWindow;
@@ -284,6 +294,7 @@ public class AstyanaxStoreManager extends AbstractCassandraStoreManager {
 
         this.clusterName = config.get(CLUSTER_NAME);
 
+        readPageSize = config.get(READ_PAGE_SIZE);
         retryDelaySlice = config.get(RETRY_DELAY_SLICE);
         retryMaxDelaySlice = config.get(RETRY_MAX_DELAY_SLICE);
         retrySuspendWindow = config.get(RETRY_SUSPEND_WINDOW);

--- a/janusgraph-cassandra/src/test/java/org/janusgraph/diskstorage/cassandra/astyanax/AstyanaxColumnPaginationTest.java
+++ b/janusgraph-cassandra/src/test/java/org/janusgraph/diskstorage/cassandra/astyanax/AstyanaxColumnPaginationTest.java
@@ -1,0 +1,155 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.cassandra.astyanax;
+
+import org.janusgraph.diskstorage.BackendException;
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
+import org.junit.BeforeClass;
+
+import org.janusgraph.CassandraStorageSetup;
+import org.janusgraph.diskstorage.cassandra.AbstractCassandraStoreTest;
+import org.janusgraph.diskstorage.cassandra.AbstractCassandraStoreManager;
+import org.janusgraph.core.JanusGraphFactory;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class AstyanaxColumnPaginationTest extends AbstractCassandraStoreTest {
+
+    private static final int DEFAULT_READ_PAGE_SIZE = 4096;
+
+    @BeforeClass
+    public static void startCassandra() {
+        CassandraStorageSetup.startCleanEmbedded();
+    }
+
+    @Override
+    public ModifiableConfiguration getBaseStorageConfiguration() {
+        return CassandraStorageSetup.getAstyanaxConfiguration(getClass().getSimpleName());
+    }
+
+    @Override
+    public AbstractCassandraStoreManager openStorageManager(Configuration c) throws BackendException {
+        return new AstyanaxStoreManager(c);
+    }
+
+    @Test
+    public void ensureReadPageSizePropertySetCorrectly() {
+        assertEquals(((AstyanaxStoreManager) manager).readPageSize, DEFAULT_READ_PAGE_SIZE);
+    }
+
+    @Test
+    public void retrieveLessThanBoundaryColumnPaginationProperties() {
+        final Graph graph = JanusGraphFactory.open(getBaseStorageConfiguration());
+        final Vertex v = graph.addVertex();
+        for(int i = 0; i < DEFAULT_READ_PAGE_SIZE - 1; i++) {
+            v.property(String.valueOf(i), i);
+        }
+        graph.tx().commit();
+
+        assertEquals(DEFAULT_READ_PAGE_SIZE - 1, graph.traversal().V(v).valueMap().next().keySet().size());
+    }
+
+    @Test
+    public void retrieveBoundaryColumnPaginationProperties() {
+        final Graph graph = JanusGraphFactory.open(getBaseStorageConfiguration());
+        final Vertex v = graph.addVertex();
+        for(int i = 0; i < DEFAULT_READ_PAGE_SIZE; i++) {
+            v.property(String.valueOf(i), i);
+        }
+        graph.tx().commit();
+
+        assertEquals(DEFAULT_READ_PAGE_SIZE, graph.traversal().V(v).valueMap().next().keySet().size());
+    }
+
+    @Test
+    public void retrieveBeyondBoundaryColumnPaginationProperties() {
+        final Graph graph = JanusGraphFactory.open(getBaseStorageConfiguration());
+        final Vertex v = graph.addVertex();
+        for(int i = 0; i < DEFAULT_READ_PAGE_SIZE + 1; i++) {
+            v.property(String.valueOf(i), i);
+        }
+        graph.tx().commit();
+
+        assertEquals(DEFAULT_READ_PAGE_SIZE + 1, graph.traversal().V(v).valueMap().next().keySet().size());
+    }
+
+    @Test
+    public void retrieveWayBeyondBoundaryColumnPaginationProperties() {
+        final Graph graph = JanusGraphFactory.open(getBaseStorageConfiguration());
+        final Vertex v = graph.addVertex();
+        for (int i = 0; i < DEFAULT_READ_PAGE_SIZE * 5; i++) {
+            v.property(String.valueOf(i), i);
+        }
+        graph.tx().commit();
+
+        assertEquals(DEFAULT_READ_PAGE_SIZE * 5, graph.traversal().V(v).valueMap().next().keySet().size());
+    }
+
+    @Test
+    public void retrieveLessThanBoundaryColumnPaginationEdges() {
+        final Graph graph = JanusGraphFactory.open(getBaseStorageConfiguration());
+        final Vertex v = graph.addVertex();
+        final Vertex v2 = graph.addVertex();
+        for(int i = 0; i < DEFAULT_READ_PAGE_SIZE - 1; i++) {
+            v.addEdge("edgeLabel", v2);
+        }
+        graph.tx().commit();
+
+        assertEquals(DEFAULT_READ_PAGE_SIZE - 1, graph.traversal().V(v).outE().toList().size());
+    }
+
+    @Test
+    public void retrieveBoundaryColumnPaginationEdges() {
+        final Graph graph = JanusGraphFactory.open(getBaseStorageConfiguration());
+        final Vertex v = graph.addVertex();
+        final Vertex v2 = graph.addVertex();
+        for(int i = 0; i < DEFAULT_READ_PAGE_SIZE; i++) {
+            v.addEdge("edgeLabel", v2);
+        }
+        graph.tx().commit();
+
+        assertEquals(DEFAULT_READ_PAGE_SIZE, graph.traversal().V(v).outE().toList().size());
+    }
+
+    @Test
+    public void retrieveBeyondBoundaryColumnPaginationEdges() {
+        final Graph graph = JanusGraphFactory.open(getBaseStorageConfiguration());
+        final Vertex v = graph.addVertex();
+        final Vertex v2 = graph.addVertex();
+        for(int i = 0; i < DEFAULT_READ_PAGE_SIZE + 1; i++) {
+            v.addEdge("edgeLabel", v2);
+        }
+        graph.tx().commit();
+
+        assertEquals(DEFAULT_READ_PAGE_SIZE + 1, graph.traversal().V(v).outE().toList().size());
+    }
+
+    @Test
+    public void retrieveWayBeyondBoundaryColumnPaginationEdges() {
+        final Graph graph = JanusGraphFactory.open(getBaseStorageConfiguration());
+        final Vertex v = graph.addVertex();
+        final Vertex v2 = graph.addVertex();
+        for (int i = 0; i < DEFAULT_READ_PAGE_SIZE * 5; i++) {
+            v.addEdge("edgeLabel", v2);
+        }
+        graph.tx().commit();
+
+        assertEquals(DEFAULT_READ_PAGE_SIZE * 5, graph.traversal().V(v).outE().toList().size());
+    }
+}


### PR DESCRIPTION
#411 

JanusGraph has a tendency to make queries to Cassandra with _very_ large
limits. For example, any query without a `.limit()` clause will fetch
all matching columns from a given row. These requests are usually
range-bound (e.g., only requesting columns that are edges, based on the
serialization logic) but are not limited.

Fetching millions of columns in a single request is not very friendly to
Cassandra; in production we've observed memory allocation spikes in
excess of 10GB in a 30s period. On my local machine, calling

graph.traversal().V(id).outE().count()

prior to this commit will cause my Cassandra instance to OOM in
approximately 10 seconds.

This patch places a hard cap on the number of columns returned (per row)
via a single request to Cassandra. If, for a given request, a row has
more columns available in the requested range than the cap, the system
makes additional requests for that row until the requested number of
columns is returned or no more columns are available.

This code is somewhat more subtle that may be expected due to Titan's
use of the Astyanax API - it's not uncommon for Titan to make a request
for multiple keys concurrently, in which case the `limit` parameter
applies to each key - not the request as a whole. This has two
implications:

1.  We need to use a different API (getRow, rather than getKeySlice) to
fetch columns for rows that met the limit on the initial query, since
the starting column must be manipulated on a per-row basis

2. The page size needs to be relatively conservative, in case a single
request is made for hundreds of keys at once. This is relatively
unlikely, especially given the natural infrequency of supernodes,
but it's something that we must be aware of.

Signed-off-by: David Pitera <dpitera@us.ibm.com>