### PR TITLE
Failure to correctly set ids.store-name=titan_ids can corrupt a Titan Cassandra Issue #418

### DIFF
--- a/docs/advanced.txt
+++ b/docs/advanced.txt
@@ -20,3 +20,5 @@ include::serializer.txt[]
 include::hadoop.txt[]
 
 include::monitoring.txt[]
+
+include::migrating.txt[]

--- a/docs/migrating.txt
+++ b/docs/migrating.txt
@@ -1,0 +1,31 @@
+[[migrating-titan]]
+== Migrating from Titan
+
+This page describes some of the Configuration options that JanusGraph provides to allow migration of data from a data store which had previously been created by Titan.
+
+=== Configuration
+
+When connecting to an existing Titan data store the `graph.titan-version` property should be set to the Titan version used to create that store.
+
+[source, properties]
+----
+graph.titan-version=1.0.0
+----
+
+The ID store name in JanusGraph is configurable via the `ids.store-name` property whereas in Titan it was a constant. If the `graph.titan-version` has been set, as in the example above, then you do **not** need to explicitly set this value as it will default to `titan_ids`.
+
+=== Cassandra
+
+The default keyspace used by Titan was `titan` and in order to reuse that existing keyspace the `storage.cassandra.keyspace` property needs to be set accordingly.
+
+[source, properties]
+----
+graph.titan-version=1.0.0
+storage.cassandra.keyspace=titan
+----
+
+These configuration options allow JanusGraph to read data from a Cassandra database which had previously been created by Titan.  However, once JanusGraph writes back to that database it will register additional serializers which mean that it will no longer be compatible with Titan. Users are therefore encouraged to backup the data in Casssandra before attempting to use it with the JanusGraph release. 
+
+=== BerkeleyDB
+
+The BerkeleyDB version has been updated, and it contains changes to the file format stored on disk. This file format change is forward compatible with previous versions of BerkeleyDB, so existing graph data stored with Titan can be read in. However, once the data has been read in with the newer version of BerkeleyDB, those files can no longer be read by the older version. Users are encouraged to backup the BerkeleyDB storage directory before attempting to use it with the JanusGraph release.

--- a/docs/migrating.txt
+++ b/docs/migrating.txt
@@ -24,7 +24,19 @@ graph.titan-version=1.0.0
 storage.cassandra.keyspace=titan
 ----
 
-These configuration options allow JanusGraph to read data from a Cassandra database which had previously been created by Titan.  However, once JanusGraph writes back to that database it will register additional serializers which mean that it will no longer be compatible with Titan. Users are therefore encouraged to backup the data in Casssandra before attempting to use it with the JanusGraph release. 
+These configuration options allow JanusGraph to read data from a Cassandra database which had previously been created by Titan. However, once JanusGraph writes back to that database it will register additional serializers which mean that it will no longer be compatible with Titan. Users are therefore encouraged to backup the data in Casssandra before attempting to use it with the JanusGraph release. 
+
+=== HBase
+
+The name of the table used by Titan was `titan` and in order to reuse that existing table the `storage.hbase.table` property needs to be set accordingly.
+
+[source, properties]
+----
+graph.titan-version=1.0.0
+storage.hbase.table=titan
+----
+
+These configuration options allow JanusGraph to read data from an HBase database which had previously been created by Titan. However, once JanusGraph writes back to that database it will register additional serializers which mean that it will no longer be compatible with Titan. Users are therefore encouraged to backup the data in HBase before attempting to use it with the JanusGraph release. 
 
 === BerkeleyDB
 

--- a/docs/upgrade.txt
+++ b/docs/upgrade.txt
@@ -19,15 +19,7 @@ your code and configuration accordingly:
   duplicate a word, e.g., `TitanGraph` is simply `JanusGraph` rather than
   `JanusGraphGraph`
 
-*IMPORTANT* If you are pointing JanusGraph at an existing Titan database you will need to
-set the `ids.store-name` property to `titan_ids` in your JanusGraph properties file.
-Failure to do this could result in id allocation issues.
-See https://github.com/JanusGraph/janusgraph/issues/228[228] for more details.
-
-The BerkeleyDB version has been updated, and it contains changes to the file
-format stored on disk. This file format change is forward compatible with
-previous versions of BerkeleyDB, so existing graph data stored with Titan
-can be read in. However, once the data has been read in with the newer version
-of BerkeleyDB, those files can no longer be read by the older version. Users
-are encouraged to backup the BerkeleyDB storage directory before attempting to
-use it with the JanusGraph release.
+*IMPORTANT* If you are pointing JanusGraph at an existing Titan database you will
+need to set the `graph.titan-version` property. For more information on how to
+configure JanusGraph to read data which had previously been written by Titan
+refer to <<migrating-titan>>.

--- a/janusgraph-cassandra/src/test/java/org/janusgraph/graphdb/CassandraGraphTest.java
+++ b/janusgraph-cassandra/src/test/java/org/janusgraph/graphdb/CassandraGraphTest.java
@@ -128,7 +128,12 @@ public abstract class CassandraGraphTest extends JanusGraphTest {
                             wc.get(ConfigElement.getPath(GraphDatabaseConfiguration.TITAN_COMPATIBLE_VERSIONS), 
                                         GraphDatabaseConfiguration.TITAN_COMPATIBLE_VERSIONS.getDatatype())
                 ));
-
+        
+        wc.set(ConfigElement.getPath(GraphDatabaseConfiguration.IDS_STORE_NAME), JanusGraphConstants.TITAN_ID_STORE_NAME);
+        assertTrue(JanusGraphConstants.TITAN_ID_STORE_NAME.equals(
+                            wc.get(ConfigElement.getPath(GraphDatabaseConfiguration.IDS_STORE_NAME), 
+                                        GraphDatabaseConfiguration.IDS_STORE_NAME.getDatatype())
+                ));
         graph = (StandardJanusGraph) JanusGraphFactory.open(wc);
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -724,7 +724,7 @@ public class GraphDatabaseConfiguration {
     public static final ConfigOption<String> IDS_STORE_NAME = new ConfigOption<>(IDS_NS, "store-name",
         "The name of the ID KCVStore. IDS_STORE_NAME is meant to be used only for backward compatibility with Titan, " +
             "and should not be used explicitly in normal operations or in new graphs.",
-        ConfigOption.Type.GLOBAL_OFFLINE, "janusgraph_ids");
+        ConfigOption.Type.GLOBAL_OFFLINE, JanusGraphConstants.JANUSGRAPH_ID_STORE_NAME);
 
 
     /**
@@ -1506,12 +1506,13 @@ public class GraphDatabaseConfiguration {
             throw new JanusGraphException(String.format(INCOMPATIBLE_VERSION_EXCEPTION, version, JanusGraphConstants.VERSION));
         }
 
-        // When connection to a store created by Titan the ID store name will not be in the
+        // When connecting to a store created by Titan the ID store name will not be in the
         // global configuration. To ensure compatibility override the default to titan_ids.
         boolean localTitanConfigured = localbc.get(TITAN_COMPATIBLE_VERSIONS) != null;
+        boolean localIdStoreIsDefault = JanusGraphConstants.JANUSGRAPH_ID_STORE_NAME.equals(localbc.get(IDS_STORE_NAME));
 
         if (localTitanConfigured == true) {
-            boolean usingTitanIdStore = JanusGraphConstants.TITAN_ID_STORE_NAME.equals(localbc.get(IDS_STORE_NAME));
+            boolean usingTitanIdStore = localIdStoreIsDefault == true || JanusGraphConstants.TITAN_ID_STORE_NAME.equals(localbc.get(IDS_STORE_NAME));
             boolean existingKeyStore = kcvsConfig.get(IDS_STORE_NAME.getName(), IDS_STORE_NAME.getDatatype()) != null;
 
         	Preconditions.checkArgument(usingTitanIdStore,"ID store for Titan compatibility has not been initialized to: " + JanusGraphConstants.TITAN_ID_STORE_NAME);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/JanusGraphConstants.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/JanusGraphConstants.java
@@ -51,6 +51,11 @@ public class JanusGraphConstants {
     public static final List<String> TITAN_COMPATIBLE_VERSIONS;
 
     /**
+     * Name of the ids.store-name used by JanusGraph which is configurable
+     */
+    public static final String JANUSGRAPH_ID_STORE_NAME = "janusgraph_ids";
+
+    /**
      * Past name of the ids.store-name used by Titan Graph but which was not configurable
      */
     public static final String TITAN_ID_STORE_NAME = "titan_ids";

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/JanusGraphConstants.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/JanusGraphConstants.java
@@ -50,6 +50,11 @@ public class JanusGraphConstants {
      */
     public static final List<String> TITAN_COMPATIBLE_VERSIONS;
 
+    /**
+     * Past name of the ids.store-name used by Titan Graph but which was not configurable
+     */
+    public static final String TITAN_ID_STORE_NAME = "titan_ids";
+
     static {
 
         /*


### PR DESCRIPTION
To fix Issue #418 added a check for the following:

1. `graph.titan-version` is set and is '1.0.0'
2. `ids.store-name` is set in LOCAL and equal to 'titan_ids'
3. `ids.store-name` is not set in GLOBAL ( as read from KCVSConfiguration )

If all the above are true then set `ids.store-name` in the overwrite modifiable configuration to be `titan_ids`. This then prevents the global configuration inheriting the default value of janusgraph_ids but only in the case where ids.store-name had not already been set.

It will now throw an exception and abort if `graph.titan-version` has been set and `ids.store-name` was not also set to the value `titan_ids` which should help preserve data integrity.

Signed-off-by: Scott McQuillan <scott.mcquillan@uk.ibm.com>