### PR TITLE
Add configuration props for CQL PoolingOptions

### DIFF
--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
@@ -144,6 +144,48 @@ public interface CQLConfigOptions {
             ConfigOption.Type.FIXED,
             64);
 
+    ConfigOption<Integer> LOCAL_CORE_CONNECTIONS_PER_HOST = new ConfigOption<>(
+            CQL_NS,
+            "local-core-connections-per-host",
+            "The number of connections initially created and kept open to each host for local datacenter",
+            ConfigOption.Type.FIXED,
+            1);
+
+    ConfigOption<Integer> REMOTE_CORE_CONNECTIONS_PER_HOST = new ConfigOption<>(
+            CQL_NS,
+            "remote-core-connections-per-host",
+            "The number of connections initially created and kept open to each host for remote datacenter",
+            ConfigOption.Type.FIXED,
+            1);
+
+    ConfigOption<Integer> LOCAL_MAX_CONNECTIONS_PER_HOST = new ConfigOption<>(
+            CQL_NS,
+            "local-max-connections-per-host",
+            "The maximum number of connections that can be created per host for local datacenter",
+            ConfigOption.Type.FIXED,
+            1);
+
+    ConfigOption<Integer> REMOTE_MAX_CONNECTIONS_PER_HOST = new ConfigOption<>(
+            CQL_NS,
+            "remote-max-connections-per-host",
+            "The maximum number of connections that can be created per host for remote datacenter",
+            ConfigOption.Type.FIXED,
+            1);
+
+    ConfigOption<Integer> LOCAL_MAX_REQUESTS_PER_CONNECTION = new ConfigOption<>(
+            CQL_NS,
+            "local-max-requests-per-connection",
+            "The maximum number of requests per connection for local datacenter",
+            ConfigOption.Type.FIXED,
+            1024);
+
+    ConfigOption<Integer> REMOTE_MAX_REQUESTS_PER_CONNECTION = new ConfigOption<>(
+            CQL_NS,
+            "remote-max-requests-per-connection",
+            "The maximum number of requests per connection for remote datacenter",
+            ConfigOption.Type.FIXED,
+            256);
+
     // SSL
     ConfigNamespace SSL_NS = new ConfigNamespace(
             CQL_NS,

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
@@ -25,9 +25,15 @@ import static org.janusgraph.diskstorage.cql.CQLConfigOptions.BATCH_STATEMENT_SI
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CLUSTER_NAME;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.ONLY_USE_LOCAL_CONSISTENCY_FOR_SYSTEM_OPERATIONS;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.KEYSPACE;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.LOCAL_CORE_CONNECTIONS_PER_HOST;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.LOCAL_DATACENTER;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.LOCAL_MAX_CONNECTIONS_PER_HOST;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.LOCAL_MAX_REQUESTS_PER_CONNECTION;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.PROTOCOL_VERSION;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.READ_CONSISTENCY;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REMOTE_CORE_CONNECTIONS_PER_HOST;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REMOTE_MAX_CONNECTIONS_PER_HOST;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REMOTE_MAX_REQUESTS_PER_CONNECTION;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REPLICATION_FACTOR;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REPLICATION_OPTIONS;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REPLICATION_STRATEGY;
@@ -85,8 +91,10 @@ import com.datastax.driver.core.BatchStatement;
 import com.datastax.driver.core.BatchStatement.Type;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Cluster.Builder;
+import com.datastax.driver.core.HostDistance;
 import com.datastax.driver.core.JdkSSLOptions;
 import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.PoolingOptions;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
@@ -248,7 +256,25 @@ public class CQLStoreManager extends DistributedStoreManager implements KeyColum
             }
         }
 
-        return builder.build();
+        // Build the PoolingOptions based on the configurations
+        PoolingOptions poolingOptions = new PoolingOptions();
+        poolingOptions
+            .setMaxRequestsPerConnection(
+                    HostDistance.LOCAL,
+                    configuration.get(LOCAL_MAX_REQUESTS_PER_CONNECTION))
+            .setMaxRequestsPerConnection(
+                    HostDistance.REMOTE,
+                    configuration.get(REMOTE_MAX_REQUESTS_PER_CONNECTION));
+        poolingOptions
+            .setConnectionsPerHost(
+                    HostDistance.LOCAL,
+                    configuration.get(LOCAL_CORE_CONNECTIONS_PER_HOST),
+                    configuration.get(LOCAL_MAX_CONNECTIONS_PER_HOST))
+            .setConnectionsPerHost(
+                    HostDistance.REMOTE,
+                    configuration.get(REMOTE_CORE_CONNECTIONS_PER_HOST),
+                    configuration.get(REMOTE_MAX_CONNECTIONS_PER_HOST));
+        return builder.withPoolingOptions(poolingOptions).build();
     }
 
     Session initializeSession(final String keyspaceName) {


### PR DESCRIPTION
Make CQL PoolingOptions be configurable by adding the following new
properties under `storage.cql` :
- local-core-connection-per-host:
  The number of connections initially created and kept open to each host
  for local datacenter
- local-max-connection-per-host:
  The maximum number of connections that can be created per host for
  local datacenter
- local-max-request-per-connection:
  The maximum number of requests per connection for local datacenter
- remote-core-connection-per-host:
  The number of connections initially created and kept open to each host
  for remote datacenter
- remote-max-connection-per-host:
  The maximum number of connections that can be created per host for
  remote datacenter
- remote-max-request-per-connection:
  The maximum number of requests per connection for remote datacenter

Ref: related issue #775 

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

