### PR TITLE
Support multiple serializer versions

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphIoRegistryV1d0.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphIoRegistryV1d0.java
@@ -20,26 +20,26 @@ import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONIo;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoIo;
 import org.janusgraph.core.attribute.Geoshape;
 import org.janusgraph.graphdb.relations.RelationIdentifier;
-import org.janusgraph.graphdb.tinkerpop.io.graphson.JanusGraphSONModuleV2d0;
+import org.janusgraph.graphdb.tinkerpop.io.graphson.JanusGraphSONModuleV1d0;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
-public class JanusGraphIoRegistry extends AbstractIoRegistry {
+public class JanusGraphIoRegistryV1d0 extends AbstractIoRegistry {
 
-    private static JanusGraphIoRegistry INSTANCE = new JanusGraphIoRegistry();
+    private static JanusGraphIoRegistryV1d0 INSTANCE = new JanusGraphIoRegistryV1d0();
 
     // todo: made the constructor temporarily public to workaround an interoperability issue with hadoop in tp3 GA https://issues.apache.org/jira/browse/TINKERPOP3-771
 
-    public JanusGraphIoRegistry() {
-        register(GraphSONIo.class, null, JanusGraphSONModuleV2d0.getInstance());
+    public JanusGraphIoRegistryV1d0() {
+        register(GraphSONIo.class, null, JanusGraphSONModuleV1d0.getInstance());
         register(GryoIo.class, RelationIdentifier.class, null);
         register(GryoIo.class, Geoshape.class, new Geoshape.GeoShapeGryoSerializer());
         register(GryoIo.class, P.class, new JanusGraphPSerializer());
     }
 
-    public static JanusGraphIoRegistry getInstance() {
+    public static JanusGraphIoRegistryV1d0 getInstance() {
         return INSTANCE;
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/io/graphson/JanusGraphSONModule.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/io/graphson/JanusGraphSONModule.java
@@ -14,8 +14,12 @@
 
 package org.janusgraph.graphdb.tinkerpop.io.graphson;
 
-import org.janusgraph.core.attribute.Geoshape;
-import org.janusgraph.graphdb.relations.RelationIdentifier;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONTokens;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.TinkerPopJacksonModule;
 import org.apache.tinkerpop.shaded.jackson.core.JsonGenerationException;
@@ -27,39 +31,29 @@ import org.apache.tinkerpop.shaded.jackson.databind.SerializerProvider;
 import org.apache.tinkerpop.shaded.jackson.databind.deser.std.StdDeserializer;
 import org.apache.tinkerpop.shaded.jackson.databind.jsontype.TypeSerializer;
 import org.apache.tinkerpop.shaded.jackson.databind.ser.std.StdSerializer;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import org.janusgraph.core.attribute.Geoshape;
+import org.janusgraph.graphdb.relations.RelationIdentifier;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
-public class JanusGraphSONModule extends TinkerPopJacksonModule {
+public abstract class JanusGraphSONModule extends TinkerPopJacksonModule {
 
     private static final String TYPE_NAMESPACE = "janusgraph";
 
-    private static final Map<Class, String> TYPE_DEFINITIONS = Collections.unmodifiableMap(
-            new LinkedHashMap<Class, String>() {{
-                put(RelationIdentifier.class, "RelationIdentifier");
-                put(Geoshape.class, "Geoshape");
-            }});
+    private static final Map<Class, String> TYPE_DEFINITIONS = Collections
+            .unmodifiableMap(new LinkedHashMap<Class, String>() {
+                {
+                    put(RelationIdentifier.class, "RelationIdentifier");
+                    put(Geoshape.class, "Geoshape");
+                }
+            });
 
-    private JanusGraphSONModule() {
+    protected JanusGraphSONModule() {
         super("janusgraph");
         addSerializer(RelationIdentifier.class, new RelationIdentifierSerializer());
-        addSerializer(Geoshape.class, new Geoshape.GeoshapeGsonSerializerV1d0());
 
         addDeserializer(RelationIdentifier.class, new RelationIdentifierDeserializer());
-        addDeserializer(Geoshape.class, new Geoshape.GeoshapeGsonDeserializerV1d0());
-    }
-
-    private static final JanusGraphSONModule INSTANCE = new JanusGraphSONModule();
-
-    public static final JanusGraphSONModule getInstance() {
-        return INSTANCE;
     }
 
     @Override
@@ -80,13 +74,14 @@ public class JanusGraphSONModule extends TinkerPopJacksonModule {
 
         @Override
         public void serialize(final RelationIdentifier relationIdentifier, final JsonGenerator jsonGenerator,
-                              final SerializerProvider serializerProvider) throws IOException, JsonGenerationException {
+                final SerializerProvider serializerProvider) throws IOException, JsonGenerationException {
             jsonGenerator.writeString(relationIdentifier.toString());
         }
 
         @Override
         public void serializeWithType(final RelationIdentifier relationIdentifier, final JsonGenerator jsonGenerator,
-                                      final SerializerProvider serializerProvider, final TypeSerializer typeSerializer) throws IOException, JsonProcessingException {
+                final SerializerProvider serializerProvider, final TypeSerializer typeSerializer)
+                throws IOException, JsonProcessingException {
             typeSerializer.writeTypePrefixForScalar(relationIdentifier, jsonGenerator);
             jsonGenerator.writeStartObject();
             jsonGenerator.writeStringField(GraphSONTokens.VALUE, relationIdentifier.toString());
@@ -102,7 +97,8 @@ public class JanusGraphSONModule extends TinkerPopJacksonModule {
         }
 
         @Override
-        public RelationIdentifier deserialize(final JsonParser jsonParser, final DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+        public RelationIdentifier deserialize(final JsonParser jsonParser,
+                final DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
             jsonParser.nextToken();
             final Map<String, Object> mapData = deserializationContext.readValue(jsonParser, Map.class);
             return RelationIdentifier.parse((String) mapData.get(GraphSONTokens.VALUE));

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/io/graphson/JanusGraphSONModuleV1d0.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/io/graphson/JanusGraphSONModuleV1d0.java
@@ -1,0 +1,37 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.io.graphson;
+
+import org.janusgraph.core.attribute.Geoshape;
+
+/**
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public class JanusGraphSONModuleV1d0 extends JanusGraphSONModule {
+
+    private JanusGraphSONModuleV1d0() {
+        super();
+        addSerializer(Geoshape.class, new Geoshape.GeoshapeGsonSerializerV1d0());
+
+        addDeserializer(Geoshape.class, new Geoshape.GeoshapeGsonDeserializerV1d0());
+    }
+
+    private static final JanusGraphSONModuleV1d0 INSTANCE = new JanusGraphSONModuleV1d0();
+
+    public static final JanusGraphSONModuleV1d0 getInstance() {
+        return INSTANCE;
+    }
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/io/graphson/JanusGraphSONModuleV2d0.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/io/graphson/JanusGraphSONModuleV2d0.java
@@ -1,0 +1,37 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.io.graphson;
+
+import org.janusgraph.core.attribute.Geoshape;
+
+/**
+ * Supports GraphSON 2.0
+ */
+public class JanusGraphSONModuleV2d0 extends JanusGraphSONModule {
+
+    private JanusGraphSONModuleV2d0() {
+        super();
+        addSerializer(Geoshape.class, new Geoshape.GeoshapeGsonSerializerV2d0());
+
+        addDeserializer(Geoshape.class, new Geoshape.GeoshapeGsonDeserializerV2d0());
+    }
+
+    private static final JanusGraphSONModuleV2d0 INSTANCE = new JanusGraphSONModuleV2d0();
+
+    public static final JanusGraphSONModuleV2d0 getInstance() {
+        return INSTANCE;
+    }
+
+}

--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-berkeleyje.yaml
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-berkeleyje.yaml
@@ -15,9 +15,9 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoLiteMessageSerializerV1d0, config: {ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }}
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV2d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }}
 processors:
   - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
   - { className: org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor, config: { cacheExpirationTime: 600000, cacheMaxSize: 1000 }}

--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server.yaml
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server.yaml
@@ -15,9 +15,9 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoLiteMessageSerializerV1d0, config: {ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }}
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV2d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }}
 processors:
   - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
   - { className: org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor, config: { cacheExpirationTime: 600000, cacheMaxSize: 1000 }}


### PR DESCRIPTION
Fixes issue #420
Updated JanusGraphIoRegistry to use GraphSON 2.0 by default.
I didn't create it as JanusGraphIoRegistryV2d0 because TinkerPop 3.3 introduces a method to help determine version requirements - apache/tinkerpop#706 .

Created JanusGraphIoRegistryV1d0 to use GraphSON 1.0 for backwards compatibility.

Signed-off-by: Robert Dale <robdale@gmail.com>

Thank you for contributing to JanusGraph.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [x] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

