### PR TITLE
Add Sift Security as a production user [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The following users have deployed JanusGraph in production.
 * [FiNC](https://finc.com)
 * [G DATA](https://gdatasoftware.com)
 * [Seeq](https://seeq.com)
+* [Sift Security](https://siftsecurity.com)
 * [Uber](https://uber.com)
 
 The following companies offer JanusGraph hosted as-a-service:


### PR DESCRIPTION
This use case was described recently by Ray Canzanese at a meetup in NYC:
https://twitter.com/JanusGraph/status/900459659513008128

@rcanzanese, please approve this PR to confirm that Sift Security is OK with being featured in this list. Thanks for your presentation!