### PR TITLE
No extra binary deps needed for Bigtable [skip ci]

### DIFF
--- a/docs/bigtable.txt
+++ b/docs/bigtable.txt
@@ -15,8 +15,8 @@ ____
 
 === Bigtable Setup
 
-Bigtable implements the HBase interface for all data access operations, and requires some extra binary dependencies and
-some specific configuration options to connect.
+Bigtable implements the HBase interface for all data access operations, and
+requires a few configuration options to connect.
 
 ==== Connecting to Bigtable
 


### PR DESCRIPTION
After PR #592, the user does not need to add any additional binary
dependencies to their JanusGraph build. This change updates the docs to
clarify this; should have been included in the same PR.

/cc: @igorbernstein2