### PR TITLE
Update janusgraph compatible versions to include 0.1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <tag>HEAD</tag>
     </scm>
     <properties>
-        <janusgraph.compatible.versions />
+        <janusgraph.compatible.versions>0.1.0,0.1.1</janusgraph.compatible.versions>
         <titan.compatible-versions>1.0.0,1.1.0-SNAPSHOT</titan.compatible-versions>
         <tinkerpop.version>3.2.5</tinkerpop.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
Fixes #275 and, in my testing, allows the use of the latest JanusGraph with databases from previous versions.