### PR TITLE
Remove inaccurate nullable annotations to resolve Coverity findings

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexMutation.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexMutation.java
@@ -71,8 +71,7 @@ public class IndexMutation extends Mutation<IndexEntry,IndexEntry> {
     public static final Function<IndexEntry,String> ENTRY2FIELD_FCT = new Function<IndexEntry, String>() {
         @Nullable
         @Override
-        public String apply(@Nullable IndexEntry indexEntry) {
-            Preconditions.checkNotNull(indexEntry);
+        public String apply(final IndexEntry indexEntry) {
             return indexEntry.field;
         }
     };

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/cache/KCVEntryMutation.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/cache/KCVEntryMutation.java
@@ -15,7 +15,6 @@
 package org.janusgraph.diskstorage.keycolumnvalue.cache;
 
 import com.google.common.base.Function;
-import com.google.common.base.Preconditions;
 import org.janusgraph.diskstorage.Entry;
 import org.janusgraph.diskstorage.Mutation;
 import org.janusgraph.diskstorage.StaticBuffer;
@@ -35,8 +34,7 @@ public class KCVEntryMutation extends Mutation<Entry,Entry> {
     public static final Function<Entry,StaticBuffer> ENTRY2COLUMN_FCT = new Function<Entry, StaticBuffer>() {
         @Nullable
         @Override
-        public StaticBuffer apply(@Nullable Entry entry) {
-            Preconditions.checkNotNull(entry);
+        public StaticBuffer apply(final Entry entry) {
             return entry.getColumn();
         }
     };

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
@@ -424,8 +424,7 @@ public class IndexSerializer {
             return Iterables.transform(this, new Function<RecordEntry[], Object[]>() {
                 @Nullable
                 @Override
-                public Object[] apply(@Nullable RecordEntry[] record) {
-                    Preconditions.checkNotNull(record);
+                public Object[] apply(final RecordEntry[] record) {
                     return getValues(record);
                 }
             });
@@ -563,8 +562,8 @@ public class IndexSerializer {
                 new Function<Condition<JanusGraphElement>, Condition<JanusGraphElement>>() {
                     @Nullable
                     @Override
-                    public Condition<JanusGraphElement> apply(@Nullable Condition<JanusGraphElement> condition) {
-                        Preconditions.checkArgument(condition != null && condition instanceof PredicateCondition);
+                    public Condition<JanusGraphElement> apply(final Condition<JanusGraphElement> condition) {
+                        Preconditions.checkArgument(condition instanceof PredicateCondition);
                         PredicateCondition pc = (PredicateCondition) condition;
                         PropertyKey key = (PropertyKey) pc.getKey();
                         return new PredicateCondition<String, JanusGraphElement>(key2Field(index,key), pc.getPredicate(), pc.getValue());

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/StandardJanusGraph.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/StandardJanusGraph.java
@@ -628,8 +628,7 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
 
     private static final Predicate<InternalRelation> SCHEMA_FILTER = new Predicate<InternalRelation>() {
         @Override
-        public boolean apply(@Nullable InternalRelation internalRelation) {
-            Preconditions.checkNotNull(internalRelation);
+        public boolean apply(final InternalRelation internalRelation) {
             return internalRelation.getType() instanceof BaseRelationType && internalRelation.getVertex(0) instanceof JanusGraphSchemaVertex;
         }
     };

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/FulgoraGraphComputer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/FulgoraGraphComputer.java
@@ -301,8 +301,7 @@ public class FulgoraGraphComputer implements JanusGraphComputer {
                         new Function<Map<String, Object>, Map<String, Object>>() {
                             @Nullable
                             @Override
-                            public Map<String, Object> apply(@Nullable Map<String, Object> o) {
-                                Preconditions.checkNotNull(o);
+                            public Map<String, Object> apply(final Map<String, Object> o) {
                                 return Maps.filterKeys(o, s -> !VertexProgramHelper.isTransientVertexComputeKey(s, vertexProgram.getVertexComputeKeys()));
                             }
                         });

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/condition/ConditionUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/condition/ConditionUtil.java
@@ -15,7 +15,6 @@
 package org.janusgraph.graphdb.query.condition;
 
 import com.google.common.base.Function;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import org.janusgraph.core.JanusGraphElement;
 
@@ -32,8 +31,7 @@ public class ConditionUtil {
         return transformation(condition,new Function<Condition<E>, Condition<E>>() {
             @Nullable
             @Override
-            public Condition<E> apply(@Nullable Condition<E> cond) {
-                Preconditions.checkNotNull(cond);
+            public Condition<E> apply(final Condition<E> cond) {
                 if (cond.getType()== Condition.Type.LITERAL) return transformation.apply(cond);
                 else return null;
             }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -1081,8 +1081,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
                     private JanusGraphRelation previous = null;
 
                     @Override
-                    public boolean apply(@Nullable InternalRelation relation) {
-                        Preconditions.checkNotNull(relation);
+                    public boolean apply(final InternalRelation relation) {
                         if ((relation instanceof JanusGraphEdge) && relation.isLoop()
                                 && query.getDirection() != Direction.BOTH) {
                             if (relation.equals(previous))
@@ -1179,8 +1178,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
                     final Set<PropertyKey> keys = Sets.newHashSet();
                     ConditionUtil.traversal(query.getCondition(), new Predicate<Condition<JanusGraphElement>>() {
                         @Override
-                        public boolean apply(@Nullable Condition<JanusGraphElement> cond) {
-                            Preconditions.checkNotNull(cond);
+                        public boolean apply(final Condition<JanusGraphElement> cond) {
                             Preconditions.checkArgument(cond.getType() != Condition.Type.LITERAL || cond instanceof PredicateCondition);
                             if (cond instanceof PredicateCondition)
                                 keys.add(((PredicateCondition<PropertyKey, JanusGraphElement>) cond).getKey());
@@ -1191,8 +1189,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
                     Set<JanusGraphVertex> vertexSet = Sets.newHashSet();
                     for (JanusGraphRelation r : addedRelations.getView(new Predicate<InternalRelation>() {
                         @Override
-                        public boolean apply(@Nullable InternalRelation relation) {
-                            Preconditions.checkNotNull(relation);
+                        public boolean apply(final InternalRelation relation) {
                             return keys.contains(relation.getType());
                         }
                     })) {
@@ -1209,8 +1206,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
                     vertices = com.google.common.collect.Iterators.transform(newVertexIndexEntries.get(standardIndexKey.getValue(), standardIndexKey.getKey()).iterator(), new com.google.common.base.Function<JanusGraphVertexProperty, JanusGraphVertex>() {
                         @Nullable
                         @Override
-                        public JanusGraphVertex apply(@Nullable JanusGraphVertexProperty o) {
-                            Preconditions.checkNotNull(o);
+                        public JanusGraphVertex apply(final JanusGraphVertexProperty o) {
                             return o.element();
                         }
                     });
@@ -1226,8 +1222,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
                                         && !addedRelations.isEmpty()) {
                 return (Iterator) addedRelations.getView(new Predicate<InternalRelation>() {
                     @Override
-                    public boolean apply(@Nullable InternalRelation relation) {
-                        Preconditions.checkNotNull(relation);
+                    public boolean apply(final InternalRelation relation) {
                         return query.getResultType().isInstance(relation) && !relation.isInvisible() && query.matches(relation);
                     }
                 }).iterator();
@@ -1328,7 +1323,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
 
     private final Function<Object, JanusGraphVertex> vertexIDConversionFct = new Function<Object, JanusGraphVertex>() {
         @Override
-        public JanusGraphVertex apply(@Nullable Object id) {
+        public JanusGraphVertex apply(final Object id) {
             Preconditions.checkNotNull(id);
             Preconditions.checkArgument(id instanceof Long);
             return getInternalVertex((Long) id);
@@ -1337,7 +1332,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
 
     private final Function<Object, JanusGraphEdge> edgeIDConversionFct = new Function<Object, JanusGraphEdge>() {
         @Override
-        public JanusGraphEdge apply(@Nullable Object id) {
+        public JanusGraphEdge apply(final Object id) {
             Preconditions.checkNotNull(id);
             Preconditions.checkArgument(id instanceof RelationIdentifier);
             return ((RelationIdentifier)id).findEdge(StandardJanusGraphTx.this);
@@ -1346,7 +1341,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
 
     private final Function<Object, JanusGraphVertexProperty> propertyIDConversionFct = new Function<Object, JanusGraphVertexProperty>() {
         @Override
-        public JanusGraphVertexProperty apply(@Nullable Object id) {
+        public JanusGraphVertexProperty apply(final Object id) {
             Preconditions.checkNotNull(id);
             Preconditions.checkArgument(id instanceof RelationIdentifier);
             return ((RelationIdentifier)id).findProperty(StandardJanusGraphTx.this);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/ElementHelper.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/ElementHelper.java
@@ -15,7 +15,6 @@
 package org.janusgraph.graphdb.util;
 
 import com.google.common.base.Function;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import org.janusgraph.core.*;
@@ -42,8 +41,7 @@ public class ElementHelper {
             return Iterables.transform((((JanusGraphVertex) element).query()).keys(key.name()).properties(), new Function<JanusGraphVertexProperty, Object>() {
                 @Nullable
                 @Override
-                public Object apply(@Nullable JanusGraphVertexProperty janusgraphProperty) {
-                    Preconditions.checkNotNull(janusgraphProperty);
+                public Object apply(final JanusGraphVertexProperty janusgraphProperty) {
                     return janusgraphProperty.value();
                 }
             });

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/config/HadoopConfiguration.java
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/config/HadoopConfiguration.java
@@ -112,8 +112,7 @@ public class HadoopConfiguration implements WriteConfiguration {
 
         Iterable<String> prefixedKeys = Iterables.filter(internalKeys, new Predicate<String>() {
             @Override
-            public boolean apply(@Nullable String internalKey) {
-                Preconditions.checkNotNull(internalKey);
+            public boolean apply(final String internalKey) {
                 String k = internalKey;
                 if (null != prefix) {
                     if (k.startsWith(prefix)) {


### PR DESCRIPTION
Relates to #535. Previous attempt to resolve this finding category using `Preconditions.checkNotNull` (see b9e83bd56dc90d57d4e84c0c96fe649bf6787488) did not work. This PR updates to instead remove the `@Nullable` annotations and revert the `Preconditions.checkNotNull` calls.