### PR TITLE
Include janusgraph-release profile when deploying snapshots [skip ci]

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -104,7 +104,7 @@ earlier.  It will appear on Maven Central in an hour or two.
 
 Finally, push your local changes to Github:
 
-```bash 
+```bash
 # cd to the janusgraph repository root if not already there
 git push origin $BRANCH_NAME
 git push origin refs/tags/$RELEASE_VERSION
@@ -124,5 +124,5 @@ SNAPSHOT version's artifacts to the Sonatype OSS snapshots repository.
 ```bash
 # From the repository root
 git checkout $BRANCH_NAME
-mvn clean deploy
+mvn clean deploy -Pjanusgraph-release
 ```


### PR DESCRIPTION
so that the sources are attached and published.

Fixes #470

Signed-off-by: Jason Plurad <pluradj@us.ibm.com>

This is a documentation change only since the snapshots are pushed manually, and the [current 0.2.0-SNAPSHOT](https://oss.sonatype.org/content/repositories/snapshots/org/janusgraph/janusgraph-core/0.2.0-SNAPSHOT/) has source attached.

Thank you for contributing to JanusGraph.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there an issue associated with this PR? Is it referenced in the commit message?
- [X] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

