### PR TITLE
Switch to Travis CI latest image versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+group: travis_latest
 language: java
 sudo: true
 services:


### PR DESCRIPTION
Use `group: travis_latest` instead of `dist: trusty` to pick up the latest
Travis CI image changes. The new default is `group: travis_lts` which is
equivalent to the now-deprecated `dist: trusty`.

More info in this blog post:
https://blog.travis-ci.com/2017-12-01-new-update-schedule-for-linux-build-images

Fixes #811.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [] Have you written and/or updated unit tests to verify your changes?
- [] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [] Have you ensured that format looks appropriate for the output in which it is rendered?
- [] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.