### PR TITLE
Use try with resources, move unnecessary members to local vars

### DIFF
--- a/janusgraph-berkeleyje/src/main/java/org/janusgraph/diskstorage/berkeleyje/BerkeleyJETx.java
+++ b/janusgraph-berkeleyje/src/main/java/org/janusgraph/diskstorage/berkeleyje/BerkeleyJETx.java
@@ -50,18 +50,8 @@ public class BerkeleyJETx extends AbstractStoreTransaction {
         return tx;
     }
 
-    void registerCursor(Cursor cursor) {
-        Preconditions.checkArgument(cursor != null);
-        synchronized (openCursors) {
-            //TODO: attempt to remove closed cursors if there are too many
-            openCursors.add(cursor);
-        }
-    }
-
-    private void closeOpenIterators() throws BackendException {
-        for (Cursor cursor : openCursors) {
-            cursor.close();
-        }
+    private void closeOpenIterators() {
+        openCursors.forEach(Cursor::close);
     }
 
     LockMode getLockMode() {

--- a/janusgraph-berkeleyje/src/test/java/org/janusgraph/diskstorage/berkeleyje/BerkeleyFixedLengthKCVSTest.java
+++ b/janusgraph-berkeleyje/src/test/java/org/janusgraph/diskstorage/berkeleyje/BerkeleyFixedLengthKCVSTest.java
@@ -22,9 +22,6 @@ import org.janusgraph.diskstorage.keycolumnvalue.KeyColumnValueStoreManager;
 import org.janusgraph.diskstorage.keycolumnvalue.keyvalue.OrderedKeyValueStoreManagerAdapter;
 import org.junit.Test;
 
-import java.util.concurrent.ExecutionException;
-
-
 public class BerkeleyFixedLengthKCVSTest extends KeyColumnValueStoreTest {
 
     public KeyColumnValueStoreManager openStorageManager() throws BackendException {
@@ -33,12 +30,12 @@ public class BerkeleyFixedLengthKCVSTest extends KeyColumnValueStoreTest {
     }
 
     @Test @Override
-    public void testConcurrentGetSlice() throws ExecutionException, InterruptedException, BackendException {
+    public void testConcurrentGetSlice() {
 
     }
 
     @Test @Override
-    public void testConcurrentGetSliceAndMutate() throws BackendException, ExecutionException, InterruptedException {
+    public void testConcurrentGetSliceAndMutate() {
 
     }
 }

--- a/janusgraph-berkeleyje/src/test/java/org/janusgraph/diskstorage/berkeleyje/BerkeleyVariableLengthKCVSTest.java
+++ b/janusgraph-berkeleyje/src/test/java/org/janusgraph/diskstorage/berkeleyje/BerkeleyVariableLengthKCVSTest.java
@@ -21,9 +21,6 @@ import org.janusgraph.diskstorage.keycolumnvalue.KeyColumnValueStoreManager;
 import org.janusgraph.diskstorage.keycolumnvalue.keyvalue.OrderedKeyValueStoreManagerAdapter;
 import org.junit.Test;
 
-import java.util.concurrent.ExecutionException;
-
-
 public class BerkeleyVariableLengthKCVSTest extends KeyColumnValueStoreTest {
 
     public KeyColumnValueStoreManager openStorageManager() throws BackendException {
@@ -32,12 +29,12 @@ public class BerkeleyVariableLengthKCVSTest extends KeyColumnValueStoreTest {
     }
 
     @Test @Override
-    public void testConcurrentGetSlice() throws ExecutionException, InterruptedException, BackendException {
+    public void testConcurrentGetSlice() {
 
     }
 
     @Test @Override
-    public void testConcurrentGetSliceAndMutate() throws BackendException, ExecutionException, InterruptedException {
+    public void testConcurrentGetSliceAndMutate() {
 
     }
 }

--- a/janusgraph-berkeleyje/src/test/java/org/janusgraph/graphdb/berkeleyje/BerkeleyGraphTest.java
+++ b/janusgraph-berkeleyje/src/test/java/org/janusgraph/graphdb/berkeleyje/BerkeleyGraphTest.java
@@ -15,8 +15,9 @@
 package org.janusgraph.graphdb.berkeleyje;
 
 import org.janusgraph.core.JanusGraphException;
-import org.janusgraph.core.util.JanusGraphCleanup;
+import org.janusgraph.core.JanusGraphFactory;
 import org.janusgraph.diskstorage.Backend;
+import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.configuration.ConfigOption;
 import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
 import org.junit.Rule;
@@ -99,12 +100,11 @@ public class BerkeleyGraphTest extends JanusGraphTest {
     }
 
     @Test
-    public void testIDBlockAllocationTimeout()
-    {
+    public void testIDBlockAllocationTimeout() throws BackendException {
         config.set("ids.authority.wait-time", Duration.of(0L, ChronoUnit.NANOS));
         config.set("ids.renew-timeout", Duration.of(1L, ChronoUnit.MILLIS));
         close();
-        JanusGraphCleanup.clear(graph);
+        JanusGraphFactory.drop(graph);
         open(config);
         try {
             graph.addVertex();

--- a/janusgraph-cassandra/src/main/java/org/janusgraph/diskstorage/cassandra/embedded/CassandraEmbeddedStoreManager.java
+++ b/janusgraph-cassandra/src/main/java/org/janusgraph/diskstorage/cassandra/embedded/CassandraEmbeddedStoreManager.java
@@ -73,7 +73,7 @@ public class CassandraEmbeddedStoreManager extends AbstractCassandraStoreManager
 
     private final IRequestScheduler requestScheduler;
 
-    public CassandraEmbeddedStoreManager(Configuration config) throws BackendException {
+    public CassandraEmbeddedStoreManager(Configuration config) {
         super(config);
 
         String cassandraConfig = CASSANDRA_YAML_DEFAULT;
@@ -120,7 +120,6 @@ public class CassandraEmbeddedStoreManager extends AbstractCassandraStoreManager
     @Override
     public void close() {
         openStores.clear();
-        CassandraDaemonWrapper.stop();
     }
 
     @Override

--- a/janusgraph-cassandra/src/main/java/org/janusgraph/diskstorage/cassandra/thrift/CassandraThriftStoreManager.java
+++ b/janusgraph-cassandra/src/main/java/org/janusgraph/diskstorage/cassandra/thrift/CassandraThriftStoreManager.java
@@ -470,7 +470,7 @@ public class CassandraThriftStoreManager extends AbstractCassandraStoreManager {
         }
     }
 
-    private KsDef ensureKeyspaceExists(String keyspaceName) throws TException, BackendException {
+    private KsDef ensureKeyspaceExists(String keyspaceName) throws BackendException {
         CTConnection connection = null;
 
         try {

--- a/janusgraph-cassandra/src/test/java/org/janusgraph/diskstorage/cassandra/AbstractCassandraStoreTest.java
+++ b/janusgraph-cassandra/src/test/java/org/janusgraph/diskstorage/cassandra/AbstractCassandraStoreTest.java
@@ -140,7 +140,7 @@ public abstract class AbstractCassandraStoreTest extends KeyColumnValueStoreTest
     }
 
     @Test
-    public void testTTLSupported() throws Exception {
+    public void testTTLSupported() {
         StoreFeatures features = manager.getFeatures();
         assertTrue(features.hasCellTTL());
     }

--- a/janusgraph-cassandra/src/test/java/org/janusgraph/graphdb/CassandraGraphTest.java
+++ b/janusgraph-cassandra/src/test/java/org/janusgraph/graphdb/CassandraGraphTest.java
@@ -45,7 +45,7 @@ public abstract class CassandraGraphTest extends JanusGraphTest {
     }
 
     @Test
-    public void testHasTTL() throws Exception {
+    public void testHasTTL() {
         assertTrue(features.hasCellTTL());
     }
 

--- a/janusgraph-cassandra/src/test/java/org/janusgraph/graphdb/thrift/ThriftConnectionTest.java
+++ b/janusgraph-cassandra/src/test/java/org/janusgraph/graphdb/thrift/ThriftConnectionTest.java
@@ -46,7 +46,7 @@ public class ThriftConnectionTest {
     private CTConnectionFactory.Config factoryConfig;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         try {
             Config.setClientMode(true);
             Schema.instance.load(KSMetaData.newKeyspace("janusgraph", "SimpleStrategy", ImmutableMap.of("replication_factor", "1"), true));

--- a/janusgraph-core/src/main/java/org/janusgraph/core/attribute/Geoshape.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/attribute/Geoshape.java
@@ -449,24 +449,19 @@ public class Geoshape {
 
             if (value.getClass().isArray() && (value.getClass().getComponentType().isPrimitive() ||
                     Number.class.isAssignableFrom(value.getClass().getComponentType())) ) {
-                Geoshape shape = null;
                 int len= Array.getLength(value);
                 double[] arr = new double[len];
                 for (int i=0;i<len;i++) arr[i]=((Number)Array.get(value,i)).doubleValue();
                 switch (len) {
                     case 2:
-                        shape = point(arr[0], arr[1]);
-                        break;
+                        return point(arr[0], arr[1]);
                     case 3:
-                        shape = circle(arr[0], arr[1], arr[2]);
-                        break;
+                        return circle(arr[0], arr[1], arr[2]);
                     case 4:
-                        shape = box(arr[0], arr[1], arr[2], arr[3]);
-                        break;
+                        return box(arr[0], arr[1], arr[2], arr[3]);
                     default:
                         throw new IllegalArgumentException("Expected 2-4 coordinates to create Geoshape, but given: " + value);
                 }
-                return shape;
             } else if (value instanceof String) {
                 String[] components=null;
                 for (String delimiter : new String[]{",",";"}) {

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/Backend.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/Backend.java
@@ -673,7 +673,7 @@ public class Backend implements LockerProvider, AutoCloseable {
         }
     };
 
-    private final Function<String, Locker> TEST_LOCKER_CREATOR = lockerName -> openManagedLocker("org.janusgraph.diskstorage.util.TestLockerManager",lockerName);
+    private static final Function<String, Locker> TEST_LOCKER_CREATOR = lockerName -> openManagedLocker("org.janusgraph.diskstorage.util.TestLockerManager",lockerName);
 
     private final Map<String, Function<String, Locker>> REGISTERED_LOCKERS = ImmutableMap.of(
             "consistentkey", CONSISTENT_KEY_LOCKER_CREATOR,
@@ -691,7 +691,7 @@ public class Backend implements LockerProvider, AutoCloseable {
             return (Locker) o;
         } catch (ClassNotFoundException e) {
             throw new IllegalArgumentException("Could not find implementation class: " + classname);
-        } catch (InstantiationException e) {
+        } catch (InstantiationException | ClassCastException e) {
             throw new IllegalArgumentException("Could not instantiate implementation: " + classname, e);
         } catch (NoSuchMethodException e) {
             throw new IllegalArgumentException("Could not find method when configuring locking for: " + classname,e);
@@ -699,8 +699,6 @@ public class Backend implements LockerProvider, AutoCloseable {
             throw new IllegalArgumentException("Could not access method when configuring locking for: " + classname,e);
         } catch (InvocationTargetException e) {
             throw new IllegalArgumentException("Could not invoke method when configuring locking for: " + classname,e);
-        } catch (ClassCastException e) {
-            throw new IllegalArgumentException("Could not instantiate implementation: " + classname, e);
         }
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/BasicConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/BasicConfiguration.java
@@ -90,12 +90,11 @@ public class BasicConfiguration extends AbstractConfiguration {
         for (String key : config.getKeys("")) {
             Preconditions.checkArgument(StringUtils.isNotBlank(key));
             try {
-                ConfigElement.PathIdentifier pid = ConfigElement.parse(getRootNamespace(),key);
+                final ConfigElement.PathIdentifier pid = ConfigElement.parse(getRootNamespace(),key);
                 Preconditions.checkArgument(pid.element.isOption() && !pid.lastIsUmbrella);
-                result.put(pid,get((ConfigOption)pid.element,pid.umbrellaElements));
+                result.put(pid, get((ConfigOption) pid.element, pid.umbrellaElements));
             } catch (IllegalArgumentException e) {
                 log.debug("Ignored configuration entry for {} since it does not map to an option",key,e);
-                continue;
             }
         }
         return result;

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/ConfigOption.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/ConfigOption.java
@@ -257,19 +257,14 @@ public class ConfigOption<O> extends ConfigElement {
 
     public static <O> Predicate<O> disallowEmpty(Class<O> clazz) {
         return o -> {
-            if (o==null) {
+            if (o == null) {
                 return false;
             }
             if (o instanceof String) {
-                return StringUtils.isNotBlank((String)o);
+                return StringUtils.isNotBlank((String) o);
             }
-            if (o.getClass().isArray() && (Array.getLength(o)==0 || Array.get(o,0)==null)) {
-                return false;
-            }
-            if (o instanceof Collection && (((Collection)o).isEmpty() || ((Collection)o).iterator().next()==null)) {
-                return false;
-            }
-            return true;
+            return (!o.getClass().isArray() || (Array.getLength(o) != 0 && Array.get(o, 0) != null))
+                    && (!(o instanceof Collection) || (!((Collection) o).isEmpty() && ((Collection) o).iterator().next() != null));
         };
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/MixedConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/MixedConfiguration.java
@@ -16,10 +16,11 @@ package org.janusgraph.diskstorage.configuration;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
@@ -39,15 +40,14 @@ public class MixedConfiguration extends AbstractConfiguration {
 
     @Override
     public boolean has(ConfigOption option, String... umbrellaElements) {
-        String key = super.getPath(option,umbrellaElements);
-        if (option.isLocal() && local.get(key,option.getDatatype())!=null) return true;
-        if (option.isGlobal() && global.get(key,option.getDatatype())!=null) return true;
-        return false;
+        final String key = super.getPath(option, umbrellaElements);
+        return option.isLocal() && local.get(key, option.getDatatype()) != null
+              || option.isGlobal() && global.get(key, option.getDatatype()) != null;
     }
 
     @Override
     public<O> O get(ConfigOption<O> option, String... umbrellaElements) {
-        String key = super.getPath(option,umbrellaElements);
+        final String key = super.getPath(option,umbrellaElements);
         Object result = null;
         if (option.isLocal()) {
             result = local.get(key,option.getDatatype());
@@ -60,11 +60,10 @@ public class MixedConfiguration extends AbstractConfiguration {
 
     @Override
     public Set<String> getContainedNamespaces(ConfigNamespace umbrella, String... umbrellaElements) {
-        Set<String> result = Sets.newHashSet();
-        for (ReadConfiguration config : new ReadConfiguration[]{global,local}) {
-            result.addAll(super.getContainedNamespaces(config,umbrella,umbrellaElements));
-        }
-        return result;
+        return Arrays.stream(new ReadConfiguration[]{global,local})
+            .map(config -> super.getContainedNamespaces(config, umbrella, umbrellaElements))
+            .flatMap(Set::stream)
+            .collect(Collectors.toSet());
     }
 
     public Map<String,Object> getSubset(ConfigNamespace umbrella, String... umbrellaElements) {

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/backend/CommonsConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/backend/CommonsConfiguration.java
@@ -100,7 +100,7 @@ public class CommonsConfiguration implements WriteConfiguration {
                 return (O) o;
             } else {
                 String[] comps = o.toString().split("\\s");
-                TemporalUnit unit = null;
+                final TemporalUnit unit;
                 switch (comps.length) {
                     case 1:
                         //By default, times are in milli seconds

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/backend/KCVSConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/backend/KCVSConfiguration.java
@@ -57,7 +57,6 @@ public class KCVSConfiguration implements ConcurrentWriteConfiguration {
     private final BackendOperation.TransactionalProvider txProvider;
     private final TimestampProvider times;
     private final KeyColumnValueStore store;
-    private final String identifier;
     private final StaticBuffer rowKey;
     private final StandardSerializer serializer;
 
@@ -70,8 +69,7 @@ public class KCVSConfiguration implements ConcurrentWriteConfiguration {
         this.txProvider = txProvider;
         this.times = config.get(TIMESTAMP_PROVIDER);
         this.store = store;
-        this.identifier = identifier;
-        this.rowKey = string2StaticBuffer(this.identifier);
+        this.rowKey = string2StaticBuffer(identifier);
         this.serializer = new StandardSerializer();
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexTransaction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexTransaction.java
@@ -105,7 +105,7 @@ public class IndexTransaction implements BaseTransaction, LoggableTransaction {
     }
 
     public Stream<String> queryStream(IndexQuery query) throws BackendException {
-        return index.query(query, keyInformation,indexTx);
+        return index.query(query, keyInformation, indexTx);
     }
 
     /**

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KCVSUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KCVSUtil.java
@@ -91,14 +91,13 @@ public class KCVSUtil {
     }
 
     public static boolean containsKey(KeyColumnValueStore store, StaticBuffer key, int maxColumnLength, StoreTransaction txh) throws BackendException {
-        final StaticBuffer start = START;
         final StaticBuffer end;
         if (maxColumnLength>32) {
             end = BufferUtil.oneBuffer(maxColumnLength);
         } else {
             end = END;
         }
-        return !store.getSlice(new KeySliceQuery(key, start, end).setLimit(1),txh).isEmpty();
+        return !store.getSlice(new KeySliceQuery(key, START, end).setLimit(1),txh).isEmpty();
     }
 
     public static boolean matches(SliceQuery query, StaticBuffer column) {

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/cache/KCVSCache.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/cache/KCVSCache.java
@@ -34,7 +34,6 @@ public abstract class KCVSCache extends KCVSProxy {
     public static final List<Entry> NO_DELETIONS = ImmutableList.of();
 
     private final String metricsName;
-    private final boolean validateKeysOnly = true;
 
     protected KCVSCache(KeyColumnValueStore store, String metricsName) {
         super(store);
@@ -42,7 +41,7 @@ public abstract class KCVSCache extends KCVSProxy {
     }
 
     protected boolean hasValidateKeysOnly() {
-        return validateKeysOnly;
+        return true;
     }
 
     protected void incActionBy(int by, CacheMetricsAction action, StoreTransaction txh) {

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/keyvalue/KeySelector.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/keyvalue/KeySelector.java
@@ -50,8 +50,7 @@ public class KeySelector {
     }
 
     public boolean reachedLimit() {
-        if (count >= limit) return true;
-        else return false;
+        return count >= limit;
     }
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/keyvalue/OrderedKeyValueStoreAdapter.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/keyvalue/OrderedKeyValueStoreAdapter.java
@@ -41,7 +41,7 @@ import java.util.*;
  */
 public class OrderedKeyValueStoreAdapter extends BaseKeyColumnValueAdapter {
 
-    private final Logger log = LoggerFactory.getLogger(OrderedKeyValueStoreAdapter.class);
+    private static final Logger log = LoggerFactory.getLogger(OrderedKeyValueStoreAdapter.class);
 
     public static final int variableKeyLength = 0;
 
@@ -234,7 +234,7 @@ public class OrderedKeyValueStoreAdapter extends BaseKeyColumnValueAdapter {
 
         if (addKeyLength) {
             result[position++] = (byte) (length >>> 8);
-            result[position++] = (byte) length;
+            result[position] = (byte) length;
         }
         return StaticArrayBuffer.of(result);
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/StandardScannerExecutor.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/StandardScannerExecutor.java
@@ -60,8 +60,6 @@ class StandardScannerExecutor extends AbstractFuture<ScanMetrics> implements Jan
     private boolean hasCompleted = false;
     private boolean interrupted = false;
 
-    private List<SliceQuery> queries;
-    private int numQueries;
     private List<BlockingQueue<SliceResult>> dataQueues;
     private DataPuller[] pullThreads;
 
@@ -97,13 +95,15 @@ class StandardScannerExecutor extends AbstractFuture<ScanMetrics> implements Jan
 
     @Override
     public void run() {
+        final List<SliceQuery> queries;
+        final int numQueries;
         try {
             job.workerIterationStart(jobConfiguration, graphConfiguration, metrics);
 
             queries = job.getQueries();
             numQueries = queries.size();
-            Preconditions.checkArgument(numQueries>0,"Must at least specify one query for job: %s",job);
-            if (numQueries>1) {
+            Preconditions.checkArgument(numQueries > 0,"Must at least specify one query for job: %s",job);
+            if (numQueries > 1) {
                 //It is assumed that the first query is the grounding query if multiple queries exist
                 SliceQuery ground = queries.get(0);
                 StaticBuffer start = ground.getSliceStart();
@@ -116,7 +116,7 @@ class StandardScannerExecutor extends AbstractFuture<ScanMetrics> implements Jan
             dataQueues = new ArrayList<>(numQueries);
             pullThreads = new DataPuller[numQueries];
 
-            for (int pos=0;pos<numQueries;pos++) {
+            for (int pos = 0; pos< numQueries; pos++) {
                 pullThreads[pos]=addDataPuller(queries.get(pos),storeTx);
             }
         }  catch (Throwable e) {

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/locking/AbstractLocker.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/locking/AbstractLocker.java
@@ -351,10 +351,8 @@ public abstract class AbstractLocker<S extends LockStatus> implements Locker {
                 checkSingleLock(entry.getKey(), entry.getValue(), tx);
             }
             ok = true;
-        } catch (TemporaryLockingException | PermanentLockingException tle) {
+        } catch (TemporaryLockingException | PermanentLockingException | AssertionError tle) {
             throw tle;
-        } catch (AssertionError ae) {
-            throw ae; // Concession to ease testing with mocks & behavior verification
         } catch (InterruptedException | TemporaryBackendException e) {
             throw new TemporaryLockingException(e);
         } catch (Throwable t) {

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/locking/LocalLockMediator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/locking/LocalLockMediator.java
@@ -257,11 +257,10 @@ public class LocalLockMediator<T> {
             @SuppressWarnings("rawtypes")
             AuditRecord other = (AuditRecord) obj;
             if (holder == null) {
-                if (other.holder != null)
-                    return false;
-            } else if (!holder.equals(other.holder))
-                return false;
-            return true;
+                return other.holder == null;
+            } else {
+                return holder.equals(other.holder);
+            }
         }
 
         @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/locking/consistentkey/ConsistentKeyLockStatus.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/locking/consistentkey/ConsistentKeyLockStatus.java
@@ -76,10 +76,9 @@ public class ConsistentKeyLockStatus implements LockStatus {
         if (checked != other.checked)
             return false;
         if (expire == null) {
-            if (other.expire != null)
-                return false;
-        } else if (!expire.equals(other.expire))
-            return false;
-        return true;
+            return other.expire == null;
+        } else {
+            return expire.equals(other.expire);
+        }
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/locking/consistentkey/ExpectedValueCheckingStoreManager.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/locking/consistentkey/ExpectedValueCheckingStoreManager.java
@@ -92,8 +92,7 @@ public class ExpectedValueCheckingStoreManager extends KCVSManagerProxy {
         StoreTransaction strongConsistentTx = manager.beginTransaction(consistentTxCfg);
 
         // Return a wrapper around both the inconsistent and consistent store transactions
-        ExpectedValueCheckingTransaction wrappedTx = new ExpectedValueCheckingTransaction(inconsistentTx, strongConsistentTx, maxReadTime);
-        return wrappedTx;
+        return new ExpectedValueCheckingTransaction(inconsistentTx, strongConsistentTx, maxReadTime);
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/locking/consistentkey/StandardLockCleanerRunnable.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/locking/consistentkey/StandardLockCleanerRunnable.java
@@ -138,10 +138,9 @@ public class StandardLockCleanerRunnable implements Runnable {
         } else if (!target.equals(other.target))
             return false;
         if (tx == null) {
-            if (other.tx != null)
-                return false;
-        } else if (!tx.equals(other.tx))
-            return false;
-        return true;
+            return other.tx == null;
+        } else {
+            return tx.equals(other.tx);
+        }
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/log/ReadMarker.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/log/ReadMarker.java
@@ -76,8 +76,7 @@ public class ReadMarker {
         if (newMarker.hasIdentifier()) {
             return hasIdentifier() && identifier.equals(newMarker.identifier);
         }
-        if (newMarker.hasStartTime()) return false;
-        return true;
+        return !newMarker.hasStartTime();
     }
 
     /**

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/log/kcvs/KCVSLog.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/log/kcvs/KCVSLog.java
@@ -200,7 +200,6 @@ public class KCVSLog implements Log, BackendOperation.TransactionalProvider {
     private final Duration readPollingInterval;
     private final Duration readLagTime;
     private final Duration maxReadTime;
-    private final boolean allowReadMarkerRecovery = true;
 
     /**
      * Thread pool to read messages in the specified interval from the various keys in a time slice AND to process
@@ -662,7 +661,7 @@ public class KCVSLog implements Log, BackendOperation.TransactionalProvider {
         @Override
         public void run() {
             try {
-                if (allowReadMarkerRecovery) setReadMarker();
+                setReadMarker();
 
                 final int timeslice = getTimeSlice(messageTimeStart);
 

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/StaticArrayBuffer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/StaticArrayBuffer.java
@@ -178,7 +178,7 @@ public class StaticArrayBuffer implements StaticBuffer {
     @Override
     public short getShort(int position) {
         int base = require(position, SHORT_LEN);
-        return (short) (((array[base++] & 0xFF) << 8) | (array[base++] & 0xFF));
+        return (short) (((array[base++] & 0xFF) << 8) | (array[base] & 0xFF));
     }
 
     @Override
@@ -215,18 +215,18 @@ public class StaticArrayBuffer implements StaticBuffer {
                 | (long) (array[offset++] & 0xFF) << 24 //
                 | (array[offset++] & 0xFF) << 16 //
                 | (array[offset++] & 0xFF) << 8 //
-                | array[offset++] & 0xFF;
+                | array[offset] & 0xFF;
     }
 
     public static void putLong(byte[] array, int offset, final long value) {
-        array[offset++]= (byte)(value >> 56);
-        array[offset++]= (byte)((value >> 48) & 0xFF);
-        array[offset++]= (byte)((value >> 40) & 0xFF);
-        array[offset++]= (byte)((value >> 32) & 0xFF);
-        array[offset++]= (byte)((value >> 24) & 0xFF);
-        array[offset++]= (byte)((value >> 16) & 0xFF);
-        array[offset++]= (byte)((value >> 8) & 0xFF);
-        array[offset++]= (byte)(value & 0xFF);
+        array[offset++] = (byte) (value >> 56  );
+        array[offset++] = (byte)((value >> 48  ) & 0xFF);
+        array[offset++] = (byte)((value >> 40  ) & 0xFF);
+        array[offset++] = (byte)((value >> 32  ) & 0xFF);
+        array[offset++] = (byte)((value >> 24  ) & 0xFF);
+        array[offset++] = (byte)((value >> 16  ) & 0xFF);
+        array[offset++] = (byte)((value >> 8   ) & 0xFF);
+        array[offset]   = (byte) (value  & 0xFF);
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/example/GraphOfTheGodsFactory.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/example/GraphOfTheGodsFactory.java
@@ -66,7 +66,7 @@ public class GraphOfTheGodsFactory {
     }
 
     private static boolean mixedIndexNullOrExists(StandardJanusGraph graph, String indexName) {
-        return indexName == null || graph.getIndexSerializer().containsIndex(indexName) == true;
+        return indexName == null || graph.getIndexSerializer().containsIndex(indexName);
     }
 
     public static void load(final JanusGraph graph, String mixedIndexName, boolean uniqueNameCompositeIndex) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/StandardJanusGraph.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/StandardJanusGraph.java
@@ -100,34 +100,34 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
         TraversalStrategies.GlobalCache.registerStrategies(StandardJanusGraphTx.class, graphStrategies);
     }
 
-    private GraphDatabaseConfiguration config;
-    private Backend backend;
-    private IDManager idManager;
-    private VertexIDAssigner idAssigner;
-    private TimestampProvider times;
+    private final GraphDatabaseConfiguration config;
+    private final Backend backend;
+    private final IDManager idManager;
+    private final VertexIDAssigner idAssigner;
+    private final TimestampProvider times;
 
     //Serializers
-    protected IndexSerializer indexSerializer;
-    protected EdgeSerializer edgeSerializer;
-    protected Serializer serializer;
+    protected final IndexSerializer indexSerializer;
+    protected final EdgeSerializer edgeSerializer;
+    protected final Serializer serializer;
 
     //Caches
-    public SliceQuery vertexExistenceQuery;
-    private RelationQueryCache queryCache;
-    private SchemaCache schemaCache;
+    public final SliceQuery vertexExistenceQuery;
+    private final RelationQueryCache queryCache;
+    private final SchemaCache schemaCache;
 
     //Log
-    private ManagementLogger managementLogger;
+    private final ManagementLogger managementLogger;
 
     //Shutdown hook
     private volatile ShutdownThread shutdownHook;
 
-    private volatile boolean isOpen = true;
-    private AtomicLong txCounter;
+    private volatile boolean isOpen;
+    private final AtomicLong txCounter;
 
-    private Set<StandardJanusGraphTx> openTransactions;
+    private final Set<StandardJanusGraphTx> openTransactions;
 
-    private String name = null;
+    private final String name;
 
     public StandardJanusGraph(GraphDatabaseConfiguration configuration) {
 
@@ -612,13 +612,13 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
         for (IndexSerializer.IndexUpdate indexUpdate : indexUpdates) {
             assert indexUpdate.isAddition() || indexUpdate.isDeletion();
             if (indexUpdate.isCompositeIndex()) {
-                IndexSerializer.IndexUpdate<StaticBuffer,Entry> update = indexUpdate;
+                final IndexSerializer.IndexUpdate<StaticBuffer,Entry> update = indexUpdate;
                 if (update.isAddition())
                     mutator.mutateIndex(update.getKey(), Lists.newArrayList(update.getEntry()), KCVSCache.NO_DELETIONS);
                 else
                     mutator.mutateIndex(update.getKey(), KeyColumnValueStore.NO_ADDITIONS, Lists.newArrayList(update.getEntry()));
             } else {
-                IndexSerializer.IndexUpdate<String,IndexEntry> update = indexUpdate;
+                final IndexSerializer.IndexUpdate<String,IndexEntry> update = indexUpdate;
                 has2iMods = true;
                 IndexTransaction itx = mutator.getIndexTransaction(update.getIndex().getBackingIndexName());
                 String indexStore = ((MixedIndexType)update.getIndex()).getStoreName();

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/RelationIndexStatusWatcher.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/RelationIndexStatusWatcher.java
@@ -61,7 +61,7 @@ public class RelationIndexStatusWatcher
         Timer t = new Timer(TimestampProviders.MILLI).start();
         boolean timedOut;
         while (true) {
-            SchemaStatus actualStatus = null;
+            final SchemaStatus actualStatus;
             JanusGraphManagement management = null;
             try {
                 management = g.openManagement();

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/log/StandardLogProcessorFramework.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/log/StandardLogProcessorFramework.java
@@ -228,7 +228,7 @@ public class StandardLogProcessorFramework implements LogProcessorFramework {
             for (int i=1;i<=retryAttempts;i++) {
                 StandardJanusGraphTx tx = (StandardJanusGraphTx)graph.newTransaction();
                 StandardChangeState changes = new StandardChangeState();
-                StandardTransactionId transactionId = null;
+                final StandardTransactionId transactionId;
                 try {
                     ReadBuffer content = message.getContent().asReadBuffer();
                     String senderId =  message.getSenderId();

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/log/StandardTransactionLogProcessor.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/log/StandardTransactionLogProcessor.java
@@ -78,7 +78,6 @@ public class StandardTransactionLogProcessor implements TransactionRecovery {
     private final StandardJanusGraph graph;
     private final Serializer serializer;
     private final TimestampProvider times;
-    private final Log txLog;
     private final Duration persistenceTime;
     private final Duration readTime = Duration.ofSeconds(1);
     private final AtomicLong txCounter = new AtomicLong(0);
@@ -104,7 +103,7 @@ public class StandardTransactionLogProcessor implements TransactionRecovery {
         this.graph = graph;
         this.serializer = graph.getDataSerializer();
         this.times = graph.getConfiguration().getTimestampProvider();
-        this.txLog = graph.getBackend().getSystemTxLog();
+        final Log txLog = graph.getBackend().getSystemTxLog();
         this.persistenceTime = graph.getConfiguration().getMaxWriteTime();
         this.verboseLogging = graph.getConfiguration().getConfiguration()
                 .get(GraphDatabaseConfiguration.VERBOSE_TX_RECOVERY);
@@ -127,7 +126,7 @@ public class StandardTransactionLogProcessor implements TransactionRecovery {
                 .build();
 
         ReadMarker start = ReadMarker.fromTime(startTime);
-        this.txLog.registerReader(start,new TxLogMessageReader());
+        txLog.registerReader(start,new TxLogMessageReader());
 
         cleaner = new BackgroundCleaner();
         cleaner.start();

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/management/JanusGraphManager.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/management/JanusGraphManager.java
@@ -45,7 +45,6 @@ public class JanusGraphManager implements GraphManager {
 
     private final Map<String, Graph> graphs = new ConcurrentHashMap<>();
     private final Map<String, TraversalSource> traversalSources = new ConcurrentHashMap<>();
-    private Settings settings = null;
     private final Object instantiateGraphLock = new Object();
 
     private static JanusGraphManager instance = null;
@@ -60,7 +59,6 @@ public class JanusGraphManager implements GraphManager {
      */
     public JanusGraphManager(Settings settings) {
         initialize();
-        this.settings = settings;
         // Open graphs defined at server start in settings.graphs
         settings.graphs.forEach((key, value) -> {
             final StandardJanusGraph graph = (StandardJanusGraph) JanusGraphFactory.open(value, key);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/FulgoraGraphComputer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/FulgoraGraphComputer.java
@@ -76,7 +76,7 @@ public class FulgoraGraphComputer implements JanusGraphComputer {
     private boolean executed = false;
 
     private int numThreads = 1;//Math.max(1,Runtime.getRuntime().availableProcessors());
-    private int readBatchSize = 10000;
+    private final int readBatchSize;
     private final int writeBatchSize;
 
     private ResultGraph resultGraphMode = null;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/FulgoraVertexProperty.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/FulgoraVertexProperty.java
@@ -80,13 +80,13 @@ public class FulgoraVertexProperty<V> implements JanusGraphVertexProperty<V> {
     }
 
     @Override
-    public <V> Property<V> property(String s, V v) {
+    public <A> Property<A> property(String s, A v) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public <V> V valueOrNull(PropertyKey key) {
-        return (V)property(key.name()).orElse(null);
+    public <A> A valueOrNull(PropertyKey key) {
+        return (A) property(key.name()).orElse(null);
     }
 
     @Override
@@ -105,7 +105,7 @@ public class FulgoraVertexProperty<V> implements JanusGraphVertexProperty<V> {
     }
 
     @Override
-    public <V> V value(String key) {
+    public <A> A value(String key) {
         throw Property.Exceptions.propertyDoesNotExist(this,key);
     }
 
@@ -139,7 +139,7 @@ public class FulgoraVertexProperty<V> implements JanusGraphVertexProperty<V> {
     }
 
     @Override
-    public <V> Iterator<Property<V>> properties(String... propertyKeys) {
+    public <A> Iterator<Property<A>> properties(String... propertyKeys) {
         return Collections.emptyIterator();
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/VertexMapJob.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/VertexMapJob.java
@@ -53,9 +53,7 @@ public class VertexMapJob implements VertexScanJob {
         }
 
         @Override
-        public final void accessProperties() {
-            return; //Allowed
-        }
+        public final void accessProperties() { }
 
         @Override
         public void accessSetProperty() {
@@ -107,7 +105,7 @@ public class VertexMapJob implements VertexScanJob {
 
     @Override
     public void process(JanusGraphVertex vertex, ScanMetrics metrics) {
-        PreloadedVertex v = (PreloadedVertex) vertex;
+        final PreloadedVertex v = (PreloadedVertex) vertex;
         if (vertexMemory != null) {
             VertexMemoryHandler vh = new VertexMemoryHandler(vertexMemory, v);
             v.setPropertyMixing(vh);
@@ -115,16 +113,15 @@ public class VertexMapJob implements VertexScanJob {
         v.setAccessCheck(MAPREDUCE_CHECK);
         if (idManager.isPartitionedVertex(v.longId()) && !idManager.isCanonicalVertexId(v.longId())) {
             return; //Only consider the canonical partition vertex representative
-        } else {
-            for (Map.Entry<MapReduce, FulgoraMapEmitter> mapJob : mapJobs.entrySet()) {
-                MapReduce job = mapJob.getKey();
-                try {
-                    job.map(v, mapJob.getValue());
-                    metrics.incrementCustom(MAP_JOB_SUCCESS);
-                } catch (Throwable ex) {
-                    log.error("Encountered exception executing map job [" + job + "] on vertex [" + vertex + "]:", ex);
-                    metrics.incrementCustom(MAP_JOB_FAILURE);
-                }
+        }
+        for (Map.Entry<MapReduce, FulgoraMapEmitter> mapJob : mapJobs.entrySet()) {
+            final MapReduce job = mapJob.getKey();
+            try {
+                job.map(v, mapJob.getValue());
+                metrics.incrementCustom(MAP_JOB_SUCCESS);
+            } catch (Throwable ex) {
+                log.error("Encountered exception executing map job [" + job + "] on vertex [" + vertex + "]:", ex);
+                metrics.incrementCustom(MAP_JOB_FAILURE);
             }
         }
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/QueryUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/QueryUtil.java
@@ -99,14 +99,14 @@ public class QueryUtil {
             return false;
         }
         for (final Condition<?> child : ((And<?>) condition).getChildren()) {
-            if (isQNFLiteralOrNot(child)) {
-                continue;
-            } else if (child instanceof Or) {
-                for (Condition<?> child2 : ((Or<?>) child).getChildren()) {
-                    if (!isQNFLiteralOrNot(child2)) return false;
+            if (!isQNFLiteralOrNot(child)) {
+                if (child instanceof Or) {
+                    for (Condition<?> child2 : ((Or<?>) child).getChildren()) {
+                        if (!isQNFLiteralOrNot(child2)) return false;
+                    }
+                } else {
+                    return false;
                 }
-            } else {
-                return false;
             }
         }
         return true;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/ResultMergeSortIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/ResultMergeSortIterator.java
@@ -74,7 +74,7 @@ public class ResultMergeSortIterator<R> implements Iterator<R> {
             nextSecond = second.next();
             assert nextSecond != null;
         }
-        R result = null;
+        final R result;
         if (nextFirst == null && nextSecond == null) {
             return null;
         } else if (nextFirst == null) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
@@ -655,7 +655,7 @@ public abstract class BasicVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q
             entireKey[i]=tx.getExistingPropertyKey(type.getSortKey()[i]);
         }
         if (type.isEdgeLabel() && !type.multiplicity().isUnique(dir)) entireKey[i++]=ImplicitKey.ADJACENT_ID;
-        if (!type.multiplicity().isConstrained()) entireKey[i++]=ImplicitKey.JANUSGRAPHID;
+        if (!type.multiplicity().isConstrained()) entireKey[i]=ImplicitKey.JANUSGRAPHID;
         return entireKey;
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/VertexLongList.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/VertexLongList.java
@@ -99,7 +99,7 @@ public class VertexLongList implements VertexListInternal {
 
     @Override
     public void addAll(VertexList vertexlist) {
-        LongArrayList otherVertexIds = null;
+        final LongArrayList otherVertexIds;
         if (vertexlist instanceof VertexLongList) {
             otherVertexIds = ((VertexLongList) vertexlist).vertices;
         } else if (vertexlist instanceof VertexArrayList) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/AbstractTypedRelation.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/AbstractTypedRelation.java
@@ -59,12 +59,7 @@ public abstract class AbstractTypedRelation extends AbstractElement implements I
      * Cannot currently throw exception when removed since internal logic relies on access to the edge
      * beyond its removal. TODO: reconcile with access validation logic
      */
-    protected final void verifyAccess() {
-        return;
-//        if (isRemoved()) {
-//            throw InvalidElementException.removedException(this);
-//        }
-    }
+    protected final void verifyAccess() { }
 
 	/* ---------------------------------------------------------------
 	 * Immutable Aspects of Relation

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/RelationComparator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/RelationComparator.java
@@ -98,7 +98,7 @@ public class RelationComparator implements Comparator<InternalRelation> {
             Object o2 = ((JanusGraphVertexProperty) r2).value();
             Preconditions.checkArgument(o1 != null && o2 != null);
             if (!o1.equals(o2)) {
-                int objectCompare = 0;
+                final int objectCompare;
                 if (Comparable.class.isAssignableFrom(((PropertyKey) t1).dataType())) {
                     objectCompare = ((Comparable) o1).compareTo(o2);
                 } else {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/schema/VertexLabelDefinition.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/schema/VertexLabelDefinition.java
@@ -43,7 +43,7 @@ public class VertexLabelDefinition extends SchemaElementDefinition {
     }
 
     public boolean hasDefaultConfiguration() {
-        return isPartitioned==false && isStatic==false;
+        return !isPartitioned && !isStatic;
     }
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/AdjacentVertexFilterOptimizerStrategy.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/AdjacentVertexFilterOptimizerStrategy.java
@@ -78,9 +78,9 @@ public class AdjacentVertexFilterOptimizerStrategy extends AbstractTraversalStra
                     //Now, check that this step is preceded by VertexStep that returns edges
                     Step<?, ?> currentStep = originalStep.getPreviousStep();
                     while (true) {
-                        if (currentStep instanceof HasStep || currentStep instanceof IdentityStep) {
-                            //We can jump over those steps as we move backward
-                        } else break;
+                        if (!(currentStep instanceof HasStep) && !(currentStep instanceof IdentityStep)) {
+                            break;
+                        } //We can jump over other steps as we move backward
                     }
                     if (currentStep instanceof VertexStep) {
                         VertexStep vertexStep = (VertexStep) currentStep;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/HasStepFolder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/HasStepFolder.java
@@ -112,12 +112,7 @@ public interface HasStepFolder<S, E> extends Step<S, E> {
                 }
                 graphStep.addIds(ids);
                 if (!ids.isEmpty()) traversal.removeStep(currentStep);
-            }
-            else if (currentStep instanceof IdentityStep) {
-                // do nothing, has no impact
-            } else if (currentStep instanceof NoOpBarrierStep) {
-                // do nothing, has no impact
-            } else {
+            } else if (!(currentStep instanceof IdentityStep) && !(currentStep instanceof NoOpBarrierStep)) {
                 break;
             }
             currentStep = currentStep.getNextStep();
@@ -134,25 +129,12 @@ public interface HasStepFolder<S, E> extends Step<S, E> {
                     currentStep.getLabels().forEach(janusgraphStep::addLabel);
                     traversal.removeStep(currentStep);
                 }
-            } else if (currentStep instanceof IdentityStep) {
-                // do nothing, has no impact
-            } else if (currentStep instanceof NoOpBarrierStep) {
-                // do nothing, has no impact
-            } else {
+            } else if (!(currentStep instanceof IdentityStep) && !(currentStep instanceof NoOpBarrierStep)) {
                 break;
             }
             currentStep = currentStep.getNextStep();
         }
     }
-
-//    public static boolean addLabeledStepAsIdentity(Step<?,?> currentStep, final Traversal.Admin<?, ?> traversal) {
-//        if (currentStep.getLabel().isPresent()) {
-//            final IdentityStep identityStep = new IdentityStep<>(traversal);
-//            identityStep.setLabel(currentStep.getLabel().get());
-//            TraversalHelper.insertAfterStep(identityStep, currentStep, traversal);
-//            return true;
-//        } else return false;
-//    }
 
     static void foldInOrder(final HasStepFolder janusgraphStep, final Traversal.Admin<?, ?> traversal,
                                    final Traversal<?, ?> rootTraversal, boolean isVertexOrder) {
@@ -165,13 +147,7 @@ public interface HasStepFolder<S, E> extends Step<S, E> {
                     traversal.removeStep(lastOrder);
                 }
                 lastOrder = (OrderGlobalStep) currentStep;
-            } else if (currentStep instanceof IdentityStep) {
-                // do nothing, can be skipped
-            } else if (currentStep instanceof HasStep) {
-                // do nothing, can be skipped
-            } else if (currentStep instanceof NoOpBarrierStep) {
-                // do nothing, can be skipped
-            } else {
+            } else if (!(currentStep instanceof IdentityStep) && !(currentStep instanceof HasStep) && !(currentStep instanceof NoOpBarrierStep)) {
                 break;
             }
             currentStep = currentStep.getNextStep();

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphPropertiesStep.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphPropertiesStep.java
@@ -16,6 +16,7 @@ package org.janusgraph.graphdb.tinkerpop.optimize;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
+import org.apache.tinkerpop.gremlin.structure.Property;
 import org.janusgraph.core.*;
 import org.janusgraph.graphdb.query.BaseQuery;
 import org.janusgraph.graphdb.query.Query;
@@ -77,7 +78,7 @@ public class JanusGraphPropertiesStep<E> extends PropertiesStep<E> implements Ha
             return (Iterator<E>) iterable.iterator();
         }
         assert getReturnType().forValues();
-        return (Iterator<E>) Iterators.transform(iterable.iterator(), p -> p.value());
+        return (Iterator<E>) Iterators.transform(iterable.iterator(), Property::value);
     }
 
     @SuppressWarnings("deprecation")
@@ -153,7 +154,7 @@ public class JanusGraphPropertiesStep<E> extends PropertiesStep<E> implements Ha
      */
 
     private final List<HasContainer> hasContainers;
-    private int limit = BaseQuery.NO_LIMIT;
+    private int limit;
     private final List<HasStepFolder.OrderEntry> orders = new ArrayList<>();
 
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphStep.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphStep.java
@@ -110,10 +110,10 @@ public class JanusGraphStep<S, E extends Element> extends GraphStep<S, E> implem
         this.addAll(Collections.singleton(hasContainer));
     }
 
-    private <E extends Element> Iterator<E> iteratorList(final Iterator<E> iterator) {
-        final List<E> list = new ArrayList<>();
+    private <A extends Element> Iterator<A> iteratorList(final Iterator<A> iterator) {
+        final List<A> list = new ArrayList<>();
         while (iterator.hasNext()) {
-            final E e = iterator.next();
+            final A e = iterator.next();
             if (HasContainer.testAll(e, this.hasContainers))
                 list.add(e);
         }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphTraversalUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphTraversalUtil.java
@@ -66,7 +66,7 @@ public class JanusGraphTraversalUtil {
     }
 
     public static JanusGraphTransaction getTx(Traversal.Admin<?, ?> traversal) {
-        JanusGraphTransaction tx = null;
+        final JanusGraphTransaction tx;
         Optional<Graph> optGraph = TraversalHelper.getRootTraversal(traversal.asAdmin()).getGraph();
 
         if (traversal instanceof FulgoraElementTraversal) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphVertexStep.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphVertexStep.java
@@ -130,7 +130,7 @@ public class JanusGraphVertexStep<E extends Element> extends VertexStep<E> imple
      */
 
     private final List<HasContainer> hasContainers;
-    private int limit = BaseQuery.NO_LIMIT;
+    private int limit;
     private final List<OrderEntry> orders = new ArrayList<>();
 
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -384,8 +384,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
         //Make canonical partitioned vertex id
         if (idInspector.isPartitionedVertex(vertexId)) vertexId=idManager.getCanonicalVertexId(vertexId);
 
-        InternalVertex v = null;
-        v = vertexCache.get(vertexId, externalVertexRetriever);
+        final InternalVertex v = vertexCache.get(vertexId, externalVertexRetriever);
         return (null == v || v.isRemoved()) ? null : v;
     }
 
@@ -468,7 +467,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
                 lifecycle = getExistingVertex(canonicalVertexId).getLifeCycle();
             }
 
-            InternalVertex vertex = null;
+            final InternalVertex vertex;
             if (idInspector.isRelationTypeId(vertexId)) {
                 if (idInspector.isPropertyKeyId(vertexId)) {
                     if (IDManager.isSystemRelationTypeId(vertexId)) {
@@ -960,14 +959,12 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
 
     @Override
     public PropertyKeyMaker makePropertyKey(String name) {
-        StandardPropertyKeyMaker maker = new StandardPropertyKeyMaker(this, name, indexSerializer, attributeHandler);
-        return maker;
+        return new StandardPropertyKeyMaker(this, name, indexSerializer, attributeHandler);
     }
 
     @Override
     public EdgeLabelMaker makeEdgeLabel(String name) {
-        StandardEdgeLabelMaker maker = new StandardEdgeLabelMaker(this, name, indexSerializer, attributeHandler);
-        return maker;
+        return new StandardEdgeLabelMaker(this, name, indexSerializer, attributeHandler);
     }
 
     //-------- Vertex Labels -----------------
@@ -1087,8 +1084,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
             if (vertex.isNew()) return false;
             //In addition to deleted, we need to also check for added relations since those can potentially
             //replace existing ones due to a multiplicity constraint
-            if (vertex.hasRemovedRelations() || vertex.hasAddedRelations()) return true;
-            return false;
+            return vertex.hasRemovedRelations() || vertex.hasAddedRelations();
         }
 
         @Override
@@ -1099,7 +1095,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
             InternalVertex vertex = query.getVertex();
             if (type.multiplicity().isConstrained() && vertex.hasAddedRelations()) {
                 final RelationComparator comparator = new RelationComparator(vertex);
-                if (!Iterables.isEmpty(vertex.getAddedRelations(internalRelation -> comparator.compare((InternalRelation)result,internalRelation)==0))) return true;
+                return !Iterables.isEmpty(vertex.getAddedRelations(internalRelation -> comparator.compare((InternalRelation) result, internalRelation) == 0));
             }
             return false;
         }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardTransactionBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardTransactionBuilder.java
@@ -41,7 +41,7 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
 
     private boolean hasEnabledBatchLoading = false;
 
-    private boolean assignIDsImmediately = false;
+    private final boolean assignIDsImmediately;
 
     private boolean preloadedData = false;
 
@@ -55,7 +55,7 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
 
     private boolean acquireLocks = true;
 
-    private boolean propertyPrefetching = true;
+    private final boolean propertyPrefetching;
 
     private boolean singleThreaded = false;
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/ConcurrentLRUCache.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/ConcurrentLRUCache.java
@@ -305,7 +305,6 @@ public class ConcurrentLRUCache<V> {
                 oldestEntry = newOldestEntry == Long.MAX_VALUE ? oldestEntry : newOldestEntry;
                 newOldestEntry = Long.MAX_VALUE;
                 newestEntry = newNewestEntry;
-                newNewestEntry = -1;
                 wantToLongeep = lowerWaterMark - numLongept;
                 wantToRemove = sz - lowerWaterMark - numRemoved;
 
@@ -505,7 +504,7 @@ public class ConcurrentLRUCache<V> {
     private static class CacheEntry<Long, V> implements Comparable<CacheEntry<Long, V>> {
         final Long key;
         final V value;
-        volatile long lastAccessed = 0;
+        volatile long lastAccessed;
         long lastAccessedCopy = 0;
 
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/PreloadedVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/PreloadedVertex.java
@@ -189,19 +189,13 @@ public class PreloadedVertex extends CacheVertex {
 
     public static final AccessCheck CLOSEDSTAR_CHECK = new AccessCheck() {
         @Override
-        public final void accessEdges() {
-            return; //Allowed
-        }
+        public final void accessEdges() { }
 
         @Override
-        public final void accessProperties() {
-            return; //Allowed
-        }
+        public final void accessProperties() { }
 
         @Override
-        public void accessSetProperty() {
-            return; //Allowed
-        }
+        public void accessSetProperty() { }
 
         @Override
         public Retriever<SliceQuery, EntryList> retrieveSliceQuery() {
@@ -215,19 +209,13 @@ public class PreloadedVertex extends CacheVertex {
 
     public static final AccessCheck OPENSTAR_CHECK = new AccessCheck() {
         @Override
-        public final void accessEdges() {
-            return; //Allowed
-        }
+        public final void accessEdges() { }
 
         @Override
-        public final void accessProperties() {
-            return; //Allowed
-        }
+        public final void accessProperties() { }
 
         @Override
-        public void accessSetProperty() {
-            return; //Allowed
-        }
+        public void accessSetProperty() { }
 
         @Override
         public Retriever<SliceQuery, EntryList> retrieveSliceQuery() {

--- a/janusgraph-core/src/main/java/org/janusgraph/util/datastructures/IterablesUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/util/datastructures/IterablesUtil.java
@@ -20,6 +20,8 @@ import com.google.common.collect.Iterables;
 
 import javax.annotation.Nullable;
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * Utility class for interacting with {@link Iterable}.
@@ -47,16 +49,7 @@ public class IterablesUtil {
     }
 
     public static <O> Iterable<O> limitedIterable(final Iterable<O> iterable, final int limit) {
-        return Iterables.filter(iterable,new Predicate<O>() {
-
-            int count = 0;
-
-            @Override
-            public boolean apply(@Nullable O o) {
-                count++;
-                return count<=limit;
-            }
-        });
+        return StreamSupport.stream(iterable.spliterator(), false).limit(limit).collect(Collectors.toList());
     }
 
     public static int size(Iterable i) {

--- a/janusgraph-core/src/main/java/org/janusgraph/util/datastructures/RandomRemovalList.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/util/datastructures/RandomRemovalList.java
@@ -69,8 +69,8 @@ public class RandomRemovalList<T> implements Collection<T>, Iterator<T> {
         assert size >= 0;
         if (size == 0) throw new NoSuchElementException("List is empty");
         int numTries = 0;
-        T element = null;
-        int pos = -1;
+        T element;
+        int pos;
         do {
             pos = random.nextInt(list.size());
             element = list.get(pos);

--- a/janusgraph-core/src/main/java/org/janusgraph/util/system/ConfigurationFileFilter.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/util/system/ConfigurationFileFilter.java
@@ -93,7 +93,8 @@ public class ConfigurationFileFilter {
                     File outputDir = new File(outputContextDir.getPath() + contextPath);
 
                     if (!outputDir.exists()) {
-                        outputDir.mkdirs();
+                        Preconditions.checkState(outputDir.mkdirs(), "Unable to create output directory {}",
+                            outputDir.getAbsolutePath());
                     }
 
                     parseErrors += processFile(f, new File(outputContextDir.getPath() + contextPath + f.getName()));

--- a/janusgraph-core/src/main/java/org/janusgraph/util/system/ConfigurationLint.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/util/system/ConfigurationLint.java
@@ -51,9 +51,8 @@ public class ConfigurationLint {
     }
 
     public static Status validate(String filename) throws IOException {
-        Properties p = new Properties();
-        try(FileInputStream fis = new FileInputStream(filename)) {
-            p.load(fis);
+        try (final FileInputStream fis = new FileInputStream(filename)) {
+            new Properties().load(fis);
         }
 
         final PropertiesConfiguration apc;

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticSearchConfigTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticSearchConfigTest.java
@@ -336,13 +336,13 @@ public class ElasticSearchConfigTest {
         for (final Entry<String, KeyInformation> entry : IndexProviderTest.getMapping(idx.getFeatures(), "english", "keyword").entrySet()) {
            idx.register(storeName, entry.getKey(), entry.getValue(), itx);
         }
-        assertEquals(0, itx.query(new IndexQuery(storeName, PredicateCondition.of(IndexProviderTest.NAME, Text.PREFIX, "ali"))).size());
+        assertEquals(0, itx.queryStream(new IndexQuery(storeName, PredicateCondition.of(IndexProviderTest.NAME, Text.PREFIX, "ali"))).count());
         itx.add(storeName, "doc", IndexProviderTest.NAME, "alice", false);
         itx.commit();
         Thread.sleep(1500L); // Slightly longer than default 1s index.refresh_interval
         itx = new IndexTransaction(idx, indexRetriever, txConfig, maxWrite);
-        assertEquals(0, itx.query(new IndexQuery(storeName, PredicateCondition.of(IndexProviderTest.NAME, Text.PREFIX, "zed"))).size());
-        assertEquals(1, itx.query(new IndexQuery(storeName, PredicateCondition.of(IndexProviderTest.NAME, Text.PREFIX, "ali"))).size());
+        assertEquals(0, itx.queryStream(new IndexQuery(storeName, PredicateCondition.of(IndexProviderTest.NAME, Text.PREFIX, "zed"))).count());
+        assertEquals(1, itx.queryStream(new IndexQuery(storeName, PredicateCondition.of(IndexProviderTest.NAME, Text.PREFIX, "ali"))).count());
         itx.rollback();
     }
 

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/config/HBaseAuthHelper.java
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/config/HBaseAuthHelper.java
@@ -48,9 +48,6 @@ public class HBaseAuthHelper {
             Class<?> clazz = HBaseAuthHelper.class.getClassLoader().loadClass(className);
             Method m = clazz.getMethod(methodName, methodArgType);
             return (Configuration)m.invoke(null, inner);
-        } catch (ClassNotFoundException | NoSuchMethodException | InvocationTargetException
-                | IllegalAccessException e) {
-            log.error("Failed to call {}.{}({})", className, methodName, methodArgType.getSimpleName(), e);
         } catch (Throwable t) {
             log.error("Failed to call {}.{}({})", className, methodName, methodArgType.getSimpleName(), t);
         }
@@ -77,9 +74,6 @@ public class HBaseAuthHelper {
                 Method obtainAuthTokenForJob = clazz.getMethod("obtainAuthTokenForJob", Configuration.class, Job.class);
                 obtainAuthTokenForJob.invoke(user, configuration, job);
                 log.info("Obtained HBase Auth Token from ZooKeeper quorum {} for job {}", configuration.get(quorumCfgKey), job.getJobName());
-            } catch (ClassNotFoundException | InvocationTargetException | NoSuchMethodException
-                    | IllegalAccessException e) {
-                log.error("Failed to generate or store HBase auth token", e);
             } catch (Throwable t) {
                 log.error("Failed to generate or store HBase auth token", t);
             }

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/config/HadoopConfiguration.java
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/config/HadoopConfiguration.java
@@ -30,9 +30,6 @@ import com.google.common.base.Preconditions;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
 import org.janusgraph.diskstorage.util.time.Durations;
 
-
-import javax.annotation.Nullable;
-
 public class HadoopConfiguration implements WriteConfiguration {
 
     private static final Logger log =
@@ -84,7 +81,7 @@ public class HadoopConfiguration implements WriteConfiguration {
             // This is a conceptual leak; the config layer should ideally only handle standard library types
             String s = config.get(internalKey);
             String[] comps = s.split("\\s");
-            TemporalUnit unit = null;
+            final TemporalUnit unit;
             switch (comps.length) {
                 case 1:
                     //By default, times are in milli seconds

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cassandra/CassandraBinaryInputFormat.java
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cassandra/CassandraBinaryInputFormat.java
@@ -50,7 +50,6 @@ public class CassandraBinaryInputFormat extends AbstractBinaryInputFormat {
     private static final String RANGE_BATCH_SIZE_CONFIG = "cassandra.range.batch.size";
 
     private final ColumnFamilyInputFormat columnFamilyInputFormat = new ColumnFamilyInputFormat();
-    private ColumnFamilyRecordReader columnFamilyRecordReader;
     RecordReader<StaticBuffer, Iterable<Entry>> janusgraphRecordReader;
 
     public RecordReader<StaticBuffer, Iterable<Entry>> getRecordReader() {
@@ -65,10 +64,8 @@ public class CassandraBinaryInputFormat extends AbstractBinaryInputFormat {
     @Override
     public RecordReader<StaticBuffer, Iterable<Entry>> createRecordReader(final InputSplit inputSplit, final TaskAttemptContext taskAttemptContext)
             throws IOException, InterruptedException {
-        columnFamilyRecordReader =
-            (ColumnFamilyRecordReader) columnFamilyInputFormat.createRecordReader(inputSplit, taskAttemptContext);
-        janusgraphRecordReader =
-            new CassandraBinaryRecordReader(columnFamilyRecordReader);
+        janusgraphRecordReader = new CassandraBinaryRecordReader(
+                (ColumnFamilyRecordReader) columnFamilyInputFormat.createRecordReader(inputSplit, taskAttemptContext));
         return janusgraphRecordReader;
     }
 

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/hbase/HBaseBinaryInputFormat.java
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/hbase/HBaseBinaryInputFormat.java
@@ -51,7 +51,6 @@ public class HBaseBinaryInputFormat extends AbstractBinaryInputFormat {
     private final TableInputFormat tableInputFormat = new TableInputFormat();
     private RecordReader<ImmutableBytesWritable, Result> tableReader;
     private byte[] edgeStoreFamily;
-    private RecordReader<StaticBuffer, Iterable<Entry>> janusgraphRecordReader;
 
     @Override
     public List<InputSplit> getSplits(final JobContext jobContext) throws IOException, InterruptedException {
@@ -61,9 +60,7 @@ public class HBaseBinaryInputFormat extends AbstractBinaryInputFormat {
     @Override
     public RecordReader<StaticBuffer, Iterable<Entry>> createRecordReader(final InputSplit inputSplit, final TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
         tableReader = tableInputFormat.createRecordReader(inputSplit, taskAttemptContext);
-        janusgraphRecordReader =
-                new HBaseBinaryRecordReader(tableReader, edgeStoreFamily);
-        return janusgraphRecordReader;
+        return new HBaseBinaryRecordReader(tableReader, edgeStoreFamily);
     }
 
     @Override

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/test/java/org/janusgraph/hadoop/HBaseInputFormatIT.java
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/test/java/org/janusgraph/hadoop/HBaseInputFormatIT.java
@@ -14,6 +14,7 @@
 
 package org.janusgraph.hadoop;
 
+import com.google.common.base.Preconditions;
 import org.janusgraph.HBaseStorageSetup;
 import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;

--- a/janusgraph-hbase-parent/janusgraph-hbase-core/src/main/java/org/janusgraph/diskstorage/hbase/HBaseKeyColumnValueStore.java
+++ b/janusgraph-hbase-parent/janusgraph-hbase-core/src/main/java/org/janusgraph/diskstorage/hbase/HBaseKeyColumnValueStore.java
@@ -165,7 +165,7 @@ public class HBaseKeyColumnValueStore implements KeyColumnValueStore {
 
         try {
             TableMask table = null;
-            Result[] results = null;
+            final Result[] results;
 
             try {
                 table = cnx.getTable(tableName);
@@ -180,7 +180,7 @@ public class HBaseKeyColumnValueStore implements KeyColumnValueStore {
             assert results.length==keys.size();
 
             for (int i = 0; i < results.length; i++) {
-                Result result = results[i];
+                final Result result = results[i];
                 NavigableMap<byte[], NavigableMap<byte[], NavigableMap<Long, byte[]>>> f = result.getMap();
 
                 if (f == null) { // no result for this key

--- a/janusgraph-hbase-parent/janusgraph-hbase-core/src/main/java/org/janusgraph/diskstorage/hbase/HBaseStoreManager.java
+++ b/janusgraph-hbase-parent/janusgraph-hbase-core/src/main/java/org/janusgraph/diskstorage/hbase/HBaseStoreManager.java
@@ -243,10 +243,8 @@ public class HBaseStoreManager extends DistributedStoreManager implements KeyCol
     private final int regionCount;
     private final int regionsPerServer;
     private final ConnectionMask cnx;
-    private final org.apache.hadoop.conf.Configuration hconf;
     private final boolean shortCfNames;
     private final boolean skipSchemaCheck;
-    private final String compatClass;
     private final HBaseCompat compat;
     // Cached return value of getDeployment() as requesting it can be expensive.
     private Deployment deployment = null;
@@ -272,7 +270,7 @@ public class HBaseStoreManager extends DistributedStoreManager implements KeyCol
         this.regionCount = config.has(REGION_COUNT) ? config.get(REGION_COUNT) : -1;
         this.regionsPerServer = config.has(REGIONS_PER_SERVER) ? config.get(REGIONS_PER_SERVER) : -1;
         this.skipSchemaCheck = config.get(SKIP_SCHEMA_CHECK);
-        this.compatClass = config.has(COMPAT_CLASS) ? config.get(COMPAT_CLASS) : null;
+        final String compatClass = config.has(COMPAT_CLASS) ? config.get(COMPAT_CLASS) : null;
         this.compat = HBaseCompatLoader.getCompat(compatClass);
 
         /*
@@ -289,7 +287,7 @@ public class HBaseStoreManager extends DistributedStoreManager implements KeyCol
          * which in turn applies the contents of hbase-default.xml and then
          * applies the contents of hbase-site.xml.
          */
-        this.hconf = HBaseConfiguration.create();
+        final org.apache.hadoop.conf.Configuration hconf = HBaseConfiguration.create();
 
         // Copy a subset of our commons config into a Hadoop config
         int keysLoaded=0;

--- a/janusgraph-hbase-parent/janusgraph-hbase-core/src/test/java/org/janusgraph/HBaseStorageSetup.java
+++ b/janusgraph-hbase-parent/janusgraph-hbase-core/src/test/java/org/janusgraph/HBaseStorageSetup.java
@@ -232,7 +232,9 @@ public class HBaseStorageSetup {
 
         log.info("Shutdown HBase");
 
-        stat.getFile().delete();
+        if (!stat.getFile().delete()) {
+            log.warn("Unable to delete stat file {}", stat.getFile().getAbsolutePath());
+        }
 
         log.info("Deleted {}", stat.getFile());
 

--- a/janusgraph-hbase-parent/janusgraph-hbase-core/src/test/java/org/janusgraph/diskstorage/hbase/HBaseStoreManagerMutationTest.java
+++ b/janusgraph-hbase-parent/janusgraph-hbase-core/src/test/java/org/janusgraph/diskstorage/hbase/HBaseStoreManagerMutationTest.java
@@ -56,7 +56,7 @@ public class HBaseStoreManagerMutationTest {
             List<StaticBuffer> deletions = new ArrayList<>();
 
             // 100 columns each row
-            int i = 0;
+            int i;
             for (i = 0; i < 100; i++) {
                 col = KeyColumnValueStoreUtil.longToByteBuffer(i);
                 val = KeyColumnValueStoreUtil.longToByteBuffer(i + 100);

--- a/janusgraph-lucene/src/main/java/org/janusgraph/diskstorage/lucene/LuceneIndex.java
+++ b/janusgraph-lucene/src/main/java/org/janusgraph/diskstorage/lucene/LuceneIndex.java
@@ -780,7 +780,7 @@ public class LuceneIndex implements IndexProvider {
         private synchronized IndexSearcher getSearcher(String store) throws BackendException {
             IndexSearcher searcher = searchers.get(store);
             if (searcher == null) {
-                IndexReader reader = null;
+                final IndexReader reader;
                 try {
                     reader = DirectoryReader.open(getStoreDirectory(store));
                     searcher = new IndexSearcher(reader);

--- a/janusgraph-lucene/src/test/java/org/janusgraph/diskstorage/lucene/LuceneExample.java
+++ b/janusgraph-lucene/src/test/java/org/janusgraph/diskstorage/lucene/LuceneExample.java
@@ -14,6 +14,7 @@
 
 package org.janusgraph.diskstorage.lucene;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import org.locationtech.spatial4j.context.SpatialContext;
@@ -60,7 +61,9 @@ public abstract class LuceneExample {
     @Before
     public void setup() {
         if (path.exists()) IOUtils.deleteDirectory(path,false);
-        if (!path.exists() && path.isDirectory()) path.mkdirs();
+        if (!path.exists() && path.isDirectory()) {
+            Preconditions.checkState(path.mkdirs());
+        }
     }
 
     private SpatialStrategy getSpatialStrategy(String key) {
@@ -105,7 +108,6 @@ public abstract class LuceneExample {
         //Search
         IndexReader reader = DirectoryReader.open(FSDirectory.open(path.toPath()));
         IndexSearcher searcher = new IndexSearcher(reader);
-        analyzer = new StandardAnalyzer();
 
         //Auesee
         BooleanQuery.Builder filter = new BooleanQuery.Builder();
@@ -148,7 +150,7 @@ public abstract class LuceneExample {
             Object value = kv.getValue();
 
             if (value instanceof Number) {
-                Field field = null;
+                final Field field;
                 if (value instanceof Integer || value instanceof Long) {
                     field = new LongPoint(key, ((Number)value).longValue());
                 } else { //double or float

--- a/janusgraph-lucene/src/test/java/org/janusgraph/diskstorage/lucene/LuceneIndexTest.java
+++ b/janusgraph-lucene/src/test/java/org/janusgraph/diskstorage/lucene/LuceneIndexTest.java
@@ -29,8 +29,6 @@ import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Date;
 
@@ -44,9 +42,6 @@ import static org.junit.Assert.assertTrue;
  */
 
 public class LuceneIndexTest extends IndexProviderTest {
-
-    private static final Logger log =
-            LoggerFactory.getLogger(LuceneIndexTest.class);
 
     @Rule
     public TestName methodName = new TestName();

--- a/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrRunner.java
+++ b/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrRunner.java
@@ -15,6 +15,7 @@
 package org.janusgraph.diskstorage.solr;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import org.apache.commons.io.FileUtils;
 import org.apache.solr.cloud.MiniSolrCloudCluster;
 
@@ -59,7 +60,7 @@ public class SolrRunner {
         File temp = new File(TMP_DIRECTORY + File.separator + "solr-" + System.nanoTime());
         assert !temp.exists();
 
-        temp.mkdirs();
+        Preconditions.checkState(temp.mkdirs(), "Unable to create solr temporary directory {}", temp.getAbsolutePath());
         temp.deleteOnExit();
 
         final String solrXml = new String(Files.readAllBytes(new File(solrHome, "solr.xml").toPath()));

--- a/janusgraph-test/src/main/java/org/janusgraph/diskstorage/indexing/IndexProviderTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/diskstorage/indexing/IndexProviderTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -205,31 +206,38 @@ public abstract class IndexProviderTest {
 
         for (String store : stores) {
             //Token
-            List<String> result = tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "world")));
+            List<String> result = tx.queryStream(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "world")))
+                .collect(Collectors.toList());
             assertEquals(ImmutableSet.of("doc1", "doc2"), ImmutableSet.copyOf(result));
             assertEquals(ImmutableSet.copyOf(result), ImmutableSet.copyOf(tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "wOrLD")))));
-            assertEquals(1, tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "bob"))).size());
-            assertEquals(0, tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "worl"))).size());
-            assertEquals(1, tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "Tomorrow world"))).size());
-            assertEquals(1, tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "WorLD HELLO"))).size());
-            assertEquals(1, tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS_FUZZY, "boby"))).size());
+            assertEquals(1, tx.queryStream(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "bob"))).count());
+            assertEquals(0, tx.queryStream(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "worl"))).count());
+            assertEquals(1, tx.queryStream(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "Tomorrow world"))).count());
+            assertEquals(1, tx.queryStream(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "WorLD HELLO"))).count());
+            assertEquals(1, tx.queryStream(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS_FUZZY, "boby"))).count());
 
 
             //Ordering
-            result = tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "world"), orderTimeDesc));
+            result = tx.queryStream(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "world"), orderTimeDesc))
+                    .collect(Collectors.toList());
             assertEquals(ImmutableList.of("doc2", "doc1"), result);
-            result = tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "world"), orderWeightDesc));
+            result = tx.queryStream(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "world"), orderWeightDesc))
+                    .collect(Collectors.toList());
             assertEquals(ImmutableList.of("doc2", "doc1"), result);
-            result = tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "world"), orderTimeAsc));
+            result = tx.queryStream(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "world"), orderTimeAsc))
+                    .collect(Collectors.toList());
             assertEquals(ImmutableList.of("doc1", "doc2"), result);
-            result = tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "world"), orderWeightAsc));
+            result = tx.queryStream(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "world"), orderWeightAsc))
+                    .collect(Collectors.toList());
             assertEquals(ImmutableList.of("doc1", "doc2"), result);
-            result = tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "world"), jointOrder));
+            result = tx.queryStream(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS, "world"), jointOrder))
+                    .collect(Collectors.toList());
             assertEquals(ImmutableList.of("doc2", "doc1"), result);
 
-            result = tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS_PREFIX, "w")));
+            result = tx.queryStream(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS_PREFIX, "w")))
+                    .collect(Collectors.toList());
             assertEquals(ImmutableSet.of("doc1", "doc2"), ImmutableSet.copyOf(result));
-            result = tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS_PREFIX, "wOr")));
+            result = tx.queryStream(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS_PREFIX, "wOr"))).collect(Collectors.toList());
             assertEquals(ImmutableSet.of("doc1", "doc2"), ImmutableSet.copyOf(result));
             assertEquals(0,tx.query(new IndexQuery(store, PredicateCondition.of(TEXT, Text.CONTAINS_PREFIX, "bobi"))).size());
 

--- a/janusgraph-test/src/main/java/org/janusgraph/olap/OLAPTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/olap/OLAPTest.java
@@ -495,7 +495,7 @@ public abstract class OLAPTest extends JanusGraphBaseTest {
     private void expand(Vertex v, final int distance, final int diameter, final int branch) {
         v.property(VertexProperty.Cardinality.single, "distance", distance);
         if (distance<diameter) {
-            JanusGraphVertex previous = null;
+//          JanusGraphVertex previous = null;
             for (int i=0;i<branch;i++) {
                 JanusGraphVertex u = tx.addVertex();
                 u.addEdge("likes",v);
@@ -505,7 +505,7 @@ public abstract class OLAPTest extends JanusGraphBaseTest {
 //                    u.addEdge("knows",previous);
 //                    log.error("knows {}->{}", u.id(), v.id());
 //                }
-                previous=u;
+//              previous=u;
                 expand(u,distance+1,diameter,branch);
             }
         }


### PR DESCRIPTION
Use try with resources
Make some class members final
Remove redundant throws declarations
Use JanusGraphFactory.drop() instead of .clear()
Inline some local variables and return
Remove unused methods
Make some members local
Check the result of File::mkdirs and File::delete

Addresses #783, #781, #740. #819, #820 in part

Signed-off-by: Alexander Patrikalakis <amcp@amazon.co.jp>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

