### PR TITLE
HTTPS, HTTP Basic auth and custom authentication support (#612, #645)

### DIFF
--- a/docs/elasticsearch.txt
+++ b/docs/elasticsearch.txt
@@ -15,7 +15,7 @@ JanusGraph supports https://www.elastic.co/[Elasticsearch] as an index backend. 
 * *Temporal*: Nanosecond granularity temporal indexing.
 * *Custom Analyzer*: Choose to use a custom analyzer
 
-Please see <<version-compat>> for details on what versions of ES will work with JanusGraph.
+Please see <<version-compat>> for details on what versions of Elasticsearch will work with JanusGraph.
 
 [IMPORTANT]
 ===============================
@@ -38,7 +38,7 @@ For security reasons Elasticsearch must be run under a non-root account
 
 === Elasticsearch Configuration Overview
 
-JanusGraph supports HTTP client connections to a running Elasticsearch cluster. Please see <<version-compat>> for details on what versions of ES will work with the different client types in JanusGraph.
+JanusGraph supports HTTP(S) client connections to a running Elasticsearch cluster. Please see <<version-compat>> for details on what versions of Elasticsearch will work with the different client types in JanusGraph.
 
 [NOTE]
 JanusGraph's index options start with the string "`index.[X].`" where "`[X]`" is a user-defined name for the backend. This user-defined name must be passed to JanusGraph's ManagementSystem interface when building a mixed index, as described in <<index-mixed>>, so that JanusGraph knows which of potentially multiple configured index backends to use. Configuration snippets in this chapter use the name `search`, whereas prose discussion of options typically write `[X]` in the same position. The exact index name is not significant as long as it is used consistently in JanusGraph's configuration and when administering indices.
@@ -84,6 +84,135 @@ JanusGraph only uses default values for `index-name` and `health-request-timeout
 
 The REST client accepts the `index.[X].bulk-refresh` option. This option controls when changes are made visible to search. See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html[?refresh documentation] for more information.
 
+==== REST Client HTTPS Configuration
+
+SSL support for HTTP can be enabled by setting the `index.[X].elasticsearch.ssl.enabled` configuration option to `true`. Note that depending on your configuration you may need to change the value of `index.[X].port` if your HTTPS port number is different from the default one for the REST API (9200).
+
+When SSL is enabled you may also configure the location and password of the truststore. This can be done as follows:
+
+[source, properties]
+----
+index.search.elasticsearch.ssl.truststore.location=/path/to/your/truststore.jks
+index.search.elasticsearch.ssl.truststore.password=truststorepwd
+----
+
+Note that these settings apply only to Elasticsearch REST client and do not affect any other SSL connections in JanusGraph.
+
+Configuration of the client keystore is also supported:
+
+[source, properties]
+----
+index.search.elasticsearch.ssl.keystore.location=/path/to/your/keystore.jks
+index.search.elasticsearch.ssl.keystore.storepassword=keystorepwd
+index.search.elasticsearch.ssl.keystore.keypassword=keypwd
+----
+
+Any of the passwords can be empty.
+
+If needed, the SSL hostname verification can be disabled by setting the `index.[X].elasticsearch.ssl.disable-hostname-verification` property value to `true` and the support for self-signed SSL certificates can be enabled by setting `index.[X].elasticsearch.ssl.allow-self-signed-certificates` property value to `true`.
+
+[TIP]
+It is not recommended to rely on the self-signed SSL certificates or to disable the hostname verification for a production system as it significantly limits the client's ability to provide the secure communication channel with the Elasticsearch server(s). This may result in leaking the confidential data which may be a part of your JanusGraph index.
+
+==== REST Client HTTP Authentication
+
+REST client supports the following authentication options: Basic HTTP Authentication (username/password) and custom authentication based on the user-provided implementation.
+
+These authentication methods are independent from SSL client authentication described above.
+
+===== REST Client Basic HTTP Authentication
+
+Basic HTTP Authentication is available regardless of the state of SSL support.  Optionally, an authentication realm can be specified via `index.[X].elasticsearch.http.auth.basic.realm` property.
+
+
+[source, properties]
+----
+index.search.elasticsearch.http.auth.type=basic
+index.search.elasticsearch.http.auth.basic.username=httpuser
+index.search.elasticsearch.http.auth.basic.password=httppassword
+----
+
+[TIP]
+It is highly recommended to use SSL (e.g. setting `index.[X].elasticsearch.ssl.enabled` to `true`) when using this option as the credentials can be intercepted when sent over an unencrypted connection!
+
+===== REST Client Custom HTTP Authentication
+
+Additional authentication methods can be implemented by providing your own implementation. The custom authenticator is configured as follows:
+
+[source, properties]
+----
+index.search.elasticsearch.http.auth.custom.authenticator-class=fully.qualified.class.Name
+index.search.elasticsearch.elasticsearch.http.auth.custom.authenticator-args=arg1,arg2,...
+----
+
+Argument list is optional and can be empty.
+
+The class specified there has to implement the `org.janusgraph.diskstorage.es.rest.util.RestClientAuthenticator` interface or extend `org.janusgraph.diskstorage.es.rest.util.RestClientAuthenticatorBase` convenience class. The implementation gets access to HTTP client configuration and can customize the client as needed. Refer to <<javadoc>> for more information.
+
+For example, the following code snippet implements an authenticator allowing the
+Elasticsearch REST client to authenticate and get authorized against AWS IAM:
+
+[source,java]
+----
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.janusgraph.diskstorage.es.rest.util.RestClientAuthenticatorBase;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.regions.DefaultAwsRegionProviderChain;
+import com.google.common.base.Supplier;
+
+import vc.inreach.aws.request.AWSSigner;
+import vc.inreach.aws.request.AWSSigningRequestInterceptor;
+
+/**
+ * <p>
+ * Elasticsearch REST HTTP(S) client callback implementing AWS request signing.
+ * </p>
+ * <p>
+ * The signer is based on AWS SDK default provider chain, allowing multiple options for providing
+ * the caller credentials. See {@link DefaultAWSCredentialsProviderChain} documentation for the details.
+ * </p>
+ */
+public class AWSV4AuthHttpClientConfigCallback extends RestClientAuthenticatorBase {
+
+    private static final String AWS_SERVICE_NAME = "es";
+    private HttpRequestInterceptor awsSigningInterceptor;
+
+    public AWSV4AuthHttpClientConfigCallback(final String[] args) {
+        // does not require any configuration
+    }
+
+    @Override
+    public void init() throws IOException {
+        DefaultAWSCredentialsProviderChain awsCredentialsProvider = new DefaultAWSCredentialsProviderChain();
+        final Supplier<LocalDateTime> clock = () -> LocalDateTime.now(ZoneOffset.UTC);
+
+        // using default region provider chain
+        // (http://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-region-selection.html)
+        DefaultAwsRegionProviderChain regionProviderChain = new DefaultAwsRegionProviderChain();
+        final String awsRegion = regionProviderChain.getRegion();
+
+        final AWSSigner awsSigner = new AWSSigner(awsCredentialsProvider, awsRegion, AWS_SERVICE_NAME, clock);
+        this.awsSigningInterceptor = new AWSSigningRequestInterceptor(awsSigner);
+    }
+
+    @Override
+    public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
+        return httpClientBuilder.addInterceptorLast(awsSigningInterceptor);/
+    }
+}
+
+----
+
+This custom authenticator does not use any constructor arguments.
+
+
+
 ==== Ingest Pipelines
 If using Elasticsearch 5.0 or higher, a different ingest pipelines can be set for each mixed index.
 Ingest pipeline can be use to pre-process documents before indexing. A pipeline is composed by a series of processors. Each processor transforms the document in some way.
@@ -95,14 +224,16 @@ See https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html[
 
 === Secure Elasticsearch
 
-Elasticsearch does not perform authentication or authorization. A client that can connect to ES is trusted by ES. When Elasticsearch runs on an unsecured or public network, particularly the Internet, it should be deployed with some type of external security. This is generally done with a combination of firewalling and tunneling of Elasticsearch's ports. Elasticsearch has two client-facing ports to consider:
+Elasticsearch does not perform authentication or authorization. A client that can connect to Elasticsearch is trusted by Elasticsearch. When Elasticsearch runs on an unsecured or public network, particularly the Internet, it should be deployed with some type of external security. This is generally done with a combination of firewalling, tunneling of Elasticsearch's ports or by using Elasticsearch extensions such as https://www.elastic.co/guide/en/x-pack/current/index.html[X-Pack]. Elasticsearch has two client-facing ports to consider:
 
 * The HTTP REST API, usually on port 9200
 * The native "transport" protocol, usually on port 9300
 
 A client uses either one protocol/port or the other, but not both simultaneously. Securing the HTTP protocol port is generally done with a combination of firewalling and a reverse proxy with SSL encryption and HTTP authentication. There are a couple of ways to approach security on the native "transport" protocol port:
 
-Tunnel ES's native "transport" protocol:: This approach can be implemented with SSL/TLS tunneling (for instance via https://www.stunnel.org/index.html[stunnel]), a VPN, or SSH port forwarding. SSL/TLS tunnels require non-trivial setup and monitoring: one or both ends of the tunnel need a certificate, and the stunnel processes need to be configured and running continuously. The setup for most secure VPNs is likewise non-trivial. Some Elasticsearch service providers handle server-side tunnel management and provide a custom Elasticsearch `transport.type` to simplify the client setup.
+In addition to that, some hosted Elasticsearch services offer other methods of authentication and authorization. For example, AWS Elasticsearch Service requires the use of HTTPS and offers an option for using IAM-based access control. For that the requests sent to this service must be signed. This can be achieved by using a custom authenticator (see above).
+
+Tunnel Elasticsearch's native "transport" protocol:: This approach can be implemented with SSL/TLS tunneling (for instance via https://www.stunnel.org/index.html[stunnel]), a VPN, or SSH port forwarding. SSL/TLS tunnels require non-trivial setup and monitoring: one or both ends of the tunnel need a certificate, and the stunnel processes need to be configured and running continuously. The setup for most secure VPNs is likewise non-trivial. Some Elasticsearch service providers handle server-side tunnel management and provide a custom Elasticsearch `transport.type` to simplify the client setup.
 Add a firewall rule that allows only trusted clients to connect on Elasticsearch's native protocol port:: This is typically done at the host firewall level. Easy to configure, but very weak security by itself.
 
 [[es-cfg-index-create]]
@@ -116,9 +247,9 @@ JanusGraph supports customization of the index settings it uses when creating it
 
 Settings customized through this mechanism are only applied when JanusGraph attempts to create its index in Elasticsearch. If JanusGraph finds that its index already exists, then it does not attempt to recreate it, and these settings have no effect.
 
-==== Embedding ES index creation settings with `create.ext`
+==== Embedding Elasticsearch index creation settings with `create.ext`
 
-JanusGraph iterates over all properties prefixed with `index.[X].elasticsearch.create.ext.`, where `[X]` is an index name such as `search`. It strips the prefix from each property key. The remainder of the stripped key will be interpreted as an Elasticsearch index creation setting. The value associated with the key is not modified. The stripped key and unmodified value are passed as part of the `settings` object in the Elasticsearch create index request that JanusGraph issues when bootstrapping on ES. This allows embedding arbitrary index creation settings settings in JanusGraph's properties. Here's an example configuration fragment that customizes three Elasticsearch index settings using the `create.ext` config mechanism:
+JanusGraph iterates over all properties prefixed with `index.[X].elasticsearch.create.ext.`, where `[X]` is an index name such as `search`. It strips the prefix from each property key. The remainder of the stripped key will be interpreted as an Elasticsearch index creation setting. The value associated with the key is not modified. The stripped key and unmodified value are passed as part of the `settings` object in the Elasticsearch create index request that JanusGraph issues when bootstrapping on Elasticsearch. This allows embedding arbitrary index creation settings settings in JanusGraph's properties. Here's an example configuration fragment that customizes three Elasticsearch index settings using the `create.ext` config mechanism:
 
 [source, properties]
 ----

--- a/janusgraph-es/pom.xml
+++ b/janusgraph-es/pom.xml
@@ -21,6 +21,7 @@
         <skip.es.test>${skipTests}</skip.es.test>
         <es.docker.image>docker.elastic.co/elasticsearch/elasticsearch</es.docker.image>
         <elasticsearch.docker.test.version>${elasticsearch.test.version}</elasticsearch.docker.test.version>
+        <powermock.version>1.6.1</powermock.version>
     </properties>
     <dependencies>
         <dependency>
@@ -101,6 +102,31 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
         <!-- End logging backends. -->
+
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-core</artifactId>
+			<version>${powermock.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-reflect</artifactId>
+			<version>${powermock.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-module-junit4</artifactId>
+			<version>${powermock.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito</artifactId>
+			<version>${powermock.version}</version>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
     <build>
         <resources>

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
 import org.janusgraph.diskstorage.es.compat.ES6Compat;
+import org.janusgraph.diskstorage.es.rest.util.HttpAuthTypes;
 import org.locationtech.spatial4j.shape.Rectangle;
 import org.apache.commons.lang.StringUtils;
 import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
@@ -166,6 +167,86 @@ public class ElasticSearchIndex implements IndexProvider {
 
     public static final ConfigNamespace ES_INGEST_PIPELINES =
             new ConfigNamespace(ELASTICSEARCH_NS, "ingest-pipeline", "Ingest pipeline applicable to a store of an index.");
+
+    public static final ConfigNamespace SSL_NS =
+            new ConfigNamespace(ELASTICSEARCH_NS, "ssl", "Elasticsearch SSL configuration");
+
+    public static final ConfigOption<Boolean> SSL_ENABLED =
+            new ConfigOption<>(SSL_NS, "enabled",
+            "Controls use of the SSL connection to Elasticsearch.", ConfigOption.Type.LOCAL, false);
+
+    public static final ConfigOption<Boolean> SSL_DISABLE_HOSTNAME_VERIFICATION =
+            new ConfigOption<>(SSL_NS, "disable-hostname-verification",
+            "Disables the SSL hostname verification if set to true. Hostname verification is enabled by default.",
+            ConfigOption.Type.LOCAL, false);
+
+    public static final ConfigOption<Boolean> SSL_ALLOW_SELF_SIGNED_CERTIFICATES =
+            new ConfigOption<>(SSL_NS, "allow-self-signed-certificates",
+            "Controls the accepting of the self-signed SSL certificates.",
+            ConfigOption.Type.LOCAL, false);
+
+    public static final ConfigNamespace SSL_TRUSTSTORE_NS =
+            new ConfigNamespace(SSL_NS, "truststore", "Configuration options for SSL Truststore.");
+
+    public static final ConfigOption<String> SSL_TRUSTSTORE_LOCATION =
+            new ConfigOption<>(SSL_TRUSTSTORE_NS, "location",
+            "Marks the location of the SSL Truststore.", ConfigOption.Type.LOCAL, "");
+
+    public static final ConfigOption<String> SSL_TRUSTSTORE_PASSWORD =
+            new ConfigOption<>(SSL_TRUSTSTORE_NS, "password",
+            "The password to access SSL Truststore.", ConfigOption.Type.LOCAL, "", val -> val != null);
+
+    public static final ConfigNamespace SSL_KEYSTORE_NS =
+            new ConfigNamespace(SSL_NS, "keystore", "Configuration options for SSL Keystore.");
+
+    public static final ConfigOption<String> SSL_KEYSTORE_LOCATION =
+            new ConfigOption<>(SSL_KEYSTORE_NS, "location",
+            "Marks the location of the SSL Keystore.", ConfigOption.Type.LOCAL, "");
+
+    public static final ConfigOption<String> SSL_KEYSTORE_PASSWORD =
+            new ConfigOption<>(SSL_KEYSTORE_NS, "storepassword",
+            "The password to access SSL Keystore.", ConfigOption.Type.LOCAL, "", val -> val != null);
+
+    public static final ConfigOption<String> SSL_KEY_PASSWORD =
+            new ConfigOption<>(SSL_KEYSTORE_NS, "keypassword",
+            "The password to access the key in the SSL Keystore. If the option is not present, the value of \"storepassword\" is used.",
+            ConfigOption.Type.LOCAL, "", val -> val != null);
+
+    public static final ConfigNamespace ES_HTTP_NS =
+            new ConfigNamespace(ELASTICSEARCH_NS, "http", "Configuration options for HTTP(S) transport.");
+
+    public static final ConfigNamespace ES_HTTP_AUTH_NS =
+            new ConfigNamespace(ES_HTTP_NS, "auth", "Configuration options for HTTP(S) authentication.");
+
+    public static final ConfigOption<String> ES_HTTP_AUTH_TYPE =
+            new ConfigOption<>(ES_HTTP_AUTH_NS, "type",
+            "Authentication type to be used for HTTP(S) access.", ConfigOption.Type.LOCAL, HttpAuthTypes.NONE.toString());
+
+    public static final ConfigNamespace ES_HTTP_AUTH_BASIC_NS =
+            new ConfigNamespace(ES_HTTP_AUTH_NS, "basic", "Configuration options for HTTP(S) Basic authentication.");
+
+    public static final ConfigOption<String> ES_HTTP_AUTH_USERNAME =
+            new ConfigOption<>(ES_HTTP_AUTH_BASIC_NS, "username",
+            "Username for HTTP(S) authentication.", ConfigOption.Type.LOCAL, "");
+
+    public static final ConfigOption<String> ES_HTTP_AUTH_PASSWORD =
+            new ConfigOption<>(ES_HTTP_AUTH_BASIC_NS, "password",
+            "Password for HTTP(S) authentication.", ConfigOption.Type.LOCAL, "");
+
+    public static final ConfigOption<String> ES_HTTP_AUTH_REALM = new ConfigOption<>(ES_HTTP_AUTH_BASIC_NS,
+            "realm", "Realm value for HTTP(S) authentication. If empty, any realm is accepted.",
+            ConfigOption.Type.LOCAL, "");
+
+    public static final ConfigNamespace ES_HTTP_AUTH_CUSTOM_NS =
+            new ConfigNamespace(ES_HTTP_AUTH_NS, "custom", "Configuration options for custom HTTP(S) authenticator.");
+
+    public static final ConfigOption<String> ES_HTTP_AUTHENTICATOR_CLASS = new ConfigOption<>(
+            ES_HTTP_AUTH_CUSTOM_NS, "authenticator-class", "Authenticator fully qualified class name.",
+            ConfigOption.Type.LOCAL, "");
+
+    public static final ConfigOption<String[]> ES_HTTP_AUTHENTICATOR_ARGS = new ConfigOption<>(
+            ES_HTTP_AUTH_CUSTOM_NS, "authenticator-args", "Comma-separated custom authenticator constructor arguments.",
+            ConfigOption.Type.LOCAL, new String[0]);
 
     public static final int HOST_PORT_DEFAULT = 9200;
 

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestClientSetup.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestClientSetup.java
@@ -1,0 +1,256 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.es.rest;
+
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.INDEX_HOSTS;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.INDEX_PORT;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHost;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback;
+import org.elasticsearch.client.RestClientBuilder.RequestConfigCallback;
+import org.janusgraph.diskstorage.configuration.ConfigOption;
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.diskstorage.es.ElasticSearchClient;
+import org.janusgraph.diskstorage.es.ElasticSearchIndex;
+import org.janusgraph.diskstorage.es.rest.util.BasicAuthHttpClientConfigCallback;
+import org.janusgraph.diskstorage.es.rest.util.HttpAuthTypes;
+import org.janusgraph.diskstorage.es.rest.util.RestClientAuthenticator;
+import org.janusgraph.diskstorage.es.rest.util.SSLConfigurationCallback;
+import org.janusgraph.diskstorage.es.rest.util.SSLConfigurationCallback.Builder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Create an instance of Elasticsearch REST {@link org.elasticsearch.client.RestClient} from a JanusGraph
+ * {@link org.janusgraph.diskstorage.configuration.Configuration}.
+ */
+public class RestClientSetup {
+
+    private static final Logger log = LoggerFactory.getLogger(RestClientSetup.class);
+
+    public ElasticSearchClient connect(Configuration config) throws IOException {
+        log.debug("Configuring RestClient");
+
+        final List<HttpHost> hosts = new ArrayList<>();
+        final int defaultPort = config.has(INDEX_PORT) ? config.get(INDEX_PORT) : ElasticSearchIndex.HOST_PORT_DEFAULT;
+        final String httpScheme = config.get(ElasticSearchIndex.SSL_ENABLED).booleanValue() ? "https" : "http";
+        for (String host : config.get(INDEX_HOSTS)) {
+            String[] hostparts = host.split(":");
+            String hostname = hostparts[0];
+            int hostport = defaultPort;
+            if (hostparts.length == 2) hostport = Integer.parseInt(hostparts[1]);
+            log.debug("Configured remote host: {} : {}", hostname, hostport);
+            hosts.add(new HttpHost(hostname, hostport, httpScheme));
+        }
+        final RestClient rc = getRestClient(hosts.toArray(new HttpHost[hosts.size()]), config);
+
+        final int scrollKeepAlive = config.get(ElasticSearchIndex.ES_SCROLL_KEEP_ALIVE);
+        Preconditions.checkArgument(scrollKeepAlive >= 1, "Scroll keep-alive should be greater than or equal to 1");
+        final RestElasticSearchClient client = getElasticSearchClient(rc, scrollKeepAlive);
+        if (config.has(ElasticSearchIndex.BULK_REFRESH)) {
+            client.setBulkRefresh(config.get(ElasticSearchIndex.BULK_REFRESH));
+        }
+
+        return client;
+    }
+
+    protected RestClient getRestClient(HttpHost[] hosts, Configuration config) {
+        final RestClientBuilder restClientBuilder = getRestClientBuilder(hosts);
+
+        final HttpClientConfigCallback httpClientConfigCallback = getHttpClientConfigCallback(config);
+        if (httpClientConfigCallback != null) {
+            restClientBuilder.setHttpClientConfigCallback(httpClientConfigCallback);
+        }
+
+        final RequestConfigCallback requestConfigCallback = getRequestConfigCallback(config);
+        if (requestConfigCallback != null) {
+            restClientBuilder.setRequestConfigCallback(requestConfigCallback);
+        }
+
+        if (config.has(ElasticSearchIndex.MAX_RETRY_TIMEOUT)) {
+            restClientBuilder.setMaxRetryTimeoutMillis(config.get(ElasticSearchIndex.MAX_RETRY_TIMEOUT));
+        }
+
+        return restClientBuilder.build();
+    }
+
+    protected RestClientBuilder getRestClientBuilder(HttpHost[] hosts) {
+        return RestClient.builder(hosts);
+    }
+
+    protected RestElasticSearchClient getElasticSearchClient(RestClient rc, int scrollKeepAlive) {
+        return new RestElasticSearchClient(rc, scrollKeepAlive);
+    }
+
+    /**
+     * <p>
+     * Returns the callback for customizing the {@link RequestConfig} or null if no
+     * customization is needed.
+     * </p>
+     * <p>
+     * See {@link RestClientBuilder#setRequestConfigCallback(RequestConfigCallback) for more details.
+     * </p>
+     *
+     * @param config
+     *            ES index configuration
+     * @return callback or null if the request customization is not needed
+     */
+    protected RequestConfigCallback getRequestConfigCallback(Configuration config) {
+        return null;
+    }
+
+    /**
+     * <p>
+     * Returns the callback for customizing {@link CloseableHttpAsyncClient} or null if no
+     * customization is needed.
+     * </p>
+     * <p>
+     * See {@link RestClientBuilder#setHttpClientConfigCallback(HttpClientConfigCallback) for more details.
+     * </p>
+     *
+     * @param config
+     *            ES index configuration
+     * @return callback or null if the client customization is not needed
+     */
+    protected HttpClientConfigCallback getHttpClientConfigCallback(Configuration config) {
+
+        final List<HttpClientConfigCallback> callbackList = new LinkedList<>();
+
+        final HttpAuthTypes authType = ConfigOption.getEnumValue(config.get(ElasticSearchIndex.ES_HTTP_AUTH_TYPE),
+                HttpAuthTypes.class);
+        log.debug("Configuring HTTP(S) authentication type {}", authType);
+
+        switch (authType) {
+        case BASIC:
+            callbackList.add(new BasicAuthHttpClientConfigCallback(
+                    config.has(ElasticSearchIndex.ES_HTTP_AUTH_REALM) ? config.get(ElasticSearchIndex.ES_HTTP_AUTH_REALM) : "",
+                    config.get(ElasticSearchIndex.ES_HTTP_AUTH_USERNAME),
+                    config.get(ElasticSearchIndex.ES_HTTP_AUTH_PASSWORD)));
+            break;
+        case CUSTOM:
+            callbackList.add(getCustomAuthenticator(
+                    config.get(ElasticSearchIndex.ES_HTTP_AUTHENTICATOR_CLASS),
+                    config.get(ElasticSearchIndex.ES_HTTP_AUTHENTICATOR_ARGS)));
+            break;
+        case NONE:
+            break;
+        default:
+            // not expected
+            throw new IllegalArgumentException("Authentication type \"" + authType + "\" is not implemented");
+        }
+
+        if (config.get(ElasticSearchIndex.SSL_ENABLED).booleanValue()) {
+            // Custom SSL configuration
+            final Builder sslConfCBBuilder = getSSLConfigurationCallbackBuilder();
+            boolean configureSSL = false;
+            if (config.has(ElasticSearchIndex.SSL_TRUSTSTORE_LOCATION)) {
+                sslConfCBBuilder.withTrustStore(config.get(ElasticSearchIndex.SSL_TRUSTSTORE_LOCATION),
+                        config.get(ElasticSearchIndex.SSL_TRUSTSTORE_PASSWORD));
+                configureSSL = true;
+            }
+            if (config.has(ElasticSearchIndex.SSL_KEYSTORE_LOCATION)) {
+                final String keystorePassword = config.get(ElasticSearchIndex.SSL_KEYSTORE_PASSWORD);
+                sslConfCBBuilder.withKeyStore(config.get(ElasticSearchIndex.SSL_KEYSTORE_LOCATION),
+                        keystorePassword,
+                        config.has(ElasticSearchIndex.SSL_KEY_PASSWORD) ? config.get(ElasticSearchIndex.SSL_KEY_PASSWORD) : keystorePassword);
+                configureSSL = true;
+            }
+
+            if (config.has(ElasticSearchIndex.SSL_DISABLE_HOSTNAME_VERIFICATION) &&
+                    config.has(ElasticSearchIndex.SSL_DISABLE_HOSTNAME_VERIFICATION)) {
+                log.warn("SSL hostname verification is disabled, Elasticsearch HTTPS connections may not be secure");
+                sslConfCBBuilder.disableHostNameVerification();
+                configureSSL = true;
+            }
+
+            if (config.has(ElasticSearchIndex.SSL_ALLOW_SELF_SIGNED_CERTIFICATES) &&
+                    config.has(ElasticSearchIndex.SSL_ALLOW_SELF_SIGNED_CERTIFICATES)) {
+                log.warn("Self-signed SSL certificate support is enabled, Elasticsearch HTTPS connections may not be secure");
+                sslConfCBBuilder.allowSelfSignedCertificates();
+                configureSSL = true;
+            }
+
+            if (configureSSL) {
+                callbackList.add(sslConfCBBuilder.build());
+            }
+        }
+
+        if (callbackList.isEmpty()) {
+            return null;
+        }
+
+        // will execute the chain of individual callbacks
+        return new HttpClientConfigCallback() {
+
+            @Override
+            public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
+                for(HttpClientConfigCallback cb: callbackList) {
+                    cb.customizeHttpClient(httpClientBuilder);
+                }
+                return httpClientBuilder;
+            }
+        };
+    }
+
+    protected SSLConfigurationCallback.Builder getSSLConfigurationCallbackBuilder() {
+        return SSLConfigurationCallback.Builder.create();
+    }
+
+    protected RestClientAuthenticator getCustomAuthenticator(String authClassName, String[] authClassConstructurArgList) {
+        Preconditions.checkArgument(StringUtils.isNotEmpty(authClassName),
+                "Custom authenticator class name cannot be empty");
+        Preconditions.checkNotNull(authClassConstructurArgList,
+                "Custom authenticator class constructor argument list cannot be null");
+
+        final RestClientAuthenticator authenticator;
+
+        try {
+            final Class<?> c = Class.forName(authClassName);
+            Preconditions.checkArgument(RestClientAuthenticator.class.isAssignableFrom(c), "Authenticator class "
+                    + authClassName + " must be a subclass of " + RestClientAuthenticator.class.getName());
+            @SuppressWarnings("unchecked")
+            final Constructor<RestClientAuthenticator> ctr = ((Class<RestClientAuthenticator>)c).getConstructor(String[].class);
+            authenticator = ctr.newInstance((Object)authClassConstructurArgList);
+        } catch (Exception e) {
+            log.error("Unable to instantiate the custom authenticator {} with constructor arguments \"{}\"",
+                    authClassName, authClassConstructurArgList, e);
+            throw new RuntimeException("Unable to instantiate the custom authenticator", e);
+        }
+
+        try {
+            authenticator.init();
+        } catch (IOException e) {
+            log.error("Unable to initialize the custom authenticator {} with constructor arguments \"{}\"",
+                    authClassName, authClassConstructurArgList, e);
+            throw new RuntimeException("Unable to initialize the custom authenticator", e);
+        }
+
+        return authenticator;
+    }
+}

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/util/BasicAuthHttpClientConfigCallback.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/util/BasicAuthHttpClientConfigCallback.java
@@ -1,0 +1,51 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.es.rest.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback;
+
+import com.google.common.base.Preconditions;
+
+public class BasicAuthHttpClientConfigCallback implements HttpClientConfigCallback {
+
+    private final CredentialsProvider credentialsProvider;
+
+    public BasicAuthHttpClientConfigCallback(final String realm, final String username, final String password) {
+        Preconditions.checkArgument(StringUtils.isNotEmpty(username), "HTTP Basic Authentication: username must be provided");
+        Preconditions.checkArgument(StringUtils.isNotEmpty(password), "HTTP Basic Authentication: password must be provided");
+
+        credentialsProvider = new BasicCredentialsProvider();
+
+        final AuthScope authScope;
+        if (StringUtils.isNotEmpty(realm)) {
+            authScope = new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT, realm, AuthScope.ANY_SCHEME);
+        } else {
+            authScope = AuthScope.ANY;
+        }
+        credentialsProvider.setCredentials(authScope, new UsernamePasswordCredentials(username, password));
+    }
+
+    @Override
+    public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
+        httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+        return httpClientBuilder;
+    }
+}

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/util/HttpAuthTypes.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/util/HttpAuthTypes.java
@@ -1,0 +1,26 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.es.rest.util;
+
+public enum HttpAuthTypes {
+    /** No authentication - default */
+    NONE,
+    /** Basic authentication with username/password */
+    BASIC,
+    /** Custom authentication with a provided authenticator implementation. Please refer to the documentation for
+     * the custom authenticator.
+     */
+    CUSTOM
+}

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/util/RestClientAuthenticator.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/util/RestClientAuthenticator.java
@@ -1,0 +1,42 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.es.rest.util;
+
+import java.io.IOException;
+
+import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback;
+import org.elasticsearch.client.RestClientBuilder.RequestConfigCallback;
+
+/**
+ * <p>
+ * A class instance implementing this interface may customize some aspects of
+ * JanusGraph Elasticsearch REST client to implement a custom authentication method.
+ * </p>
+ * <p>
+ * An implementation must provide a constructor that accepts a String[]. It will receive
+ * the value(s) from {@link org.janusgraph.diskstorage.es.ElasticSearchIndex#ES_HTTP_AUTHENTICATOR_ARGS}.
+ * If no authenticator arguments are provided, a zero-size array is passed to the
+ * constructor. The constructor must not perform any blocking operations.
+ * </p>
+ */
+public interface RestClientAuthenticator extends HttpClientConfigCallback, RequestConfigCallback {
+
+    /**
+     * Initializes the authenticator. This method may perform the blocking I/O operations if needed.
+     * @throws IOException
+     */
+    void init() throws IOException;
+
+}

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/util/RestClientAuthenticatorBase.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/util/RestClientAuthenticatorBase.java
@@ -1,0 +1,41 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.es.rest.util;
+
+import java.io.IOException;
+
+import org.apache.http.client.config.RequestConfig.Builder;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+
+/**
+ * Base class for custom REST client authenticators.
+ */
+public abstract class RestClientAuthenticatorBase implements RestClientAuthenticator {
+
+    @Override
+    public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
+        return httpClientBuilder;
+    }
+
+    @Override
+    public Builder customizeRequestConfig(Builder requestConfigBuilder) {
+        return requestConfigBuilder;
+    }
+
+    @Override
+    public void init() throws IOException {
+        // does nothing
+    }
+}

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/util/SSLConfigurationCallback.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/util/SSLConfigurationCallback.java
@@ -1,0 +1,176 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.es.rest.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+
+import javax.net.ssl.SSLContext;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLContexts;
+import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback;
+
+/**
+ * Use {@link Builder#create()} or {@link Builder#createCustom(SSLContextBuilder)} to create an instance of this callback
+ *
+ */
+public class SSLConfigurationCallback implements HttpClientConfigCallback {
+
+    private final String trustStoreFile;
+    private final String trustStorePassword;
+    private final String keyStoreFile;
+    private final String keyStorePassword;
+    private final String keyPassword;
+    private final SSLContextBuilder sslContextBuilder;
+    private final boolean disableHostNameVerification;
+    private final boolean allowSelfSignedCertificates;
+
+    private SSLConfigurationCallback(final SSLContextBuilder sslContextBuilder,
+            final String trustStoreFile,
+            final String trustStorePassword,
+            final String keyStoreFile,
+            final String keyStorePassword,
+            final String keyPassword,
+            final boolean disableHostNameVerification,
+            final boolean allowSelfSignedCertificates) {
+
+        this.sslContextBuilder = sslContextBuilder;
+
+        this.trustStoreFile = trustStoreFile;
+        this.trustStorePassword = trustStorePassword;
+
+        this.keyStoreFile = keyStoreFile;
+        this.keyStorePassword = keyStorePassword;
+        this.keyPassword = keyPassword;
+
+        this.disableHostNameVerification = disableHostNameVerification;
+        this.allowSelfSignedCertificates = allowSelfSignedCertificates;
+    }
+
+    @Override
+    public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
+        final SSLContext sslcontext;
+
+        final TrustStrategy trustStrategy = allowSelfSignedCertificates ? new TrustSelfSignedStrategy() : null;
+
+        try {
+            if (StringUtils.isNotEmpty(trustStoreFile)) {
+                sslContextBuilder.loadTrustMaterial(new File(trustStoreFile), trustStorePassword.toCharArray(), trustStrategy);
+            } else {
+                sslContextBuilder.loadTrustMaterial(trustStrategy);
+            }
+        } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException e ) {
+            throw new RuntimeException("Invalid trust store file " + trustStoreFile, e);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to load trust store data from " + trustStoreFile, e);
+        }
+
+        try {
+            if (StringUtils.isNotEmpty(keyStoreFile)) {
+                sslContextBuilder.loadKeyMaterial(new File(keyStoreFile), keyStorePassword.toCharArray(), keyPassword.toCharArray());
+            }
+        } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | UnrecoverableKeyException e ) {
+            throw new RuntimeException("Invalid key store file " + keyStoreFile, e);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to load key store data from " + keyStoreFile, e);
+        }
+
+        try {
+            sslcontext = sslContextBuilder.build();
+        } catch (KeyManagementException | NoSuchAlgorithmException e) {
+            throw new RuntimeException("SSL context initialization failed", e);
+        }
+
+        httpClientBuilder.setSSLContext(sslcontext);
+
+        if (disableHostNameVerification) {
+            httpClientBuilder.setSSLHostnameVerifier(new NoopHostnameVerifier());
+        }
+
+        return httpClientBuilder;
+    }
+
+    /**
+     * Constructs the instance of SSLConfigurationCallback
+     */
+    public static class Builder {
+        private final SSLContextBuilder sslContextBuilder;
+
+        private String trustStoreFile;
+        private String trustStorePassword;
+        private String keyStoreFile;
+        private String keyStorePassword;
+        private String keyPassword;
+        private boolean disableHostNameVerification;
+        private boolean allowSelfSignedCertificates;
+
+        private Builder(final SSLContextBuilder sslContextBuilder) {
+            this.sslContextBuilder = sslContextBuilder;
+        }
+
+        public static Builder createCustom(final SSLContextBuilder sslContextBuilder) {
+            return new Builder(sslContextBuilder);
+        }
+
+        public static Builder create() {
+            return new Builder(SSLContexts.custom());
+        }
+
+        public Builder withTrustStore(final String trustStoreFile, final String trustStorePassword) {
+            this.trustStoreFile = trustStoreFile;
+            this.trustStorePassword = trustStorePassword;
+            return this;
+        }
+
+        public Builder withKeyStore(final String keyStoreFile, final String keyStorePassword, final String keyPassword) {
+            this.keyStoreFile = keyStoreFile;
+            this.keyStorePassword = keyStorePassword;
+            this.keyPassword = keyPassword;
+            return this;
+        }
+
+        public Builder disableHostNameVerification() {
+            this.disableHostNameVerification = true;
+            return this;
+        }
+
+        public Builder allowSelfSignedCertificates() {
+            this.allowSelfSignedCertificates = true;
+            return this;
+        }
+
+        public SSLConfigurationCallback build() {
+            return new SSLConfigurationCallback(sslContextBuilder,
+                    trustStoreFile,
+                    trustStorePassword,
+                    keyStoreFile,
+                    keyStorePassword,
+                    keyPassword,
+                    disableHostNameVerification,
+                    allowSelfSignedCertificates);
+        }
+    }
+}

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/rest/RestClientSetupTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/rest/RestClientSetupTest.java
@@ -1,0 +1,562 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.es.rest;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.net.ssl.SSLContext;
+
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.RequestConfig.Builder;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback;
+import org.janusgraph.diskstorage.configuration.BasicConfiguration;
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
+import org.janusgraph.diskstorage.configuration.backend.CommonsConfiguration;
+import org.janusgraph.diskstorage.es.ElasticSearchClient;
+import org.janusgraph.diskstorage.es.ElasticSearchIndex;
+import org.janusgraph.diskstorage.es.rest.util.HttpAuthTypes;
+import org.janusgraph.diskstorage.es.rest.util.RestClientAuthenticator;
+import org.janusgraph.diskstorage.es.rest.util.SSLConfigurationCallback;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({RestClientBuilder.class, HttpAsyncClientBuilder.class})
+public class RestClientSetupTest {
+
+    private static final String INDEX_NAME = "junit";
+    private static final String SCHEME_HTTP = "http";
+    private static final String SCHEME_HTTPS = "https";
+
+    private static final String ES_HOST_01 = "es-host-01";
+    private static final String ES_HOST_02 = "es-host-02";
+
+    private static final int ES_PORT = 8080;
+    private static final int ES_SCROLL_KA =
+            ElasticSearchIndex.ES_SCROLL_KEEP_ALIVE.getDefaultValue().intValue() * 2;
+    private static final String ES_BULK_REFRESH =
+            String.valueOf(!Boolean.valueOf(ElasticSearchIndex.BULK_REFRESH.getDefaultValue()).booleanValue());
+
+    private static AtomicInteger instanceCount = new AtomicInteger();
+
+    @Captor
+    ArgumentCaptor<HttpHost[]> hostListCaptor;
+
+    @Captor
+    ArgumentCaptor<Integer> scrollKACaptor;
+
+    @Spy
+    private RestClientSetup restClientSetup = new RestClientSetup();
+
+    @Mock
+    private RestClient restClientMock;
+
+    @Mock
+    private RestElasticSearchClient restElasticSearchClientMock;
+
+    @Mock
+    private SSLContext sslContextMock;
+
+    private RestClientBuilder restClientBuilderMock;
+
+    @Before
+    public void setUp() {
+
+        restClientBuilderMock = PowerMockito.mock(RestClientBuilder.class);
+
+        doReturn(restClientMock).when(restClientBuilderMock).build();
+    }
+
+    private ElasticSearchClient baseConfigTest(Map<String, String> extraConfigValues) throws Exception {
+        final CommonsConfiguration cc = new CommonsConfiguration(new BaseConfiguration());
+        cc.set("index." + INDEX_NAME + ".backend", "elasticsearch");
+        cc.set("index." + INDEX_NAME + ".elasticsearch.interface", "REST_CLIENT");
+        for(Map.Entry<String, String> me: extraConfigValues.entrySet()) {
+            cc.set(me.getKey(), me.getValue());
+        }
+
+        final ModifiableConfiguration config = new ModifiableConfiguration(GraphDatabaseConfiguration.ROOT_NS, cc,
+                BasicConfiguration.Restriction.NONE);
+
+        doReturn(restClientBuilderMock).
+            when(restClientSetup).getRestClientBuilder(any());
+        doReturn(restElasticSearchClientMock).when(restClientSetup).
+            getElasticSearchClient(any(RestClient.class), anyInt());
+
+        return restClientSetup.connect(config.restrictTo(INDEX_NAME));
+    }
+
+    private List<HttpHost[]> baseHostsConfigTest(Map<String, String> extraConfigValues) throws Exception {
+        final ElasticSearchClient elasticClient = baseConfigTest(ImmutableMap.<String, String>builder().
+                putAll(extraConfigValues).
+                build());
+
+        assertSame(restElasticSearchClientMock, elasticClient);
+
+        verify(restClientSetup).getRestClient(hostListCaptor.capture(), any(Configuration.class));
+        final List<HttpHost[]> hostsConfigured = hostListCaptor.getAllValues();
+        return hostsConfigured;
+    }
+
+    @Test
+    public void testConnectBasicHttpConfigurationSingleHost() throws Exception {
+
+        final List<HttpHost[]> hostsConfigured = baseHostsConfigTest(ImmutableMap.<String, String>builder().
+                put("index." + INDEX_NAME + ".hostname", ES_HOST_01).
+                build());
+
+        assertNotNull(hostsConfigured);
+        assertEquals(1, hostsConfigured.size());
+
+        final HttpHost host0 = hostsConfigured.get(0)[0];
+        assertEquals(ES_HOST_01, host0.getHostName());
+        assertEquals(SCHEME_HTTP, host0.getSchemeName());
+        assertEquals(ElasticSearchIndex.HOST_PORT_DEFAULT, host0.getPort());
+
+        verify(restClientSetup).getElasticSearchClient(same(restClientMock), scrollKACaptor.capture());
+        assertEquals(ElasticSearchIndex.ES_SCROLL_KEEP_ALIVE.getDefaultValue().intValue(),
+                scrollKACaptor.getValue().intValue());
+
+        verify(restElasticSearchClientMock, never()).setBulkRefresh(anyString());
+    }
+
+    @Test
+    public void testConnectBasicHttpConfigurationMultiHost() throws Exception {
+        final List<HttpHost[]> hostsConfigured = baseHostsConfigTest(ImmutableMap.<String, String>builder().
+                put("index." + INDEX_NAME + ".hostname", ES_HOST_01 + "," + ES_HOST_02).
+                build());
+
+        assertNotNull(hostsConfigured);
+        assertEquals(1, hostsConfigured.size());
+
+        final HttpHost host0 = hostsConfigured.get(0)[0];
+        assertEquals(ES_HOST_01, host0.getHostName());
+        assertEquals(SCHEME_HTTP, host0.getSchemeName());
+        assertEquals(ElasticSearchIndex.HOST_PORT_DEFAULT, host0.getPort());
+
+        final HttpHost host1 = hostsConfigured.get(0)[1];
+        assertEquals(ES_HOST_02, host1.getHostName());
+        assertEquals(SCHEME_HTTP, host1.getSchemeName());
+        assertEquals(ElasticSearchIndex.HOST_PORT_DEFAULT, host1.getPort());
+
+        verify(restClientSetup).getElasticSearchClient(same(restClientMock), scrollKACaptor.capture());
+        assertEquals(ElasticSearchIndex.ES_SCROLL_KEEP_ALIVE.getDefaultValue().intValue(),
+                scrollKACaptor.getValue().intValue());
+
+        verify(restElasticSearchClientMock, never()).setBulkRefresh(anyString());
+    }
+
+    @Test
+    public void testConnectBasicHttpConfigurationAllOptions() throws Exception {
+
+        final List<HttpHost[]> hostsConfigured = baseHostsConfigTest(ImmutableMap.<String, String>builder().
+                put("index." + INDEX_NAME + ".hostname", ES_HOST_01).
+                put("index." + INDEX_NAME + ".port", String.valueOf(ES_PORT)).
+                put("index." + INDEX_NAME + ".elasticsearch.scroll-keep-alive", String.valueOf(ES_SCROLL_KA)).
+                put("index." + INDEX_NAME + ".elasticsearch.bulk-refresh", String.valueOf(ES_BULK_REFRESH)).
+                build());
+
+        assertNotNull(hostsConfigured);
+        assertEquals(1, hostsConfigured.size());
+
+        HttpHost host0 = hostsConfigured.get(0)[0];
+        assertEquals(ES_HOST_01, host0.getHostName());
+        assertEquals(SCHEME_HTTP, host0.getSchemeName());
+        assertEquals(ES_PORT, host0.getPort());
+
+        verify(restClientSetup).getElasticSearchClient(same(restClientMock), scrollKACaptor.capture());
+        assertEquals(ES_SCROLL_KA,
+                scrollKACaptor.getValue().intValue());
+
+        verify(restElasticSearchClientMock).setBulkRefresh(eq(ES_BULK_REFRESH));
+    }
+
+    @Test
+    public void testConnectBasicHttpsConfigurationSingleHost() throws Exception {
+
+        final List<HttpHost[]> hostsConfigured = baseHostsConfigTest(ImmutableMap.<String, String>builder().
+                put("index." + INDEX_NAME + ".hostname", ES_HOST_01).
+                put("index." + INDEX_NAME + ".elasticsearch.ssl.enabled", "true").
+                build());
+
+        assertNotNull(hostsConfigured);
+        assertEquals(1, hostsConfigured.size());
+
+        HttpHost host0 = hostsConfigured.get(0)[0];
+        assertEquals(ES_HOST_01, host0.getHostName());
+        assertEquals(SCHEME_HTTPS, host0.getSchemeName());
+        assertEquals(ElasticSearchIndex.HOST_PORT_DEFAULT, host0.getPort());
+
+        verify(restClientSetup).getElasticSearchClient(same(restClientMock), scrollKACaptor.capture());
+        assertEquals(ElasticSearchIndex.ES_SCROLL_KEEP_ALIVE.getDefaultValue().intValue(),
+                scrollKACaptor.getValue().intValue());
+
+        verify(restElasticSearchClientMock, never()).setBulkRefresh(anyString());
+    }
+
+    private HttpClientConfigCallback authTestBase(Map<String, String> extraConfigValues) throws Exception {
+
+        baseConfigTest(ImmutableMap.<String, String>builder().
+                put("index." + INDEX_NAME + ".backend", "elasticsearch").
+                put("index." + INDEX_NAME + ".hostname", ES_HOST_01).
+                putAll(extraConfigValues).
+                build()
+            );
+
+        final ArgumentCaptor<HttpClientConfigCallback> hcccCaptor = ArgumentCaptor.forClass(HttpClientConfigCallback.class);
+
+        // callback is passed to the client builder
+        verify(restClientBuilderMock).setHttpClientConfigCallback(hcccCaptor.capture());
+
+        final HttpClientConfigCallback hccc = hcccCaptor.getValue();
+        assertNotNull(hccc);
+
+        return hccc;
+    }
+
+    private CredentialsProvider basicAuthTestBase(final Map<String, String> extraConfigValues, final String realm,
+            final String username, final String password) throws Exception {
+        final HttpClientConfigCallback hccc = authTestBase(
+                ImmutableMap.<String, String>builder().
+                    put("index." + INDEX_NAME + ".elasticsearch.interface", "REST_CLIENT").
+                    put("index." + INDEX_NAME + ".elasticsearch.http.auth.type", HttpAuthTypes.BASIC.toString()).
+                    put("index." + INDEX_NAME + ".elasticsearch.http.auth.basic.username", username).
+                    put("index." + INDEX_NAME + ".elasticsearch.http.auth.basic.password", password).
+                    put("index." + INDEX_NAME + ".elasticsearch.http.auth.basic.realm", realm).
+                    putAll(extraConfigValues).
+                    build()
+                );
+
+        final HttpAsyncClientBuilder hacb = PowerMockito.mock(HttpAsyncClientBuilder.class);
+        doReturn(hacb).when(hacb).setDefaultCredentialsProvider(anyObject());
+        hccc.customizeHttpClient(hacb);
+
+        final ArgumentCaptor<BasicCredentialsProvider> cpCaptor = ArgumentCaptor.forClass(BasicCredentialsProvider.class);
+        verify(hacb).setDefaultCredentialsProvider(cpCaptor.capture());
+
+        final CredentialsProvider cp = cpCaptor.getValue();
+        assertNotNull(cp);
+
+        return cp;
+    }
+
+    @Test
+    public void testHttpBasicAuthConfiguration() throws Exception {
+
+        // testing that the appropriate values are passed to the client builder via credentials provider
+        final String testRealm = "testRealm";
+        final String testUser = "testUser";
+        final String testPassword = "testPassword";
+
+        final CredentialsProvider cp = basicAuthTestBase(ImmutableMap.<String, String>builder().
+                build(), testRealm, testUser, testPassword);
+
+        final Credentials credentials = cp.getCredentials(new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT, testRealm));
+        assertNotNull(credentials);
+        assertEquals(testUser, credentials.getUserPrincipal().getName());
+        assertEquals(testPassword, credentials.getPassword());
+    }
+
+    @Test
+    public void testCustomAuthenticator() throws Exception {
+
+        final String uniqueInstanceKey = String.valueOf(instanceCount.getAndIncrement());
+        final String[] customAuthArgs = new String[]{
+                uniqueInstanceKey,
+                "arg1",
+                "arg2"
+        };
+        final String serializedArgList = StringUtils.join(customAuthArgs,',');
+        final HttpClientConfigCallback hccc = authTestBase(
+                ImmutableMap.<String, String>builder().
+                    put("index." + INDEX_NAME + ".elasticsearch.interface", "REST_CLIENT").
+                    put("index." + INDEX_NAME + ".elasticsearch.http.auth.type", HttpAuthTypes.CUSTOM.toString()).
+                    put("index." + INDEX_NAME + ".elasticsearch.http.auth.custom.authenticator-class", TestCustomAuthenticator.class.getName()).
+                    put("index." + INDEX_NAME + ".elasticsearch.http.auth.custom.authenticator-args",
+                            serializedArgList).
+                    build()
+                );
+
+        verify(restClientSetup).getCustomAuthenticator(
+                eq(TestCustomAuthenticator.class.getName()),
+                eq(customAuthArgs));
+
+        TestCustomAuthenticator customAuth = TestCustomAuthenticator.instanceMap.get(uniqueInstanceKey);
+        assertNotNull(customAuth);
+
+        // authenticator has been instantiated, verifying it has been called
+        assertEquals(1, customAuth.numInitCalls);
+
+        // verifying that the custom callback is in the chain
+        final HttpAsyncClientBuilder hacb = PowerMockito.mock(HttpAsyncClientBuilder.class);
+        doReturn(hacb).when(hacb).setDefaultCredentialsProvider(anyObject());
+        hccc.customizeHttpClient(hacb);
+
+        assertEquals(1, customAuth.customizeHttpClientHistory.size());
+        assertSame(hacb, customAuth.customizeHttpClientHistory.get(0));
+        assertArrayEquals(customAuthArgs, customAuth.args);
+    }
+
+    public SSLConfigurationCallback.Builder sslSettingsTestBase(final Map<String, String> extraConfigValues) throws Exception {
+
+        final SSLConfigurationCallback.Builder sslConfBuilderMock = mock(SSLConfigurationCallback.Builder.class);
+
+        doReturn(sslConfBuilderMock).when(restClientSetup).getSSLConfigurationCallbackBuilder();
+
+        authTestBase(
+                ImmutableMap.<String, String>builder().
+                    put("index." + INDEX_NAME + ".elasticsearch.interface", "REST_CLIENT").
+                    put("index." + INDEX_NAME + ".elasticsearch.ssl.enabled", "true").
+                    putAll(extraConfigValues).
+                    build()
+                );
+
+        verify(restClientSetup).getSSLConfigurationCallbackBuilder();
+        return sslConfBuilderMock;
+    }
+
+    @Test
+    public void testSSLTrustStoreSettingsOnly() throws Exception {
+
+        final String trustStoreFile = "/a/b/c/truststore.jks";
+        final String trustStorePassword = "averysecretpassword";
+
+        final SSLConfigurationCallback.Builder sslConfBuilderMock = sslSettingsTestBase(
+                ImmutableMap.<String, String>builder().
+                    put("index." + INDEX_NAME + ".elasticsearch.ssl.truststore.location", trustStoreFile).
+                    put("index." + INDEX_NAME + ".elasticsearch.ssl.truststore.password", trustStorePassword).
+                    build()
+                );
+
+        verify(restClientSetup).getSSLConfigurationCallbackBuilder();
+        verify(sslConfBuilderMock).withTrustStore(eq(trustStoreFile), eq(trustStorePassword));
+        verify(sslConfBuilderMock).build();
+        verifyNoMoreInteractions(sslConfBuilderMock);
+    }
+
+    @Test
+    public void testSSLKeyStoreSettingsOnly() throws Exception {
+
+        final String keyStoreFile = "/a/b/c/keystore.jks";
+        final String keyStorePassword = "key_store_password";
+        final String keyPassword = "key_password";
+
+        final SSLConfigurationCallback.Builder sslConfBuilderMock = sslSettingsTestBase(
+                ImmutableMap.<String, String>builder().
+                    put("index." + INDEX_NAME + ".elasticsearch.ssl.keystore.location", keyStoreFile).
+                    put("index." + INDEX_NAME + ".elasticsearch.ssl.keystore.storepassword", keyStorePassword).
+                    put("index." + INDEX_NAME + ".elasticsearch.ssl.keystore.keypassword", keyPassword).
+                    build()
+                );
+
+        verify(restClientSetup).getSSLConfigurationCallbackBuilder();
+        verify(sslConfBuilderMock).withKeyStore(eq(keyStoreFile), eq(keyStorePassword), eq(keyPassword));
+        verify(sslConfBuilderMock).build();
+        verifyNoMoreInteractions(sslConfBuilderMock);
+    }
+
+    @Test
+    public void testSSLKeyStoreSettingsOnlyEmptyKeyPass() throws Exception {
+
+        final String keyStoreFile = "/a/b/c/keystore.jks";
+        final String keyStorePassword = "key_store_password";
+        final String keyPassword = "";
+
+        final SSLConfigurationCallback.Builder sslConfBuilderMock = sslSettingsTestBase(
+                ImmutableMap.<String, String>builder().
+                    put("index." + INDEX_NAME + ".elasticsearch.ssl.keystore.location", keyStoreFile).
+                    put("index." + INDEX_NAME + ".elasticsearch.ssl.keystore.storepassword", keyStorePassword).
+                    put("index." + INDEX_NAME + ".elasticsearch.ssl.keystore.keypassword", keyPassword).
+                    build()
+                );
+
+        verify(restClientSetup).getSSLConfigurationCallbackBuilder();
+        verify(sslConfBuilderMock).withKeyStore(eq(keyStoreFile), eq(keyStorePassword), eq(keyPassword));
+        verify(sslConfBuilderMock).build();
+        verifyNoMoreInteractions(sslConfBuilderMock);
+    }
+
+    @Test
+    public void testSSLKeyStoreSettingsOnlyNoKeyPass() throws Exception {
+
+        final String keyStoreFile = "/a/b/c/keystore.jks";
+        final String keyStorePassword = "key_store_password";
+
+        final SSLConfigurationCallback.Builder sslConfBuilderMock = sslSettingsTestBase(
+                ImmutableMap.<String, String>builder().
+                    put("index." + INDEX_NAME + ".elasticsearch.ssl.keystore.location", keyStoreFile).
+                    put("index." + INDEX_NAME + ".elasticsearch.ssl.keystore.storepassword", keyStorePassword).
+                    build()
+                );
+
+        verify(restClientSetup).getSSLConfigurationCallbackBuilder();
+        verify(sslConfBuilderMock).withKeyStore(eq(keyStoreFile), eq(keyStorePassword), eq(keyStorePassword));
+        verify(sslConfBuilderMock).build();
+        verifyNoMoreInteractions(sslConfBuilderMock);
+    }
+
+    @Test
+    public void testSSLKeyAndTrustStoreSettingsOnly() throws Exception {
+
+        final String trustStoreFile = "/a/b/c/truststore.jks";
+        final String trustStorePassword = "averysecretpassword";
+
+        final String keyStoreFile = "/a/b/c/keystore.jks";
+        final String keyStorePassword = "key_store_password";
+        final String keyPassword = "key_password";
+
+        final SSLConfigurationCallback.Builder sslConfBuilderMock = sslSettingsTestBase(
+                ImmutableMap.<String, String>builder().
+                    put("index." + INDEX_NAME + ".elasticsearch.ssl.truststore.location", trustStoreFile).
+                    put("index." + INDEX_NAME + ".elasticsearch.ssl.truststore.password", trustStorePassword).
+                    put("index." + INDEX_NAME + ".elasticsearch.ssl.keystore.location", keyStoreFile).
+                    put("index." + INDEX_NAME + ".elasticsearch.ssl.keystore.storepassword", keyStorePassword).
+                    put("index." + INDEX_NAME + ".elasticsearch.ssl.keystore.keypassword", keyPassword).
+                    build()
+                );
+
+        verify(restClientSetup).getSSLConfigurationCallbackBuilder();
+        verify(sslConfBuilderMock).withTrustStore(eq(trustStoreFile), eq(trustStorePassword));
+        verify(sslConfBuilderMock).withKeyStore(eq(keyStoreFile), eq(keyStorePassword), eq(keyPassword));
+        verify(sslConfBuilderMock).build();
+        verifyNoMoreInteractions(sslConfBuilderMock);
+    }
+
+    @Test
+    public void testSSLDisableHostNameVerifier() throws Exception {
+
+        final SSLConfigurationCallback.Builder sslConfBuilderMock = sslSettingsTestBase(
+                ImmutableMap.<String, String>builder().
+                    put("index." + INDEX_NAME + ".elasticsearch.ssl.disable-hostname-verification", "true").
+                    build()
+                );
+
+        verify(restClientSetup).getSSLConfigurationCallbackBuilder();
+        verify(sslConfBuilderMock).disableHostNameVerification();
+        verify(sslConfBuilderMock).build();
+        verifyNoMoreInteractions(sslConfBuilderMock);
+    }
+
+    @Test
+    public void testSSLDisableHostNameVerifierDefaultOff() throws Exception {
+
+        final SSLConfigurationCallback.Builder sslConfBuilderMock = mock(SSLConfigurationCallback.Builder.class);
+
+        doReturn(sslConfBuilderMock).when(restClientSetup).getSSLConfigurationCallbackBuilder();
+
+        baseConfigTest(ImmutableMap.<String, String>builder().
+                put("index." + INDEX_NAME + ".elasticsearch.ssl.enabled", "true").
+                build()
+            );
+
+        verify(restClientSetup).getSSLConfigurationCallbackBuilder();
+        verify(sslConfBuilderMock, never()).disableHostNameVerification();
+    }
+
+    @Test
+    public void testSSLAllowSelfSignedCerts() throws Exception {
+
+        final SSLConfigurationCallback.Builder sslConfBuilderMock = sslSettingsTestBase(
+                ImmutableMap.<String, String>builder().
+                    put("index." + INDEX_NAME + ".elasticsearch.ssl.allow-self-signed-certificates", "true").
+                    build()
+                );
+
+        verify(restClientSetup).getSSLConfigurationCallbackBuilder();
+        verify(sslConfBuilderMock).allowSelfSignedCertificates();
+        verify(sslConfBuilderMock).build();
+        verifyNoMoreInteractions(sslConfBuilderMock);
+    }
+
+    @Test
+    public void testSSLAllowSelfSignedCertsDefaultOff() throws Exception {
+
+        final SSLConfigurationCallback.Builder sslConfBuilderMock = mock(SSLConfigurationCallback.Builder.class);
+
+        doReturn(sslConfBuilderMock).when(restClientSetup).getSSLConfigurationCallbackBuilder();
+
+        baseConfigTest(ImmutableMap.<String, String>builder().
+                put("index." + INDEX_NAME + ".elasticsearch.ssl.enabled", "true").
+                build()
+            );
+
+        verify(restClientSetup).getSSLConfigurationCallbackBuilder();
+        verify(sslConfBuilderMock, never()).allowSelfSignedCertificates();
+    }
+
+    public static class TestCustomAuthenticator implements RestClientAuthenticator {
+
+        private static final Map<String, TestCustomAuthenticator> instanceMap = new HashMap<String, TestCustomAuthenticator>();
+
+        private String[] args;
+
+        private List<Builder> customizeRequestConfigHistory = new LinkedList<Builder>();
+        private List<HttpAsyncClientBuilder> customizeHttpClientHistory = new LinkedList<HttpAsyncClientBuilder>();
+        private int numInitCalls;
+
+        public TestCustomAuthenticator(String[] args) {
+            this.args = args;
+            Preconditions.checkArgument(instanceMap.put(args[0], this) == null, "Non-unique key used");
+        }
+
+        @Override
+        public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
+            customizeHttpClientHistory.add(httpClientBuilder);
+            return httpClientBuilder;
+        }
+
+        @Override
+        public Builder customizeRequestConfig(Builder requestConfigBuilder) {
+            customizeRequestConfigHistory.add(requestConfigBuilder);
+            return requestConfigBuilder;
+        }
+
+        @Override
+        public void init() throws IOException {
+            numInitCalls++;
+        }
+    }
+}

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/rest/util/BasicAuthHttpClientConfigCallbackTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/rest/util/BasicAuthHttpClientConfigCallbackTest.java
@@ -1,0 +1,91 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.es.rest.util;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({HttpAsyncClientBuilder.class})
+public class BasicAuthHttpClientConfigCallbackTest {
+
+    private static final String HTTP_USER = "testuser";
+    private static final String HTTP_PASSWORD = "testpass";
+    private static final String HTTP_REALM = "testrealm";
+
+    private HttpAsyncClientBuilder httpAsyncClientBuilderMock = PowerMockito.mock(HttpAsyncClientBuilder.class);
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        when(httpAsyncClientBuilderMock.setDefaultCredentialsProvider(anyObject())).thenReturn(httpAsyncClientBuilderMock);
+    }
+
+    private CredentialsProvider basicAuthTestBase(final String realm, final String username, final String password) {
+        final BasicAuthHttpClientConfigCallback cb = new BasicAuthHttpClientConfigCallback(realm, username, password);
+
+        cb.customizeHttpClient(httpAsyncClientBuilderMock);
+
+        final ArgumentCaptor<BasicCredentialsProvider> cpCaptor = ArgumentCaptor.forClass(BasicCredentialsProvider.class);
+
+        verify(httpAsyncClientBuilderMock).setDefaultCredentialsProvider(cpCaptor.capture());
+
+        final CredentialsProvider cp = cpCaptor.getValue();
+        assertNotNull(cp);
+
+        return cp;
+    }
+
+    @Test
+    public void testSetDefaultCredentialsProviderNoRealm() throws Exception {
+
+        final CredentialsProvider cp = basicAuthTestBase("", HTTP_USER, HTTP_PASSWORD);
+
+        // expected: will match any host and any realm
+        final Credentials credentialsForRealm1 = cp.getCredentials(new AuthScope("dummyhost1", 1234, "dummyrealm1"));
+        assertEquals(HTTP_USER, credentialsForRealm1.getUserPrincipal().getName());
+        assertEquals(HTTP_PASSWORD, credentialsForRealm1.getPassword());
+    }
+
+    @Test
+    public void testSetDefaultCredentialsProviderWithRealm() throws Exception {
+
+        final CredentialsProvider cp = basicAuthTestBase(HTTP_REALM, HTTP_USER, HTTP_PASSWORD);
+
+        // expected: will match any host in that specific realm
+        final Credentials credentialsForRealm1 = cp.getCredentials(new AuthScope("dummyhost1", 1234, HTTP_REALM));
+        assertEquals(HTTP_USER, credentialsForRealm1.getUserPrincipal().getName());
+        assertEquals(HTTP_PASSWORD, credentialsForRealm1.getPassword());
+
+        // ...but not in any other realms
+        final Credentials credentialsForRealm3 = cp.getCredentials(new AuthScope("dummyhost1", 1234, "Not_" + HTTP_REALM));
+        assertNull(credentialsForRealm3);
+    }
+}

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/rest/util/SSLConfigurationCallbackTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/rest/util/SSLConfigurationCallbackTest.java
@@ -1,0 +1,174 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.es.rest.util;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({HttpAsyncClientBuilder.class})
+public class SSLConfigurationCallbackTest {
+
+    @Mock
+    private SSLContextBuilder sslContextBuilderMock;
+
+    @Mock
+    private SSLContext sslContextMock;
+
+    private HttpAsyncClientBuilder httpAsyncClientBuilderMock = PowerMockito.mock(HttpAsyncClientBuilder.class);
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        when(httpAsyncClientBuilderMock.setSSLContext(anyObject())).thenReturn(httpAsyncClientBuilderMock);
+
+        doReturn(sslContextMock).when(sslContextBuilderMock).build();
+        doReturn(sslContextBuilderMock).when(sslContextBuilderMock).loadTrustMaterial(
+                any(File.class), any(char[].class), any(TrustStrategy.class));
+    }
+
+    @Test
+    public void testSSLContextInitTrustStoreOnly() throws Exception {
+
+        final String trustStoreFile = "/a/b/c/truststore.jks";
+        final String trustStorePassword = "trustStorePassword";
+
+        final SSLConfigurationCallback cb = SSLConfigurationCallback.Builder.
+                createCustom(sslContextBuilderMock).
+                withTrustStore(trustStoreFile, trustStorePassword).
+                build();
+
+        cb.customizeHttpClient(httpAsyncClientBuilderMock);
+
+        verify(sslContextBuilderMock).loadTrustMaterial(eq(new File(trustStoreFile)),
+                eq(trustStorePassword.toCharArray()), same(null));
+        verify(httpAsyncClientBuilderMock).setSSLContext(sslContextMock);
+        verify(sslContextBuilderMock).build();
+
+        verifyNoMoreInteractions(sslContextMock, sslContextBuilderMock);
+    }
+
+    @Test
+    public void testSSLContextInitKeyStoreOnly() throws Exception {
+
+        final String keyStoreFile = "/a/b/c/keystore.jks";
+        final String keyStorePassword = "keyStorePassword";
+        final String keyPassword = "keyPassword";
+
+        final SSLConfigurationCallback cb = SSLConfigurationCallback.Builder.
+                createCustom(sslContextBuilderMock).
+                withKeyStore(keyStoreFile, keyStorePassword, keyPassword).
+                build();
+
+        cb.customizeHttpClient(httpAsyncClientBuilderMock);
+
+        verify(sslContextBuilderMock).loadKeyMaterial(eq(new File(keyStoreFile)),
+                eq(keyStorePassword.toCharArray()), eq(keyPassword.toCharArray()));
+        verify(httpAsyncClientBuilderMock).setSSLContext(sslContextMock);
+        verify(sslContextBuilderMock).loadTrustMaterial((TrustStrategy)null);
+        verify(sslContextBuilderMock).build();
+
+        verifyNoMoreInteractions(sslContextMock, sslContextBuilderMock);
+    }
+
+    @Test
+    public void testDisableHostNameVerificationDefaultOff() throws Exception {
+        final SSLConfigurationCallback cb = SSLConfigurationCallback.Builder.
+                createCustom(sslContextBuilderMock).
+                build();
+        cb.customizeHttpClient(httpAsyncClientBuilderMock);
+        // assuming that the callback does not modify the default host name verifier if not requested
+        verify(sslContextBuilderMock).loadTrustMaterial((TrustStrategy)null);
+        verify(sslContextBuilderMock).build();
+        verify(httpAsyncClientBuilderMock).setSSLContext(sslContextMock);
+        verifyNoMoreInteractions(sslContextMock, sslContextBuilderMock, httpAsyncClientBuilderMock);
+    }
+
+    @Test
+    public void testDisableHostNameVerification() throws Exception {
+        final SSLConfigurationCallback cb = SSLConfigurationCallback.Builder.
+                createCustom(sslContextBuilderMock).
+                disableHostNameVerification().
+                build();
+        cb.customizeHttpClient(httpAsyncClientBuilderMock);
+        final ArgumentCaptor<HostnameVerifier> hostnameVerifierCaptor = ArgumentCaptor.forClass(HostnameVerifier.class);
+        verify(httpAsyncClientBuilderMock).setSSLHostnameVerifier(hostnameVerifierCaptor.capture());
+        verify(sslContextBuilderMock).loadTrustMaterial((TrustStrategy)null);
+        verify(sslContextBuilderMock).build();
+        verify(httpAsyncClientBuilderMock).setSSLContext(sslContextMock);
+        verifyNoMoreInteractions(sslContextMock, sslContextBuilderMock, httpAsyncClientBuilderMock);
+
+        assertEquals(1, hostnameVerifierCaptor.getAllValues().size());
+        final HostnameVerifier verifier = hostnameVerifierCaptor.getValue();
+        // this assertion is implementation-specific but should be good enough
+        // given the simplicity of the class under test
+        assertTrue(verifier instanceof NoopHostnameVerifier);
+    }
+
+    @Test
+    public void testAllowSelfSignedCertsDefaultOff() throws Exception {
+        final SSLConfigurationCallback cb = SSLConfigurationCallback.Builder.
+                createCustom(sslContextBuilderMock).
+                build();
+        cb.customizeHttpClient(httpAsyncClientBuilderMock);
+
+        verify(sslContextBuilderMock).loadTrustMaterial((TrustStrategy)null);
+        verify(sslContextBuilderMock).build();
+        verify(httpAsyncClientBuilderMock).setSSLContext(sslContextMock);
+        verifyNoMoreInteractions(sslContextMock, sslContextBuilderMock, httpAsyncClientBuilderMock);
+    }
+
+    @Test
+    public void testAllowSelfSignedCerts() throws Exception {
+        final SSLConfigurationCallback cb = SSLConfigurationCallback.Builder.
+                createCustom(sslContextBuilderMock).
+                allowSelfSignedCertificates().
+                build();
+        cb.customizeHttpClient(httpAsyncClientBuilderMock);
+        final ArgumentCaptor<TrustStrategy> trustStrategyCaptor = ArgumentCaptor.forClass(TrustStrategy.class);
+        verify(sslContextBuilderMock).loadTrustMaterial(trustStrategyCaptor.capture());
+        verify(sslContextBuilderMock).build();
+        verify(httpAsyncClientBuilderMock).setSSLContext(sslContextMock);
+        verifyNoMoreInteractions(sslContextMock, sslContextBuilderMock, httpAsyncClientBuilderMock);
+
+        assertEquals(1, trustStrategyCaptor.getAllValues().size());
+        final TrustStrategy trustStrategy = trustStrategyCaptor.getValue();
+        // this assertion is implementation-specific but should be good enough
+        // given the simplicity of the class under test
+        assertTrue(trustStrategy instanceof TrustSelfSignedStrategy);
+    }
+}


### PR DESCRIPTION

Fixes #645 and #612: multiple changes for ES REST transport settings

- refactor client set-up code to make it more testable
- extract REST client set-up logic to a separate class
- add a set of unit tests for client configuration
- add new options for enabling SSL (e.g. HTTPS) for the client (off by
  default) and optionally configuring SSL trust store and its password
- implement HTTP basic authentication
- implement support for custom HTTP authenticator callback - to be used
  externally for other authentication types such as AWS SigV4


NOTE: This PR is primarily for preview purposes, to get the sense if the approach selected is not out of the line. If it is acceptable in general, I will update the documentation and resubmit.
