### PR TITLE
Issue #723: hasId short-circuits following steps

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphStep.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphStep.java
@@ -14,7 +14,6 @@
 
 package org.janusgraph.graphdb.tinkerpop.optimize;
 
-import com.google.common.collect.Iterables;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.janusgraph.core.JanusGraphQuery;
 import org.janusgraph.core.JanusGraphTransaction;
@@ -119,6 +118,15 @@ public class JanusGraphStep<S, E extends Element> extends GraphStep<S, E> implem
                 list.add(e);
         }
         return list.iterator();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (hasContainers != null ? hasContainers.hashCode() : 0);
+        result = 31 * result + limit;
+        result = 31 * result + (orders != null ? orders.hashCode() : 0);
+        return result;
     }
 }
 

--- a/janusgraph-test/src/test/java/org/janusgraph/blueprints/process/traversal/strategy/optimization/JanusGraphStepStrategyTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/blueprints/process/traversal/strategy/optimization/JanusGraphStepStrategyTest.java
@@ -115,7 +115,8 @@ public class JanusGraphStepStrategyTest {
                         g_V("name", eq("marko"), "name", eq("bob"), "name", eq("stephen")).out("knows"), Collections.emptyList()},
                 {__.V().hasId(1), g_V(T.id, 1), Collections.emptyList()},
                 {__.V().hasId(within(1, 2)), g_V(T.id, 1, T.id, 2), Collections.emptyList()},
-                {__.V().hasId(1).has("name", "marko"), g_V(T.id, 1, "name", eq("marko")), Collections.emptyList()}
+                {__.V().hasId(1).has("name", "marko"), g_V(T.id, 1, "name", eq("marko")), Collections.emptyList()},
+                {__.V().hasId(1).hasLabel("Person"), g_V(T.id, 1, "~label", eq("Person")), Collections.emptyList()}
         });
     }
 }


### PR DESCRIPTION
This PR addresses Issue #723 .

foldInIds now correctly leaves other hasContainers intact so that additional predicates are enforced.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

