### PR TITLE
Create ES ConfigOption MAX_RETRIES_IN_MILLIS

### DIFF
--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
@@ -122,6 +122,11 @@ public class ElasticSearchIndex implements IndexProvider {
             "This string should be formatted as a natural number followed by the lowercase letter " +
             "\"s\", e.g. 3s or 60s.", ConfigOption.Type.MASKABLE, "30s");
 
+    public static final ConfigOption<Integer> MAX_RETRY_TIMEOUT =
+            new ConfigOption<>(ELASTICSEARCH_NS, "max-retry-timeout",
+            "Sets the maximum timeout (in milliseconds) to honour in case of multiple retries of the same request " +
+            "sent using the ElasticSearch Rest Client by JanusGraph.", ConfigOption.Type.MASKABLE, Integer.class);
+
     public static final ConfigOption<String> BULK_REFRESH =
             new ConfigOption<>(ELASTICSEARCH_NS, "bulk-refresh",
             "Elasticsearch bulk API refresh setting used to control when changes made by this request are made " +

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchSetup.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchSetup.java
@@ -18,6 +18,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
 import org.janusgraph.diskstorage.configuration.ConfigNamespace;
 import org.janusgraph.diskstorage.configuration.Configuration;
 import org.janusgraph.diskstorage.es.rest.RestElasticSearchClient;
@@ -66,7 +67,11 @@ public enum ElasticSearchSetup {
                 log.debug("Configured remote host: {} : {}", hostname, hostport);
                 hosts.add(new HttpHost(hostname, hostport, "http"));
             }
-            RestClient rc = RestClient.builder(hosts.toArray(new HttpHost[hosts.size()])).build();
+            final RestClientBuilder rcb = RestClient.builder(hosts.toArray(new HttpHost[hosts.size()]));
+            if (config.has(ElasticSearchIndex.MAX_RETRY_TIMEOUT)) {
+                rcb.setMaxRetryTimeoutMillis(config.get(ElasticSearchIndex.MAX_RETRY_TIMEOUT));
+            }
+            final RestClient rc = rcb.build();
 
             final int scrollKeepAlive = config.get(ElasticSearchIndex.ES_SCROLL_KEEP_ALIVE);
             Preconditions.checkArgument(scrollKeepAlive >= 1, "Scroll Keep alive should be greater or equals than 1");


### PR DESCRIPTION
The ES RestClient does [not
support](https://github.com/elastic/elasticsearch/issues/21789#issuecomment-263243530)
a per request timeout configuration, however it does at least support a
timeout configuration option `maxRetriesInMillis` that will timeout the
overall request, including retries. It can be useful for others to
configure this timeout, especially given the fact that users can
configure their gremlin-script-execution timeout.

Issues: #688

Thank you for contributing to JanusGraph.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [x] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

