### PR TITLE
Fix Coverity build

### DIFF
--- a/analysis/coverity-scan.sh
+++ b/analysis/coverity-scan.sh
@@ -100,10 +100,31 @@ fi
 
 if ! [ -d "${COVERITY_BUILD_OUTPUT_DIR}" ]; then
   echo "Running Maven build with Coverity analysis ..."
-  mvn -DskipTests=true -T 1C -B -V clean
+  # reconfigure Coverity to skip files that cause build errors
+  "${COVERITY_ANALYSIS_DIR}"/bin/cov-configure --delete-compiler-config template-javac-config-0
+  "${COVERITY_ANALYSIS_DIR}"/bin/cov-configure --delete-compiler-config template-java-config-0
+  "${COVERITY_ANALYSIS_DIR}"/bin/cov-configure --java \
+    --xml-option=skip_file:AbstractVertex.java \
+    --xml-option=skip_file:CacheVertex.java \
+    --xml-option=skip_file:CacheVertexProperty.java \
+    --xml-option=skip_file:EdgeLabelVertex.java \
+    --xml-option=skip_file:GraphDatabaseConfiguration.java \
+    --xml-option=skip_file:ImplicitKey.java \
+    --xml-option=skip_file:JanusGraph.java \
+    --xml-option=skip_file:JanusGraphSchemaVertex.java \
+    --xml-option=skip_file:JanusGraphVertex.java \
+    --xml-option=skip_file:PreloadedVertex.java \
+    --xml-option=skip_file:PropertyKeyVertex.java \
+    --xml-option=skip_file:RelationTypeVertex.java \
+    --xml-option=skip_file:StandardJanusGraphTx.java \
+    --xml-option=skip_file:StandardVertex.java \
+    --xml-option=skip_file:StaticArrayBuffer.java \
+    --xml-option=skip_file:VertexLabelVertex.java
+  # run Coverity build
   "${COVERITY_ANALYSIS_DIR}"/bin/cov-build \
     --dir "${COVERITY_BUILD_OUTPUT_DIR}" \
-    mvn -DskipTests=true -T 1C -B -V package
+    --java-cmd-line-buf-size 102400 \
+    mvn -DskipTests=true -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -B -V clean install
 else
   echo "Maven build already done; remove the '${COVERITY_BUILD_OUTPUT_DIR}' directory to re-run."
 fi


### PR DESCRIPTION
Fixes #860. The Coverity build has errors processing a number of JanusGraph source files and it appears that this can impact the analysis of other files in the same module. This is problematic in janusgraph-core because it results in a loss of 55% of source files, which fails the Coverity build.

This PR reconfigures Coverity to skip the 16 offending files in janusgraph-core. Skipping these files allows the other 561 files (97%) to be analyzed. The Coverity [build errors](https://github.com/JanusGraph/janusgraph/files/1598228/coverity_errors.txt) themselves do not map to javac errors/warnings nor do they appear to be code issues that can be addressed in JanusGraph. These issues have been raised to the Coverity team (see below).

> On Mon, Jan 1, 2018..., sjudeng <***> wrote:
> 
> I was able to reduce this issue down to a streamlined javac call involving
> 16 offending source files (see attached build-log.txt). The Coverity build
> reports errors processing these files. If I omit these files and run the
> Coverity build on the remaining 561 source files then the build passes with
> full coverage.
>
> Is it expected to have Coverity build errors on Java source files that
> compile without error/warning using javac? It's not clear that the Coverity
> build errors are code issues that we could fix/workaround on our end. Is it
> possible to have Coverity compile files individually as a fallback in case
> of errors? It appears that the errors are causing other files (in the same
> compilation unit?) to be lost. If I run cov-build javac on each file
> (including the offending files) separately then the overall coverage is
> 97%, whereas with all files in a single command the coverage is 41%.


-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

