### PR TITLE
Fixes #640: uncomment the Solr dependency.

### DIFF
--- a/janusgraph-all/pom.xml
+++ b/janusgraph-all/pom.xml
@@ -73,14 +73,11 @@
             <artifactId>janusgraph-es</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!--
-        Commented since it requires Hadoop 2 and TP3 requires Hadoop 1.
         <dependency>
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-solr</artifactId>
             <version>${project.version}</version>
         </dependency>
-        -->
         <dependency>
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-lucene</artifactId>


### PR DESCRIPTION
Fixes #640.

The comment which hides Solr says that the dependency is not valid because it
requires Hadoop 2 while TinkerPop 3 only works with Hadoop 1.

JanusGraph currently depends on TinkerPop 3.2.6; per the docs:
http://tinkerpop.apache.org/docs/3.2.6/upgrade/
"Hadoop1 is no longer supported. Hadoop2 is now the only supported Hadoop
version in TinkerPop."

Thus, it should be safe to uncomment this dependency.

-----

Thank you for contributing to JanusGraph.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [-] Have you written and/or updated unit tests to verify your changes?
- [-] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [-] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [-] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [-] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.