### PR TITLE
Check if vertex tx open on cache removal

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/vertexcache/GuavaVertexCache.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/vertexcache/GuavaVertexCache.java
@@ -17,6 +17,7 @@ package org.janusgraph.graphdb.transaction.vertexcache;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.*;
 import org.janusgraph.graphdb.internal.InternalVertex;
+import org.janusgraph.graphdb.vertices.AbstractVertex;
 import org.janusgraph.util.datastructures.Retriever;
 
 import java.util.ArrayList;
@@ -51,7 +52,7 @@ public class GuavaVertexCache implements VertexCache {
                         //Should only get evicted based on size constraint or replaced through add
                         assert (notification.getCause() == RemovalCause.SIZE || notification.getCause() == RemovalCause.REPLACED) : "Cause: " + notification.getCause();
                         InternalVertex v = notification.getValue();
-                        if (v.isModified()) {
+                        if (((AbstractVertex) v).isTxOpen() && v.isModified()) {
                             volatileVertices.putIfAbsent(notification.getKey(), v);
                         }
                     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/AbstractVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/AbstractVertex.java
@@ -60,6 +60,10 @@ public abstract class AbstractVertex extends AbstractElement implements Internal
         return tx.isOpen() ? tx : tx.getNextTx();
     }
 
+    public final boolean isTxOpen() {
+        return tx.isOpen();
+    }
+
     @Override
     public long getCompareId() {
         if (tx.isPartitionedVertex(this)) return tx.getIdInspector().getCanonicalVertexId(longId());


### PR DESCRIPTION
Since the Guava cache [processes its removals
asynchronously](https://github.com/google/guava):

"""
Caches built with CacheBuilder do not perform cleanup and evict values
"automatically," or instantly after a value expires, or anything of the
sort. Instead, it performs small amounts of maintenance during write
operations, or during occasional read operations if writes are rare.
The reason for this is as follows: if we wanted to perform Cache
maintenance continuously, we would need to create a thread, and its
operations would be competing with user operations for shared locks.
Additionally, some environments restrict the creation of threads, which
would make CacheBuilder unusable in that environment.
"""

there is a chance that we reach the onRemoval code _after_ the vertex
being removed due to cache eviction asynchronous processing has indeed
_already been removed and processed_ by user interaction. In this
scenario, the transaction is not open, and more importantly, this
denotes that the vertex processing is done and we do not need to add the
vertex to the volatileVertices map.

Issues: #503
Signed-off-by: David Pitera <dpitera@us.ibm.com>

Thank you for contributing to JanusGraph.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [x] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

