### PR TITLE
Upgrading Cloud Bigtable dependency to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <hbase098.version>${hbase098.core.version}-hadoop2</hbase098.version>
         <hbase100.core.version>1.2.6</hbase100.core.version>
         <hbase100.version>${hbase100.core.version}</hbase100.version>
-        <bigtable.version>1.0.0-pre3</bigtable.version>
+        <bigtable.version>1.0.0</bigtable.version>
         <scylladb.version>1.7.1</scylladb.version>
         <!-- align with org.apache.hbase:hbase -->
         <jackson1.version>1.9.13</jackson1.version>


### PR DESCRIPTION
Upgrading Cloud Bigtable dependency to 1.0.0.  I testing out some basic JanusGraph functionality against Cloud Bigtable, and things seemed to work.  The current documentation for Cloud Bigtable will work with this change.

@mbrukman, FYI.