### PR TITLE
Use legacy SpatialContextFactory path in solr module for backwards compatibility

### DIFF
--- a/janusgraph-dist/src/assembly/static/conf/solr/schema.xml
+++ b/janusgraph-dist/src/assembly/static/conf/solr/schema.xml
@@ -533,7 +533,7 @@
 
     <fieldType name="geo"
                class="solr.SpatialRecursivePrefixTreeFieldType"
-               spatialContextFactory="org.locationtech.spatial4j.context.SpatialContextFactory"
+               spatialContextFactory="com.spatial4j.core.context.SpatialContextFactory"
                distErrPct="0.000"
                maxDistErr="0.000009"
                distanceUnits="kilometers"

--- a/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
+++ b/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
@@ -854,7 +854,10 @@ public class SolrIndex implements IndexProvider {
     @Override
     public void clearStorage() throws BackendException {
         try {
-            if (mode!=Mode.CLOUD) throw new UnsupportedOperationException("Operation only supported for SolrCloud");
+            if (mode!=Mode.CLOUD) {
+                logger.error("Operation only supported for SolrCloud. Cores must be deleted manually through the Solr API when using HTTP mode.");
+                return;
+            }
             logger.debug("Clearing storage from Solr: {}", solrClient);
             final ZkStateReader zkStateReader = ((CloudSolrClient) solrClient).getZkStateReader();
             zkStateReader.updateClusterState();


### PR DESCRIPTION
Fixes #533. Also updates `SolrIndex.clearStorage()` to log an error instead of throw an exception in HTTP mode. This is so `JanusGraphFactory.drop()` still completes cleanly in this case. Cores are created externally in Solr HTTP so it's necessary/logical that they must also be deleted externally.