### PR TITLE
Errors deserialising Geoshape objects created by Titan

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/core/attribute/Geoshape.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/attribute/Geoshape.java
@@ -554,14 +554,14 @@ public class Geoshape {
             long l = VariableLong.readPositive(buffer);
             assert l>0 && l<Integer.MAX_VALUE;
             int length = (int)l;
+            int position = ((ReadArrayBuffer) buffer).getPosition();
             InputStream inputStream = new ByteArrayInputStream(buffer.getBytes(length));
             try {
                 return GeoshapeBinarySerializer.read(inputStream);
             } catch (IOException e) {
                 // retry using legacy point deserialization
                 try {
-                    ((ReadArrayBuffer) buffer).movePositionTo(0);
-                    VariableLong.readPositive(buffer);
+                    ((ReadArrayBuffer) buffer).movePositionTo(position);
                     final float lat = buffer.getFloat();
                     final float lon = buffer.getFloat();
                     return point(lat, lon);

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/serializer/SerializerTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/serializer/SerializerTest.java
@@ -379,6 +379,7 @@ public class SerializerTest extends SerializerTestCommon {
     @Test
     public void testLegacyPointSerialization() {
         Geoshape geo = Geoshape.point(0.5, 2.5);
+        Geoshape geo2 = Geoshape.point(1.5, 3.5);
         DataOutput out = serialize.getDataOutput(128);
 
         int length = geo.size();
@@ -389,9 +390,22 @@ public class SerializerTest extends SerializerTestCommon {
                 out.putFloat((float) (i==0 ? geo.getPoint(j).getLatitude() : geo.getPoint(j).getLongitude()));
             }
         }
+        
+        // Add a second point to the same buffer
+        
+        length = geo2.size();
+        VariableLong.writePositive(out,length);
+        for (int i = 0; i < 2; i++) {
+            for (int j = 0; j < length; j++) {
+                Geoshape.Point point = geo2.getPoint(j);
+                out.putFloat((float) (i==0 ? geo2.getPoint(j).getLatitude() : geo2.getPoint(j).getLongitude()));
+            }
+        }
 
         ReadBuffer b = out.getStaticBuffer().asReadBuffer();
+        
         assertEquals(geo, serialize.readObjectNotNull(b, Geoshape.class));
+        assertEquals(geo2, serialize.readObjectNotNull(b, Geoshape.class));
     }
 
     private static class SerialEntry {


### PR DESCRIPTION
This pull request is a continuation of a discussion @sjudeng from issue #420.

While testing I noticed that the latitude and longitude values being deserialised by JanusGraph didn't match those originally written by Titan. The problem looks like there's a bug in changes made in #376 when the repositioning of the buffer. The problem appears to be in the assumption that the buffer position always starts at zero. Adding a second geo point to the buffer used in the unit test [SerializerTest#testLegacyPointSerialization](https://github.com/JanusGraph/janusgraph/blob/78bbe5aa65dc2f31e13a004fa21a213de2741cc4/janusgraph-test/src/test/java/org/janusgraph/graphdb/serializer/SerializerTest.java#L380) will cause the original implementation to fail when attempting to deserialise the second geo point.

Fortunately there's a getPosition() method which can be used to store the position and changing the code to use this instead of rewinding back to zero resolves the issue.