### PR TITLE
Check whether a polygon is closed or not

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/core/attribute/JtsGeoshapeHelper.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/attribute/JtsGeoshapeHelper.java
@@ -32,6 +32,7 @@ import com.vividsolutions.jts.geom.Coordinate;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -79,7 +80,7 @@ public class JtsGeoshapeHelper extends GeoshapeHelper {
     @Override
     public Geoshape polygon(List<double[]> coordinates) {
         Preconditions.checkArgument(coordinates.size() >= 4, "Too few coordinate pairs provided");
-        Preconditions.checkArgument(coordinates.get(0) != coordinates.get(coordinates.size()-1), "Polygon is not closed");
+        Preconditions.checkArgument(Arrays.equals(coordinates.get(0), coordinates.get(coordinates.size()-1)), "Polygon is not closed");
         final PolygonBuilder builder = this.getContext().getShapeFactory().polygon();
         for (double[] coordinate : coordinates) {
             Preconditions.checkArgument(coordinate.length==2 && Geoshape.isValidCoordinate(coordinate[1], coordinate[0]), "Invalid coordinate provided");

--- a/janusgraph-test/src/test/java/org/janusgraph/core/attribute/JtsGeoshapeHelperTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/core/attribute/JtsGeoshapeHelperTest.java
@@ -16,10 +16,19 @@ package org.janusgraph.core.attribute;
 
 import org.janusgraph.core.attribute.GeoshapeHelper;
 import org.janusgraph.core.attribute.JtsGeoshapeHelper;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContextFactory;
 import org.locationtech.spatial4j.shape.ShapeFactory;
 import org.locationtech.spatial4j.shape.jts.JtsShapeFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Test of JtsGeoshapeHelper.
@@ -41,5 +50,36 @@ public class JtsGeoshapeHelperTest extends GeoshapeHelperTest {
     @Override
     public ShapeFactory getShapeFactory() {
         return new JtsShapeFactory((JtsSpatialContext) getHelper().context, (JtsSpatialContextFactory) getHelper().factory);
+    }
+
+    @Test
+    public void testPolygon() {
+        if (supportJts()) {
+            List<double[]> coordinates = new ArrayList<>();
+            coordinates.add(new double[]{1.0,1.0});
+            coordinates.add(new double[]{3.0,1.0});
+            coordinates.add(new double[]{2.0,4.0});
+            coordinates.add(new double[]{1.0,1.0});
+            Geoshape polygon = getHelper().polygon(coordinates);
+
+            Assert.assertEquals(4, polygon.size());
+        }
+    }
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testInvalidPolygon() {
+        if (supportJts()) {
+            List<double[]> coordinates = new ArrayList<>();
+            coordinates.add(new double[]{1.0,1.0});
+            coordinates.add(new double[]{3.0,1.0});
+            coordinates.add(new double[]{2.0,4.0});
+            coordinates.add(new double[]{1.0,2.0});
+            thrown.expect(IllegalArgumentException.class);
+            thrown.expectMessage(equalTo("Polygon is not closed"));
+            getHelper().polygon(coordinates);
+        }
     }
 }

--- a/janusgraph-test/src/test/java/org/janusgraph/core/attribute/JtsGeoshapeHelperTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/core/attribute/JtsGeoshapeHelperTest.java
@@ -16,7 +16,6 @@ package org.janusgraph.core.attribute;
 
 import org.janusgraph.core.attribute.GeoshapeHelper;
 import org.janusgraph.core.attribute.JtsGeoshapeHelper;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -29,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test of JtsGeoshapeHelper.
@@ -53,7 +53,7 @@ public class JtsGeoshapeHelperTest extends GeoshapeHelperTest {
     }
 
     @Test
-    public void testPolygon() {
+    public void testPolygonIsClosed() {
         if (supportJts()) {
             List<double[]> coordinates = new ArrayList<>();
             coordinates.add(new double[]{1.0,1.0});
@@ -62,7 +62,7 @@ public class JtsGeoshapeHelperTest extends GeoshapeHelperTest {
             coordinates.add(new double[]{1.0,1.0});
             Geoshape polygon = getHelper().polygon(coordinates);
 
-            Assert.assertEquals(4, polygon.size());
+            assertEquals(4, polygon.size());
         }
     }
 


### PR DESCRIPTION
To ensure a polygon is closed, its first point and last point should be equal.
