### PR TITLE
Resolve read-only transaction errors in TinkerPop GraphComputer tests

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/core/ReadOnlyTransactionException.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/ReadOnlyTransactionException.java
@@ -1,0 +1,27 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core;
+
+public class ReadOnlyTransactionException extends UnsupportedOperationException {
+
+    public ReadOnlyTransactionException(String msg) {
+        super(msg);
+    }
+
+    public ReadOnlyTransactionException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/VertexProgramScanJob.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/VertexProgramScanJob.java
@@ -16,6 +16,7 @@ package org.janusgraph.graphdb.olap.computer;
 
 import org.janusgraph.core.JanusGraph;
 import org.janusgraph.core.JanusGraphVertex;
+import org.janusgraph.core.ReadOnlyTransactionException;
 import org.janusgraph.diskstorage.EntryList;
 import org.janusgraph.diskstorage.configuration.Configuration;
 import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
@@ -103,7 +104,12 @@ public class VertexProgramScanJob<M> implements VertexScanJob {
             }
         } else {
             v.setPropertyMixing(vh);
-            vertexProgram.execute(v, vh, memory);
+            try {
+                vertexProgram.execute(v, vh, memory);
+            } catch (ReadOnlyTransactionException e) {
+                // Ignore read-only transaction errors in FulgoraGraphComputer. In testing these errors are associated
+                // with cleanup of TraversalVertexProgram.HALTED_TRAVERSALS properties which can safely remain in graph.
+            }
         }
         vh.setInExecute(false);
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/CacheVertexProperty.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/CacheVertexProperty.java
@@ -133,7 +133,7 @@ public class CacheVertexProperty extends AbstractVertexProperty {
 
     @Override
     public void remove() {
-        if (!tx().isRemovedRelation(super.longId()) && !tx().getConfiguration().isReadOnly()) {
+        if (!tx().isRemovedRelation(super.longId())) {
             tx().removeRelation(this);
         }// else throw InvalidElementException.removedException(this);
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -275,7 +275,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
 
     private void verifyWriteAccess(JanusGraphVertex... vertices) {
         if (config.isReadOnly())
-            throw new UnsupportedOperationException("Cannot create new entities in read-only transaction");
+            throw new ReadOnlyTransactionException("Cannot create new entities in read-only transaction");
         for (JanusGraphVertex v : vertices) {
             if (v.hasId() && idInspector.isUnmodifiableVertex(v.longId()) && !v.isNew())
                 throw new SchemaViolationException("Cannot modify unmodifiable vertex: "+v);


### PR DESCRIPTION
The original (pre-TinkerPop-3.2.4) implementation didn't check whether transaction was read-only and (as expected) threw UnsupportedOperationExceptions when calling CacheVertexProperty.remove() during OLAP traversals. This behavior causes numerous TinkerPop test failures starting in v3.2.4,  where TraversalVertexProgram.HALTED_TRAVERSALS are cleaned up in [TraversalVertexProgram](https://github.com/apache/tinkerpop/blob/3.2.4/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java#L294-L296). Interestingly the logic is in 3.2.3 as well so I'm not sure why tests only started failing on this in 3.2.4.

Initial updates to always silently ignore the read-only transaction errors resulted in issues as identified in #427. The update here fixes #427 by limiting updates to ignore read-only transaction errors to just FulgoraGraphComputer, which itself is used/supported only for testing. All default/TinkerPop tests are passing (no additional test opt-outs were required).