### PR TITLE
Remove VertexCentricQueryBuilder orderBy cardinality check

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BaseVertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BaseVertexCentricQueryBuilder.java
@@ -205,7 +205,6 @@ public abstract class BaseVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q>
         Preconditions.checkArgument(key != null && order != null, "Need to specify and key and an order");
         Preconditions.checkArgument(Comparable.class.isAssignableFrom(key.dataType()),
                 "Can only order on keys with comparable data type. [%s] has datatype [%s]", key.name(), key.dataType());
-        Preconditions.checkArgument(key.cardinality() == Cardinality.SINGLE, "Ordering is undefined on multi-valued key [%s]", key.name());
         Preconditions.checkArgument(!(key instanceof SystemRelationType), "Cannot use system types in ordering: %s", key);
         Preconditions.checkArgument(!orders.containsKey(key));
         Preconditions.checkArgument(orders.isEmpty(), "Only a single sort order is supported on vertex queries");


### PR DESCRIPTION
While it is true that JanusGraph's VertexCentricQuery does not know how
to orderBy multplicity > SINGLE, this check is actually acting a red
herring.

VertexCentricIndexes are meant to either return a list of
vertexProperties or edges-- where we order and sort these returns by
either a vertex property's properties (metaproperties) or vertex's
adjacent edge's properties.

Metaproperties and edge properties are-- by construction-- inherently
single valued, i.e. we cannot store multiple values on a singular edge
property or metaproperty key.

However, you can create metaproperties and edge properties adhering to a
given JanusGraph propertyKey whose cardinality > SINGLE, i.e. equal to
LIST or SET. The current cardinality check is disallowing users to use
vertex centric indexes on these existing edges and metaproperties
without changing their schemae, which is an ~impossible effort on a large
graph.

Therefore, the check here-- to ensure that the VertexCentricQuery
sorts by a propertyKey with a cardinality equivalent to SINGLE is
superfluous and arguably incorrect; by design, these queries sort
metaproperties and edge properties, which cannot store multiple values
for a given key.

Furthermore, any VertexCentricQuery constructed from a TinkerPop gremlin
traversal will never add the orderBy step to a vertexProperty (the only
type of property that can actually store multiple values):
https://github.com/JanusGraph/janusgraph/blob/master/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/HasStepFolder.java#L181

This just leaves us in a situation where you may argue that a user
previously using the queryBuilder API directly to try to orderBy vertexProperties with
cardinality > SINGLE will no longer receive an error. However, the
alternative was _not_ true: a user trying to orderBy
vertexProperties with cardinality == SINGLE did not receive an error,
even though such a request on an ordering makes no sense. Similarly,
ordering by a single propertyKey stored with multiple values makes
no sense, as we are only actually returning a singular propertyKey.

In this scenario now, instead of getting an error, we will receive
results with an undefined ordering, which actually matches the behavior
as the behavior currently exists:

gremlin> def v = graph.addVertex(); for (int i = 0; i < 3; i++) {
v.property("sensor", i, "time", i); }; graph.tx().commit();
==>null
gremlin> graph.vertices()
==>v[4184]
gremlin> graph.traversal().V(4184).properties() // we have 1 property with LIST value on our vertex
==>vp[sensor->0.0]
==>vp[sensor->1.0]
==>vp[sensor->2.0]
gremlin> graph.traversal().V(4184).properties().next().properties() // each value in list has a metaproperty of time equivalent to its own value
==>p[time->0]
gremlin> graph.traversal().V(4184).next().query().orderBy("time",
decr).properties()
==>vp[sensor->2.0]
==>vp[sensor->1.0]
==>vp[sensor->0.0]
gremlin> graph.traversal().V(4184).next().query().orderBy("sensor",
decr).properties() // we can sort vertexProperties by their metaProperties
==>vp[sensor->0.0]
==>vp[sensor->1.0]
==>vp[sensor->2.0]
gremlin> graph.traversal().V(4184).next().query().orderBy("time", decr).properties() // Notice, there is no defined ordering for properties without metapropertie
==>vp[sensor->10.0]
==>vp[sensor->2.0]
==>vp[sensor->1.0]
==>vp[sensor->0.0]
gremlin> graph.traversal().V(4184).next().query().orderBy("sensor", decr).properties() // Similarly there is no defined ordering if we sort by vertex properties themselves
==>vp[sensor->0.0]
==>vp[sensor->1.0]
==>vp[sensor->2.0]
gremlin> graph.traversal().V(4184).next().property("sensor", 10);
==>vp[sensor->10.0]
gremlin> graph.traversal().V(4184).next().property("sensor", -10, "time", -10);
==>vp[sensor->-10.0]
gremlin> graph.traversal().V(4184).next().query().orderBy("time", decr).properties() // however ordering definitely works when applicable, i.e. a vertex property has metaproperties in question
==>vp[sensor->10.0]
==>vp[sensor->2.0]
==>vp[sensor->1.0]
==>vp[sensor->0.0]
==>vp[sensor->-10.0]

Therefore, this undefined ordering is what we expect in this scenario
where we use the API incorrectly, i.e. trying to orderBy a
vertexProperty when the query is meant to orderBy a metaproperty or edge
property, which is guaranteed to only store a singular value and
therefore the check is not necessary.

Issues: #456

Signed-off-by: David Pitera <dpitera@us.ibm.com>