### PR TITLE
Add `[skip ci]` instructions for docs changes.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
-Thank you for contributing to JanusGraph.
+-----
+
+Thank you for contributing to JanusGraph!
 
 In order to streamline the review of the contribution we ask you
 to ensure the following steps have been taken:
@@ -11,12 +13,15 @@ to ensure the following steps have been taken:
 
 ### For code changes:
 - [ ] Have you written and/or updated unit tests to verify your changes?
-- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
+- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
 - [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
 - [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?
 
 ### For documentation related changes:
 - [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
+- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
+  tag to the first line of your commit message to avoid spending CPU cycles in
+  Travis CI when no code, tests, or build configuration are modified?
 
 ### Note:
 Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.


### PR DESCRIPTION
Also adds a horizontal line at the top of the template so that it
cleanly separates itself from the user's commit for readability (they've
been previously running into each other, which is distracting and
confusing.

Also made a few minor formatting changes in terms of whitespace
elimination, punctuation, etc.

-----

Thank you for contributing to JanusGraph.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [] Is there an issue associated with this PR? Is it referenced in the commit message?
- [] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [] Is your initial contribution a single, squashed commit?

### For code changes:
- [] Have you written and/or updated unit tests to verify your changes?
- [] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
- [x] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit and your PR title to avoid spending CPU
  cycles when no code or tests are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

