### PR TITLE
Update to TinkerPop 3.2.6

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/VertexState.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/VertexState.java
@@ -93,7 +93,7 @@ public class VertexState<M> {
 
     public M getMessage(MessageScope scope, Map<MessageScope,Integer> scopeMap) {
         assert scope!=null && isValidIdMap(scopeMap) && scopeMap.containsKey(scope);
-        if (scopeMap.size()==1) return (M)previousMessages;
+        if (scopeMap.size()==1 || previousMessages == null) return (M)previousMessages;
         else return (M)((Object[])previousMessages)[scopeMap.get(scope)];
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <properties>
         <janusgraph.compatible.versions />
         <titan.compatible-versions>1.0.0,1.1.0-SNAPSHOT</titan.compatible-versions>
-        <tinkerpop.version>3.2.5</tinkerpop.version>
+        <tinkerpop.version>3.2.6</tinkerpop.version>
         <junit.version>4.12</junit.version>
         <mrunit.version>1.1.0</mrunit.version>
         <cassandra.version>2.1.18</cassandra.version>


### PR DESCRIPTION
Fixes #475. All default and TinkerPop tests are passing.