### PR TITLE
Fix case of JanusGraph packages in docs. [skip ci]

### DIFF
--- a/docs/configuredgraphfactory.adoc
+++ b/docs/configuredgraphfactory.adoc
@@ -95,7 +95,7 @@ server's YAML's `graphs` map. For example:
 
 [source, properties]
 ----
-graphManager: org.JanusGraph.graphdb.management.JanusGraphManager
+graphManager: org.janusgraph.graphdb.management.JanusGraphManager
 graphs: {
   ConfigurationManagementGraph: conf/JanusGraph-configurationmanagement.properties
 }
@@ -108,7 +108,7 @@ example, look like:
 
 [source, properties]
 ----
-gremlin.graph=org.JanusGraph.core.JanusGraphFactory
+gremlin.graph=org.janusgraph.core.JanusGraphFactory
 storage.backend=cassandrathrift
 graph.graphname=ConfigurationManagementGraph
 storage.hostname=127.0.0.1
@@ -349,7 +349,7 @@ For backwards compatibility, any graphs that do not supply this parameter but su
 
 [source, properties]
 ----
-graphManager: org.JanusGraph.graphdb.management.JanusGraphManager
+graphManager: org.janusgraph.graphdb.management.JanusGraphManager
 graphs {
   graph1: conf/graph1.properties,
   graph2: conf/graph2.properties


### PR DESCRIPTION
`org.JanusGraph` is incorrect; should be `org.janusgraph` instead.

Fixes #825.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [] Have you written and/or updated unit tests to verify your changes?
- [] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
- [x] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

