### PR TITLE
Fix #777: Allow external indexing of properties with spaces

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -21,3 +21,4 @@ Orion Health
 IBM
 Rafael Fernandes <luizrafael@gmail.com>
 Robert Dale <robdale@gmail.com>
+Seeq

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -35,6 +35,7 @@ Alexander Vieth <alex@lagoa.com>
 Anderson de Andrade <adeandrade@verticalscope.com>
 Andy Keffalas <akeffala@nearinfinity.com>
 Austin Harris <austin.w.harris@gmail.com>
+Austin Sharp <austin.sharp@seeq.com>
 Blake Eggleston <bdeggleston@gmail.com>
 Bobby Norton <bobby@thinkaurelius.com>
 Brad Anderson <brad@sankatygroup.com>
@@ -58,6 +59,7 @@ Frederick Haebin Na <haebin.na@gmail.com>
 Homer Strong <homer.strong@gmail.com>
 janar <janar@yahoo-inc.com>
 Jason Plurad <pluradj@us.ibm.com>
+Jason Rust <jason.rust@seeq.com>
 Joe Ferner <joe@fernsroth.com>
 Joshua Shinavier <josh@fortytwo.net>
 Justin Corpron <justin.corpron@justinc-677.glassdoor.local>

--- a/docs/basics.adoc
+++ b/docs/basics.adoc
@@ -224,7 +224,7 @@ mgmt.commit()
 
 Properties on vertices and edges are key-value pairs. For instance, the property `name='Daniel'` has the key `name` and the value `'Daniel'`. Property keys are part of the JanusGraph schema and can constrain the allowed data types and cardinality of values.
 
-To define a property key, call `makePropertyKey(String)` on an open graph or management transaction and provide the name of the property key as the argument. Property key names must be unique in the graph. This method returns a builder for the property keys.
+To define a property key, call `makePropertyKey(String)` on an open graph or management transaction and provide the name of the property key as the argument. Property key names must be unique in the graph, and it is recommended to avoid spaces or special characters in property names. This method returns a builder for the property keys.
 
 ==== Property Key Data Type
 

--- a/docs/directindex.adoc
+++ b/docs/directindex.adoc
@@ -59,6 +59,10 @@ Names of property keys that contain non-alphanumeric characters must be placed i
 [source, java]
 graph.indexQuery("vertexByText", "v.\"first_name\":john").vertices()
 
+Some property key names may be transformed by the JanusGraph indexing backend implementation. For instance, an indexing backend that does not permit spaces in field names may transform "My Field Name" to "My•Field•Name", or an indexing backend like Solr may append type information to the name, transforming "myBooleanField" to "myBooleanField_b". These transformations happen in the index backend's implementation of IndexProvider, in the "mapKey2Field" method. Indexing backends may reserve special characters (such as '•') and prohibit indexing of fields that contain them. For this reason it is recommended to avoid spaces and special characters in property names.
+
+In general, making direct index queries depends on implementation details of JanusGraph indexing backends that are normally hidden from users, so it's best to verify a query empirically against the indexing backend in use.
+
 ==== Element Identifier Collision
 
 The strings "v.", "e.", and "p." are used to identify a vertex, edge or property element respectively in a query. If the field name or the query value contains the same sequence of characters, this can cause a collision in the query string and parsing errors as in the following example:

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexProvider.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexProvider.java
@@ -14,6 +14,7 @@
 
 package org.janusgraph.diskstorage.indexing;
 
+import org.apache.commons.lang.StringUtils;
 import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.BaseTransaction;
 import org.janusgraph.diskstorage.BaseTransactionConfig;
@@ -23,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import com.google.common.base.Preconditions;
+
 /**
  * External index for querying.
  * An index can contain an arbitrary number of index stores which are updated and queried separately.
@@ -31,6 +34,16 @@ import java.util.stream.Stream;
  */
 
 public interface IndexProvider extends IndexInformation {
+    /*
+     * An obscure unicode character (•) provided as a convenience for implementations of {@link #mapKey2Field}, for
+     * instance to replace spaces in property keys. See #777.
+     */
+    char REPLACEMENT_CHAR = '\u2022';
+
+    static void checkKeyValidity(String key) {
+        Preconditions.checkArgument(!StringUtils.containsAny(key, new char[]{ IndexProvider.REPLACEMENT_CHAR }),
+            "Invalid key name containing reserved character %c provided: %s", IndexProvider.REPLACEMENT_CHAR, key);
+    }
 
     /**
      * This method registers a new key for the specified index store with the given data type. This allows the IndexProvider

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
@@ -22,7 +22,6 @@ import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
 import org.janusgraph.diskstorage.es.compat.ES6Compat;
 import org.locationtech.spatial4j.shape.Rectangle;
-import org.apache.commons.lang.StringUtils;
 import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
 import org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter;
 import org.apache.tinkerpop.shaded.jackson.databind.SerializationFeature;
@@ -70,7 +69,6 @@ import org.janusgraph.graphdb.query.condition.Not;
 import org.janusgraph.graphdb.query.condition.Or;
 import org.janusgraph.graphdb.query.condition.PredicateCondition;
 import org.janusgraph.graphdb.types.ParameterType;
-import org.javatuples.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1054,8 +1052,8 @@ public class ElasticSearchIndex implements IndexProvider {
 
     @Override
     public String mapKey2Field(String key, KeyInformation information) {
-        Preconditions.checkArgument(!StringUtils.containsAny(key,new char[]{' '}),"Invalid key name provided: %s",key);
-        return key;
+        IndexProvider.checkKeyValidity(key);
+        return key.replace(' ', IndexProvider.REPLACEMENT_CHAR);
     }
 
     @Override

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticSearchIndexTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticSearchIndexTest.java
@@ -69,6 +69,8 @@ public class ElasticSearchIndexTest extends IndexProviderTest {
     static CloseableHttpClient httpClient;
     static ObjectMapper objectMapper;
 
+    private static char REPLACEMENT_CHAR = '\u2022';
+
     @BeforeClass
     public static void startElasticsearch() throws Exception {
         esr = new ElasticsearchRunner();
@@ -246,5 +248,16 @@ public class ElasticSearchIndexTest extends IndexProviderTest {
             assertEquals(1, tx.queryStream(new IndexQuery("ingestvertex", PredicateCondition.of(TEXT, Text.CONTAINS, "bob"))).count());
             assertEquals(1, tx.queryStream(new IndexQuery("ingestvertex", PredicateCondition.of(STRING, Cmp.EQUAL, "hello"))).count());
         }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMapKey2Field_IllegalCharacter() {
+        index.mapKey2Field("here is an illegal character: " + REPLACEMENT_CHAR, null);
+    }
+
+    @Test
+    public void testMapKey2Field_MappingSpaces() {
+        String expected = "field" + REPLACEMENT_CHAR + "name" + REPLACEMENT_CHAR + "with" + REPLACEMENT_CHAR + "spaces";
+        assertEquals(expected, index.mapKey2Field("field name with spaces", null));
     }
 }

--- a/janusgraph-lucene/src/main/java/org/janusgraph/diskstorage/lucene/LuceneIndex.java
+++ b/janusgraph-lucene/src/main/java/org/janusgraph/diskstorage/lucene/LuceneIndex.java
@@ -672,7 +672,7 @@ public class LuceneIndex implements IndexProvider {
             throw new TemporaryBackendException("Could not execute Lucene query", e);
         }
     }
-    
+
     @Override
     public BaseTransactionConfigurable beginTransaction(BaseTransactionConfig config) throws BackendException {
         return new Transaction(config);
@@ -725,8 +725,8 @@ public class LuceneIndex implements IndexProvider {
 
     @Override
     public String mapKey2Field(String key, KeyInformation information) {
-        Preconditions.checkArgument(!StringUtils.containsAny(key,new char[]{' '}),"Invalid key name provided: %s",key);
-        return key;
+        IndexProvider.checkKeyValidity(key);
+        return key.replace(' ', REPLACEMENT_CHAR);
     }
 
     @Override

--- a/janusgraph-lucene/src/test/java/org/janusgraph/diskstorage/lucene/LuceneIndexTest.java
+++ b/janusgraph-lucene/src/test/java/org/janusgraph/diskstorage/lucene/LuceneIndexTest.java
@@ -36,6 +36,7 @@ import java.util.Date;
 
 import java.util.UUID;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -47,6 +48,8 @@ public class LuceneIndexTest extends IndexProviderTest {
 
     private static final Logger log =
             LoggerFactory.getLogger(LuceneIndexTest.class);
+
+    private static char REPLACEMENT_CHAR = '\u2022';
 
     @Rule
     public TestName methodName = new TestName();
@@ -136,4 +139,16 @@ public class LuceneIndexTest extends IndexProviderTest {
 //        // This fails under Lucene but works in ES
 //        log.info("Skipping " + getClass().getSimpleName() + "." + methodName.getMethodName());
 //    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMapKey2Field_IllegalCharacter() {
+        index.mapKey2Field("here is an illegal character: " + REPLACEMENT_CHAR, null);
+    }
+
+    @Test
+    public void testMapKey2Field_MappingSpaces() {
+        String expected = "field" + REPLACEMENT_CHAR + "name" + REPLACEMENT_CHAR + "with" + REPLACEMENT_CHAR + "spaces";
+        assertEquals(expected, index.mapKey2Field("field name with spaces", null));
+    }
 }

--- a/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
+++ b/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
@@ -205,7 +205,6 @@ public class SolrIndex implements IndexProvider {
             "When mutating - wait for the index to reflect new mutations before returning. This can have a negative impact on performance.",
             ConfigOption.Type.LOCAL, false);
 
-
     private static final IndexFeatures SOLR_FEATURES = new IndexFeatures.Builder()
         .supportsDocumentTTL()
         .setDefaultStringMapping(Mapping.TEXT)
@@ -940,7 +939,9 @@ public class SolrIndex implements IndexProvider {
 
     @Override
     public String mapKey2Field(String key, KeyInformation keyInfo) {
-        Preconditions.checkArgument(!StringUtils.containsAny(key, new char[]{' '}),"Invalid key name provided: %s",key);
+        IndexProvider.checkKeyValidity(key);
+        key = key.replace(' ', REPLACEMENT_CHAR);
+
         if (!dynFields) return key;
         if (ParameterType.MAPPED_NAME.hasParameter(keyInfo.getParameters())) return key;
         String postfix;

--- a/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrIndexTest.java
+++ b/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrIndexTest.java
@@ -29,6 +29,8 @@ import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.janusgraph.diskstorage.indexing.IndexProvider;
 import org.janusgraph.diskstorage.indexing.IndexProviderTest;
 import org.janusgraph.diskstorage.indexing.IndexQuery;
+import org.janusgraph.diskstorage.indexing.KeyInformation;
+import org.janusgraph.diskstorage.indexing.StandardKeyInformation;
 import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
 import org.janusgraph.graphdb.query.condition.PredicateCondition;
 import org.junit.AfterClass;
@@ -165,4 +167,17 @@ public class SolrIndexTest extends IndexProviderTest {
      */
     @Override @Test @Ignore
     public void clearStorageTest() throws Exception { }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMapKey2Field_IllegalCharacter() {
+        KeyInformation keyInfo = new StandardKeyInformation(Boolean.class, Cardinality.SINGLE);
+        index.mapKey2Field("here is an illegal character: •", keyInfo);
+    }
+
+    @Test
+    public void testMapKey2Field_MappingSpaces() {
+        KeyInformation keyInfo = new StandardKeyInformation(Boolean.class, Cardinality.SINGLE);
+        assertEquals("field•name•with•spaces_b", index.mapKey2Field("field name with spaces", keyInfo));
+    }
 }


### PR DESCRIPTION
Fixes #777 

Replace spaces in property names with an obscure unicode character in mapKey2Field() so that external indexing backends (Lucene, ElasticSearch, Solr) that disallow spaces in field names can still index those properties.

Added unit tests for all 3 backends and tested with a production ES index.

Also added another commit to update AUTHORS.txt and CONTRIBUTORS.txt to reflect this PR and 260e6fc7bb54f818a10f4c34938a512ebfaf22cc.

I'm targeting the 0.2 branch because for our use of JanusGraph this is a blocking bug, and so it would be quite nice to have it in an 0.2.1 release so we don't have to keep using our own snapshot build.

Since this was my first attempt at contributing, I'll note a couple interesting things I discovered:

- The ES tests (at least) don't run correctly on Windows. I tried fixing this (detecting OS and using elasticsearch.bat instead, taskkill instead of kill) but wasn't able to get it working consistently so just used an Ubuntu VM.
- On that Ubuntu VM, the BerkeleyElasticsearchTest failed when doing 'mvn clean install in janusgraph-es project. Not sure why, but maybe there's some non-obvious dependency that maven didn't pull down?
- Importing the JanusGraph pomfile into IntelliJ worked flawlessly 👍 

PR Template checklist:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)? *As noted above, 0.2 rather than master.*
- [ ] Is your initial contribution a single, squashed commit? *No, but I think the commits make sense to be separated.*

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? *N/A*
- [x] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository? *N/A*
- [x] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository? *N/A*