### PR TITLE
Remove duplicate dependency

### DIFF
--- a/janusgraph-codepipelines-ci/pom.xml
+++ b/janusgraph-codepipelines-ci/pom.xml
@@ -78,11 +78,6 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>2.6.6</version>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.6.6</version>
-        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
Resolves this warning when building...
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar -> duplicate declaration of version 2.6.6 @ org.janusgraph:janusgraph-codepipelines-ci:[unknown-version], /tmp/janusgraph/janusgraph-codepipelines-ci/pom.xml, line 81, column 21