### PR TITLE
Enclosing transaction is closed error fix

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -181,7 +181,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
     /**
      * Whether or not this transaction is open
      */
-    private boolean isOpen;
+    private volatile boolean isOpen;
 
     private final VertexConstructor existingVertexRetriever;
     private final VertexConstructor externalVertexRetriever;


### PR DESCRIPTION
Fixed enclosing transaction is closed error when multiple threads interact with graph
Fixes #422