### PR TITLE
Use Coverity/Travis vars consistently [skip ci]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ script:
 
 after_success:
   # Upload test coverage reports to Codecov
-  - if [ "${COVERITY_SCAN_BRANCH}" == 1 ] || [ -n "${COVERITY_ONLY:-}" ]; then
+  - if [ "${TRAVIS_BRANCH}" == "${COVERITY_BRANCH_NAME}" ] || [ -n "${COVERITY_ONLY:-}" ]; then
       echo "Skipping test coverage report upload in Coverity branch/job";
     else
       bash <(curl -s https://codecov.io/bash);


### PR DESCRIPTION
Instead of using `$COVERITY_SCAN_BRANCH` which isn't used anywhere else in this
script, be more consistent and use `$TRAVIS_BRANCH` and `$COVERITY_BRANCH_NAME`.

Context: https://github.com/JanusGraph/janusgraph/pull/761#discussion_r153380194

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [] Is there an issue associated with this PR? Is it referenced in the commit message?
- [] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [] Have you written and/or updated unit tests to verify your changes?
- [] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [] Have you ensured that format looks appropriate for the output in which it is rendered?
- [] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

