### PR TITLE
Add JanusGraph specific authentication.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ env:
 
   matrix:
     # sort modules by test time with quickest modules first
+    - MODULE='server'
     - MODULE='hadoop-parent/janusgraph-hadoop-2'
     - MODULE='lucene'
     - MODULE='solr' ARGS='-Pdocker,solr7'

--- a/docs/basics.adoc
+++ b/docs/basics.adoc
@@ -70,7 +70,7 @@ There are several example configuration files in the `conf/` directory that can 
 [source, java]
 ----
 // Connect to Cassandra on localhost using a default configuration
-graph = JanusGraphFactory.open("conf/janusgraph-cassandra.properties")
+graph = JanusGraphFactory.open("conf/gremlin-server/http-janusgraph-hbase-server.properties")
 // Connect to HBase on localhost using a default configuration
 graph = JanusGraphFactory.open("conf/janusgraph-hbase.properties")
 ----
@@ -635,22 +635,113 @@ bin/gremlin-server.sh ./conf/gremlin-server/http-gremlin-server.yaml
 curl -XPOST -Hcontent-type:application/json -d '{"gremlin":"g.V().count()"}' http://[IP for JanusGraph server host]:8182
 ```
 
+=== JanusGraph Server as Both a WebSocket and HTTP Endpoint
+
+As of JanusGraph 0.2.0, you can configure your gremlin-server.yaml to accept both WebSocket and HTTP connections over the same port. This can be achieved by changing the channelizer in any of the previous examples as follows.
+
+```
+channelizer: org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer
+```
+
 === Advanced JanusGraph Server Configurations
 
-==== WebSocket versus HTTP
+==== Authentication over HTTP
 
-JanusGraph Server must be run with a configuration for either WebSocket (for Gremlin Console or other WebSocket programs) or re-configured for HTTP to work with HTTP clients.
+IMPORTANT: In the following example, credentialsDb should be different from the graph(s) you are using. It should be configured with the correct backend and a different keyspace, table, or storage directory as appropriate for the configured backend. This graph will be used for storing usernames and passwords.
 
-Currently, there is no way to configure a single running instance of JanusGraph Server to communicate simultaneously with clients talking WebSocket and HTTP.
-However, it is possible to create configuration files (following the steps in this chapter) for both WebSocket and HTTP and start two instances of the JanusGraph Server by pointing it to the various configurations when it is started.
-In this way, the same JanusGraph database instance can be reached through different JanusGraph Servers through both WebSocket and HTTP calls.
-Make sure the port parameter in each yaml configuration is different if starting more than one JanusGraph Server on the same machine:
+===== HTTP Basic authentication
+To enable Basic authentication in JanusGraph Server include the following configuration in your gremlin-server.yaml.
 
 ```
-port: 8182
+ authentication: {
+   authenticator: org.janusgraph.graphdb.tinkerpop.gremlin.server.auth.JanusGraphSimpleAuthenticator,
+   authenticationHandler: org.apache.tinkerpop.gremlin.server.handler.HttpBasicAuthenticationHandler,
+   config: {
+     defaultUsername: user,
+     defaultPassword: password,
+     credentialsDb: conf/janusgraph-credentials-server.properties
+    }
+ }
 ```
 
-In the future, the option to have one running instance of JanusGraph Server supporting multiple protocols may be possible.
+Verify that basic authentication is configured correctly. For example
+
+```
+curl -v -XPOST http://localhost:8182 -d '{"gremlin": "g.V().count()"}'
+```
+
+should return a 401 if the authentication is configured correctly and
+
+```
+curl -v -XPOST http://localhost:8182 -d '{"gremlin": "g.V().count()"}' -u user:password
+```
+should return a 200 and the result of 4 if authentication is configured correctly.
+
+==== Authentication over WebSocket
+Authentication over WebSocket occurs through a Simple Authentication and Security Layer (https://en.wikipedia.org/wiki/Simple_Authentication_and_Security_Layer[SASL]) mechanism.
+
+
+To enable SASL authentication include the following configuration in the gremlin-server.yaml
+
+```
+authentication: {
+  authenticator: org.janusgraph.graphdb.tinkerpop.gremlin.server.auth.JanusGraphSimpleAuthenticator,
+  authenticationHandler: org.apache.tinkerpop.gremlin.server.handler.SaslAuthenticationHandler,
+  config: {
+    defaultUsername: user,
+    defaultPassword: password,
+    credentialsDb: conf/janusgraph-credentials-server.properties
+  }
+}
+```
+
+IMPORTANT: In the preceding example, credentialsDb should be different from the graph(s) you are using. It should be configured with the correct backend and a different keyspace, table, or storage directory as appropriate for the configured backend. This graph will be used for storing usernames and passwords.
+
+If you are connecting through the gremlin console, your remote yaml file should ammend the `username` and `password` properties with the appropriate values.
+
+```
+username: user
+password: password
+```
+
+==== Authentication over HTTP and WebSocket
+If you are using the combined channelizer for both HTTP and WebSocket you can use the SaslAndHMACAuthenticator to authorize through either WebSocket through SASL, HTTP through basic auth, and HTTP through hash-based messsage authentication code (https://en.wikipedia.org/wiki/Hash-based_message_authentication_code[HMAC]) Auth. HMAC is a token based authentication designed to be used over HTTP. You first acquire a token via the `/session` endpoint and then use that to authenticate. It is used to amortize the time spent encrypting the password using basic auth.
+
+The gremlin-server.yaml should include the following configurations
+
+```
+authentication: {
+  authenticator: org.janusgraph.graphdb.tinkerpop.gremlin.server.auth.SaslAndHMACAuthenticator,
+  authenticationHandler: org.janusgraph.graphdb.tinkerpop.gremlin.server.handler.SaslAndHMACAuthenticationHandler,
+  config: {
+    defaultUsername: user,
+    defaultPassword: password,
+    hmacSecret: secret,
+    credentialsDb: conf/janusgraph-credentials-server.properties
+  }
+}
+```
+
+IMPORTANT: In the preceding example, credentialsDb should be different from the graph(s) you are using. It should be configured with the correct backend and a different keyspace, table, or storage directory as appropriate for the configured backend. This graph will be used for storing usernames and passwords.
+
+IMPORTANT: Note the hmacSecret here. This should be the same across all running JanusGraph servers if you want to be able to use the same HMAC token on each server.
+
+For HMAC authentication over HTTP, this creates a `/session` endpoint that provides a token that expires after an hour by default. This timeout for the token can be configured through the `tokenTimeout` configuration option in the `authentication.config` map. This value is a Long value and in milliseconds.
+
+You can obtain the token using curl by issuing a get request to the `/session` endpoint. For example
+
+```
+curl http://localhost:8182/session -XGET -u user:password
+
+{"token": "dXNlcjoxNTA5NTQ2NjI0NDUzOkhrclhYaGhRVG9KTnVSRXJ5U2VpdndhalJRcVBtWEpSMzh5WldqRTM4MW89"}
+```
+
+You can then use that token for authentication by using the "Authorization: Token" header. For example
+
+```
+curl -v http://localhost:8182/session -XPOST -d '{"gremlin": "g.V().count()"}' -H "Authorization: Token dXNlcjoxNTA5NTQ2NjI0NDUzOkhrclhYaGhRVG9KTnVSRXJ5U2VpdndhalJRcVBtWEpSMzh5WldqRTM4MW89"
+```
+
 
 [[gremlin-server-with-janusgraph]]
 ==== Using TinkerPop Gremlin Server with JanusGraph

--- a/janusgraph-all/pom.xml
+++ b/janusgraph-all/pom.xml
@@ -30,6 +30,11 @@
         </dependency>
         <dependency>
             <groupId>org.janusgraph</groupId>
+            <artifactId>janusgraph-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-cassandra</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/janusgraph-server/pom.xml
+++ b/janusgraph-server/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.janusgraph</groupId>
+        <artifactId>janusgraph</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>janusgraph-server</artifactId>
+    <name>janusgraph-server</name>
+    <url>http://janusgraph.org</url>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.janusgraph</groupId>
+            <artifactId>janusgraph-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tinkerpop</groupId>
+            <artifactId>gremlin-server</artifactId>
+            <version>${tinkerpop.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <!-- TESTING -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <version>3.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.janusgraph</groupId>
+            <artifactId>janusgraph-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/janusgraph-server/src/main/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/HMACAuthenticator.java
+++ b/janusgraph-server/src/main/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/HMACAuthenticator.java
@@ -1,0 +1,223 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.gremlin.server.auth;
+
+import static org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraphTokens.PROPERTY_PASSWORD;
+import static org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraphTokens.PROPERTY_USERNAME;
+import static org.janusgraph.graphdb.tinkerpop.gremlin.server.handler.HttpHMACAuthenticationHandler.PROPERTY_GENERATE_TOKEN;
+import static org.janusgraph.graphdb.tinkerpop.gremlin.server.handler.HttpHMACAuthenticationHandler.PROPERTY_TOKEN;
+
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.tinkerpop.gremlin.server.auth.AuthenticatedUser;
+import org.apache.tinkerpop.gremlin.server.auth.AuthenticationException;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.mindrot.jbcrypt.BCrypt;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * A class for doing Basic Auth and Token auth using an HMAC intended to be used with
+ * the HMACAuthenticationHandler
+ *
+ * @author Keith Lohnes lohnesk@gmail.com
+ */
+public class HMACAuthenticator extends JanusGraphAbstractAuthenticator {
+
+    /**
+     * Hmac algorithm defaults to hmacsha256
+     */
+    public static final String CONFIG_HMAC_ALGO = "hmacAlgo";
+
+    /**
+     * How long an auth token should stay valid
+     */
+    public static final String CONFIG_TOKEN_TIMEOUT = "tokenTimeout";
+
+    /**
+     * Hmac secret config
+     */
+    public static final String CONFIG_HMAC_SECRET = "hmacSecret";
+
+    private static final String AUTH_ERROR = "Username and/or password are incorrect";
+
+    private static final String DEFAULT_HMAC_ALGO = "HmacSHA256";
+
+    private static final char[] DEFAULT_HMAC_SECRET = "secret".toCharArray();
+
+    private static final Long DEFAULT_HMAC_TOKEN_TIMEOUT = 3600000L;
+
+    private char[] secret;
+    private String hmacAlgo;
+    private Long timeout;
+
+    @Override
+    public boolean requireAuthentication() {
+        return true;
+    }
+
+    @Override
+    public SaslNegotiator newSaslNegotiator(final InetAddress remoteAddress) {
+        throw new RuntimeException("HMACAuthenticator does not use SASL!");
+    }
+
+    public SaslNegotiator newSaslNegotiator() {
+        throw new RuntimeException("HMACAuthenticator does not use SASL!");
+    }
+
+    public void setup(final Map<String,Object> config) {
+    		Preconditions.checkArgument(config != null, "Credential configuration cannot be null");
+        Preconditions.checkState(config.containsKey(CONFIG_HMAC_SECRET), 
+        			String.format("Credential configuration missing the %s key", CONFIG_HMAC_SECRET));
+
+        if (null != config && config.containsKey(CONFIG_HMAC_ALGO)) {
+            hmacAlgo = config.get(CONFIG_HMAC_ALGO).toString();
+        } else {
+            hmacAlgo = DEFAULT_HMAC_ALGO;
+        }
+
+        if (null != config && config.containsKey(CONFIG_TOKEN_TIMEOUT)) {
+            timeout = ((Number) config.get(CONFIG_TOKEN_TIMEOUT)).longValue();
+        } else {
+            timeout = DEFAULT_HMAC_TOKEN_TIMEOUT;
+        }
+
+        super.setup(config);
+
+        if (null != config & config.containsKey(CONFIG_HMAC_SECRET)) {
+            secret = config.get(CONFIG_HMAC_SECRET).toString().toCharArray();
+        } else {
+            secret = DEFAULT_HMAC_SECRET;
+        }
+    }
+
+    @Override
+    public AuthenticatedUser authenticate(final Map<String, String> credentials) throws AuthenticationException {
+        if (credentials.get(PROPERTY_GENERATE_TOKEN) != null) {
+            final AuthenticatedUser user = authenticateUser(credentials);
+            if (user == null) {
+                throw new AuthenticationException(AUTH_ERROR);
+            }
+            credentials.put(PROPERTY_TOKEN, getToken(credentials));
+            return user;
+        } else if (credentials.get(PROPERTY_TOKEN) != null) {
+            if (validateToken(credentials)) {
+                return new AuthenticatedUser(credentials.get(PROPERTY_USERNAME));
+            } else {
+                throw new AuthenticationException("Invalid token");
+            }
+        } else {
+            return authenticateUser(credentials);
+        }
+    }
+
+    private AuthenticatedUser authenticateUser(final Map<String, String> credentials) throws AuthenticationException {
+        final Vertex v = credentialStore.findUser(credentials.get(PROPERTY_USERNAME));
+        if (null == v || !BCrypt.checkpw(credentials.get(PROPERTY_PASSWORD), v.value(PROPERTY_PASSWORD))) {
+            throw new AuthenticationException(AUTH_ERROR);
+        }
+        return new AuthenticatedUser(credentials.get(PROPERTY_USERNAME));
+    }
+
+    private boolean validateToken(Map<String, String> credentials) {
+        final String token = credentials.get(PROPERTY_TOKEN);
+        final Map<String, String> tokenMap = parseToken(token);
+        final String username = tokenMap.get(PROPERTY_USERNAME);
+        final String time = tokenMap.get("time");
+        final String password = credentialStore.findUser(username).value(PROPERTY_PASSWORD);
+        final String salt = getBcryptSaltFromStoredPassword(password);
+        final String expected = generateToken(username, salt, time);
+        final Long timeLong = Long.parseLong(time);
+        final Long currentTime = new Date().getTime();
+        final String base64Token = new String(Base64.getUrlEncoder().encode(token.getBytes()));
+        //Short circuit if the lengths aren't the same or time has expired
+        if (timeLong + timeout < currentTime || expected.length() != base64Token.length()) {
+            return false;
+        } else {
+            //Don't short circuit comparison to prevent timing attacks
+            boolean isValid = true;
+            for (int i = 0; i < expected.length(); i++) {
+                if (base64Token.charAt(i) != expected.charAt(i)) {
+                    isValid = false;
+                }
+            }
+            return isValid;
+        }
+    }
+
+    private Map<String, String> parseToken(final String token) {
+        final String[] parts = token.split(":");
+        return ImmutableMap.of(PROPERTY_USERNAME, parts[0], "time", parts[1], "hmac", parts[2]);
+    }
+
+    private String generateToken(final String username, final String salt, final String time) {
+        try {
+            final CharBuffer secretAndSalt = CharBuffer.allocate(secret.length + salt.length() + 1);
+            secretAndSalt.put(secret);
+            secretAndSalt.put(":");
+            secretAndSalt.put(salt);
+            final String tokenPrefix = username + ":" + time.toString() + ":";
+            final SecretKeySpec keySpec = new SecretKeySpec(toBytes(secretAndSalt.array()), hmacAlgo);
+            final Mac hmac = Mac.getInstance(hmacAlgo);
+            hmac.init(keySpec);
+            hmac.update(username.getBytes());
+            hmac.update(time.toString().getBytes());
+            final Base64.Encoder encoder = Base64.getUrlEncoder();
+            final byte[] hmacbytes = encoder.encode(hmac.doFinal());
+            final byte[] tokenbytes = tokenPrefix.getBytes();
+            final byte[] token = ByteBuffer.wrap(new byte[tokenbytes.length + hmacbytes.length]).put(tokenbytes).put(hmacbytes).array();
+            return new String(encoder.encode(token));
+        } catch (Exception ex){
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private String getToken(final Map<String, String> credentials) {
+        final String username = credentials.get(PROPERTY_USERNAME);
+        final Vertex user = credentialStore.findUser(username);
+        final String password = user.value(PROPERTY_PASSWORD);
+        final String salt = getBcryptSaltFromStoredPassword(password);
+        final String time = Long.toString(new Date().getTime());
+        return generateToken(username, salt, time);
+    }
+
+    //In BCrypt, the salt is the 22 chars after the 3rd $
+    private String getBcryptSaltFromStoredPassword(String password) {
+        Integer saltStart = StringUtils.ordinalIndexOf(password, "$", 3);
+        return password.substring(saltStart + 1, saltStart + 23);
+    }
+
+    private byte[] toBytes(char[] chars) {
+      CharBuffer charBuffer = CharBuffer.wrap(chars);
+      ByteBuffer byteBuffer = Charset.forName("UTF-8").encode(charBuffer);
+      byte[] bytes = Arrays.copyOfRange(byteBuffer.array(),
+              byteBuffer.position(), byteBuffer.limit());
+      Arrays.fill(charBuffer.array(), '\u0000'); //Clear sensitive data from memory
+      Arrays.fill(byteBuffer.array(), (byte) 0); //Clear sensitive data from memory
+      return bytes;
+  }
+}

--- a/janusgraph-server/src/main/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/JanusGraphAbstractAuthenticator.java
+++ b/janusgraph-server/src/main/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/JanusGraphAbstractAuthenticator.java
@@ -1,0 +1,121 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.gremlin.server.auth;
+
+import static org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraphTokens.PROPERTY_USERNAME;
+import static org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator.CONFIG_CREDENTIALS_DB;
+
+import java.net.InetAddress;
+import java.util.Map;
+
+import org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraph;
+import org.apache.tinkerpop.gremlin.server.auth.Authenticator;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.janusgraph.core.Cardinality;
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.JanusGraphFactory;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.JanusGraphIndex;
+import org.janusgraph.core.schema.SchemaAction;
+import org.janusgraph.core.schema.SchemaStatus;
+import org.janusgraph.graphdb.database.management.ManagementSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * An abstract class to handle the initial setup of indexes for authentication.
+ */
+abstract public class JanusGraphAbstractAuthenticator implements Authenticator {
+
+    private static final Logger logger = LoggerFactory.getLogger(JanusGraphAbstractAuthenticator.class);
+
+    /**
+     * Default username
+     */
+    public static final String CONFIG_DEFAULT_USER = "defaultUsername";
+
+    /**
+     * Default password for default username.
+     */
+    public static final String CONFIG_DEFAULT_PASSWORD = "defaultPassword";
+
+    private static final String USERNAME_INDEX_NAME = "byUsername";
+
+    protected CredentialGraph credentialStore;
+    protected JanusGraph backingGraph;
+
+    @Override
+    public boolean requireAuthentication() {
+        return true;
+    }
+
+    @Override
+    abstract public SaslNegotiator newSaslNegotiator(final InetAddress remoteAddress);
+
+    public CredentialGraph createCredentialGraph(JanusGraph graph) {
+        return new CredentialGraph(graph);
+    }
+
+    public JanusGraph openGraph(String conf) {
+        return JanusGraphFactory.open(conf);
+    }
+
+    @Override
+    public void setup(final Map<String,Object> config) {
+        logger.info("Initializing authentication with the {}", this.getClass().getName());
+        Preconditions.checkArgument(config != null, String.format(
+                    "Could not configure a %s - provide a 'config' in the 'authentication' settings",
+                    this.getClass().getName()));
+        
+
+        Preconditions.checkState(config.containsKey(CONFIG_CREDENTIALS_DB), String.format(
+                    "Credential configuration missing the %s key that points to a graph config file or graph name", CONFIG_CREDENTIALS_DB));
+
+        if (!config.containsKey(CONFIG_DEFAULT_USER) || !config.containsKey(CONFIG_DEFAULT_PASSWORD)) {
+            logger.warn(String.format("%s and %s should be defined to bootstrap authentication", CONFIG_DEFAULT_USER, CONFIG_DEFAULT_PASSWORD));
+        }
+
+        final JanusGraph graph = openGraph(config.get(CONFIG_CREDENTIALS_DB).toString());
+        backingGraph = graph;
+        credentialStore = createCredentialGraph(graph);
+        graph.tx().rollback();
+        ManagementSystem mgmt = (ManagementSystem) graph.openManagement();
+        if (!mgmt.containsGraphIndex(USERNAME_INDEX_NAME)) {
+            final PropertyKey username = mgmt.makePropertyKey(PROPERTY_USERNAME).dataType(String.class).cardinality(Cardinality.SINGLE).make();
+            mgmt.buildIndex(USERNAME_INDEX_NAME, Vertex.class).addKey(username).unique().buildCompositeIndex();
+            mgmt.commit();
+            mgmt = (ManagementSystem) graph.openManagement();
+            final JanusGraphIndex index = mgmt.getGraphIndex(USERNAME_INDEX_NAME);
+            if (!index.getIndexStatus(username).equals(SchemaStatus.ENABLED)) {
+                try {
+                    mgmt = (ManagementSystem) graph.openManagement();
+                    mgmt.updateIndex(mgmt.getGraphIndex(USERNAME_INDEX_NAME), SchemaAction.REINDEX);
+                    ManagementSystem.awaitGraphIndexStatus(graph, USERNAME_INDEX_NAME).status(SchemaStatus.ENABLED).call();
+                    mgmt.commit();
+                } catch (InterruptedException rude) {
+                    mgmt.rollback();
+                    throw new RuntimeException("Timed out waiting for byUsername index to be created on credential graph", rude);
+                }
+            }
+        }
+
+        final String defaultUser = config.get(CONFIG_DEFAULT_USER).toString();
+        if (credentialStore.findUser(defaultUser) == null) {
+            credentialStore.createUser(defaultUser, config.get(CONFIG_DEFAULT_PASSWORD).toString());
+        }
+    }
+}

--- a/janusgraph-server/src/main/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/JanusGraphSimpleAuthenticator.java
+++ b/janusgraph-server/src/main/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/JanusGraphSimpleAuthenticator.java
@@ -1,0 +1,55 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.gremlin.server.auth;
+
+import java.net.InetAddress;
+import java.util.Map;
+
+import org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraph;
+import org.apache.tinkerpop.gremlin.server.auth.AuthenticatedUser;
+import org.apache.tinkerpop.gremlin.server.auth.AuthenticationException;
+import org.apache.tinkerpop.gremlin.server.auth.Authenticator;
+import org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+
+/**
+ * A simple implementation of an {@link Authenticator} that uses a {@link Graph} instance as a credential store.
+ * Management of the credential store can be handled through the {@link CredentialGraph} DSL.
+ */
+public class JanusGraphSimpleAuthenticator extends JanusGraphAbstractAuthenticator {
+
+    protected SimpleAuthenticator simpleAuthenticator;
+
+    @Override
+    public void setup(final Map<String, Object> config) {
+        super.setup(config);
+        this.backingGraph.close();
+        simpleAuthenticator = createSimpleAuthenticator();
+        simpleAuthenticator.setup(config);
+    }
+
+    @Override
+    public SaslNegotiator newSaslNegotiator(final InetAddress remoteAddress) {
+        return simpleAuthenticator.newSaslNegotiator(remoteAddress);
+    }
+
+    public AuthenticatedUser authenticate(final Map<String, String> credentials) throws AuthenticationException {
+        return simpleAuthenticator.authenticate(credentials);
+    }
+
+    protected SimpleAuthenticator createSimpleAuthenticator() {
+        return new SimpleAuthenticator();
+    }
+}

--- a/janusgraph-server/src/main/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/SaslAndHMACAuthenticator.java
+++ b/janusgraph-server/src/main/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/SaslAndHMACAuthenticator.java
@@ -1,0 +1,80 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.gremlin.server.auth;
+
+import org.apache.tinkerpop.gremlin.server.auth.AuthenticatedUser;
+import org.apache.tinkerpop.gremlin.server.auth.AuthenticationException;
+
+import java.net.InetAddress;
+import java.util.Map;
+
+/**
+ * A wrapper authenticator that instantiates A JansuGraphSimpleAuthenticator (for Sasl)
+ * and an HMACAuthenticator (for http)
+ * @author Keith Lohnes lohnesk@gmail.com
+ */
+public class SaslAndHMACAuthenticator extends JanusGraphAbstractAuthenticator {
+
+    private static final String ILLEGAL_STATE_MESSAGE =
+        "This exception is likely due to a misconfiguration. Try using the SaslAndHMACAuthenticationHandler as the " +
+        "authenticationHandler in the server authentication configuration";
+
+    private static final String INCORRECT_CLASS_USAGE = "SaslAndHMACAuthenticator is a wrapper for two auths and should not be called directly.";
+
+    private JanusGraphSimpleAuthenticator janusSimpleAuthenticator;
+    private HMACAuthenticator hmacAuthenticator ;
+
+    @Override
+    public SaslNegotiator newSaslNegotiator(final InetAddress remoteAddress) {
+        throw new RuntimeException(INCORRECT_CLASS_USAGE);
+    }
+
+    public SaslNegotiator newSaslNegotiator() {
+        throw new RuntimeException(INCORRECT_CLASS_USAGE);
+    }
+
+    @Override
+    public void setup(final Map<String,Object> config) {
+        this.janusSimpleAuthenticator = createSimpleAuthenticator();
+        this.hmacAuthenticator = createHMACAuthenticator();
+        super.setup(config);
+        this.janusSimpleAuthenticator.simpleAuthenticator = this.janusSimpleAuthenticator.createSimpleAuthenticator();
+        this.janusSimpleAuthenticator.simpleAuthenticator.setup(config);
+        this.hmacAuthenticator.setup(config);
+    }
+
+    @Override
+    public AuthenticatedUser authenticate(final Map<String, String> credentials) throws AuthenticationException {
+        throw new IllegalStateException(ILLEGAL_STATE_MESSAGE);
+    }
+
+    public JanusGraphSimpleAuthenticator getSimpleAuthenticator() {
+        return this.janusSimpleAuthenticator;
+    }
+
+    public HMACAuthenticator getHMACAuthenticator() {
+        return this.hmacAuthenticator;
+    }
+
+    protected JanusGraphSimpleAuthenticator createSimpleAuthenticator() {
+        return new JanusGraphSimpleAuthenticator();
+    }
+
+    protected HMACAuthenticator createHMACAuthenticator() {
+        return new HMACAuthenticator();
+    }
+
+
+}

--- a/janusgraph-server/src/main/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/handler/HttpHMACAuthenticationHandler.java
+++ b/janusgraph-server/src/main/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/handler/HttpHMACAuthenticationHandler.java
@@ -1,0 +1,145 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.gremlin.server.handler;
+
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraphTokens.PROPERTY_PASSWORD;
+import static org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraphTokens.PROPERTY_USERNAME;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.tinkerpop.gremlin.server.auth.Authenticator;
+import org.apache.tinkerpop.gremlin.server.handler.AbstractAuthenticationHandler;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.util.ReferenceCountUtil;
+
+/**
+ * An Authentication Handler intended to be used with the HMACAuthenticator
+ * to provide Basic Auth and Token auth using an HMAC token
+ *
+ * @author Keith Lohnes lohnesk@gmail.com
+ */
+public class HttpHMACAuthenticationHandler extends AbstractAuthenticationHandler {
+
+    private final Base64.Decoder decoder = Base64.getUrlDecoder();
+
+    private final String basic = "Basic ";
+    private final String token = "Token ";
+
+    public static final String PROPERTY_TOKEN = "TOKEN";
+    public static final String PROPERTY_GENERATE_TOKEN = "GENERATE_TOKEN";
+
+    public HttpHMACAuthenticationHandler(final Authenticator authenticator) {
+        super(authenticator);
+    }
+
+    @Override
+    public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
+        if (msg instanceof FullHttpRequest) {
+            final FullHttpRequest req = (FullHttpRequest) msg;
+            final HttpMethod method = req.getMethod();
+            final Map<String, String> credentialsMap = getCredentialsMap(ctx, req);
+            if (credentialsMap == null) {
+                sendError(ctx, msg);
+                return;
+            }
+            if ("/session".equals(req.getUri()) && method.equals(HttpMethod.GET)) {
+                try {
+                    credentialsMap.put(PROPERTY_GENERATE_TOKEN, "true");
+                    authenticator.authenticate(credentialsMap);
+                } catch (Exception e) {
+                    sendError(ctx, msg);
+                    return;
+                }
+                replyWithToken(ctx, msg, credentialsMap.get(PROPERTY_TOKEN));
+            } else {
+                try {
+                    authenticator.authenticate(credentialsMap);
+                    ctx.fireChannelRead(req);
+                } catch (Exception e) {
+                    sendError(ctx, msg);
+                    return;
+                }
+            }
+        }
+    }
+
+    private Map<String, String> getCredentialsMap(final ChannelHandlerContext ctx, final FullHttpRequest req) {
+        // strip off "Basic " from the Authorization header (RFC 2617)
+        // or "Token "
+        final String authorizationHeader = req.headers().get("Authorization");
+        if (authorizationHeader == null) {
+            return null;
+        }
+        if (!(authorizationHeader.startsWith(basic) || authorizationHeader.startsWith(token))) {
+            return null;
+        }
+        final String authType = authorizationHeader.startsWith(basic) ? basic : token;
+        return getAuthCredMap(authorizationHeader, authType);
+    }
+
+    private Map<String, String> getAuthCredMap(final String authorizationHeader, final String authType) {
+        final byte[] decodedAuthParams;
+        final String authorization;
+        try {
+            final String encodedAuthParams = authorizationHeader.substring(authType.length());
+            decodedAuthParams = decoder.decode(encodedAuthParams);
+            authorization = new String(decodedAuthParams);
+        } catch (IndexOutOfBoundsException | IllegalArgumentException e) {
+            return null;
+        }
+        final Map<String,String> credentials = new HashMap<>();
+
+        if (authType.equals(basic)) {
+            final String[] split = authorization.split(":");
+            if (split.length != 2) {
+                return null;
+            }
+            credentials.put(PROPERTY_USERNAME, split[0]);
+            credentials.put(PROPERTY_PASSWORD, split[1]);
+        } else {
+            credentials.put(PROPERTY_TOKEN, authorization);
+        }
+        return credentials;
+    }
+
+    private void sendError(final ChannelHandlerContext ctx, final Object msg) {
+        ctx.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, UNAUTHORIZED)).addListener(ChannelFutureListener.CLOSE);
+        ReferenceCountUtil.release(msg);
+    }
+
+    private void replyWithToken(final ChannelHandlerContext ctx, final Object msg, final String token) {
+        final String json = "{\"token\": \"" + token + "\"}";
+        final byte[] jsonBytes = json.getBytes();
+        final FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, OK, Unpooled.wrappedBuffer(jsonBytes));
+        response.headers().set(CONTENT_TYPE, "application/json");
+        response.headers().set(CONTENT_LENGTH, response.content().readableBytes());
+        ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+        ReferenceCountUtil.release(msg);
+    }
+}

--- a/janusgraph-server/src/main/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/handler/SaslAndHMACAuthenticationHandler.java
+++ b/janusgraph-server/src/main/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/handler/SaslAndHMACAuthenticationHandler.java
@@ -1,0 +1,67 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.gremlin.server.handler;
+
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaders.Names.UPGRADE;
+import static org.apache.tinkerpop.gremlin.server.AbstractChannelizer.PIPELINE_AUTHENTICATOR;
+
+import org.apache.tinkerpop.gremlin.server.Settings;
+import org.apache.tinkerpop.gremlin.server.auth.Authenticator;
+import org.apache.tinkerpop.gremlin.server.handler.SaslAuthenticationHandler;
+import org.janusgraph.graphdb.tinkerpop.gremlin.server.auth.HMACAuthenticator;
+import org.janusgraph.graphdb.tinkerpop.gremlin.server.auth.SaslAndHMACAuthenticator;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpMessage;
+
+/**
+ * A class for doing Basic Auth and Token auth using an HMAC as well as
+ * Sasl authentication
+ * @author Keith Lohnes lohnesk@gmail.com
+ */
+@ChannelHandler.Sharable
+public class SaslAndHMACAuthenticationHandler extends SaslAuthenticationHandler {
+
+    private final String HMAC_AUTH = "hmac_authenticator";
+    private HMACAuthenticator hmacAuthenticator;
+
+    public SaslAndHMACAuthenticationHandler(final Authenticator authenticator, final Settings.AuthenticationSettings authenticationSettings) {
+        super(((SaslAndHMACAuthenticator) authenticator).getSimpleAuthenticator(), authenticationSettings);
+        hmacAuthenticator = ((SaslAndHMACAuthenticator) authenticator).getHMACAuthenticator();
+    }
+
+    @Override
+    public void channelRead(final ChannelHandlerContext ctx, final Object obj) throws Exception {
+        if (obj instanceof HttpMessage && !isWebSocket((HttpMessage)obj)) {
+            if (null == ctx.pipeline().get(HMAC_AUTH)) {
+                final HttpHMACAuthenticationHandler authHandler = new HttpHMACAuthenticationHandler(hmacAuthenticator);
+                ctx.pipeline().addAfter(PIPELINE_AUTHENTICATOR, HMAC_AUTH, authHandler);
+            }
+            ctx.fireChannelRead(obj);
+        } else {
+            super.channelRead(ctx, obj);
+        }
+    }
+
+    private boolean isWebSocket(final HttpMessage msg) {
+        final String connectionHeader = msg.headers().get(CONNECTION);
+        final String upgradeHeader = msg.headers().get(UPGRADE);
+        return (null != connectionHeader && connectionHeader.equalsIgnoreCase("Upgrade")) ||
+               (null != upgradeHeader && upgradeHeader.equalsIgnoreCase("WebSocket"));
+    }
+
+}

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/HMACAuthenticatorTest.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/HMACAuthenticatorTest.java
@@ -1,0 +1,519 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.gremlin.server.auth;
+
+import static org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraphTokens.PROPERTY_PASSWORD;
+import static org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraphTokens.PROPERTY_USERNAME;
+import static org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator.CONFIG_CREDENTIALS_DB;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.isA;
+import static org.janusgraph.graphdb.tinkerpop.gremlin.server.handler.HttpHMACAuthenticationHandler.PROPERTY_GENERATE_TOKEN;
+import static org.janusgraph.graphdb.tinkerpop.gremlin.server.handler.HttpHMACAuthenticationHandler.PROPERTY_TOKEN;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
+
+import java.net.InetAddress;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraph;
+import org.apache.tinkerpop.gremlin.server.auth.AuthenticationException;
+import org.apache.tinkerpop.gremlin.structure.Transaction;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.easymock.EasyMockSupport;
+import org.janusgraph.core.Cardinality;
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.JanusGraphIndex;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.core.schema.PropertyKeyMaker;
+import org.janusgraph.core.schema.SchemaStatus;
+import org.janusgraph.graphdb.database.management.ManagementSystem;
+import org.junit.Test;
+import org.mindrot.jbcrypt.BCrypt;
+
+public class HMACAuthenticatorTest extends EasyMockSupport {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetupNullConfig() {
+        final HMACAuthenticator authenticator = new HMACAuthenticator();
+        authenticator.setup(null);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testSetupNoCredDb() {
+        final HMACAuthenticator authenticator = new HMACAuthenticator();
+        authenticator.setup(new HashMap<String, Object>());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testSetupNoHmacSecret() {
+        final HMACAuthenticator authenticator = new HMACAuthenticator();
+        final Map<String, Object> configMap = new HashMap<String, Object>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        authenticator.setup(configMap);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testSetupEmptyNoUserDefault() {
+        final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .createMock();
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final Map<String, Object> configMap = new HashMap<String, Object>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        authenticator.setup(configMap);
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public void testSetupEmptyCredGraphNoPassDefault() {
+        final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .createMock();
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final Map<String, Object> configMap = new HashMap<String, Object>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        authenticator.setup(configMap);
+    }
+
+    @Test
+    public void testSetupEmptyCredGraphNoUserIndex() {
+        final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .createMock();
+
+        final Map<String, Object> configMap = new HashMap<String, Object>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
+
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final ManagementSystem mgmt = createMock(ManagementSystem.class);
+        final Transaction tx = createMock(Transaction.class);
+        final PropertyKey pk = createMock(PropertyKey.class);
+        final PropertyKeyMaker pkm = createMock(PropertyKeyMaker.class);
+        final JanusGraphManagement.IndexBuilder indexBuilder = createMock(JanusGraphManagement.IndexBuilder.class);
+        final JanusGraphIndex index = createMock(JanusGraphIndex.class);
+        final PropertyKey[] pks = {pk};
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        expect(credentialGraph.findUser("user")).andReturn(null);
+        expect(credentialGraph.createUser(eq("user"), eq("pass"))).andReturn(null);
+        expect(graph.openManagement()).andReturn(mgmt).times(2);
+        expect(graph.tx()).andReturn(tx);
+        expect(index.getFieldKeys()).andReturn(pks);
+        expect(index.getIndexStatus(eq(pk))).andReturn(SchemaStatus.ENABLED);
+
+        tx.rollback();
+        expectLastCall();
+
+        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(false);
+        expect(mgmt.makePropertyKey(PROPERTY_USERNAME)).andReturn(pkm);
+        expect(pkm.dataType(eq(String.class))).andReturn(pkm);
+        expect(pkm.cardinality(Cardinality.SINGLE)).andReturn(pkm);
+        expect(pkm.make()).andReturn(pk);
+        expect(mgmt.buildIndex(eq("byUsername"), eq(Vertex.class))).andReturn(indexBuilder);
+        expect(mgmt.getGraphIndex(eq("byUsername"))).andReturn(index);
+        expect(indexBuilder.addKey(eq(pk))).andReturn(indexBuilder);
+        expect(indexBuilder.unique()).andReturn(indexBuilder);
+        expect(indexBuilder.buildCompositeIndex()).andReturn(index);
+
+        mgmt.commit();
+        expectLastCall();
+
+        mgmt.rollback();
+        expectLastCall();
+
+        replayAll();
+
+        authenticator.setup(configMap);
+    }
+
+    @Test
+    public void testPassEmptyCredGraphUserIndex() {
+        final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .createMock();
+
+        final Map<String, Object> configMap = new HashMap<>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
+
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final ManagementSystem mgmt = createMock(ManagementSystem.class);
+        final Transaction tx = createMock(Transaction.class);
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
+        expect(credentialGraph.findUser("user")).andReturn(null);
+        expect(credentialGraph.createUser(eq("user"), eq("pass"))).andReturn(null);
+        expect(graph.openManagement()).andReturn(mgmt);
+        expect(graph.tx()).andReturn(tx);
+        tx.rollback();
+        expectLastCall();
+        replayAll();
+
+        authenticator.setup(configMap);
+    }
+
+    @Test
+    public void testSetupDefaultUserNonEmptyCredGraph() {
+        final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .createMock();
+
+        final Map<String, Object> configMap = new HashMap<String, Object>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
+
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final ManagementSystem mgmt = createMock(ManagementSystem.class);
+        final Transaction tx = createMock(Transaction.class);
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
+        expect(graph.openManagement()).andReturn(mgmt);
+        expect(graph.tx()).andReturn(tx);
+        expect(credentialGraph.findUser("user")).andReturn(createMock(Vertex.class));
+        tx.rollback();
+        expectLastCall();
+
+        replayAll();
+
+        authenticator.setup(configMap);
+    }
+
+    @Test
+    public void testAuthenticateBasicAuthValid() throws AuthenticationException {
+        final Map<String, String> credentials = new HashMap<>();
+        credentials.put(PROPERTY_USERNAME, "user");
+        credentials.put(PROPERTY_PASSWORD, "pass");
+
+        final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .createMock();
+
+        final Map<String, Object> configMap = new HashMap<String, Object>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
+
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final ManagementSystem mgmt = createMock(ManagementSystem.class);
+        final Transaction tx = createMock(Transaction.class);
+        final Vertex userVertex = createMock(Vertex.class);
+        final String bcryptedPass = BCrypt.hashpw("pass", BCrypt.gensalt(4));
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        expect(credentialGraph.findUser(eq("user"))).andReturn(userVertex).times(2);
+        expect(userVertex.value(eq(PROPERTY_PASSWORD))).andReturn(bcryptedPass);
+        expect(graph.openManagement()).andReturn(mgmt);
+        expect(graph.tx()).andReturn(tx);
+        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
+        tx.rollback();
+        expectLastCall();
+
+        replayAll();
+        authenticator.setup(configMap);
+        authenticator.authenticate(credentials);
+        verifyAll();
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void testAuthenticateBasicAuthInvalid() throws AuthenticationException {
+       final Map<String, String> credentials = new HashMap<>();
+       credentials.put(PROPERTY_USERNAME, "user");
+       credentials.put(PROPERTY_PASSWORD, "invalid");
+
+       final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .createMock();
+
+        final Map<String, Object> configMap = new HashMap<String, Object>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
+
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final ManagementSystem mgmt = createMock(ManagementSystem.class);
+        final Transaction tx = createMock(Transaction.class);
+        final Vertex userVertex = createMock(Vertex.class);
+        final String bcryptedPass = BCrypt.hashpw("pass", BCrypt.gensalt(4));
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        expect(credentialGraph.findUser(eq("user"))).andReturn(userVertex).times(2);
+        expect(userVertex.value(eq(PROPERTY_PASSWORD))).andReturn(bcryptedPass);
+        expect(graph.tx()).andReturn(tx);
+        expect(graph.openManagement()).andReturn(mgmt);
+        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
+        tx.rollback();
+        expectLastCall();
+
+        tx.rollback();
+        expectLastCall();
+
+        replayAll();
+        authenticator.setup(configMap);
+        authenticator.authenticate(credentials);
+        verifyAll();
+
+    }
+
+    @Test
+    public void testTokenAuth() throws AuthenticationException {
+        final Map<String, String> sharedVars = testAuthenticateGenerateToken();
+        testAuthenticateWithToken(sharedVars);
+        testFailureShortenedToken(sharedVars);
+        testTokenTimeout(sharedVars);
+    }
+
+    private Map<String, String> testAuthenticateGenerateToken() throws AuthenticationException {
+        final Map<String, String> credentials = new HashMap<>();
+        credentials.put(PROPERTY_USERNAME, "user");
+        credentials.put(PROPERTY_PASSWORD, "pass");
+        credentials.put(PROPERTY_GENERATE_TOKEN, "true");
+
+        final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .createMock();
+
+        final Map<String, Object> configMap = new HashMap<String, Object>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
+        configMap.put(HMACAuthenticator.CONFIG_HMAC_ALGO, "HmacSHA256");
+
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final ManagementSystem mgmt = createMock(ManagementSystem.class);
+        final Transaction tx = createMock(Transaction.class);
+        final Vertex userVertex = createMock(Vertex.class);
+        final String bcryptedPass = BCrypt.hashpw("pass", BCrypt.gensalt(4));
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        expect(credentialGraph.findUser(eq("user"))).andReturn(userVertex).anyTimes();
+        expect(userVertex.value(eq(PROPERTY_PASSWORD))).andReturn(bcryptedPass).times(2);
+        expect(graph.openManagement()).andReturn(mgmt);
+        expect(graph.tx()).andReturn(tx);
+        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
+        tx.rollback();
+        expectLastCall();
+
+        replayAll();
+        authenticator.setup(configMap);
+        assertNotNull(authenticator.authenticate(credentials));
+        final String hmacToken = credentials.get(PROPERTY_TOKEN);
+        assertNotNull(hmacToken);
+        verifyAll();
+        resetAll();
+        final Map<String, String> sharedVars = new HashMap<>();
+        sharedVars.put("hmacToken", hmacToken);
+        sharedVars.put("encryptedPass", bcryptedPass);
+        return sharedVars;
+    }
+
+    private void testFailureShortenedToken(final Map<String, String> sharedVars) throws AuthenticationException {
+        final String token = sharedVars.get("hmacToken");
+        final String bcryptedPass = sharedVars.get("encryptedPass");
+        final Map<String, String> credentials = new HashMap<>();
+        final String encodedString = new String(Base64.getUrlDecoder().decode(token));
+        final String brokenToken = encodedString.substring(0, encodedString.length() - 5);
+        credentials.put(PROPERTY_TOKEN, brokenToken);
+
+        final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .createMock();
+
+        final Map<String, Object> configMap = new HashMap<String, Object>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
+        configMap.put(HMACAuthenticator.CONFIG_HMAC_ALGO, "HmacSHA256");
+        configMap.put(HMACAuthenticator.CONFIG_TOKEN_TIMEOUT, 3600000);
+
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final ManagementSystem mgmt = createMock(ManagementSystem.class);
+        final Transaction tx = createMock(Transaction.class);
+        final Vertex userVertex = createMock(Vertex.class);
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        expect(credentialGraph.findUser(eq("user"))).andReturn(userVertex).anyTimes();
+        expect(userVertex.value(eq(PROPERTY_PASSWORD))).andReturn(bcryptedPass);
+        expect(graph.openManagement()).andReturn(mgmt);
+        expect(graph.tx()).andReturn(tx);
+        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
+        tx.rollback();
+        expectLastCall();
+
+        replayAll();
+        authenticator.setup(configMap);
+        try {
+            authenticator.authenticate(credentials);
+            assertFalse(true);
+        } catch (AuthenticationException ex) {
+            assertNotNull(ex);
+            verifyAll();
+            resetAll();
+        }
+    }
+
+    private void testAuthenticateWithToken(final Map<String, String> sharedVars) throws AuthenticationException {
+        final String token = sharedVars.get("hmacToken");
+        final String bcryptedPass = sharedVars.get("encryptedPass");
+        final Map<String, String> credentials = new HashMap<>();
+        credentials.put(PROPERTY_TOKEN, new String(Base64.getUrlDecoder().decode(token)));
+
+        final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .createMock();
+
+        final Map<String, Object> configMap = new HashMap<String, Object>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
+        configMap.put(HMACAuthenticator.CONFIG_HMAC_ALGO, "HmacSHA256");
+        configMap.put(HMACAuthenticator.CONFIG_TOKEN_TIMEOUT, 3600000);
+
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final ManagementSystem mgmt = createMock(ManagementSystem.class);
+        final Transaction tx = createMock(Transaction.class);
+        final Vertex userVertex = createMock(Vertex.class);
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        expect(credentialGraph.findUser(eq("user"))).andReturn(userVertex).anyTimes();
+        expect(userVertex.value(eq(PROPERTY_PASSWORD))).andReturn(bcryptedPass);
+        expect(graph.openManagement()).andReturn(mgmt);
+        expect(graph.tx()).andReturn(tx);
+        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
+        tx.rollback();
+        expectLastCall();
+
+        replayAll();
+        authenticator.setup(configMap);
+        assertNotNull(authenticator.authenticate(credentials));
+        verifyAll();
+        resetAll();
+    }
+
+    private void testTokenTimeout(final Map<String, String> sharedVars) {
+        final String token = sharedVars.get("hmacToken");
+        final String bcryptedPass = sharedVars.get("encryptedPass");
+        final Map<String, String> credentials = new HashMap<>();
+        credentials.put(PROPERTY_TOKEN, new String(Base64.getUrlDecoder().decode(token)));
+
+        final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .createMock();
+
+        final Map<String, Object> configMap = new HashMap<String, Object>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
+        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
+        configMap.put(HMACAuthenticator.CONFIG_HMAC_ALGO, "HmacSHA256");
+        configMap.put(HMACAuthenticator.CONFIG_TOKEN_TIMEOUT, 1);
+
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final ManagementSystem mgmt = createMock(ManagementSystem.class);
+        final Transaction tx = createMock(Transaction.class);
+        final Vertex userVertex = createMock(Vertex.class);
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        expect(credentialGraph.findUser(eq("user"))).andReturn(userVertex).anyTimes();
+        expect(userVertex.value(eq(PROPERTY_PASSWORD))).andReturn(bcryptedPass);
+        expect(graph.openManagement()).andReturn(mgmt);
+        expect(graph.tx()).andReturn(tx);
+        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
+        tx.rollback();
+        expectLastCall();
+
+        replayAll();
+        authenticator.setup(configMap);
+        AuthenticationException ae = null;
+        try {
+            authenticator.authenticate(credentials);
+        } catch (AuthenticationException e) {
+            ae = e;
+        }
+        assertNotNull(ae);
+        verifyAll();
+
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testNewSaslNegotiatorOfInetAddr() {
+        final HMACAuthenticator authenticator = new HMACAuthenticator();
+        authenticator.newSaslNegotiator(createMock(InetAddress.class));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testNewSaslNegotiator() {
+        final HMACAuthenticator authenticator = new HMACAuthenticator();
+        authenticator.newSaslNegotiator();
+    }
+}

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/JanusGraphSimpleAuthenticatorTest.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/JanusGraphSimpleAuthenticatorTest.java
@@ -1,0 +1,199 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.gremlin.server.auth;
+
+import static org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraphTokens.PROPERTY_USERNAME;
+import static org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator.CONFIG_CREDENTIALS_DB;
+
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.isA;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraph;
+import org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator;
+import org.apache.tinkerpop.gremlin.structure.Transaction;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.easymock.EasyMock;
+import org.easymock.EasyMockSupport;
+import org.janusgraph.core.Cardinality;
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.JanusGraphIndex;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.core.schema.PropertyKeyMaker;
+import org.janusgraph.core.schema.SchemaStatus;
+import org.janusgraph.graphdb.database.management.ManagementSystem;
+import org.junit.Test;
+
+public class JanusGraphSimpleAuthenticatorTest extends EasyMockSupport {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetupNullConfig() {
+        JanusGraphSimpleAuthenticator authenticator = new JanusGraphSimpleAuthenticator();
+        authenticator.setup(null);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testSetupNoCredDb() {
+        final JanusGraphSimpleAuthenticator authenticator = new JanusGraphSimpleAuthenticator();
+        authenticator.setup(new HashMap<String, Object>());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testSetupEmptyNoUserDefault() {
+        final JanusGraphSimpleAuthenticator authenticator = createMockBuilder(JanusGraphSimpleAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .createMock();
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final Map<String, Object> configMap = new HashMap<String, Object>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(JanusGraphSimpleAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        expect(credentialGraph.countUsers()).andReturn(0l);
+        authenticator.setup(configMap);
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public void testSetupEmptyCredGraphNoPassDefault() {
+        final JanusGraphSimpleAuthenticator authenticator = createMockBuilder(JanusGraphSimpleAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .createMock();
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final Map<String, Object> configMap = new HashMap<String, Object>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(JanusGraphSimpleAuthenticator.CONFIG_DEFAULT_USER, "user");
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        expect(credentialGraph.countUsers()).andReturn(0l);
+        authenticator.setup(configMap);
+    }
+
+    @Test
+    public void testSetupEmptyCredGraphNoUserIndex() {
+        final JanusGraphSimpleAuthenticator authenticator = createMockBuilder(JanusGraphSimpleAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .addMockedMethod("createSimpleAuthenticator")
+            .createMock();
+
+        final Map<String, Object> configMap = new HashMap<String, Object>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(JanusGraphSimpleAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
+        configMap.put(JanusGraphSimpleAuthenticator.CONFIG_DEFAULT_USER, "user");
+
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final ManagementSystem mgmt = createMock(ManagementSystem.class);
+        final Transaction tx = createMock(Transaction.class);
+        final PropertyKey pk = createMock(PropertyKey.class);
+        final PropertyKeyMaker pkm = createMock(PropertyKeyMaker.class);
+        final JanusGraphManagement.IndexBuilder indexBuilder = createMock(JanusGraphManagement.IndexBuilder.class);
+        final JanusGraphIndex index = createMock(JanusGraphIndex.class);
+        final PropertyKey[] pks = {pk};
+        final SimpleAuthenticator sa = createMock(SimpleAuthenticator.class);
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        expect(authenticator.createSimpleAuthenticator()).andReturn(sa);
+        expect(credentialGraph.findUser("user")).andReturn(null);
+        expect(credentialGraph.createUser(eq("user"), eq("pass"))).andReturn(null);
+        expect(graph.openManagement()).andReturn(mgmt);
+        expect(graph.tx()).andReturn(tx);
+        sa.setup(configMap);
+        EasyMock.expectLastCall();
+        graph.close();
+        EasyMock.expectLastCall();
+        tx.rollback();
+        EasyMock.expectLastCall();
+        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(false);
+        expect(mgmt.makePropertyKey(PROPERTY_USERNAME)).andReturn(pkm);
+        expect(pkm.dataType(eq(String.class))).andReturn(pkm);
+        expect(pkm.cardinality(Cardinality.SINGLE)).andReturn(pkm);
+        expect(pkm.make()).andReturn(pk);
+        expect(mgmt.buildIndex(eq("byUsername"), eq(Vertex.class))).andReturn(indexBuilder);
+        expect(mgmt.getGraphIndex(eq("byUsername"))).andReturn(index);
+        expect(indexBuilder.addKey(eq(pk))).andReturn(indexBuilder);
+        expect(indexBuilder.unique()).andReturn(indexBuilder);
+        expect(indexBuilder.buildCompositeIndex()).andReturn(index);
+        expect(index.getFieldKeys()).andReturn(pks);
+        expect(index.getIndexStatus(eq(pk))).andReturn(SchemaStatus.ENABLED);
+
+        expect(graph.tx()).andReturn(tx);
+        expect(graph.openManagement()).andReturn(mgmt);
+
+        tx.rollback();
+        EasyMock.expectLastCall().atLeastOnce();
+
+        mgmt.commit();
+        EasyMock.expectLastCall();
+
+        mgmt.rollback();
+        EasyMock.expectLastCall();
+
+        replayAll();
+        
+        authenticator.setup(configMap);
+    }
+
+    @Test
+    public void testPassEmptyCredGraphUserIndex() {
+        final JanusGraphSimpleAuthenticator authenticator = createMockBuilder(JanusGraphSimpleAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .addMockedMethod("createSimpleAuthenticator")
+            .createMock();
+
+        final Map<String, Object> configMap = new HashMap<>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(JanusGraphSimpleAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
+        configMap.put(JanusGraphSimpleAuthenticator.CONFIG_DEFAULT_USER, "user");
+
+        final SimpleAuthenticator sa = createMock(SimpleAuthenticator.class);
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final ManagementSystem mgmt = createMock(ManagementSystem.class);
+        final Transaction tx = createMock(Transaction.class);
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        expect(authenticator.createSimpleAuthenticator()).andReturn(sa);
+        expect(credentialGraph.findUser("user")).andReturn(null);
+        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
+        expect(credentialGraph.createUser(eq("user"), eq("pass"))).andReturn(null);
+        expect(graph.openManagement()).andReturn(mgmt);
+        expect(graph.tx()).andReturn(tx);
+
+        sa.setup(configMap);
+        EasyMock.expectLastCall();
+        graph.close();
+        EasyMock.expectLastCall();
+        tx.rollback();
+        EasyMock.expectLastCall();
+
+        replayAll();
+
+        authenticator.setup(configMap);
+    }
+}

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/SaslAndHMACAuthenticatorTest.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/SaslAndHMACAuthenticatorTest.java
@@ -1,0 +1,263 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.gremlin.server.auth;
+
+import static org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraphTokens.PROPERTY_USERNAME;
+import static org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator.CONFIG_CREDENTIALS_DB;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.isA;
+
+import java.net.InetAddress;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraph;
+import org.apache.tinkerpop.gremlin.server.auth.AuthenticationException;
+import org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator;
+import org.apache.tinkerpop.gremlin.structure.Transaction;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.easymock.EasyMockSupport;
+import org.janusgraph.core.Cardinality;
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.JanusGraphIndex;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.core.schema.PropertyKeyMaker;
+import org.janusgraph.core.schema.SchemaStatus;
+import org.janusgraph.graphdb.database.management.ManagementSystem;
+import org.junit.Test;
+
+public class SaslAndHMACAuthenticatorTest extends EasyMockSupport {
+
+    @Test(expected = RuntimeException.class)
+    public void testNewSaslNegotiator() {
+        new SaslAndHMACAuthenticator().newSaslNegotiator();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testNewSaslNegotiatorInet() {
+        final InetAddress inet = createMock(InetAddress.class);
+        new SaslAndHMACAuthenticator().newSaslNegotiator(inet);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testAuthenticate() throws AuthenticationException {
+        new SaslAndHMACAuthenticator().authenticate(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetupNullConfig() {
+        final SaslAndHMACAuthenticator authenticator = new SaslAndHMACAuthenticator();
+        authenticator.setup(null);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testSetupNoCredDb() {
+        final SaslAndHMACAuthenticator authenticator = new SaslAndHMACAuthenticator();
+        authenticator.setup(new HashMap<String, Object>());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testSetupEmptyNoUserDefault() {
+        final SaslAndHMACAuthenticator authenticator = createMockBuilder(SaslAndHMACAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .createMock();
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final Map<String, Object> configMap = new HashMap<String, Object>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(SaslAndHMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        authenticator.setup(configMap);
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public void testSetupEmptyCredGraphNoPassDefault() {
+        final SaslAndHMACAuthenticator authenticator = createMockBuilder(SaslAndHMACAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .createMock();
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final Map<String, Object> configMap = new HashMap<String, Object>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(SaslAndHMACAuthenticator.CONFIG_DEFAULT_USER, "user");
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        authenticator.setup(configMap);
+    }
+
+    @Test
+    public void testSetupEmptyCredGraphNoUserIndex() {
+        final SaslAndHMACAuthenticator authenticator = createMockBuilder(SaslAndHMACAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .addMockedMethod("createSimpleAuthenticator")
+            .addMockedMethod("createHMACAuthenticator")
+            .createMock();
+
+        final Map<String, Object> configMap = new HashMap<String, Object>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(SaslAndHMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
+        configMap.put(SaslAndHMACAuthenticator.CONFIG_DEFAULT_USER, "user");
+
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final ManagementSystem mgmt = createMock(ManagementSystem.class);
+        final JanusGraphSimpleAuthenticator janusSimpleAuthenticator = createMock(JanusGraphSimpleAuthenticator.class);
+        final HMACAuthenticator hmacAuthenticator = createMock(HMACAuthenticator.class);
+        final SimpleAuthenticator simpleAuthenticator = createMock(SimpleAuthenticator.class);
+        final Transaction tx = createMock(Transaction.class);
+        final PropertyKey pk = createMock(PropertyKey.class);
+        final PropertyKeyMaker pkm = createMock(PropertyKeyMaker.class);
+        final JanusGraphManagement.IndexBuilder indexBuilder = createMock(JanusGraphManagement.IndexBuilder.class);
+        final JanusGraphIndex index = createMock(JanusGraphIndex.class);
+        final PropertyKey[] pks = {pk};
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        expect(authenticator.createSimpleAuthenticator()).andReturn(janusSimpleAuthenticator);
+        expect(authenticator.createHMACAuthenticator()).andReturn(hmacAuthenticator);
+        hmacAuthenticator.setup(configMap);
+        expectLastCall();
+        expect(janusSimpleAuthenticator.createSimpleAuthenticator()).andReturn(simpleAuthenticator);
+        simpleAuthenticator.setup(configMap);
+        expectLastCall();
+
+        expect(credentialGraph.findUser("user")).andReturn(null);
+        expect(credentialGraph.createUser(eq("user"), eq("pass"))).andReturn(null);
+        expect(graph.openManagement()).andReturn(mgmt).times(2);
+        expect(graph.tx()).andReturn(tx);
+        expect(index.getFieldKeys()).andReturn(pks);
+        expect(index.getIndexStatus(eq(pk))).andReturn(SchemaStatus.ENABLED);
+
+        tx.rollback();
+        expectLastCall();
+
+        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(false);
+        expect(mgmt.makePropertyKey(PROPERTY_USERNAME)).andReturn(pkm);
+        expect(pkm.dataType(eq(String.class))).andReturn(pkm);
+        expect(pkm.cardinality(Cardinality.SINGLE)).andReturn(pkm);
+        expect(pkm.make()).andReturn(pk);
+        expect(mgmt.buildIndex(eq("byUsername"), eq(Vertex.class))).andReturn(indexBuilder);
+        expect(mgmt.getGraphIndex(eq("byUsername"))).andReturn(index);
+        expect(indexBuilder.addKey(eq(pk))).andReturn(indexBuilder);
+        expect(indexBuilder.unique()).andReturn(indexBuilder);
+        expect(indexBuilder.buildCompositeIndex()).andReturn(index);
+
+        mgmt.commit();
+        expectLastCall();
+
+        mgmt.rollback();
+        expectLastCall();
+
+        replayAll();
+
+        authenticator.setup(configMap);
+    }
+
+    @Test
+    public void testPassEmptyCredGraphUserIndex() {
+        final SaslAndHMACAuthenticator authenticator = createMockBuilder(SaslAndHMACAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .addMockedMethod("createSimpleAuthenticator")
+            .addMockedMethod("createHMACAuthenticator")
+            .createMock();
+
+        final Map<String, Object> configMap = new HashMap<>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(SaslAndHMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
+        configMap.put(SaslAndHMACAuthenticator.CONFIG_DEFAULT_USER, "user");
+
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final ManagementSystem mgmt = createMock(ManagementSystem.class);
+        final HMACAuthenticator hmacAuthenticator = createMock(HMACAuthenticator.class);
+        final JanusGraphSimpleAuthenticator janusSimpleAuthenticator = createMock(JanusGraphSimpleAuthenticator.class);
+        final SimpleAuthenticator simpleAuthenticator = createMock(SimpleAuthenticator.class);
+        final Transaction tx = createMock(Transaction.class);
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        expect(authenticator.createSimpleAuthenticator()).andReturn(janusSimpleAuthenticator);
+        expect(authenticator.createHMACAuthenticator()).andReturn(hmacAuthenticator);
+        hmacAuthenticator.setup(configMap);
+        expectLastCall();
+        expect(janusSimpleAuthenticator.createSimpleAuthenticator()).andReturn(simpleAuthenticator);
+        simpleAuthenticator.setup(configMap);
+        expectLastCall();
+        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
+        expect(credentialGraph.findUser("user")).andReturn(null);
+        expect(credentialGraph.createUser(eq("user"), eq("pass"))).andReturn(null);
+        expect(graph.openManagement()).andReturn(mgmt);
+        expect(graph.tx()).andReturn(tx);
+        tx.rollback();
+        expectLastCall();
+        replayAll();
+
+        authenticator.setup(configMap);
+    }
+
+    @Test
+    public void testSetupDefaultUserNonEmptyCredGraph() {
+        final SaslAndHMACAuthenticator authenticator = createMockBuilder(SaslAndHMACAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createCredentialGraph")
+            .addMockedMethod("createSimpleAuthenticator")
+            .addMockedMethod("createHMACAuthenticator")
+            .createMock();
+
+        final Map<String, Object> configMap = new HashMap<String, Object>();
+        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+        configMap.put(SaslAndHMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
+        configMap.put(SaslAndHMACAuthenticator.CONFIG_DEFAULT_USER, "user");
+
+        final JanusGraph graph = createMock(JanusGraph.class);
+        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
+        final ManagementSystem mgmt = createMock(ManagementSystem.class);
+        final JanusGraphSimpleAuthenticator janusSimpleAuthenticator = createMock(JanusGraphSimpleAuthenticator.class);
+        final HMACAuthenticator hmacAuthenticator = createMock(HMACAuthenticator.class);
+        final SimpleAuthenticator simpleAuthenticator = createMock(SimpleAuthenticator.class);
+        final Transaction tx = createMock(Transaction.class);
+
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
+        expect(authenticator.createSimpleAuthenticator()).andReturn(janusSimpleAuthenticator);
+        expect(authenticator.createHMACAuthenticator()).andReturn(hmacAuthenticator);
+        hmacAuthenticator.setup(configMap);
+        expectLastCall();
+        expect(janusSimpleAuthenticator.createSimpleAuthenticator()).andReturn(simpleAuthenticator);
+        simpleAuthenticator.setup(configMap);
+        expectLastCall();
+        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
+        expect(graph.openManagement()).andReturn(mgmt);
+        expect(graph.tx()).andReturn(tx);
+        expect(credentialGraph.findUser("user")).andReturn(createMock(Vertex.class));
+        tx.rollback();
+        expectLastCall();
+
+        replayAll();
+
+        authenticator.setup(configMap);
+    }
+
+}

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/handler/HttpHMACAuthenticationHandlerTest.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/handler/HttpHMACAuthenticationHandlerTest.java
@@ -1,0 +1,181 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.gremlin.server.handler;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
+import static org.easymock.EasyMock.and;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.isA;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Base64;
+import java.util.Map;
+
+import org.apache.tinkerpop.gremlin.server.auth.AuthenticatedUser;
+import org.apache.tinkerpop.gremlin.server.auth.Authenticator;
+import org.easymock.Capture;
+import org.easymock.CaptureType;
+import org.easymock.EasyMock;
+import org.easymock.EasyMockSupport;
+import org.easymock.IArgumentMatcher;
+import org.junit.Test;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+public class HttpHMACAuthenticationHandlerTest extends EasyMockSupport {
+
+    @Test
+    public void testChannelReadBasicAuthNoAuthHeader() {
+        final ChannelHandlerContext ctx = createMock(ChannelHandlerContext.class);
+        final FullHttpRequest msg = createMock(FullHttpRequest.class);
+        final HttpHeaders headers = createMock(HttpHeaders.class);
+        final Authenticator authenticator = createMock(Authenticator.class);
+        final ChannelFuture cf = createMock(ChannelFuture.class);
+
+        expect(msg.getMethod()).andReturn(HttpMethod.POST);
+        expect(msg.headers()).andReturn(headers).anyTimes();
+        expect(headers.get(eq("Authorization"))).andReturn(null);
+        expect(ctx.writeAndFlush(eqHttpStatus(UNAUTHORIZED))).andReturn(cf);
+        expect(cf.addListener(ChannelFutureListener.CLOSE)).andReturn(null);
+        expect(msg.release()).andReturn(false);
+        HttpHMACAuthenticationHandler handler = new HttpHMACAuthenticationHandler(authenticator);
+        replayAll();
+        handler.channelRead(ctx,(Object) msg);
+        verifyAll();
+    }
+
+    @Test
+    public void testChannelReadBasicAuthIncorrectScheme() {
+        final ChannelHandlerContext ctx = createMock(ChannelHandlerContext.class);
+        final FullHttpRequest msg = createMock(FullHttpRequest.class);
+        final HttpHeaders headers = createMock(HttpHeaders.class);
+        final Authenticator authenticator = createMock(Authenticator.class);
+        final ChannelFuture cf = createMock(ChannelFuture.class);
+
+        expect(msg.getMethod()).andReturn(HttpMethod.POST);
+        expect(msg.headers()).andReturn(headers).anyTimes();
+        expect(headers.get("Authorization")).andReturn("bogus");
+        expect(ctx.writeAndFlush(eqHttpStatus(UNAUTHORIZED))).andReturn(cf);
+        expect(cf.addListener(ChannelFutureListener.CLOSE)).andReturn(null);
+        expect(msg.release()).andReturn(false);
+
+        final HttpHMACAuthenticationHandler handler = new HttpHMACAuthenticationHandler(authenticator);
+        replayAll();
+        handler.channelRead(ctx,(Object) msg);
+        verifyAll();
+    }
+
+    @Test
+    public void testChannelReadBasicAuth() throws Exception {
+        final ChannelHandlerContext ctx = createMock(ChannelHandlerContext.class);
+        final FullHttpRequest msg = createMock(FullHttpRequest.class);
+        final HttpHeaders headers = createMock(HttpHeaders.class);
+        final Authenticator authenticator = createMock(Authenticator.class);
+        final String encodedUserNameAndPass = Base64.getEncoder().encodeToString("user:pass".getBytes());
+        expect(msg.getMethod()).andReturn(HttpMethod.POST);
+        expect(msg.headers()).andReturn(headers).anyTimes();
+        expect(msg.getUri()).andReturn("/");
+        expect(headers.get(eq("Authorization"))).andReturn("Basic " + encodedUserNameAndPass);
+        expect(ctx.fireChannelRead(isA(FullHttpRequest.class))).andReturn(ctx);
+        expect(authenticator.authenticate(isA(Map.class))).andReturn(new AuthenticatedUser("foo"));
+        final HttpHMACAuthenticationHandler handler = new HttpHMACAuthenticationHandler(authenticator);
+        replayAll();
+        handler.channelRead(ctx,(Object) msg);
+        verifyAll();
+    }
+
+    @Test
+    public void testChannelReadGetAuthToken() throws Exception {
+        final ChannelHandlerContext ctx = createMock(ChannelHandlerContext.class);
+        final FullHttpRequest msg = createMock(FullHttpRequest.class);
+        final HttpHeaders headers = createMock(HttpHeaders.class);
+        final Authenticator authenticator = createMock(Authenticator.class);
+        final ChannelFuture cf = createMock(ChannelFuture.class);
+        final String encodedUserNameAndPass = Base64.getEncoder().encodeToString("user:pass".getBytes());
+        final Capture<Map<String, String>> credMap = EasyMock.newCapture(CaptureType.ALL);
+        expect(msg.getMethod()).andReturn(HttpMethod.GET);
+        expect(msg.headers()).andReturn(headers).anyTimes();
+        expect(msg.getUri()).andReturn("/session");
+        expect(headers.get(eq("Authorization"))).andReturn("Basic " + encodedUserNameAndPass);
+        expect(authenticator.authenticate(and(isA(Map.class), capture(credMap)))).andReturn(new AuthenticatedUser("foo"));
+        expect(ctx.writeAndFlush(eqHttpStatus(OK))).andReturn(cf);
+        expect(cf.addListener(ChannelFutureListener.CLOSE)).andReturn(null);
+        expect(msg.release()).andReturn(false);
+        final HttpHMACAuthenticationHandler handler = new HttpHMACAuthenticationHandler(authenticator);
+        replayAll();
+        handler.channelRead(ctx,(Object) msg);
+        verifyAll();
+        assertNotNull(credMap.getValue().get(HttpHMACAuthenticationHandler.PROPERTY_GENERATE_TOKEN));
+    }
+
+    @Test
+    public void testChannelReadTokenAuth() throws Exception {
+        final ChannelHandlerContext ctx = createMock(ChannelHandlerContext.class);
+        final FullHttpRequest msg = createMock(FullHttpRequest.class);
+        final HttpHeaders headers = createMock(HttpHeaders.class);
+        final Authenticator authenticator = createMock(Authenticator.class);
+        final String encodedToken = Base64.getEncoder().encodeToString("askdjhf823asdlkfsasd".getBytes());
+        expect(msg.getMethod()).andReturn(HttpMethod.GET);
+        expect(msg.headers()).andReturn(headers).anyTimes();
+        expect(msg.getUri()).andReturn("/");
+        expect(headers.get(eq("Authorization"))).andReturn("Token " + encodedToken);
+        expect(ctx.fireChannelRead(isA(FullHttpRequest.class))).andReturn(ctx);
+        expect(authenticator.authenticate(isA(Map.class))).andReturn(new AuthenticatedUser("foo"));
+        final HttpHMACAuthenticationHandler handler = new HttpHMACAuthenticationHandler(authenticator);
+        replayAll();
+        handler.channelRead(ctx,(Object) msg);
+        verifyAll();
+    }
+
+
+    private static DefaultFullHttpResponse eqHttpStatus(HttpResponseStatus status) {
+        EasyMock.reportMatcher(new WithCorrectHttpResponse(status));
+        return null;
+    }
+
+    static class WithCorrectHttpResponse implements IArgumentMatcher {
+        private HttpResponseStatus expected;
+
+        public WithCorrectHttpResponse(HttpResponseStatus expected) {
+            this.expected = expected;
+        }
+
+        public boolean matches(Object actual) {
+            if (!(actual instanceof DefaultFullHttpResponse)) {
+                return false;
+            }
+            return expected.equals(((DefaultFullHttpResponse) actual).getStatus());
+        }
+
+        public void appendTo(StringBuffer buffer) {
+            buffer.append("eqHttpStatus(");
+            buffer.append(expected.getClass().getName());
+            buffer.append(" with status \"");
+            buffer.append(expected.toString());
+            buffer.append("\")");
+        }
+    }
+
+}

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/handler/SaslAndHMACAuthenticationHandlerTest.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/handler/SaslAndHMACAuthenticationHandlerTest.java
@@ -1,0 +1,82 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.gremlin.server.handler;
+
+import static org.apache.tinkerpop.gremlin.server.AbstractChannelizer.PIPELINE_AUTHENTICATOR;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.isA;
+
+import org.easymock.EasyMockSupport;
+import org.janusgraph.graphdb.tinkerpop.gremlin.server.auth.HMACAuthenticator;
+import org.janusgraph.graphdb.tinkerpop.gremlin.server.auth.JanusGraphSimpleAuthenticator;
+import org.janusgraph.graphdb.tinkerpop.gremlin.server.auth.SaslAndHMACAuthenticator;
+import org.junit.Test;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMessage;
+
+public class SaslAndHMACAuthenticationHandlerTest extends EasyMockSupport {
+
+    @Test
+    public void testHttpChannelReadWhenAuthenticatorHasNotBeenAdded() throws Exception {
+        final HMACAuthenticator hmacAuth = createMock(HMACAuthenticator.class);
+        final SaslAndHMACAuthenticator authenticator = createMock(SaslAndHMACAuthenticator.class);
+        final ChannelHandlerContext ctx = createMock(ChannelHandlerContext.class);
+        final ChannelPipeline pipeline = createMock(ChannelPipeline.class);
+        final HttpMessage msg = createMock(HttpMessage.class);
+        final HttpHeaders headers = createMock(HttpHeaders.class);
+
+        expect(authenticator.getHMACAuthenticator()).andReturn(hmacAuth);
+        expect(authenticator.getSimpleAuthenticator()).andReturn(createMock(JanusGraphSimpleAuthenticator.class));
+        expect(ctx.pipeline()).andReturn(pipeline).times(2);
+        expect(pipeline.get("hmac_authenticator")).andReturn(null);
+        expect(pipeline.addAfter(eq(PIPELINE_AUTHENTICATOR), eq("hmac_authenticator"), isA(ChannelHandler.class))).andReturn(null);
+        expect(msg.headers()).andReturn(headers).times(2);
+        expect(headers.get(isA(String.class))).andReturn(null).times(2);
+        expect(ctx.fireChannelRead(eq(msg))).andReturn(ctx);
+        replayAll();
+
+        final SaslAndHMACAuthenticationHandler handler = new SaslAndHMACAuthenticationHandler(authenticator, null);
+        handler.channelRead(ctx, msg);
+    }
+
+    @Test
+    public void testHttpChannelReadWhenAuthenticatorHasBeenAdded() throws Exception {
+        final SaslAndHMACAuthenticator authenticator = createMock(SaslAndHMACAuthenticator.class);
+        final HMACAuthenticator hmacAuth = createMock(HMACAuthenticator.class);
+        final ChannelHandlerContext ctx = createMock(ChannelHandlerContext.class);
+        final ChannelHandler mockHandler = createMock(ChannelHandler.class);
+        final ChannelPipeline pipeline = createMock(ChannelPipeline.class);
+        final HttpMessage msg = createMock(HttpMessage.class);
+        final HttpHeaders headers = createMock(HttpHeaders.class);
+
+        expect(authenticator.getHMACAuthenticator()).andReturn(hmacAuth);
+        expect(authenticator.getSimpleAuthenticator()).andReturn(createMock(JanusGraphSimpleAuthenticator.class));
+        expect(ctx.pipeline()).andReturn(pipeline);
+        expect(pipeline.get("hmac_authenticator")).andReturn(mockHandler);
+        expect(msg.headers()).andReturn(headers).times(2);
+        expect(headers.get(isA(String.class))).andReturn(null).times(2);
+        expect(ctx.fireChannelRead(eq(msg))).andReturn(ctx);
+        replayAll();
+
+        final SaslAndHMACAuthenticationHandler handler = new SaslAndHMACAuthenticationHandler(authenticator, null);
+        handler.channelRead(ctx, msg);
+    }
+
+}

--- a/janusgraph-server/src/test/resources/log4j.properties
+++ b/janusgraph-server/src/test/resources/log4j.properties
@@ -1,0 +1,19 @@
+# A1 is set to be a FileAppender.
+log4j.appender.A1=org.apache.log4j.FileAppender
+log4j.appender.A1.File=target/test.log
+log4j.appender.A1.Threshold=ALL
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
+
+# A2 is a ConsoleAppender.
+log4j.appender.A2=org.apache.log4j.ConsoleAppender
+log4j.appender.A2.Threshold=ALL
+# A2 uses PatternLayout.
+log4j.appender.A2.layout=org.apache.log4j.PatternLayout
+log4j.appender.A2.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{2}: %m%n
+
+# Set both appenders (A1 and A2) on the root logger.
+#log4j.rootLogger=INFO, A1, A2
+log4j.rootLogger=ERROR, A1
+

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
     <modules>
         <module>janusgraph-codepipelines-ci</module>
         <module>janusgraph-core</module>
+        <module>janusgraph-server</module>
         <module>janusgraph-test</module>
         <module>janusgraph-berkeleyje</module>
         <module>janusgraph-cql</module>


### PR DESCRIPTION
Issue: #623

This addresses a few concerns.

1) Configure a credential graph that automatically creates the appropriate JanusGraph specific indexes.

2) TinkerPop now supports (as of 3.2.6 and 3.3.0) a combined channelizer
for enabling port unification for WebSockets and HTTP. This adds the
necessary classes to enable authentication for one, the other, or both
using JanusGraph specific authentication.

3) HTTP Basic Auth is (and should be) slow. This adds an HMAC token
authentication mechanism to allow for fast authentication over HTTP.

Thank you for contributing to JanusGraph.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there an issue associated with this PR? Is it referenced in the commit message?
- [X] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you written and/or updated unit tests to verify your changes?
- [ N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ N/A] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ N/A] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered? 

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

