### PR TITLE
Issue #855: hasId optimization updates broke TinkerPop g_V_hasIdX1X_hasIdX2X process test

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/HasStepFolder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/HasStepFolder.java
@@ -125,10 +125,7 @@ public interface HasStepFolder<S, E> extends Step<S, E> {
                             Arrays.stream(graphStep.getIds()).forEach(ids::add);
                         }
                     }
-                    // clear ids to allow folding in ids from next HasContainer if relevant
-                    graphStep.clearIds();
                 });
-                graphStep.addIds(ids);
                 if (!removableHasContainers.isEmpty()) {
                     removableHasContainers.forEach(hasContainerHolder::removeHasContainer);
                 }

--- a/janusgraph-test/src/test/java/org/janusgraph/blueprints/process/traversal/strategy/optimization/JanusGraphStepStrategyTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/blueprints/process/traversal/strategy/optimization/JanusGraphStepStrategyTest.java
@@ -148,7 +148,10 @@ public class JanusGraphStepStrategyTest {
                 g_V("~label", eq("Person")).order().by(values("age")), Collections.emptyList()},
             // age property is not registered in the schema so the order should not be folded in
             {g.V().hasLabel("Person").has("lang", "java").order().by("age"),
-                g_V("~label", eq("Person"), "lang", eq("java")).order().by("age"), Collections.emptyList()}
+                g_V("~label", eq("Person"), "lang", eq("java")).order().by("age"), Collections.emptyList()},
+            // Per the TinkerGraph reference implementation, multiple hasIds in a row should not be folded
+            // into a single within(ids) lookup
+            {g.V().hasId(1).hasId(2), g_V(T.id, 1).hasId(2), Collections.emptyList()},
         });
     }
 }


### PR DESCRIPTION
Issue #855 

Updated strategy to only fold in first id lookup into JanusGraphStep to match TinkerPop reference behavior.

@sjudeng can you double check this if you get a chance? I tracked the failing test down to us folding all the ids in which in a sense makes sense to me, but doesn't line up with the TinkerPop process suite and TinkerGraph GraphStep optimizations.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

