### PR TITLE
Stream the result from Search Backend instead of use List.

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphIndexQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphIndexQuery.java
@@ -15,6 +15,7 @@
 package org.janusgraph.core;
 
 import org.janusgraph.core.schema.Parameter;
+import java.util.stream.Stream;
 import org.apache.tinkerpop.gremlin.structure.Element;
 
 /**
@@ -82,23 +83,53 @@ public interface JanusGraphIndexQuery {
     /**
      * Returns all vertices that match the query in the indexing backend.
      *
+     * @deprecated use {@link #vertexStream()} instead.
+     *
      * @return
      */
+    @Deprecated
     public Iterable<Result<JanusGraphVertex>> vertices();
+
+    /**
+     * Returns all vertices that match the query in the indexing backend.
+     *
+     * @return
+     */
+    public Stream<Result<JanusGraphVertex>> vertexStream();
+
+    /**
+     * Returns all edges that match the query in the indexing backend.
+     *
+     * @deprecated use {@link #edgeStream()} instead.
+     *
+     * @return
+     */
+    @Deprecated
+    public Iterable<Result<JanusGraphEdge>> edges();
 
     /**
      * Returns all edges that match the query in the indexing backend.
      *
      * @return
      */
-    public Iterable<Result<JanusGraphEdge>> edges();
+    public Stream<Result<JanusGraphEdge>> edgeStream();
 
     /**
      * Returns all properties that match the query in the indexing backend.
      *
+     * @deprecated use {@link #propertyStream()} instead.
+     *
      * @return
      */
+    @Deprecated
     public Iterable<Result<JanusGraphVertexProperty>> properties();
+
+	/**
+     * Returns all properties that match the query in the indexing backend.
+     *
+     * @return
+     */
+    public Stream<Result<JanusGraphVertexProperty>> propertyStream();
 
     /**
      * Returns total vertices that match the query in the indexing backend ignoring limit and offset.

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/BackendTransaction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/BackendTransaction.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import org.janusgraph.diskstorage.keycolumnvalue.cache.KCVSCache;
 import org.janusgraph.diskstorage.log.kcvs.ExternalCachePersistor;
@@ -408,12 +409,12 @@ public class BackendTransaction implements LoggableTransaction {
     }
 
 
-    public List<String> indexQuery(final String index, final IndexQuery query) {
+    public Stream<String> indexQuery(final String index, final IndexQuery query) {
         final IndexTransaction indexTx = getIndexTransaction(index);
-        return executeRead(new Callable<List<String>>() {
+        return executeRead(new Callable<Stream<String>>() {
             @Override
-            public List<String> call() throws Exception {
-                return indexTx.query(query);
+            public Stream<String> call() throws Exception {
+                return indexTx.queryStream(query);
             }
 
             @Override
@@ -423,12 +424,12 @@ public class BackendTransaction implements LoggableTransaction {
         });
     }
 
-    public Iterable<RawQuery.Result<String>> rawQuery(final String index, final RawQuery query) {
+    public Stream<RawQuery.Result<String>> rawQuery(final String index, final RawQuery query) {
         final IndexTransaction indexTx = getIndexTransaction(index);
-        return executeRead(new Callable<Iterable<RawQuery.Result<String>>>() {
+        return executeRead(new Callable<Stream<RawQuery.Result<String>>>() {
             @Override
-            public Iterable<RawQuery.Result<String>> call() throws Exception {
-                return indexTx.query(query);
+            public Stream<RawQuery.Result<String>> call() throws Exception {
+                return indexTx.queryStream(query);
             }
 
             @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexProvider.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexProvider.java
@@ -21,6 +21,7 @@ import org.janusgraph.diskstorage.BaseTransactionConfigurable;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * External index for querying.
@@ -83,7 +84,7 @@ public interface IndexProvider extends IndexInformation {
      * @throws org.janusgraph.diskstorage.BackendException
      * @see IndexQuery
      */
-    public List<String> query(IndexQuery query, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException;
+    public Stream<String> query(IndexQuery query, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException;
 
 
     /**
@@ -96,7 +97,7 @@ public interface IndexProvider extends IndexInformation {
      * @throws org.janusgraph.diskstorage.BackendException
      * @see RawQuery
      */
-    public Iterable<RawQuery.Result<String>> query(RawQuery query, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException;
+    public Stream<RawQuery.Result<String>> query(RawQuery query, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException;
 
     /**
      * Executes the given raw query against the index and returns the total hits. e.g. limit=0
@@ -110,7 +111,6 @@ public interface IndexProvider extends IndexInformation {
      */
     public Long totals(RawQuery query, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException;
 
-    
     /**
      * Returns a transaction handle for a new index transaction.
      *

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexTransaction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexTransaction.java
@@ -20,12 +20,15 @@ import org.janusgraph.diskstorage.*;
 import org.janusgraph.diskstorage.util.BackendOperation;
 import org.janusgraph.graphdb.database.idhandling.VariableLong;
 import org.janusgraph.graphdb.database.serialize.DataOutput;
+import org.janusgraph.graphdb.util.StreamIterable;
 
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Wraps the transaction handle of an index and buffers all mutations against an index for efficiency.
@@ -98,11 +101,27 @@ public class IndexTransaction implements BaseTransaction, LoggableTransaction {
         index.register(store,key,information,indexTx);
     }
 
+    /**
+     * @deprecated use {@link #queryStream(IndexQuery query)} instead.
+     */
+    @Deprecated
     public List<String> query(IndexQuery query) throws BackendException {
+        return queryStream(query).collect(Collectors.toList());
+    }
+
+    public Stream<String> queryStream(IndexQuery query) throws BackendException {
         return index.query(query,keyInformations,indexTx);
     }
 
+    /**
+     * @deprecated use {@link #queryStream(RawQuery query)} instead.
+     */
+    @Deprecated
     public Iterable<RawQuery.Result<String>> query(RawQuery query) throws BackendException {
+        return new StreamIterable<>(index.query(query,keyInformations,indexTx));
+    }
+
+    public Stream<RawQuery.Result<String>> queryStream(RawQuery query) throws BackendException {
         return index.query(query,keyInformations,indexTx);
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -892,8 +892,9 @@ public class GraphDatabaseConfiguration {
             ConfigOption.Type.MASKABLE, String.class);
 
     public static final ConfigOption<Integer> INDEX_MAX_RESULT_SET_SIZE = new ConfigOption<Integer>(INDEX_NS, "max-result-set-size",
-            "Maxium number of results to return if no limit is specified",
-            ConfigOption.Type.MASKABLE, 100000);
+            "Maxium number of results to return if no limit is specified. For index backends that support scrolling, it represents " +
+                    "the number of results in each batch",
+            ConfigOption.Type.MASKABLE, 50);
 
     public static final ConfigOption<Boolean> INDEX_NAME_MAPPING = new ConfigOption<Boolean>(INDEX_NS,"map-name",
             "Whether to use the name of the property key as the field name in the index. It must be ensured, that the" +

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
@@ -56,6 +56,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.INDEX_NAME_MAPPING;
 
@@ -522,16 +523,16 @@ public class IndexSerializer {
                 Querying
     ################################################### */
 
-    public List<Object> query(final JointIndexQuery.Subquery query, final BackendTransaction tx) {
-        IndexType index = query.getIndex();
+    public Stream<Object> query(final JointIndexQuery.Subquery query, final BackendTransaction tx) {
+        final IndexType index = query.getIndex();
         if (index.isCompositeIndex()) {
-            MultiKeySliceQuery sq = query.getCompositeQuery();
-            List<EntryList> rs = sq.execute(tx);
-            List<Object> results = new ArrayList<Object>(rs.get(0).size());
+            final MultiKeySliceQuery sq = query.getCompositeQuery();
+            final List<EntryList> rs = sq.execute(tx);
+            final List<Object> results = new ArrayList<>(rs.get(0).size());
             for (EntryList r : rs) {
                 for (java.util.Iterator<Entry> iterator = r.reuseIterator(); iterator.hasNext(); ) {
-                    Entry entry = iterator.next();
-                    ReadBuffer entryValue = entry.asReadBuffer();
+                    final Entry entry = iterator.next();
+                    final ReadBuffer entryValue = entry.asReadBuffer();
                     entryValue.movePositionTo(entry.getValuePosition());
                     switch(index.getElement()) {
                         case VERTEX:
@@ -542,12 +543,9 @@ public class IndexSerializer {
                     }
                 }
             }
-            return results;
+            return results.stream();
         } else {
-            List<String> r = tx.indexQuery(((MixedIndexType) index).getBackingIndexName(), query.getMixedQuery());
-            List<Object> result = new ArrayList<Object>(r.size());
-            for (String id : r) result.add(string2ElementId(id));
-            return result;
+            return tx.indexQuery(((MixedIndexType) index).getBackingIndexName(), query.getMixedQuery()).map(IndexSerializer::string2ElementId);
         }
     }
 
@@ -581,36 +579,7 @@ public class IndexSerializer {
         }
         return new IndexQuery(index.getStoreName(), newCondition, newOrders);
     }
-//
-//
-//
-//    public IndexQuery getQuery(String index, final ElementCategory resultType, final Condition condition, final OrderList orders) {
-//        if (isStandardIndex(index)) {
-//            Preconditions.checkArgument(orders.isEmpty());
-//            return new IndexQuery(getStoreName(resultType), condition, IndexQuery.NO_ORDER);
-//        } else {
-//            Condition newCondition = ConditionUtil.literalTransformation(condition,
-//                    new Function<Condition<JanusGraphElement>, Condition<JanusGraphElement>>() {
-//                        @Nullable
-//                        @Override
-//                        public Condition<JanusGraphElement> apply(@Nullable Condition<JanusGraphElement> condition) {
-//                            Preconditions.checkArgument(condition instanceof PredicateCondition);
-//                            PredicateCondition pc = (PredicateCondition) condition;
-//                            JanusGraphKey key = (JanusGraphKey) pc.getKey();
-//                            return new PredicateCondition<String, JanusGraphElement>(key2Field(key), pc.getPredicate(), pc.getValue());
-//                        }
-//                    });
-//            ImmutableList<IndexQuery.OrderEntry> newOrders = IndexQuery.NO_ORDER;
-//            if (!orders.isEmpty()) {
-//                ImmutableList.Builder<IndexQuery.OrderEntry> lb = ImmutableList.builder();
-//                for (int i = 0; i < orders.size(); i++) {
-//                    lb.add(new IndexQuery.OrderEntry(key2Field(orders.getKey(i)), orders.getOrder(i), orders.getKey(i).getDataType()));
-//                }
-//                newOrders = lb.build();
-//            }
-//            return new IndexQuery(getStoreName(resultType), newCondition, newOrders);
-//        }
-//    }
+
 
     /* ################################################
     	Common code used by executeQuery and executeTotals
@@ -674,20 +643,14 @@ public class IndexSerializer {
         return queryStr;
     }
     
-    public Iterable<RawQuery.Result> executeQuery(IndexQueryBuilder query, final ElementCategory resultType,
+    public Stream<RawQuery.Result> executeQuery(IndexQueryBuilder query, final ElementCategory resultType,
                                                   final BackendTransaction backendTx, final StandardJanusGraphTx transaction) {
         final MixedIndexType index = getMixedIndex(query.getIndex(), transaction);
         final String queryStr = createQueryString(query, resultType, transaction, index);
         final RawQuery rawQuery = new RawQuery(index.getStoreName(),queryStr,query.getParameters());
         if (query.hasLimit()) rawQuery.setLimit(query.getLimit());
         rawQuery.setOffset(query.getOffset());
-        return Iterables.transform(backendTx.rawQuery(index.getBackingIndexName(), rawQuery), new Function<RawQuery.Result<String>, RawQuery.Result>() {
-            @Nullable
-            @Override
-            public RawQuery.Result apply(@Nullable RawQuery.Result<String> result) {
-                return new RawQuery.Result(string2ElementId(result.getResult()), result.getScore());
-            }
-        });
+        return backendTx.rawQuery(index.getBackingIndexName(), rawQuery).map(result ->  new RawQuery.Result(string2ElementId(result.getResult()), result.getScore()));
     }
 
     public Long executeTotals(IndexQueryBuilder query, final ElementCategory resultType,

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/IndexQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/IndexQueryBuilder.java
@@ -14,25 +14,23 @@
 
 package org.janusgraph.graphdb.query.graph;
 
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.janusgraph.core.*;
 import org.janusgraph.core.schema.Parameter;
-import org.janusgraph.diskstorage.indexing.RawQuery;
 import org.janusgraph.graphdb.database.IndexSerializer;
 import org.janusgraph.graphdb.internal.ElementCategory;
 import org.janusgraph.graphdb.query.BaseQuery;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
+import org.janusgraph.graphdb.util.StreamIterable;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Implementation of {@link JanusGraphIndexQuery} for string based queries that are issued directly against the specified
@@ -184,25 +182,12 @@ public class IndexQueryBuilder extends BaseQuery implements JanusGraphIndexQuery
         return this;
     }
 
-    private Iterable<Result<JanusGraphElement>> execute(ElementCategory resultType) {
+    private <E extends JanusGraphElement> Stream<Result<E>> execute(ElementCategory resultType, Class<E> resultClass) {
         Preconditions.checkNotNull(indexName);
         Preconditions.checkNotNull(query);
         if (tx.hasModifications())
             log.warn("Modifications in this transaction might not be accurately reflected in this index query: {}",query);
-        Iterable<RawQuery.Result> result = serializer.executeQuery(this,resultType,tx.getTxHandle(),tx);
-        final Function<Object, ? extends JanusGraphElement> conversionFct = tx.getConversionFunction(resultType);
-        return Iterables.filter(Iterables.transform(result, new Function<RawQuery.Result, Result<JanusGraphElement>>() {
-            @Nullable
-            @Override
-            public Result<JanusGraphElement> apply(@Nullable RawQuery.Result result) {
-                return new ResultImpl<JanusGraphElement>(conversionFct.apply(result.getResult()),result.getScore());
-            }
-        }),new Predicate<Result<JanusGraphElement>>() {
-            @Override
-            public boolean apply(@Nullable Result<JanusGraphElement> r) {
-                return !r.getElement().isRemoved();
-            }
-        });
+        return serializer.executeQuery(this, resultType, tx.getTxHandle(),tx).map(r -> (Result<E>) new ResultImpl<>(tx.getConversionFunction(resultType).apply(r.getResult()), r.getScore())).filter(r -> !r.getElement().isRemoved());
     }
 
     private Long executeTotals(ElementCategory resultType) {
@@ -216,20 +201,35 @@ public class IndexQueryBuilder extends BaseQuery implements JanusGraphIndexQuery
     
     @Override
     public Iterable<Result<JanusGraphVertex>> vertices() {
+        return new StreamIterable<>(vertexStream());
+    }
+
+    @Override
+    public Stream<Result<JanusGraphVertex>> vertexStream() {
         setPrefixInternal(VERTEX_PREFIX);
-        return (Iterable)execute(ElementCategory.VERTEX);
+        return execute(ElementCategory.VERTEX, JanusGraphVertex.class);
     }
 
     @Override
     public Iterable<Result<JanusGraphEdge>> edges() {
+        return new StreamIterable<>(edgeStream());
+    }
+
+    @Override
+    public Stream<Result<JanusGraphEdge>> edgeStream() {
         setPrefixInternal(EDGE_PREFIX);
-        return (Iterable)execute(ElementCategory.EDGE);
+        return execute(ElementCategory.EDGE, JanusGraphEdge.class);
     }
 
     @Override
     public Iterable<Result<JanusGraphVertexProperty>> properties() {
+        return new StreamIterable<>(propertyStream());
+    }
+
+    @Override
+    public Stream<Result<JanusGraphVertexProperty>> propertyStream() {
         setPrefixInternal(PROPERTY_PREFIX);
-        return (Iterable)execute(ElementCategory.PROPERTY);
+        return execute(ElementCategory.PROPERTY, JanusGraphVertexProperty.class);
     }
     
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/StreamIterable.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/StreamIterable.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.janusgraph.graphdb.util;
+
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+/**
+ * @author davidclement90@laposte.net
+ */
+public class StreamIterable<E> implements Iterable<E>{
+
+    private final Stream<E> stream;
+
+    public StreamIterable(Stream<E> stream) {
+        this.stream = stream;
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        return stream.iterator();
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/SubqueryIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/SubqueryIterator.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.janusgraph.graphdb.util;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.janusgraph.core.JanusGraphElement;
+import org.janusgraph.core.JanusGraphException;
+import org.janusgraph.diskstorage.BackendTransaction;
+import org.janusgraph.graphdb.database.IndexSerializer;
+import org.janusgraph.graphdb.query.graph.JointIndexQuery;
+import org.janusgraph.graphdb.query.profile.QueryProfiler;
+
+import com.google.common.cache.Cache;
+
+/**
+ * @author davidclement90@laposte.net
+ */
+public class SubqueryIterator implements Iterator<JanusGraphElement>, AutoCloseable {
+
+    private final JointIndexQuery.Subquery subQuery;
+
+    private final Cache<JointIndexQuery.Subquery, List<Object>> indexCache;
+
+    private Iterator<? extends JanusGraphElement> elementIterator;
+
+    private List<Object> currentIds;
+
+    private QueryProfiler profiler;
+
+    private boolean isTimerRunning;
+
+    public SubqueryIterator(JointIndexQuery.Subquery subQuery, IndexSerializer indexSerializer, BackendTransaction tx,
+            Cache<JointIndexQuery.Subquery, List<Object>> indexCache, int limit,
+            Function<Object, ? extends JanusGraphElement> function, List<Object> otherResults) {
+        this.subQuery = subQuery;
+        this.indexCache = indexCache;
+        final List<Object> cacheResponse = indexCache.getIfPresent(subQuery);
+        final Stream<?> stream;
+        if (cacheResponse != null) {
+            stream = cacheResponse.stream();
+        } else {
+            try {
+                currentIds = new ArrayList<>();
+                profiler = QueryProfiler.startProfile(subQuery.getProfiler(), subQuery);
+                isTimerRunning = true;
+                stream = indexSerializer.query(subQuery, tx).map(r -> {
+                    currentIds.add(r);
+                    return r;
+                });
+            } catch (final Exception e) {
+                throw new JanusGraphException("Could not call index", e.getCause());
+            }
+        }
+        elementIterator = stream.limit(limit).filter(e -> otherResults == null || otherResults.contains(e)).map(function).map(r -> (JanusGraphElement) r).iterator();
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (!elementIterator.hasNext() && currentIds != null) {
+            indexCache.put(subQuery, currentIds);
+            profiler.stopTimer();
+            isTimerRunning = false;
+            profiler.setResultSize(currentIds.size());
+        }
+        return elementIterator.hasNext();
+    }
+
+    @Override
+    public JanusGraphElement next() {
+        return this.elementIterator.next();
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (isTimerRunning) {
+            profiler.stopTimer();
+        }
+    }
+
+}

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchClient.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchClient.java
@@ -43,7 +43,11 @@ public interface ElasticSearchClient extends Closeable {
 
     void bulkRequest(List<ElasticSearchMutation> requests) throws IOException;
 
-    ElasticSearchResponse search(String indexName, String type, Map<String,Object> request) throws IOException;
+    ElasticSearchResponse search(String indexName, String type, Map<String,Object> request, boolean useScroll) throws IOException;
+
+    ElasticSearchResponse search(String scrollId) throws IOException;
+
+    void deleteScroll(String scrollId) throws IOException;
 
     void addAlias(String alias, String index) throws IOException;
 

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchRequest.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchRequest.java
@@ -31,8 +31,11 @@ public class ElasticSearchRequest {
 
     private List<Map<String,RestSortInfo>> sorts;
 
+    private List<String> fields;
+
     public ElasticSearchRequest() {
         this.sorts = new ArrayList<>();
+        this.fields = new ArrayList<>();
     }
 
     public Map<String,Object> getQuery() {
@@ -61,6 +64,14 @@ public class ElasticSearchRequest {
 
     public List<Map<String,RestSortInfo>> getSorts() {
         return sorts;
+    }
+
+    public List<String> getFields() {
+        return fields;
+    }
+
+    public void setFields(List<String> fields) {
+        this.fields = fields;
     }
 
     public void addSort(String key, String order, String unmappedType) {

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchResponse.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchResponse.java
@@ -17,12 +17,15 @@ package org.janusgraph.diskstorage.es;
 import org.janusgraph.diskstorage.indexing.RawQuery;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 public class ElasticSearchResponse {
 
     private long took;
 
     private long total;
+
+    private String scrollId;
 
     private List<RawQuery.Result<String>> results;
 
@@ -42,11 +45,23 @@ public class ElasticSearchResponse {
         this.total = total;
     }
 
-    public List<RawQuery.Result<String>> getResults() {
-        return results;
+    public Stream<RawQuery.Result<String>> getResults() {
+        return results.stream();
     }
 
     public void setResults(List<RawQuery.Result<String>> results) {
         this.results = results;
+    }
+
+    public int numResults() {
+        return results.size();
+    }
+
+    public String getScrollId() {
+        return scrollId;
+    }
+
+    public void setScrollId(String scrollId) {
+        this.scrollId = scrollId;
     }
 }

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchScroll.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchScroll.java
@@ -1,0 +1,73 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.es;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Iterator;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.janusgraph.diskstorage.indexing.RawQuery;
+import org.janusgraph.diskstorage.indexing.RawQuery.Result;
+
+/**
+ * @author David Clement (david.clement90@laposte.net)
+ */
+public class ElasticSearchScroll implements Iterator<RawQuery.Result<String>> {
+
+    private final BlockingQueue<RawQuery.Result<String>> queue;
+    private boolean isFinished;
+    private final ElasticSearchClient client;
+    private final String scrollId;
+    private final int batchSize;
+
+    public ElasticSearchScroll(ElasticSearchClient client, ElasticSearchResponse initialResponse, int nbDocByQuery) {
+        queue = new LinkedBlockingQueue<>();
+        this.client = client;
+        this.scrollId = initialResponse.getScrollId();
+        this.batchSize = nbDocByQuery;
+        initialResponse.getResults().forEach(queue::add);
+        this.isFinished = initialResponse.numResults() < nbDocByQuery;
+    }
+
+    @Override
+    public boolean hasNext() {
+        try {
+            if (!queue.isEmpty()) {
+                return true;
+            }
+            if (isFinished) {
+                return false;
+            }
+            final ElasticSearchResponse res = client.search(scrollId);
+            res.getResults().forEach(queue::add);
+            isFinished = res.numResults() < batchSize;
+            if (isFinished) client.deleteScroll(scrollId);
+            return res.numResults() > 0;
+        } catch (final IOException e) {
+             throw new UncheckedIOException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Result<String> next() {
+         try {
+             return queue.take();
+         } catch (final InterruptedException e) {
+              throw new UncheckedIOException(new IOException("Interrupted waiting on queue", e));
+         }
+    }
+}

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchSetup.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchSetup.java
@@ -80,7 +80,7 @@ public enum ElasticSearchSetup {
             log.debug("Configuring RestClient");
 
             final List<HttpHost> hosts = new ArrayList<>();
-            int defaultPort = config.has(INDEX_PORT) ? config.get(INDEX_PORT) : ElasticSearchIndex.HOST_PORT_DEFAULT;
+            final int defaultPort = config.has(INDEX_PORT) ? config.get(INDEX_PORT) : ElasticSearchIndex.HOST_PORT_DEFAULT;
             for (String host : config.get(INDEX_HOSTS)) {
                 String[] hostparts = host.split(":");
                 String hostname = hostparts[0];
@@ -91,7 +91,9 @@ public enum ElasticSearchSetup {
             }
             RestClient rc = RestClient.builder(hosts.toArray(new HttpHost[hosts.size()])).build();
 
-            RestElasticSearchClient client = new RestElasticSearchClient(rc);
+            final int scrollKeepAlive = config.get(ElasticSearchIndex.ES_SCROLL_KEEP_ALIVE);
+            Preconditions.checkArgument(scrollKeepAlive >= 1, "Scroll Keep alive should be greater or equals than 1");
+            final RestElasticSearchClient client = new RestElasticSearchClient(rc, scrollKeepAlive);
             if (config.has(ElasticSearchIndex.BULK_REFRESH)) {
                 client.setBulkRefresh(config.get(ElasticSearchIndex.BULK_REFRESH));
             }

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestSearchResponse.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestSearchResponse.java
@@ -21,6 +21,7 @@ import org.janusgraph.diskstorage.indexing.RawQuery;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class RestSearchResponse extends ElasticSearchResponse {
@@ -30,11 +31,15 @@ public class RestSearchResponse extends ElasticSearchResponse {
     @JsonProperty("hits")
     private RestSearchResults hits;
 
+    @JsonProperty("_scroll_id")
+    private String scrollId;
+
     @Override
     public long getTook() {
         return took;
     }
 
+    @Override
     public void setTook(long took) {
         this.took = took;
     }
@@ -61,10 +66,23 @@ public class RestSearchResponse extends ElasticSearchResponse {
     }
 
     @Override
-    public List<RawQuery.Result<String>> getResults() {
+    public Stream<RawQuery.Result<String>> getResults() {
         return hits.getHits().stream()
-            .map(hit -> new RawQuery.Result<String>(hit.getId(),hit.getScore() != null ? hit.getScore() : 0f))
-            .collect(Collectors.toList());
+            .map(hit -> new RawQuery.Result<String>(hit.getId(),hit.getScore() != null ? hit.getScore() : 0f));
     }
 
+    @Override
+    public int numResults() {
+        return hits.getHits().size();
+    }
+
+    @Override
+    public String getScrollId() {
+        return scrollId;
+    }
+
+    @Override
+    public void setScrollId(String scrollId) {
+        this.scrollId = scrollId;
+    }
 }

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/BerkeleyElasticsearchTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/BerkeleyElasticsearchTest.java
@@ -19,6 +19,7 @@ import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
 import org.janusgraph.example.GraphOfTheGodsFactory;
 import org.janusgraph.graphdb.JanusGraphIndexTest;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
 import org.janusgraph.util.system.IOUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -65,6 +66,7 @@ public class BerkeleyElasticsearchTest extends JanusGraphIndexTest {
         config.set(INTERFACE, ElasticSearchSetup.REST_CLIENT.toString(), INDEX);
         config.set(INDEX_HOSTS, new String[]{ "127.0.0.1" }, INDEX);
         config.set(BULK_REFRESH, "wait_for", INDEX);
+        config.set(GraphDatabaseConfiguration.INDEX_MAX_RESULT_SET_SIZE, 3, INDEX);
         return config.getConfiguration();
 
     }

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticSearchIndexTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticSearchIndexTest.java
@@ -96,6 +96,7 @@ public class ElasticSearchIndexTest extends IndexProviderTest {
         config.set(INTERFACE, ElasticSearchSetup.REST_CLIENT.toString(), index);
         config.set(INDEX_HOSTS, new String[]{ "127.0.0.1" }, index);
         config.set(BULK_REFRESH, "wait_for", index);
+        config.set(GraphDatabaseConfiguration.INDEX_MAX_RESULT_SET_SIZE, 3, index);
         return config.restrictTo(index);
     }
 

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticSearchMutliTypeIndexTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticSearchMutliTypeIndexTest.java
@@ -25,7 +25,6 @@ import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.IN
 /**
  * @author David Clement (david.clement90@laposte.net)
  */
-
 public class ElasticSearchMutliTypeIndexTest extends ElasticSearchIndexTest {
 
     public Configuration getESTestConfig() {
@@ -34,6 +33,7 @@ public class ElasticSearchMutliTypeIndexTest extends ElasticSearchIndexTest {
         config.set(INTERFACE, ElasticSearchSetup.REST_CLIENT.toString(), index);
         config.set(INDEX_HOSTS, new String[]{ "127.0.0.1" }, index);
         config.set(BULK_REFRESH, "wait_for", index);
+        config.set(GraphDatabaseConfiguration.INDEX_MAX_RESULT_SET_SIZE, 3, index);
         config.set(USE_DEPRECATED_MULTITYPE_INDEX, true, index);
         return config.restrictTo(index);
     }

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ThriftElasticsearchTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ThriftElasticsearchTest.java
@@ -19,6 +19,7 @@ import org.janusgraph.CassandraStorageSetup;
 import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
 import org.janusgraph.graphdb.JanusGraphIndexTest;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -59,6 +60,7 @@ public class ThriftElasticsearchTest extends JanusGraphIndexTest {
         config.set(INTERFACE, ElasticSearchSetup.REST_CLIENT.toString(), INDEX);
         config.set(INDEX_HOSTS, new String[]{ "127.0.0.1" }, INDEX);
         config.set(BULK_REFRESH, "wait_for", INDEX);
+        config.set(GraphDatabaseConfiguration.INDEX_MAX_RESULT_SET_SIZE, 3, INDEX);
         return config.getConfiguration();
     }
 

--- a/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
+++ b/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
@@ -19,6 +19,7 @@ import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.IN
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Constructor;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -33,10 +34,14 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -62,6 +67,7 @@ import org.apache.solr.common.cloud.ClusterState;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.zookeeper.KeeperException;
 import org.janusgraph.core.Cardinality;
@@ -121,7 +127,7 @@ public class SolrIndex implements IndexProvider {
         HTTP, CLOUD;
 
         public static Mode parse(String mode) {
-            for (Mode m : Mode.values()) {
+            for (final Mode m : Mode.values()) {
                 if (m.toString().equalsIgnoreCase(mode)) return m;
             }
             throw new IllegalArgumentException("Unrecognized mode: "+mode);
@@ -218,7 +224,7 @@ public class SolrIndex implements IndexProvider {
     private final boolean dynFields;
     private final Map<String, String> keyFieldIds;
     private final String ttlField;
-    private final int maxResults;
+    private final int batchSize;
     private final boolean waitSearcher;
 
     public SolrIndex(final Configuration config) throws BackendException {
@@ -228,17 +234,17 @@ public class SolrIndex implements IndexProvider {
         mode = Mode.parse(config.get(SOLR_MODE));
         dynFields = config.get(DYNAMIC_FIELDS);
         keyFieldIds = parseKeyFieldsForCollections(config);
-        maxResults = config.get(INDEX_MAX_RESULT_SET_SIZE);
+        batchSize = config.get(INDEX_MAX_RESULT_SET_SIZE);
         ttlField = config.get(TTL_FIELD);
         waitSearcher = config.get(WAIT_SEARCHER);
 
         if (mode==Mode.CLOUD) {
-            String zookeeperUrl = config.get(SolrIndex.ZOOKEEPER_URL);
-            CloudSolrClient cloudServer = new CloudSolrClient(zookeeperUrl, true);
+            final String zookeeperUrl = config.get(SolrIndex.ZOOKEEPER_URL);
+            final CloudSolrClient cloudServer = new CloudSolrClient(zookeeperUrl, true);
             cloudServer.connect();
             solrClient = cloudServer;
         } else if (mode==Mode.HTTP) {
-            HttpClient clientParams = HttpClientUtil.createClient(new ModifiableSolrParams() {{
+            final HttpClient clientParams = HttpClientUtil.createClient(new ModifiableSolrParams() {{
                 add(HttpClientUtil.PROP_ALLOW_COMPRESSION, config.get(HTTP_ALLOW_COMPRESSION).toString());
                 add(HttpClientUtil.PROP_CONNECTION_TIMEOUT, config.get(HTTP_CONNECTION_TIMEOUT).toString());
                 add(HttpClientUtil.PROP_MAX_CONNECTIONS_PER_HOST, config.get(HTTP_MAX_CONNECTIONS_PER_HOST).toString());
@@ -254,15 +260,15 @@ public class SolrIndex implements IndexProvider {
     }
 
     private Map<String, String> parseKeyFieldsForCollections(Configuration config) throws BackendException {
-        Map<String, String> keyFieldNames = new HashMap<String, String>();
-        String[] collectionFieldStatements = config.has(KEY_FIELD_NAMES)?config.get(KEY_FIELD_NAMES):new String[0];
-        for (String collectionFieldStatement : collectionFieldStatements) {
-            String[] parts = collectionFieldStatement.trim().split("=");
+        final Map<String, String> keyFieldNames = new HashMap<String, String>();
+        final String[] collectionFieldStatements = config.has(KEY_FIELD_NAMES) ? config.get(KEY_FIELD_NAMES) : new String[0];
+        for (final String collectionFieldStatement : collectionFieldStatements) {
+            final String[] parts = collectionFieldStatement.trim().split("=");
             if (parts.length != 2) {
                 throw new PermanentBackendException("Unable to parse the collection name / key field name pair. It should be of the format collection=field");
             }
-            String collectionName = parts[0];
-            String keyFieldName = parts[1];
+            final String collectionName = parts[0];
+            final String keyFieldName = parts[1];
             keyFieldNames.put(collectionName, keyFieldName);
         }
         return keyFieldNames;
@@ -289,16 +295,10 @@ public class SolrIndex implements IndexProvider {
     @Override
     public void register(String store, String key, KeyInformation information, BaseTransaction tx) throws BackendException {
         if (mode==Mode.CLOUD) {
-            CloudSolrClient client = (CloudSolrClient) solrClient;
+            final CloudSolrClient client = (CloudSolrClient) solrClient;
             try {
                 createCollectionIfNotExists(client, configuration, store);
-            } catch (IOException e) {
-                throw new PermanentBackendException(e);
-            } catch (SolrServerException e) {
-                throw new PermanentBackendException(e);
-            } catch (InterruptedException e) {
-                throw new PermanentBackendException(e);
-            } catch (KeeperException e) {
+            } catch (final IOException | SolrServerException | InterruptedException | KeeperException e) {
                 throw new PermanentBackendException(e);
             }
         }
@@ -310,7 +310,7 @@ public class SolrIndex implements IndexProvider {
             try {
                 ((Constructor<Tokenizer>) ClassLoader.getSystemClassLoader().loadClass(analyzer)
                         .getConstructor()).newInstance();
-            } catch (ReflectiveOperationException e) {
+            } catch (final ReflectiveOperationException e) {
                 throw new PermanentBackendException(e.getMessage(),e);
             }
         }
@@ -320,7 +320,7 @@ public class SolrIndex implements IndexProvider {
             try {
                 ((Constructor<Tokenizer>) ClassLoader.getSystemClassLoader().loadClass(analyzer)
                         .getConstructor()).newInstance();
-            } catch (ReflectiveOperationException e) {
+            } catch (final ReflectiveOperationException e) {
                 throw new PermanentBackendException(e.getMessage(),e);
             }
         }
@@ -330,16 +330,16 @@ public class SolrIndex implements IndexProvider {
     public void mutate(Map<String, Map<String, IndexMutation>> mutations, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException {
         logger.debug("Mutating SOLR");
         try {
-            for (Map.Entry<String, Map<String, IndexMutation>> stores : mutations.entrySet()) {
-                String collectionName = stores.getKey();
-                String keyIdField = getKeyFieldId(collectionName);
+            for (final Map.Entry<String, Map<String, IndexMutation>> stores : mutations.entrySet()) {
+                final String collectionName = stores.getKey();
+                final String keyIdField = getKeyFieldId(collectionName);
 
-                List<String> deleteIds = new ArrayList<String>();
-                Collection<SolrInputDocument> changes = new ArrayList<SolrInputDocument>();
+                final List<String> deleteIds = new ArrayList<String>();
+                final Collection<SolrInputDocument> changes = new ArrayList<SolrInputDocument>();
 
-                for (Map.Entry<String, IndexMutation> entry : stores.getValue().entrySet()) {
-                    String docId = entry.getKey();
-                    IndexMutation mutation = entry.getValue();
+                for (final Map.Entry<String, IndexMutation> entry : stores.getValue().entrySet()) {
+                    final String docId = entry.getKey();
+                    final IndexMutation mutation = entry.getValue();
                     Preconditions.checkArgument(!(mutation.isNew() && mutation.isDeleted()));
                     Preconditions.checkArgument(!mutation.isNew() || !mutation.hasDeletions());
                     Preconditions.checkArgument(!mutation.isDeleted() || !mutation.hasAdditions());
@@ -350,9 +350,9 @@ public class SolrIndex implements IndexProvider {
                             logger.trace("Deleting entire document {}", docId);
                             deleteIds.add(docId);
                         } else {
-                            List<IndexEntry> fieldDeletions = new ArrayList<IndexEntry>(mutation.getDeletions());
+                            final List<IndexEntry> fieldDeletions = new ArrayList<IndexEntry>(mutation.getDeletions());
                             if (mutation.hasAdditions()) {
-                                for (IndexEntry indexEntry : mutation.getAdditions()) {
+                                for (final IndexEntry indexEntry : mutation.getAdditions()) {
                                     fieldDeletions.remove(indexEntry);
                                 }
                             }
@@ -361,12 +361,12 @@ public class SolrIndex implements IndexProvider {
                     }
 
                     if (mutation.hasAdditions()) {
-                        int ttl = mutation.determineTTL();
+                        final int ttl = mutation.determineTTL();
 
-                        SolrInputDocument doc = new SolrInputDocument();
+                        final SolrInputDocument doc = new SolrInputDocument();
                         doc.setField(keyIdField, docId);
 
-                        boolean isNewDoc = mutation.isNew();
+                        final boolean isNewDoc = mutation.isNew();
 
                         if (isNewDoc)
                             logger.trace("Adding new document {}", docId);
@@ -376,7 +376,7 @@ public class SolrIndex implements IndexProvider {
                         adds.keySet().stream().forEach(v-> {
                             final KeyInformation keyInformation = informations.get(collectionName, v);
                             final String solrOp = keyInformation.getCardinality() == Cardinality.SINGLE ? "set" : "add";
-                            doc.setField(v, isNewDoc ? adds.get(v) : 
+                            doc.setField(v, isNewDoc ? adds.get(v) :
                                 new HashMap<String, Object>(1) {{put(solrOp, adds.get(v));}}
                             );
                         });
@@ -391,9 +391,9 @@ public class SolrIndex implements IndexProvider {
                 commitDeletes(collectionName, deleteIds);
                 commitDocumentChanges(collectionName, changes);
             }
-        } catch (IllegalArgumentException e) {
+        } catch (final IllegalArgumentException e) {
             throw new PermanentBackendException("Unable to complete query on Solr.", e);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             throw storageException(e);
         }
     }
@@ -402,7 +402,7 @@ public class SolrIndex implements IndexProvider {
         final Map<String, String> fieldDeletes = new HashMap<String, String>(1) {{ put("set", null); }};
         final SolrInputDocument doc = new SolrInputDocument();
         doc.addField(keyIdField, docId);
-        for(IndexEntry v: fieldDeletions) {
+        for(final IndexEntry v: fieldDeletions) {
             final KeyInformation keyInformation = informations.get(collectionName, v.field);
             // If the cardinality is a Set or List, we just need to remove the individual value
             // received in the mutation and not set the field to null, but we still consolidate the values
@@ -412,7 +412,7 @@ public class SolrIndex implements IndexProvider {
                 doc.setField(vertex, keyInformation.getCardinality() == Cardinality.SINGLE?
                         fieldDeletes:new HashMap<String, Object>(1) {{ put("remove", deletes.get(vertex));}}
                         );
-            }); 
+            });
         }
 
         final UpdateRequest singleDocument = newUpdateRequest();
@@ -420,7 +420,7 @@ public class SolrIndex implements IndexProvider {
         solrClient.request(singleDocument, collectionName);
 
     }
-    
+
     private Object convertValue(Object value) throws BackendException {
         if (value instanceof Geoshape) {
             return GeoToWktConverter.convertToWktString((Geoshape) value);
@@ -440,13 +440,13 @@ public class SolrIndex implements IndexProvider {
     @Override
     public void restore(Map<String, Map<String, List<IndexEntry>>> documents, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException {
         try {
-            for (Map.Entry<String, Map<String, List<IndexEntry>>> stores : documents.entrySet()) {
+            for (final Map.Entry<String, Map<String, List<IndexEntry>>> stores : documents.entrySet()) {
                 final String collectionName = stores.getKey();
 
-                List<String> deleteIds = new ArrayList<String>();
-                List<SolrInputDocument> newDocuments = new ArrayList<SolrInputDocument>();
+                final List<String> deleteIds = new ArrayList<String>();
+                final List<SolrInputDocument> newDocuments = new ArrayList<SolrInputDocument>();
 
-                for (Map.Entry<String, List<IndexEntry>> entry : stores.getValue().entrySet()) {
+                for (final Map.Entry<String, List<IndexEntry>> entry : stores.getValue().entrySet()) {
                     final String docID = entry.getKey();
                     final List<IndexEntry> content = entry.getValue();
 
@@ -466,7 +466,7 @@ public class SolrIndex implements IndexProvider {
                 commitDeletes(collectionName, deleteIds);
                 commitDocumentChanges(collectionName, newDocuments);
             }
-        } catch (Exception e) {
+        } catch (final Exception e) {
             throw new TemporaryBackendException("Could not restore Solr index", e);
         }
     }
@@ -475,7 +475,7 @@ public class SolrIndex implements IndexProvider {
     // it will consolidate all the values into one List or Set so it can be updated with a single Solr operation
     private Map<String, Object> collectFieldValues(List<IndexEntry> content, String collectionName, KeyInformation.IndexRetriever informations) throws BackendException {
         final Map<String, Object> docs = new HashMap<>();
-        for (IndexEntry addition: content) {
+        for (final IndexEntry addition: content) {
             final KeyInformation keyInformation = informations.get(collectionName, addition.field);
             switch (keyInformation.getCardinality()) {
                 case SINGLE:
@@ -503,12 +503,12 @@ public class SolrIndex implements IndexProvider {
 
         try {
             solrClient.request(newUpdateRequest().add(documents), collectionName);
-        } catch (HttpSolrClient.RemoteSolrException rse) {
+        } catch (final HttpSolrClient.RemoteSolrException rse) {
             logger.error("Unable to save documents to Solr as one of the shape objects stored were not compatible with Solr.", rse);
             logger.error("Details in failed document batch: ");
-            for (SolrInputDocument d : documents) {
-                Collection<String> fieldNames = d.getFieldNames();
-                for (String name : fieldNames) {
+            for (final SolrInputDocument d : documents) {
+                final Collection<String> fieldNames = d.getFieldNames();
+                for (final String name : fieldNames) {
                     logger.error(name + ":" + d.getFieldValue(name).toString());
                 }
             }
@@ -523,58 +523,55 @@ public class SolrIndex implements IndexProvider {
     }
 
     @Override
-    public List<String> query(IndexQuery query, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException {
-        List<String> result;
-        String collection = query.getStore();
-        String keyIdField = getKeyFieldId(collection);
-        SolrQuery solrQuery = new SolrQuery("*:*");
-        String queryFilter = buildQueryFilter(query.getCondition(), informations.get(collection));
+    public Stream<String> query(IndexQuery query, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException {
+        final String collection = query.getStore();
+        final String keyIdField = getKeyFieldId(collection);
+        final SolrQuery solrQuery = new SolrQuery("*:*");
+        solrQuery.set(CommonParams.FL, keyIdField);
+        final String queryFilter = buildQueryFilter(query.getCondition(), informations.get(collection));
         solrQuery.addFilterQuery(queryFilter);
         if (!query.getOrder().isEmpty()) {
-            List<IndexQuery.OrderEntry> orders = query.getOrder();
-            for (IndexQuery.OrderEntry order1 : orders) {
-                String item = order1.getKey();
-                SolrQuery.ORDER order = order1.getOrder() == Order.ASC ? SolrQuery.ORDER.asc : SolrQuery.ORDER.desc;
+            final List<IndexQuery.OrderEntry> orders = query.getOrder();
+            for (final IndexQuery.OrderEntry order1 : orders) {
+                final String item = order1.getKey();
+                final SolrQuery.ORDER order = order1.getOrder() == Order.ASC ? SolrQuery.ORDER.asc : SolrQuery.ORDER.desc;
                 solrQuery.addSort(new SolrQuery.SortClause(item, order));
             }
         }
         solrQuery.setStart(0);
         if (query.hasLimit()) {
-            solrQuery.setRows(query.getLimit());
+            solrQuery.setRows(Math.min(query.getLimit(), batchSize));
         } else {
-            solrQuery.setRows(maxResults);
+            solrQuery.setRows(batchSize);
         }
+        return executeQuery(query.hasLimit() ? query.getLimit() : null, 0, collection, solrQuery, doc -> doc.getFieldValue(keyIdField).toString());
+    }
+
+    private <E> Stream<E> executeQuery(Integer limit, int offset, String collection, SolrQuery solrQuery, Function<SolrDocument, E> function) throws PermanentBackendException {
         try {
-            QueryResponse response = solrClient.query(collection, solrQuery);
-
-            if (logger.isDebugEnabled())
-                logger.debug("Executed query [{}] in {} ms", query.getCondition(), response.getElapsedTime());
-
-            int totalHits = response.getResults().size();
-
-            if (!query.hasLimit() && totalHits >= maxResults)
-                logger.warn("Query result set truncated to first [{}] elements for query: {}", maxResults, query);
-
-            result = new ArrayList<String>(totalHits);
-            for (SolrDocument hit : response.getResults()) {
-                result.add(hit.getFieldValue(keyIdField).toString());
-            }
-        } catch (IOException e) {
+            final SolrResultIterator<E> resultIterator = new SolrResultIterator<>(solrClient, limit, offset, solrQuery.getRows(), collection, solrQuery, function);
+            return StreamSupport.stream(Spliterators.spliteratorUnknownSize(resultIterator, Spliterator.ORDERED), false);
+        } catch (final IOException | UncheckedIOException e) {
             logger.error("Query did not complete : ", e);
             throw new PermanentBackendException(e);
-        } catch (SolrServerException e) {
+        } catch (final SolrServerException | UncheckedSolrException e) {
             logger.error("Unable to query Solr index.", e);
             throw new PermanentBackendException(e);
         }
-        return result;
     }
 
-    private QueryResponse runCommonQuery(RawQuery query, KeyInformation.IndexRetriever informations, BaseTransaction tx, String collection, String keyIdField) throws BackendException {
-        SolrQuery solrQuery = new SolrQuery(query.getQuery())
+
+    private SolrQuery runCommonQuery(RawQuery query, KeyInformation.IndexRetriever informations, BaseTransaction tx, String collection, String keyIdField) throws BackendException {
+        final SolrQuery solrQuery = new SolrQuery(query.getQuery())
                                 .addField(keyIdField)
                                 .setIncludeScore(true)
-                                .setStart(query.getOffset())
-                                .setRows(query.hasLimit() ? query.getLimit() : maxResults);
+                                .setStart(query.getOffset());
+        if (query.hasLimit()) {
+            solrQuery.setRows(Math.min(query.getLimit(), batchSize));
+        } else {
+            solrQuery.setRows(batchSize);
+        }
+
         for(final Parameter parameter: query.getParameters()) {
             if (parameter.value() instanceof String[]) {
                 solrQuery.setParam(parameter.key(), (String[]) parameter.value());
@@ -582,41 +579,34 @@ public class SolrIndex implements IndexProvider {
                 solrQuery.setParam(parameter.key(), (String) parameter.value());
             }
         }
-        try {
-            return solrClient.query(collection, solrQuery);
-        } catch (IOException e) {
-            logger.error("Query did not complete : ", e);
-            throw new PermanentBackendException(e);
-        } catch (SolrServerException e) {
-            logger.error("Unable to query Solr index.", e);
-            throw new PermanentBackendException(e);
-        }
+        return solrQuery;
     }
 
     @Override
-    public Iterable<RawQuery.Result<String>> query(RawQuery query, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException {
+    public Stream<RawQuery.Result<String>> query(RawQuery query, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException {
         final String collection = query.getStore();
         final String keyIdField = getKeyFieldId(collection);
-        final QueryResponse response = runCommonQuery(query, informations, tx, collection, keyIdField);
-        logger.debug("Executed query [{}] in {} ms", query.getQuery(), response.getElapsedTime());
-
-        final int totalHits = response.getResults().size();
-        if (!query.hasLimit() && totalHits >= maxResults) {
-            logger.warn("Query result set truncated to first [{}] elements for query: {}", maxResults, query);
-        }
-        return response.getResults().stream().map( r -> {
-            final double score = Double.parseDouble(r.getFieldValue("score").toString());
-            return new RawQuery.Result<String>(r.getFieldValue(keyIdField).toString(), score);
-        }).collect(Collectors.toList());
+        return executeQuery(query.hasLimit() ? query.getLimit() : null, query.getOffset(), collection, runCommonQuery(query, informations, tx, collection, keyIdField), doc -> {
+            final double score = Double.parseDouble(doc.getFieldValue("score").toString());
+            return new RawQuery.Result<>(doc.getFieldValue(keyIdField).toString(), score);
+        });
     }
 
     @Override
     public Long totals(RawQuery query, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException {
-        final String collection = query.getStore();
-        final String keyIdField = getKeyFieldId(collection);
-        final QueryResponse response = runCommonQuery(query, informations, tx, collection, keyIdField);
-        logger.debug("Executed query [{}] in {} ms", query.getQuery(), response.getElapsedTime());
-        return response.getResults().getNumFound();
+        try {
+            final String collection = query.getStore();
+            final String keyIdField = getKeyFieldId(collection);
+            final QueryResponse response = solrClient.query(collection, runCommonQuery(query, informations, tx, collection, keyIdField));
+            logger.debug("Executed query [{}] in {} ms", query.getQuery(), response.getElapsedTime());
+            return response.getResults().getNumFound();
+        } catch (final IOException e) {
+            logger.error("Query did not complete : ", e);
+            throw new PermanentBackendException(e);
+        } catch (final SolrServerException e) {
+            logger.error("Unable to query Solr index.", e);
+            throw new PermanentBackendException(e);
+        }
     }
 
     private static String escapeValue(Object value) {
@@ -625,15 +615,15 @@ public class SolrIndex implements IndexProvider {
 
     public String buildQueryFilter(Condition<JanusGraphElement> condition, KeyInformation.StoreRetriever informations) {
         if (condition instanceof PredicateCondition) {
-            PredicateCondition<String, JanusGraphElement> atom = (PredicateCondition<String, JanusGraphElement>) condition;
-            Object value = atom.getValue();
-            String key = atom.getKey();
-            JanusGraphPredicate janusgraphPredicate = atom.getPredicate();
+            final PredicateCondition<String, JanusGraphElement> atom = (PredicateCondition<String, JanusGraphElement>) condition;
+            final Object value = atom.getValue();
+            final String key = atom.getKey();
+            final JanusGraphPredicate janusgraphPredicate = atom.getPredicate();
 
             if (value instanceof Number) {
-                String queryValue = escapeValue(value);
+                final String queryValue = escapeValue(value);
                 Preconditions.checkArgument(janusgraphPredicate instanceof Cmp, "Relation not supported on numeric types: " + janusgraphPredicate);
-                Cmp numRel = (Cmp) janusgraphPredicate;
+                final Cmp numRel = (Cmp) janusgraphPredicate;
                 switch (numRel) {
                     case EQUAL:
                         return (key + ":" + queryValue);
@@ -652,7 +642,7 @@ public class SolrIndex implements IndexProvider {
                     default: throw new IllegalArgumentException("Unexpected relation: " + numRel);
                 }
             } else if (value instanceof String) {
-                Mapping map = getStringMapping(informations.get(key));
+                final Mapping map = getStringMapping(informations.get(key));
                 assert map==Mapping.TEXT || map==Mapping.STRING;
                 if (map==Mapping.TEXT && !Text.HAS_CONTAINS.contains(janusgraphPredicate))
                     throw new IllegalArgumentException("Text mapped string values only support CONTAINS queries and not: " + janusgraphPredicate);
@@ -667,7 +657,7 @@ public class SolrIndex implements IndexProvider {
                 } else if (janusgraphPredicate == Text.REGEX || janusgraphPredicate == Text.CONTAINS_REGEX) {
                     return (key + ":/" + value + "/");
                 } else if (janusgraphPredicate == Cmp.EQUAL) {
-                    String tokenizer = (String) ParameterType.STRING_ANALYZER.findParameter(informations.get(key).getParameters(), null);
+                    final String tokenizer = (String) ParameterType.STRING_ANALYZER.findParameter(informations.get(key).getParameters(), null);
                     if(tokenizer != null){
                         return tokenize(informations, value, key, janusgraphPredicate,tokenizer);
                     } else {
@@ -681,33 +671,33 @@ public class SolrIndex implements IndexProvider {
                     throw new IllegalArgumentException("Relation is not supported for string value: " + janusgraphPredicate);
                 }
             } else if (value instanceof Geoshape) {
-                Mapping map = Mapping.getMapping(informations.get(key));
+                final Mapping map = Mapping.getMapping(informations.get(key));
                 Preconditions.checkArgument(janusgraphPredicate instanceof Geo && janusgraphPredicate != Geo.DISJOINT, "Relation not supported on geo types: " + janusgraphPredicate);
                 Preconditions.checkArgument(map == Mapping.PREFIX_TREE || janusgraphPredicate == Geo.WITHIN || janusgraphPredicate == Geo.INTERSECT, "Relation not supported on geopoint types: " + janusgraphPredicate);
-                Geoshape geo = (Geoshape)value;
+                final Geoshape geo = (Geoshape)value;
                 if (geo.getType() == Geoshape.Type.CIRCLE && (janusgraphPredicate == Geo.INTERSECT || map == Mapping.DEFAULT)) {
-                    Geoshape.Point center = geo.getPoint();
+                    final Geoshape.Point center = geo.getPoint();
                     return ("{!geofilt sfield=" + key +
                             " pt=" + center.getLatitude() + "," + center.getLongitude() +
                             " d=" + geo.getRadius() + "} distErrPct=0"); //distance in kilometers
                 } else if (geo.getType() == Geoshape.Type.BOX && (janusgraphPredicate == Geo.INTERSECT || map == Mapping.DEFAULT)) {
-                    Geoshape.Point southwest = geo.getPoint(0);
-                    Geoshape.Point northeast = geo.getPoint(1);
+                    final Geoshape.Point southwest = geo.getPoint(0);
+                    final Geoshape.Point northeast = geo.getPoint(1);
                     return (key + ":[" + southwest.getLatitude() + "," + southwest.getLongitude() +
                             " TO " + northeast.getLatitude() + "," + northeast.getLongitude() + "]");
                 } else if (map == Mapping.PREFIX_TREE) {
-                    StringBuilder builder = new StringBuilder(key + ":\"");
-                    builder.append(SPATIAL_PREDICATES.get((Geo) janusgraphPredicate) + "(");
+                    final StringBuilder builder = new StringBuilder(key + ":\"");
+                    builder.append(SPATIAL_PREDICATES.get(janusgraphPredicate) + "(");
                     builder.append(geo + ")\" distErrPct=0");
                     return builder.toString();
                 } else {
                     throw new IllegalArgumentException("Unsupported or invalid search shape type: " + geo.getType());
                 }
             } else if (value instanceof Date || value instanceof Instant) {
-                String s = value.toString();
-                String queryValue = escapeValue(value instanceof Date ? toIsoDate((Date) value) : value.toString());
+                final String s = value.toString();
+                final String queryValue = escapeValue(value instanceof Date ? toIsoDate((Date) value) : value.toString());
                 Preconditions.checkArgument(janusgraphPredicate instanceof Cmp, "Relation not supported on date types: " + janusgraphPredicate);
-                Cmp numRel = (Cmp) janusgraphPredicate;
+                final Cmp numRel = (Cmp) janusgraphPredicate;
 
                 switch (numRel) {
                     case EQUAL:
@@ -727,8 +717,8 @@ public class SolrIndex implements IndexProvider {
                     default: throw new IllegalArgumentException("Unexpected relation: " + numRel);
                 }
             } else if (value instanceof Boolean) {
-                Cmp numRel = (Cmp) janusgraphPredicate;
-                String queryValue = escapeValue(value);
+                final Cmp numRel = (Cmp) janusgraphPredicate;
+                final String queryValue = escapeValue(value);
                 switch (numRel) {
                     case EQUAL:
                         return (key + ":" + queryValue);
@@ -747,14 +737,14 @@ public class SolrIndex implements IndexProvider {
                 }
             } else throw new IllegalArgumentException("Unsupported type: " + value);
         } else if (condition instanceof Not) {
-            String sub = buildQueryFilter(((Not)condition).getChild(),informations);
+            final String sub = buildQueryFilter(((Not)condition).getChild(),informations);
             if (StringUtils.isNotBlank(sub)) return "-("+sub+")";
             else return "";
         } else if (condition instanceof And) {
-            int numChildren = ((And) condition).size();
-            StringBuilder sb = new StringBuilder();
-            for (Condition<JanusGraphElement> c : condition.getChildren()) {
-                String sub = buildQueryFilter(c, informations);
+            final int numChildren = ((And) condition).size();
+            final StringBuilder sb = new StringBuilder();
+            for (final Condition<JanusGraphElement> c : condition.getChildren()) {
+                final String sub = buildQueryFilter(c, informations);
 
                 if (StringUtils.isBlank(sub))
                     continue;
@@ -769,10 +759,10 @@ public class SolrIndex implements IndexProvider {
             }
             return sb.toString();
         } else if (condition instanceof Or) {
-            StringBuilder sb = new StringBuilder();
+            final StringBuilder sb = new StringBuilder();
             int element=0;
-            for (Condition<JanusGraphElement> c : condition.getChildren()) {
-                String sub = buildQueryFilter(c,informations);
+            for (final Condition<JanusGraphElement> c : condition.getChildren()) {
+                final String sub = buildQueryFilter(c,informations);
                 if (StringUtils.isBlank(sub)) continue;
                 if (element==0) sb.append("(");
                 else sb.append(" OR ");
@@ -799,8 +789,8 @@ public class SolrIndex implements IndexProvider {
         } else if (terms.size() == 1) {
             return (key + ":(" + escapeValue(terms.get(0)) + ")");
         } else {
-            And<JanusGraphElement> andTerms = new And<JanusGraphElement>();
-            for (String term : terms) {
+            final And<JanusGraphElement> andTerms = new And<JanusGraphElement>();
+            for (final String term : terms) {
                 andTerms.add(new PredicateCondition<String, JanusGraphElement>(key, janusgraphPredicate, term));
             }
             return buildQueryFilter(andTerms, informations);
@@ -811,12 +801,12 @@ public class SolrIndex implements IndexProvider {
     private List<String> customTokenize(String tokenizerClass, String value){
         CachingTokenFilter stream = null;
         try {
-            List<String> terms = new ArrayList<>();
-            Tokenizer tokenizer = ((Constructor<Tokenizer>) ClassLoader.getSystemClassLoader().loadClass(tokenizerClass)
+            final List<String> terms = new ArrayList<>();
+            final Tokenizer tokenizer = ((Constructor<Tokenizer>) ClassLoader.getSystemClassLoader().loadClass(tokenizerClass)
                     .getConstructor()).newInstance();
             tokenizer.setReader(new StringReader(value));
             stream = new CachingTokenFilter(tokenizer);
-            TermToBytesRefAttribute termAtt = stream.getAttribute(TermToBytesRefAttribute.class);
+            final TermToBytesRefAttribute termAtt = stream.getAttribute(TermToBytesRefAttribute.class);
             stream.reset();
             while (stream.incrementToken()) {
                 terms.add(termAtt.getBytesRef().utf8ToString());
@@ -830,8 +820,8 @@ public class SolrIndex implements IndexProvider {
     }
 
     private String toIsoDate(Date value) {
-        TimeZone tz = TimeZone.getTimeZone("UTC");
-        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        final TimeZone tz = TimeZone.getTimeZone("UTC");
+        final DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
         df.setTimeZone(tz);
         return df.format(value);
     }
@@ -855,7 +845,7 @@ public class SolrIndex implements IndexProvider {
         logger.trace("Shutting down connection to Solr", solrClient);
         try {
             solrClient.close();
-        } catch (IOException e) {
+        } catch (final IOException e) {
             throw new TemporaryBackendException(e);
         }
     }
@@ -865,23 +855,23 @@ public class SolrIndex implements IndexProvider {
         try {
             if (mode!=Mode.CLOUD) throw new UnsupportedOperationException("Operation only supported for SolrCloud");
             logger.debug("Clearing storage from Solr: {}", solrClient);
-            ZkStateReader zkStateReader = ((CloudSolrClient) solrClient).getZkStateReader();
+            final ZkStateReader zkStateReader = ((CloudSolrClient) solrClient).getZkStateReader();
             zkStateReader.updateClusterState();
-            ClusterState clusterState = zkStateReader.getClusterState();
-            for (String collection : clusterState.getCollections()) {
+            final ClusterState clusterState = zkStateReader.getClusterState();
+            for (final String collection : clusterState.getCollections()) {
                 logger.debug("Clearing collection [{}] in Solr",collection);
-                UpdateRequest deleteAll = newUpdateRequest();
+                final UpdateRequest deleteAll = newUpdateRequest();
                 deleteAll.deleteByQuery("*:*");
                 solrClient.request(deleteAll, collection);
             }
 
-        } catch (SolrServerException e) {
+        } catch (final SolrServerException e) {
             logger.error("Unable to clear storage from index due to server error on Solr.", e);
             throw new PermanentBackendException(e);
-        } catch (IOException e) {
+        } catch (final IOException e) {
             logger.error("Unable to clear storage from index due to low-level I/O error.", e);
             throw new PermanentBackendException(e);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             logger.error("Unable to clear storage from index due to general error.", e);
             throw new PermanentBackendException(e);
         }
@@ -889,8 +879,8 @@ public class SolrIndex implements IndexProvider {
 
     @Override
     public boolean supports(KeyInformation information, JanusGraphPredicate janusgraphPredicate) {
-        Class<?> dataType = information.getDataType();
-        Mapping mapping = Mapping.getMapping(information);
+        final Class<?> dataType = information.getDataType();
+        final Mapping mapping = Mapping.getMapping(information);
         if (mapping!=Mapping.DEFAULT && !AttributeUtil.isString(dataType) &&
                 !(mapping==Mapping.PREFIX_TREE && AttributeUtil.isGeo(dataType))) return false;
 
@@ -925,8 +915,8 @@ public class SolrIndex implements IndexProvider {
 
     @Override
     public boolean supports(KeyInformation information) {
-        Class<?> dataType = information.getDataType();
-        Mapping mapping = Mapping.getMapping(information);
+        final Class<?> dataType = information.getDataType();
+        final Mapping mapping = Mapping.getMapping(information);
         if (Number.class.isAssignableFrom(dataType) || dataType == Date.class || dataType == Instant.class || dataType == Boolean.class || dataType == UUID.class) {
             if (mapping==Mapping.DEFAULT) return true;
         } else if (AttributeUtil.isString(dataType)) {
@@ -943,9 +933,9 @@ public class SolrIndex implements IndexProvider {
         if (!dynFields) return key;
         if (ParameterType.MAPPED_NAME.hasParameter(keyInfo.getParameters())) return key;
         String postfix;
-        Class datatype = keyInfo.getDataType();
+        final Class datatype = keyInfo.getDataType();
         if (AttributeUtil.isString(datatype)) {
-            Mapping map = getStringMapping(keyInfo);
+            final Mapping map = getStringMapping(keyInfo);
             switch (map) {
                 case TEXT: postfix = "_t"; break;
                 case STRING: postfix = "_s"; break;
@@ -998,7 +988,7 @@ public class SolrIndex implements IndexProvider {
     }
 
     private UpdateRequest newUpdateRequest() {
-        UpdateRequest req = new UpdateRequest();
+        final UpdateRequest req = new UpdateRequest();
         if(waitSearcher) {
             req.setAction(UpdateRequest.ACTION.COMMIT, true, true);
         }
@@ -1012,18 +1002,18 @@ public class SolrIndex implements IndexProvider {
     private static void createCollectionIfNotExists(CloudSolrClient client, Configuration config, String collection)
             throws IOException, SolrServerException, KeeperException, InterruptedException {
         if (!checkIfCollectionExists(client, collection)) {
-            Integer numShards = config.get(NUM_SHARDS);
-            Integer maxShardsPerNode = config.get(MAX_SHARDS_PER_NODE);
-            Integer replicationFactor = config.get(REPLICATION_FACTOR);
+            final Integer numShards = config.get(NUM_SHARDS);
+            final Integer maxShardsPerNode = config.get(MAX_SHARDS_PER_NODE);
+            final Integer replicationFactor = config.get(REPLICATION_FACTOR);
 
 
             // Ideally this property used so a new configset is not uploaded for every single
             // index (collection) created in solr.
             // if a generic configSet is not set, make the configset name the same as the collection.
             // This was the default behavior before a default configSet could be specified
-            String  genericConfigSet = config.has(SOLR_DEFAULT_CONFIG) ? config.get(SOLR_DEFAULT_CONFIG):collection;
+            final String  genericConfigSet = config.has(SOLR_DEFAULT_CONFIG) ? config.get(SOLR_DEFAULT_CONFIG):collection;
 
-            CollectionAdminRequest.Create createRequest = new CollectionAdminRequest.Create();
+            final CollectionAdminRequest.Create createRequest = new CollectionAdminRequest.Create();
 
             createRequest.setConfigName(genericConfigSet);
             createRequest.setCollectionName(collection);
@@ -1031,7 +1021,7 @@ public class SolrIndex implements IndexProvider {
             createRequest.setMaxShardsPerNode(maxShardsPerNode);
             createRequest.setReplicationFactor(replicationFactor);
 
-            CollectionAdminResponse createResponse = createRequest.process(client);
+            final CollectionAdminResponse createResponse = createRequest.process(client);
             if (createResponse.isSuccess()) {
                 logger.trace("Collection {} successfully created.", collection);
             } else {
@@ -1046,9 +1036,9 @@ public class SolrIndex implements IndexProvider {
      * Checks if the collection has already been created in Solr.
      */
     private static boolean checkIfCollectionExists(CloudSolrClient server, String collection) throws KeeperException, InterruptedException {
-        ZkStateReader zkStateReader = server.getZkStateReader();
+        final ZkStateReader zkStateReader = server.getZkStateReader();
         zkStateReader.updateClusterState();
-        ClusterState clusterState = zkStateReader.getClusterState();
+        final ClusterState clusterState = zkStateReader.getClusterState();
         return clusterState.getCollectionOrNull(collection) != null;
     }
 
@@ -1056,22 +1046,22 @@ public class SolrIndex implements IndexProvider {
      * Wait for all the collection shards to be ready.
      */
     private static void waitForRecoveriesToFinish(CloudSolrClient server, String collection) throws KeeperException, InterruptedException {
-        ZkStateReader zkStateReader = server.getZkStateReader();
+        final ZkStateReader zkStateReader = server.getZkStateReader();
         try {
             boolean cont = true;
 
             while (cont) {
                 boolean sawLiveRecovering = false;
                 zkStateReader.updateClusterState();
-                ClusterState clusterState = zkStateReader.getClusterState();
-                Map<String, Slice> slices = clusterState.getSlicesMap(collection);
+                final ClusterState clusterState = zkStateReader.getClusterState();
+                final Map<String, Slice> slices = clusterState.getSlicesMap(collection);
                 Preconditions.checkNotNull("Could not find collection:" + collection, slices);
 
                // change paths for Replica.State per Solr refactoring
                // remove SYNC state per: http://tinyurl.com/pag6rwt
-               for (Map.Entry<String, Slice> entry : slices.entrySet()) {
-                    Map<String, Replica> shards = entry.getValue().getReplicasMap();
-                    for (Map.Entry<String, Replica> shard : shards.entrySet()) {
+               for (final Map.Entry<String, Slice> entry : slices.entrySet()) {
+                    final Map<String, Replica> shards = entry.getValue().getReplicasMap();
+                    for (final Map.Entry<String, Replica> shard : shards.entrySet()) {
                         final String state = shard.getValue().getStr(ZkStateReader.STATE_PROP).toUpperCase();
                         if ((Replica.State.RECOVERING.name().equals(state) || Replica.State.DOWN.name().equals(state))
                                 && clusterState.liveNodesContain(shard.getValue().getStr(

--- a/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrResultIterator.java
+++ b/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrResultIterator.java
@@ -1,0 +1,109 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.solr;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Iterator;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Function;
+
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.StreamingResponseCallback;
+import org.apache.solr.common.SolrDocument;
+
+/**
+ * @author David Clement (david.clement90@laposte.net)
+ */
+class SolrResultIterator<E> implements Iterator<E> {
+
+    private final SolrClient solrClient;
+    private final BlockingQueue<E> queue;
+    private int count;
+    private int numBatches;
+    private final Long limit;
+    private final int offset;
+    private final int batchSize;
+    private final String collection;
+    private final SolrQuery solrQuery;
+    private final Function<SolrDocument, E> getFieldValue;
+
+    public SolrResultIterator(SolrClient solrClient, Integer limit, int offset, int nbDocByQuery, String collection, SolrQuery solrQuery, Function<SolrDocument, E> function) throws SolrServerException, IOException {
+        this.solrClient = solrClient;
+        count = 0;
+        this.offset = offset;
+        this.batchSize = nbDocByQuery;
+        queue = new LinkedBlockingQueue<>();
+        this.collection = collection;
+        this.solrQuery = solrQuery;
+        this.getFieldValue = function;
+        final long nbFound = solrClient.queryAndStreamResponse(collection, solrQuery, new SolrCallbackHandler(this, function)).getResults().getNumFound() - offset;
+        this.limit = limit != null ? Math.min(nbFound, limit) : nbFound;
+        numBatches = 1;
+    }
+
+    public BlockingQueue<E> getQueue(){
+        return queue;
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (count != 0 && count % batchSize == 0 && batchSize * numBatches < limit) {
+            try {
+                solrQuery.setStart(numBatches * batchSize + offset);
+                solrClient.queryAndStreamResponse(collection, solrQuery, new SolrCallbackHandler(this, getFieldValue));
+                numBatches++;
+            } catch (final SolrServerException e) {
+                throw new UncheckedSolrException(e.getMessage(), e);
+            } catch (final IOException e) {
+                throw new UncheckedIOException(e.getMessage(), e);
+            }
+        }
+        return count < limit;
+    }
+
+    @Override
+    public E next() {
+        try {
+            count++;
+            return queue.take();
+        } catch (final InterruptedException e) {
+             throw new UncheckedIOException(new IOException("Interrupted waiting on queue", e));
+        }
+    }
+
+    private class SolrCallbackHandler<E> extends StreamingResponseCallback {
+
+        private final SolrResultIterator<E> iterator;
+        private final Function<SolrDocument, E> function;
+
+        public SolrCallbackHandler(SolrResultIterator<E> iterator, Function<SolrDocument, E> function) {
+            this.function = function;
+            this.iterator = iterator;
+        }
+
+        @Override
+        public void streamDocListInfo(long nbFound, long start, Float aMaxScore) {
+        }
+
+        @Override
+        public void streamSolrDocument(SolrDocument doc) {
+            iterator.getQueue().add(function.apply(doc));
+        }
+    }
+}

--- a/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/UncheckedSolrException.java
+++ b/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/UncheckedSolrException.java
@@ -1,0 +1,42 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.solr;
+
+import org.apache.solr.client.solrj.SolrServerException;
+
+/**
+ * @author davidclement@laposte.net
+ */
+public class UncheckedSolrException extends RuntimeException {
+
+    private static final long serialVersionUID = -8688401420333013730L;
+
+    /**
+     * @param msg   Exception message
+     * @param cause Cause of the exception
+     */
+    public UncheckedSolrException(String msg, SolrServerException cause) {
+        super(msg, cause);
+    }
+
+    /**
+     * Constructs an exception with a generic message
+     *
+     * @param cause Cause of the exception
+     */
+    public UncheckedSolrException(SolrServerException cause) {
+        this("Permanent failure in Solr backend", cause);
+    }
+}

--- a/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/BerkeleySolrTest.java
+++ b/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/BerkeleySolrTest.java
@@ -16,6 +16,7 @@ package org.janusgraph.diskstorage.solr;
 
 import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
 import static org.janusgraph.BerkeleyStorageSetup.getBerkeleyJEConfiguration;
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.*;
 
@@ -32,6 +33,7 @@ public class BerkeleySolrTest extends SolrJanusGraphIndexTest {
         config.set(INDEX_BACKEND,"solr",INDEX);
         config.set(SolrIndex.ZOOKEEPER_URL, SolrRunner.getZookeeperUrls(), INDEX);
         config.set(SolrIndex.WAIT_SEARCHER, true, INDEX);
+        config.set(GraphDatabaseConfiguration.INDEX_MAX_RESULT_SET_SIZE, 3, INDEX);
         //TODO: set SOLR specific config options
         return config.getConfiguration();
     }

--- a/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrIndexTest.java
+++ b/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrIndexTest.java
@@ -28,8 +28,9 @@ import org.janusgraph.diskstorage.configuration.Configuration;
 import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.janusgraph.diskstorage.indexing.IndexProvider;
 import org.janusgraph.diskstorage.indexing.IndexProviderTest;
+import org.janusgraph.diskstorage.indexing.IndexQuery;
 import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
-
+import org.janusgraph.graphdb.query.condition.PredicateCondition;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -38,8 +39,12 @@ import java.util.Date;
 
 import java.util.UUID;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
 
 /**
  * @author Jared Holmberg (jholmberg@bericotechnologies.com)
@@ -70,7 +75,7 @@ public class SolrIndexTest extends IndexProviderTest {
     public String getEnglishAnalyzerName() {
         return WhitespaceTokenizer.class.getName();
     }
-    
+
     @Override
     public String getKeywordAnalyzerName() {
         return KeywordTokenizer.class.getName();
@@ -78,10 +83,11 @@ public class SolrIndexTest extends IndexProviderTest {
 
     private Configuration getLocalSolrTestConfig() {
         final String index = "solr";
-        ModifiableConfiguration config = GraphDatabaseConfiguration.buildGraphConfiguration();
+        final ModifiableConfiguration config = GraphDatabaseConfiguration.buildGraphConfiguration();
 
         config.set(SolrIndex.ZOOKEEPER_URL, SolrRunner.getZookeeperUrls(), index);
         config.set(SolrIndex.WAIT_SEARCHER, true, index);
+        config.set(GraphDatabaseConfiguration.INDEX_MAX_RESULT_SET_SIZE, 3, index);
         return config.restrictTo(index);
     }
 

--- a/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/ThriftSolrTest.java
+++ b/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/ThriftSolrTest.java
@@ -19,6 +19,7 @@ import org.janusgraph.CassandraStorageSetup;
 import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
 import org.junit.BeforeClass;
 import java.io.File;
 
@@ -34,6 +35,7 @@ public class ThriftSolrTest extends SolrJanusGraphIndexTest {
         config.set(SolrIndex.ZOOKEEPER_URL, SolrRunner.getZookeeperUrls(), INDEX);
         config.set(SolrIndex.WAIT_SEARCHER, true, INDEX);
         config.set(INDEX_BACKEND,"solr",INDEX);
+        config.set(GraphDatabaseConfiguration.INDEX_MAX_RESULT_SET_SIZE, 3, INDEX);
         //TODO: set SOLR specific config options
         return config.getConfiguration();
     }

--- a/janusgraph-test/src/main/java/org/janusgraph/diskstorage/indexing/IndexProviderTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/diskstorage/indexing/IndexProviderTest.java
@@ -979,7 +979,33 @@ public abstract class IndexProviderTest {
         assertEquals(query.toString(), 1, tx.query(query).size());
 
     }
-    
+
+    @Test
+    public void testScroll() throws BackendException {
+        final String store = "vertex";
+        initialize(store);
+        add(store, "doc1", getDocument("Hello world", 1001, 5.2), true);
+        add(store, "doc2", getDocument("Hello world", 1001, 5.2), true);
+        add(store, "doc3", getDocument("Hello world", 1001, 6.2), true);
+        add(store, "doc4", getDocument("Hello world", 1002, 7.2), true);
+        add(store, "doc5", getDocument("Hello world", 1002, 8.2), true);
+        add(store, "doc6", getDocument("Hello world", 1002, 9.2), true);
+        add(store, "doc7", getDocument("Hello world", 1002, 10.2), true);
+
+        clopen();
+
+        //Test res < batchSize
+        assertEquals(2, tx.queryStream(new IndexQuery(store, PredicateCondition.of(WEIGHT, Cmp.EQUAL, 5.2))).count());
+        //Test res = batchSize
+        assertEquals(3, tx.queryStream(new IndexQuery(store, PredicateCondition.of(TIME, Cmp.EQUAL, 1001))).count());
+        //Test res > batchSize
+        assertEquals(7, tx.queryStream(new IndexQuery(store, PredicateCondition.of(NAME, Cmp.EQUAL, "Hello world"))).count());
+        //Test res == limit
+        assertEquals(4, tx.queryStream(new IndexQuery(store, PredicateCondition.of(TIME, Cmp.EQUAL, 1002), 4)).count());
+        //Test limit % batchSize == 0
+        assertEquals(6, tx.queryStream(new IndexQuery(store, PredicateCondition.of(NAME, Cmp.EQUAL, "Hello world"), 6)).count());
+    }
+
     /* ==================================================================================
                             HELPER METHODS
      ==================================================================================*/
@@ -1057,6 +1083,14 @@ public abstract class IndexProviderTest {
         for (RawQuery.Result<String> r : result) {
             System.out.println(r.getResult() + ":"+r.getScore());
         }
+    }
+
+    private Multimap<String, Object> getDocument(String txt, final long time, final double weight) {
+        final Multimap<String, Object> toReturn = HashMultimap.create();
+        toReturn.put(NAME, txt);
+        toReturn.put(TIME, time);
+        toReturn.put(WEIGHT, weight);
+        return toReturn;
     }
 
 }

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/TestMockIndexProvider.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/TestMockIndexProvider.java
@@ -21,6 +21,7 @@ import org.janusgraph.diskstorage.indexing.*;
 import org.janusgraph.graphdb.query.JanusGraphPredicate;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.INDEX_BACKEND;
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.INDEX_NS;
@@ -65,12 +66,12 @@ public class TestMockIndexProvider implements IndexProvider {
     }
 
     @Override
-    public List<String> query(IndexQuery query, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException {
+    public Stream<String> query(IndexQuery query, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException {
         return index.query(query,informations,tx);
     }
 
     @Override
-    public Iterable<RawQuery.Result<String>> query(RawQuery query, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException {
+    public Stream<RawQuery.Result<String>> query(RawQuery query, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException {
         return index.query(query,informations,tx);
     }
 


### PR DESCRIPTION
Issue :  https://github.com/JanusGraph/janusgraph/issues/480

I can not use cursors for Solr because sort clause must include the unique key field
(https://cwiki.apache.org/confluence/display/solr/Pagination+of+Results)

Signed-off-by: David Clement <david.clement90@laposte.net>