### PR TITLE
Closing partitionVertexIdPool when VertexIDAssigner is closed

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/idassigner/VertexIDAssigner.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/idassigner/VertexIDAssigner.java
@@ -138,6 +138,7 @@ public class VertexIDAssigner implements AutoCloseable {
 
     public synchronized void close() {
         schemaIdPool.close();
+        partitionVertexIdPool.close();
         for (PartitionIDPool pool : idPools.values()) {
             pool.close();
         }


### PR DESCRIPTION
One of the two threadpools opened in VertexIDAssigner is never shutdown. This came up in my case when running JMH benchmarks. At the end of the benchmarks the threads would still be around after a close was issued.

-------------------------

Thank you for contributing to JanusGraph.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

