### PR TITLE
Revert PR #667 "Closing partitionVertexIdPool when VertexIDAssigner is closed"

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/idassigner/VertexIDAssigner.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/idassigner/VertexIDAssigner.java
@@ -138,7 +138,6 @@ public class VertexIDAssigner implements AutoCloseable {
 
     public synchronized void close() {
         schemaIdPool.close();
-        partitionVertexIdPool.close();
         for (PartitionIDPool pool : idPools.values()) {
             pool.close();
         }


### PR DESCRIPTION
Revert JanusGraph/janusgraph#667 which broke tests; see [this build](https://travis-ci.org/JanusGraph/janusgraph/builds/314003162), specifically [this job](https://travis-ci.org/JanusGraph/janusgraph/jobs/314003169).

