### PR TITLE
Use coverity-scan script in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 dist: trusty
 language: java
-sudo: false
-
+sudo: true
+services:
+  - docker
 jdk:
   - openjdk8
 
@@ -14,6 +15,8 @@ env:
     # This is the encrypted COVERITY_SCAN_TOKEN, created via the
     # `travis encrypt` command using the project repo's public key.
     - secure: "v5ixqTeb74y0vRuPcDbe3C28GDDYvqyEXA2dt+9UVU6GG7WpnmpkBf05gI1dIhp51lBhwx9WSlFBtzho+KdCBmNY/CzBRhVHe/lCQYK9Hb6uGPvuwBvC0WjJgJXsVrLFjppeRhcf+OAweVQ3uw2RPMDRvKIVMUcO1BTFjjJl6REJXNUdzGS57MtH2mmRyOEz250EwgqUELZvcOytG7fNrjMJKVK2nSsoxi0BqZIpItTWPWWeQ1wi1FplJ18A2qtD+MPfAGNSB+/a+r0Av+VCT2eGl06ZyZAzP3q/vG5IYjQ3AJsSPqcZUt4ms+2us1+kwuzXIILjzZmcfImu29+y/thndU5E5b2v+nZ4H69CUCc5OmKW2RwozLNmBIUhO0n+35va/J7FiPIqm3pwxCz5vWA3YTHDADxnIYe7+9uY/+dOK/AvP5fyu7u07vuF3liKNBdrX7ylP3kYc7FXGmYl8wCZv31iy1yTtndQ9qKef7bo8lM9Cdh39KyowrygH+Um7pr9gqf2S9jn99nQ3bib32fBWgBkLpJRwhZYHPUupZjZfgu/9woby0DuriuHZKMqZd7QUawYz6wXGlhzu78x5Tohlj1pGBwHYdcJ/Tm3PiEpyH4aYQLffkjGHJAcCW5tO8QbB0qrLYWC8xVMWuFz1TpSBRXOqVYdBfIa2UZDtOU="
+    - COVERITY_BRANCH_NAME="coverity_scan"
+    - COVERITY_EMAIL="sjudeng@gmail.com"
     # Default Elasticsearch heap size can be too large for Travis
     - ES_JAVA_OPTS="-Xms256m -Xmx512m"
 
@@ -66,38 +69,35 @@ matrix:
     - env: MODULE='cql' ARGS='-Dtest=**/graphdb/cql/* -Dtest.skip.murmur=true'
     - env: MODULE='cql' ARGS='-Dtest=**/graphdb/cql/* -Dtest.skip.byteorderedpartitioner=true -Dtest.skip.murmur-serial=true -Dtest.skip.murmur-ssl=true'
 
-addons:
-  coverity_scan:
-    # Coverity config parameters described in detail:
-    # https://scan.coverity.com/travis_ci
-    project:
-      name: "JanusGraph/janusgraph"
-      version: "0.2.0-SNAPSHOT"
-      description: "Scalable, distributed graph database"
-    notification_email: janusgraph-ci@googlegroups.com
-    build_command_prepend:
-      - if ! [ -v COVERITY_ONLY ]; then
-          echo "Skipping Coverity for non-Coverity job";
-          exit 0;
-        fi
-    build_command: mvn clean package -DskipTests=true --batch-mode
-    branch_pattern: coverity_scan
-
 install:
-  # Build and install current module and dependencies. Handle output timeouts and retry on error.
-  - if [ "${COVERITY_SCAN_BRANCH}" == 1 ] || [ -v COVERITY_ONLY ]; then
-      echo "Skipping install build step in Coverity branch/job";
+  - if [ "${TRAVIS_BRANCH}" == "${COVERITY_BRANCH_NAME}" ] && ! [ -z "${COVERITY_ONLY:-}" ]; then
+      echo "Building all modules for Coverity analysis";
+      travis_retry travis_wait \
+          mvn install -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode --show-version;
+    elif [ "${TRAVIS_BRANCH}" == "${COVERITY_BRANCH_NAME}" ] || ! [ -z "${COVERITY_ONLY:-}" ]; then
+      echo "Skipping module build on Coverity branch/job";
     else
+      echo "Building janusgraph-${MODULE} and dependencies";
       travis_retry travis_wait \
           mvn install --projects janusgraph-${MODULE} --also-make \
           -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode --show-version;
     fi
 
 script:
-  # Build and test module. Handle output timeouts and retry with a clean build on error.
-  - if [ "${COVERITY_SCAN_BRANCH}" == 1 ] || [ -v COVERITY_ONLY ]; then
-      echo "Skipping script build step in Coverity branch/job";
+  - if [ "${TRAVIS_BRANCH}" == "${COVERITY_BRANCH_NAME}" ] && ! [ -z "${COVERITY_ONLY:-}" ]; then
+      echo "Building Docker image for Coverity analysis";
+      docker build -t janusgraph/analysis analysis;
+      echo "Running Coverity scan";
+      travis_wait 50 \
+        docker run --rm \
+            -v ${HOME}/.m2:/root/.m2 -v ${PWD}:/opt/janusgraph \
+            -e COVERITY_SCAN_TOKEN="${COVERITY_SCAN_TOKEN}" \
+            -e COVERITY_EMAIL="${COVERITY_EMAIL}" \
+            -i janusgraph/analysis;
+    elif [ "${TRAVIS_BRANCH}" == "${COVERITY_BRANCH_NAME}" ] || ! [ -z "${COVERITY_ONLY:-}" ]; then
+      echo "Skipping module tests on Coverity branch/job";
     else
+      echo "Testing janusgraph-${MODULE}";
       travis_retry travis_wait 50 \
           mvn clean verify --projects janusgraph-${MODULE} ${ARGS};
     fi

--- a/analysis/Dockerfile
+++ b/analysis/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2017 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM centos:7
+
+RUN yum -y update && \
+    yum install -y java-1.8.0-openjdk-devel maven git && \
+    yum clean all
+
+WORKDIR /opt/janusgraph
+CMD ["analysis/coverity-scan.sh"]


### PR DESCRIPTION
Fixes #466 using the the script added by @mbrukman in #467 instead of the plugin to run Coverity scans in Travis. Successfully tested by updating `COVERITY_BRANCH_NAME` in .travis.yml to point to a test branch and then pushing to same (see [build #805](https://travis-ci.org/JanusGraph/janusgraph/builds/268934336)). Travis jobs for all individual modules were skipped and the `COVERITY_ONLY` job ran the scan and uploaded results to Coverity (see [job #805.16](https://travis-ci.org/JanusGraph/janusgraph/jobs/268934352)). Some notes are below.

* As noted in #467, Coverity scan performance appears to be significantly better (e.g. 95% versus 68%) when run under Docker (specifically `centos:7`). As a result these updates include enabling Docker (`sudo: true`, `servies: docker`) and running the coverity-scan script within a Docker container.
* Coverity requires an email to download scan tool and upload results. @mbrukman can you add janusgraph-ci@googlegroups.com as a Coverity user or do you have other ideas how to handle this?