### PR TITLE
Fixes #880: Add property and connection constraints

### DIFF
--- a/docs/basics.adoc
+++ b/docs/basics.adoc
@@ -329,6 +329,41 @@ Note, that schema name changes may not be immediately visible in currently runni
 Should the need arise to re-define an existing schema type, it is recommended to change the name of this type to a name that is not currently (and will never be) in use. After that, a new label or key can be defined with the original name, thereby effectively replacing the old one.
 However, note that this would not affect vertices, edges, or properties previously written with the existing type. Redefining existing graph elements is not supported online and must be accomplished through a batch graph transformation.
 
+=== Schema Constraints
+
+The definition of the schema allows users to configure explicit property and connection constraints. Properties can be bound to specific vertex label and/or edge labels. Moreover, connection constraints allow users to explicitly define which two vertex labels can be connected by an edge label. These constraints can be used to ensure that a graph matches a given domain model. For example for the graph of the gods, a `god` can be a brother of another `god`, but not of a `monster` and a `god` can have a property `age`, but `location` can not have a property `age`. These constraints are disabled by default.
+
+Enable these schema constraints by setting `schema.constraints=true`. This setting depends on the setting `schema.default`. If config `schema.default` is set to `none`, then an `IllegalArgumentException` is thrown for schema constraint violations. If `schema.default` is not set `none`, schema constraints are automatically created, but no exception is thrown.
+Activating schema constraints has no impact on the existing data, because these schema constraints are only applied during the insertion process. So reading of data is not affected at all by those constraints.
+
+Multiple properties can be bound to a vertex using `JanusGraphManagement.addProperties(VertexLabel, PropertyKey...)`, for example:
+
+[source, gremlin]
+mgmt = graph.openManagement()
+person = mgmt.makeVertexLabel('person').make()
+name = mgmt.makePropertyKey('name').dataType(String.class).cardinality(Cardinality.SET).make()
+birthDate = mgmt.makePropertyKey('birthDate').dataType(Long.class).cardinality(Cardinality.SINGLE).make()
+mgmt.addProperties(person, name, birthDate)
+mgmt.commit()
+
+Multiple properties can be bound to an edge using `JanusGraphManagement.addProperties(EdgeLabel, PropertyKey...)`, for example:
+
+[source, gremlin]
+mgmt = graph.openManagement()
+follow = mgmt.makeEdgeLabel('follow').multiplicity(MULTI).make()
+name = mgmt.makePropertyKey('name').dataType(String.class).cardinality(Cardinality.SET).make()
+mgmt.addProperties(follow, name)
+mgmt.commit()
+
+Connections can be defined using `JanusGraphManagement.addConnection(EdgeLabel, VertexLabel out, VertexLabel in)` between an outgoing, an incoming and an edge, for example:
+
+[source, gremlin]
+mgmt = graph.openManagement()
+person = mgmt.makeVertexLabel('person').make()
+company = mgmt.makeVertexLabel('company').make()
+works = mgmt.makeEdgeLabel('works').multiplicity(MULTI).make()
+mgmt.addConnection(works, person, company)
+mgmt.commit()
 
 [[gremlin]]
 == Gremlin Query Language

--- a/janusgraph-core/src/main/java/org/janusgraph/core/Connection.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/Connection.java
@@ -1,0 +1,79 @@
+// Copyright 2018 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core;
+
+import org.janusgraph.graphdb.types.TypeDefinitionDescription;
+import org.janusgraph.graphdb.types.system.BaseKey;
+
+/**
+ * Connection contains schema constraints from outgoing vertex to incoming vertex through an edge.
+ *
+ * @author Jan Jansen (jan.jansen@gdata.de)
+ */
+public class Connection {
+    private final VertexLabel incomingVertexLabel;
+    private final VertexLabel outgoingVertexLabel;
+    private final String edgeLabel;
+    private final JanusGraphEdge connectionEdge;
+
+    public Connection(JanusGraphEdge connectionEdge) {
+        this.outgoingVertexLabel = (VertexLabel) connectionEdge.outVertex();
+        this.incomingVertexLabel = (VertexLabel) connectionEdge.inVertex();
+        TypeDefinitionDescription value = connectionEdge.valueOrNull(BaseKey.SchemaDefinitionDesc);
+        this.edgeLabel = (String) value.getModifier();
+        this.connectionEdge = connectionEdge;
+    }
+
+
+    public Connection(String edgeLabel, VertexLabel outgoingVertexLabel, VertexLabel incomingVertexLabel) {
+        this.outgoingVertexLabel = outgoingVertexLabel;
+        this.incomingVertexLabel = incomingVertexLabel;
+        this.edgeLabel = edgeLabel;
+        this.connectionEdge = null;
+    }
+
+    /**
+     *
+     * @return a label from an {@link EdgeLabel}.
+     */
+    public String getEdgeLabel() {
+        return edgeLabel;
+    }
+
+    /**
+     *
+     * @return a outgoing {@link VertexLabel}.
+     */
+    public VertexLabel getOutgoingVertexLabel() {
+        return outgoingVertexLabel;
+    }
+
+    /**
+     *
+     * @return a incoming {@link VertexLabel}.
+     */
+    public VertexLabel getIncomingVertexLabel() {
+        return incomingVertexLabel;
+    }
+
+
+    /**
+     *
+     * @return a internal connection edge is used for update.
+     */
+    public JanusGraphEdge getConnectionEdge() {
+        return connectionEdge;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/EdgeLabel.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/EdgeLabel.java
@@ -15,6 +15,8 @@
 
 package org.janusgraph.core;
 
+import java.util.Collection;
+
 /**
  * EdgeLabel is an extension of {@link RelationType} for edges. Each edge in JanusGraph has a label.
  * <p/>
@@ -54,5 +56,19 @@ public interface EdgeLabel extends RelationType {
      * @return
      */
     Multiplicity multiplicity();
+
+    /**
+     * Collects all property constraints.
+     *
+     * @return a list of {@link PropertyKey} which represents all property constraints for a {@link EdgeLabel}.
+     */
+    Collection<PropertyKey> mappedProperties();
+
+    /**
+     * Collects all connection constraints.
+     *
+     * @return a list of {@link Connection} which represents all connection constraints for a {@link EdgeLabel}.
+     */
+    Collection<Connection> mappedConnections();
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/core/VertexLabel.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/VertexLabel.java
@@ -16,6 +16,8 @@ package org.janusgraph.core;
 
 import org.janusgraph.core.schema.JanusGraphSchemaType;
 
+import java.util.Collection;
+
 /**
  * A vertex label is a label attached to vertices in a JanusGraph graph. This can be used to define the nature of a
  * vertex.
@@ -43,5 +45,18 @@ public interface VertexLabel extends JanusGraphVertex, JanusGraphSchemaType {
 
     //TTL
 
+    /**
+     * Collects all property constraints.
+     *
+     * @return a list of {@link PropertyKey} which represents all property constraints for a {@link VertexLabel}.
+     */
+    Collection<PropertyKey> mappedProperties();
+
+    /**
+     * Collects all connection constraints.
+     *
+     * @return a list of {@link Connection} which represents all connection constraints for a {@link VertexLabel}.
+     */
+    Collection<Connection> mappedConnections();
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/DefaultSchemaMaker.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/DefaultSchemaMaker.java
@@ -93,6 +93,41 @@ public interface DefaultSchemaMaker {
      */
     boolean ignoreUndefinedQueryTypes();
 
+    /**
+     * Add property constraints for a given vertex label using the schema manager.
+     *
+     * @param vertexLabel to which the constraint applies.
+     * @param key defines the property which should be added to the vertex label as a constraint.
+     * @param manager is used to update the schema.
+     * @see org.janusgraph.core.schema.SchemaManager
+     */
+    default void makePropertyConstraintForVertex(VertexLabel vertexLabel, PropertyKey key, SchemaManager manager) {
+        manager.addProperties(vertexLabel, key);
+    }
 
+    /**
+     * Add property constraints for a given edge label using the schema manager.
+     *
+     * @param edgeLabel to which the constraint applies.
+     * @param key defines the property which should be added to the edge label as a constraint.
+     * @param manager is used to update the schema.
+     * @see org.janusgraph.core.schema.SchemaManager
+     */
+    default void makePropertyConstraintForEdge(EdgeLabel edgeLabel, PropertyKey key, SchemaManager manager) {
+        manager.addProperties(edgeLabel, key);
+    }
+
+    /**
+     * Add a constraint on which vertices the given edge label can connect using the schema manager.
+     *
+     * @param edgeLabel to which the constraint applies.
+     * @param outVLabel specifies the outgoing vertex for this connection.
+     * @param inVLabel specifies the incoming vertex for this connection.
+     * @param manager is used to update the schema.
+     * @see org.janusgraph.core.schema.SchemaManager
+     */
+    default void makeConnectionConstraint(EdgeLabel edgeLabel, VertexLabel outVLabel, VertexLabel inVLabel, SchemaManager manager) {
+        manager.addConnection(edgeLabel, outVLabel, inVLabel);
+    }
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/SchemaManager.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/SchemaManager.java
@@ -14,6 +14,10 @@
 
 package org.janusgraph.core.schema;
 
+import org.janusgraph.core.EdgeLabel;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.VertexLabel;
+
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
  */
@@ -53,6 +57,34 @@ public interface SchemaManager extends SchemaInspector {
      * @return
      */
     VertexLabelMaker makeVertexLabel(String name);
+
+    /**
+     * Add property constraints for a given vertex label.
+     *
+     * @param vertexLabel to which the constraints applies.
+     * @param keys defines the properties which should be added to the {@link VertexLabel} as constraints.
+     * @return a {@link VertexLabel} edited which contains the added constraints.
+     */
+    VertexLabel addProperties(VertexLabel vertexLabel, PropertyKey... keys);
+
+    /**
+     * Add property constraints for a given edge label.
+     *
+     * @param edgeLabel to which the constraints applies.
+     * @param keys defines the properties which should be added to the {@link EdgeLabel} as constraints.
+     * @return a {@link EdgeLabel} edited which contains the added constraints.
+     */
+    EdgeLabel addProperties(EdgeLabel edgeLabel, PropertyKey... keys);
+
+    /**
+     * Add a constraint on which vertices the given edge label can connect.
+     *
+     * @param edgeLabel to which the constraint applies.
+     * @param outVLabel specifies the outgoing vertex for this connection.
+     * @param inVLabel specifies the incoming vertex for this connection.
+     * @return a {@link EdgeLabel} edited which contains the added constraint.
+     */
+    EdgeLabel addConnection(EdgeLabel edgeLabel, VertexLabel outVLabel, VertexLabel inVLabel);
 
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -282,7 +282,7 @@ public class GraphDatabaseConfiguration {
     public static final ConfigOption<String> AUTO_TYPE = new ConfigOption<>(SCHEMA_NS,"default",
             "Configures the DefaultSchemaMaker to be used by this graph. If set to 'none', automatic schema creation is disabled. " +
                     "Defaults to a blueprints compatible schema maker with MULTI edge labels and SINGLE property keys",
-            ConfigOption.Type.MASKABLE, "default" , new Predicate<String>() {
+            ConfigOption.Type.MASKABLE, "default", new Predicate<String>() {
         @Override
         public boolean apply(@Nullable String s) {
             if (s==null) return false;
@@ -301,6 +301,12 @@ public class GraphDatabaseConfiguration {
                     "default", JanusGraphDefaultSchemaMaker.INSTANCE,
                     "tp3", Tp3DefaultSchemaMaker.INSTANCE);
 
+    public static final ConfigOption<Boolean> SCHEMA_CONSTRAINTS = new ConfigOption<>(SCHEMA_NS, "constraints",
+            "Configures the schema constraints to be used by this graph. If config 'schema.constraints' " +
+            "is set to 'true' and 'schema.default' is set to 'none', then an 'IllegalArgumentException' is thrown for schema constraint violations. " +
+            "If 'schema.constraints' is set to 'true' and 'schema.default' is not set 'none', schema constraints are automatically created "+
+            "as described in the config option 'schema.default'. If 'schema.constraints' is set to 'false' which is the default, then no schema constraints are applied.",
+            ConfigOption.Type.MASKABLE, false);
 
     // ################ CACHE #######################
     // ################################################
@@ -1217,6 +1223,7 @@ public class GraphDatabaseConfiguration {
     private int txVertexCacheSize;
     private int txDirtyVertexSize;
     private DefaultSchemaMaker defaultSchemaMaker;
+    private boolean hasDisabledSchemaConstraints;
     private Boolean propertyPrefetching;
     private boolean adjustQueryLimit;
     private Boolean useMultiQuery;
@@ -1524,6 +1531,8 @@ public class GraphDatabaseConfiguration {
         //Disable auto-type making when batch-loading is enabled since that may overwrite types without warning
         if (batchLoading) defaultSchemaMaker = DisableDefaultSchemaMaker.INSTANCE;
 
+        hasDisabledSchemaConstraints = !configuration.get(SCHEMA_CONSTRAINTS);
+
         txVertexCacheSize = configuration.get(TX_CACHE_SIZE);
         //Check for explicit dirty vertex cache size first, then fall back on batch-loading-dependent default
         if (configuration.has(TX_DIRTY_SIZE)) {
@@ -1664,6 +1673,10 @@ public class GraphDatabaseConfiguration {
 
     public DefaultSchemaMaker getDefaultSchemaMaker() {
         return defaultSchemaMaker;
+    }
+
+    public boolean hasDisabledSchemaConstraints() {
+        return hasDisabledSchemaConstraints;
     }
 
     public boolean allowVertexIdSetting() {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/StandardEdge.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/StandardEdge.java
@@ -77,6 +77,7 @@ public class StandardEdge extends AbstractEdge implements StandardRelation, Reas
                 }
             }
         }
+        tx().checkPropertyConstraintForEdgeOrCreatePropertyConstraint(edgeLabel(), key);
         properties.put(key, value);
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphBlueprintsGraph.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphBlueprintsGraph.java
@@ -211,6 +211,21 @@ public abstract class JanusGraphBlueprintsGraph implements JanusGraph {
     }
 
     @Override
+    public VertexLabel addProperties(VertexLabel vertexLabel, PropertyKey... keys) {
+        return getAutoStartTx().addProperties(vertexLabel, keys);
+    }
+
+    @Override
+    public EdgeLabel addProperties(EdgeLabel edgeLabel, PropertyKey... keys) {
+        return getAutoStartTx().addProperties(edgeLabel, keys);
+    }
+
+    @Override
+    public EdgeLabel addConnection(EdgeLabel edgeLabel, VertexLabel outVLabel, VertexLabel inVLabel) {
+        return getAutoStartTx().addConnection(edgeLabel, outVLabel, inVLabel);
+    }
+
+    @Override
     public boolean containsPropertyKey(String name) {
         return getAutoStartTx().containsPropertyKey(name);
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardTransactionBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardTransactionBuilder.java
@@ -47,6 +47,8 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
 
     private final DefaultSchemaMaker defaultSchemaMaker;
 
+    private boolean hasDisabledSchemaConstraints = true;
+
     private boolean verifyExternalVertexExistence = true;
 
     private boolean verifyInternalVertexExistence = false;
@@ -93,6 +95,7 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
         if (graphConfig.isBatchLoading()) enableBatchLoading();
         this.graph = graph;
         this.defaultSchemaMaker = graphConfig.getDefaultSchemaMaker();
+        this.hasDisabledSchemaConstraints = graphConfig.hasDisabledSchemaConstraints();
         this.assignIDsImmediately = graphConfig.hasFlushIDs();
         this.forceIndexUsage = graphConfig.hasForceIndexUsage();
         this.groupName = graphConfig.getMetricsPrefix();
@@ -111,6 +114,7 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
         if (graphConfig.isBatchLoading()) enableBatchLoading();
         this.graph = graph;
         this.defaultSchemaMaker = graphConfig.getDefaultSchemaMaker();
+        this.hasDisabledSchemaConstraints = graphConfig.hasDisabledSchemaConstraints();
         this.assignIDsImmediately = graphConfig.hasFlushIDs();
         this.forceIndexUsage = graphConfig.hasForceIndexUsage();
         this.groupName = graphConfig.getMetricsPrefix();
@@ -235,7 +239,7 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
                 propertyPrefetching, singleThreaded, threadBound, getTimestampProvider(), userCommitTime,
                 indexCacheWeight, getVertexCacheSize(), getDirtyVertexSize(),
                 logIdentifier, restrictedPartitions, groupName,
-                defaultSchemaMaker, customOptions);
+                defaultSchemaMaker, hasDisabledSchemaConstraints, customOptions);
         return graph.newTransaction(immutable);
     }
 
@@ -285,6 +289,11 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
     @Override
     public final DefaultSchemaMaker getAutoSchemaMaker() {
         return defaultSchemaMaker;
+    }
+
+    @Override
+    public boolean hasDisabledSchemaConstraints() {
+        return hasDisabledSchemaConstraints;
     }
 
     @Override
@@ -391,6 +400,7 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
         private final String logIdentifier;
         private final int[] restrictedPartitions;
         private final DefaultSchemaMaker defaultSchemaMaker;
+        private boolean hasDisabledSchemaConstraints = true;
 
         private final BaseTransactionConfig handleConfig;
 
@@ -406,7 +416,9 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
                 boolean isThreadBound, TimestampProvider times, Instant commitTime,
                 long indexCacheWeight, int vertexCacheSize, int dirtyVertexSize, String logIdentifier,
                 int[] restrictedPartitions,
-                String groupName, DefaultSchemaMaker defaultSchemaMaker,
+                String groupName,
+                DefaultSchemaMaker defaultSchemaMaker,
+                boolean hasDisabledSchemaConstraints,
                 Configuration customOptions) {
             this.isReadOnly = isReadOnly;
             this.hasEnabledBatchLoading = hasEnabledBatchLoading;
@@ -426,6 +438,7 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
             this.logIdentifier = logIdentifier;
             this.restrictedPartitions=restrictedPartitions;
             this.defaultSchemaMaker = defaultSchemaMaker;
+            this.hasDisabledSchemaConstraints = hasDisabledSchemaConstraints;
             this.handleConfig = new StandardBaseTransactionConfig.Builder()
                     .commitTime(commitTime)
                     .timestampProvider(times)
@@ -476,6 +489,11 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
         @Override
         public DefaultSchemaMaker getAutoSchemaMaker() {
             return defaultSchemaMaker;
+        }
+
+        @Override
+        public boolean hasDisabledSchemaConstraints() {
+            return hasDisabledSchemaConstraints;
         }
 
         @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/TransactionConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/TransactionConfiguration.java
@@ -92,6 +92,13 @@ public interface TransactionConfiguration extends BaseTransactionConfig {
     DefaultSchemaMaker getAutoSchemaMaker();
 
     /**
+     * Allows to disable schema constraints.
+     *
+     * @return True, if schema constraints should not be applied, else false.
+     */
+    boolean hasDisabledSchemaConstraints();
+
+    /**
      * Whether the graph transaction is configured to verify that an added key does not yet exist in the database.
      *
      * @return True, if vertex existence is verified, else false

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/TypeDefinitionCategory.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/TypeDefinitionCategory.java
@@ -65,15 +65,18 @@ public enum TypeDefinitionCategory {
     STATIC(Boolean.class),
 
     //Schema Edges
+    PROPERTY_KEY_EDGE(),
+    CONNECTION_EDGE(RelationCategory.EDGE, String.class),
+    UPDATE_CONNECTION_EDGE(),
     RELATIONTYPE_INDEX(),
     TYPE_MODIFIER(),
-    INDEX_FIELD(RelationCategory.EDGE,Parameter[].class),
+    INDEX_FIELD(RelationCategory.EDGE, Parameter[].class),
     INDEX_SCHEMA_CONSTRAINT();
 
     public static final Set<TypeDefinitionCategory> PROPERTYKEY_DEFINITION_CATEGORIES = ImmutableSet.of(STATUS, INVISIBLE, SORT_KEY, SORT_ORDER, SIGNATURE, MULTIPLICITY, DATATYPE);
     public static final Set<TypeDefinitionCategory> EDGELABEL_DEFINITION_CATEGORIES = ImmutableSet.of(STATUS, INVISIBLE, SORT_KEY, SORT_ORDER, SIGNATURE, MULTIPLICITY, UNIDIRECTIONAL);
     public static final Set<TypeDefinitionCategory> INDEX_DEFINITION_CATEGORIES = ImmutableSet.of(STATUS, ELEMENT_CATEGORY,INDEX_CARDINALITY,INTERNAL_INDEX, BACKING_INDEX,INDEXSTORE_NAME);
-    public static final Set<TypeDefinitionCategory> VERTEXLABEL_DEFINITION_CATEGORIES = ImmutableSet.of(PARTITIONED,STATIC);
+    public static final Set<TypeDefinitionCategory> VERTEXLABEL_DEFINITION_CATEGORIES = ImmutableSet.of(PARTITIONED, STATIC);
     public static final Set<TypeDefinitionCategory> TYPE_MODIFIER_DEFINITION_CATEGORIES;
 
     static {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/VertexLabelVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/VertexLabelVertex.java
@@ -14,9 +14,17 @@
 
 package org.janusgraph.graphdb.types;
 
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.Connection;
+import org.janusgraph.core.VertexLabel;
 import org.janusgraph.graphdb.internal.InternalVertexLabel;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.janusgraph.graphdb.types.vertices.JanusGraphSchemaVertex;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
@@ -36,6 +44,20 @@ public class VertexLabelVertex extends JanusGraphSchemaVertex implements Interna
     @Override
     public boolean isStatic() {
         return getDefinition().getValue(TypeDefinitionCategory.STATIC, Boolean.class);
+    }
+
+    @Override
+    public Collection<PropertyKey> mappedProperties() {
+        return StreamSupport.stream( getRelated(TypeDefinitionCategory.PROPERTY_KEY_EDGE, Direction.OUT).spliterator(), false)
+            .map(entry -> (PropertyKey) entry.getSchemaType())
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<Connection> mappedConnections() {
+        return StreamSupport.stream(getRelated(TypeDefinitionCategory.CONNECTION_EDGE, Direction.OUT).spliterator(), false)
+            .map(entry -> new Connection((String) entry.getModifier(), this, (VertexLabel) entry.getSchemaType()))
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/BaseLabel.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/BaseLabel.java
@@ -14,10 +14,15 @@
 
 package org.janusgraph.graphdb.types.system;
 
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.janusgraph.core.Connection;
 import org.janusgraph.core.EdgeLabel;
 import org.janusgraph.core.Multiplicity;
+import org.janusgraph.core.PropertyKey;
 import org.janusgraph.graphdb.internal.JanusGraphSchemaCategory;
-import org.apache.tinkerpop.gremlin.structure.Direction;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 public class BaseLabel extends BaseRelationType implements EdgeLabel {
 
@@ -45,6 +50,16 @@ public class BaseLabel extends BaseRelationType implements EdgeLabel {
     @Override
     public Multiplicity multiplicity() {
         return multiplicity;
+    }
+
+    @Override
+    public Collection<PropertyKey> mappedProperties() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Collection<Connection> mappedConnections() {
+        return new ArrayList<>();
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/BaseVertexLabel.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/BaseVertexLabel.java
@@ -14,8 +14,13 @@
 
 package org.janusgraph.graphdb.types.system;
 
-import org.janusgraph.graphdb.internal.InternalVertexLabel;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.Connection;
+import org.janusgraph.graphdb.internal.InternalVertexLabel;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
@@ -58,5 +63,15 @@ public class BaseVertexLabel extends EmptyVertex implements InternalVertexLabel 
     @Override
     public String toString() {
         return name();
+    }
+
+    @Override
+    public Collection<PropertyKey> mappedProperties() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Collection<Connection> mappedConnections() {
+        return new ArrayList<>();
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/typemaker/DisableDefaultSchemaMaker.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/typemaker/DisableDefaultSchemaMaker.java
@@ -18,6 +18,7 @@ import org.janusgraph.core.*;
 import org.janusgraph.core.schema.DefaultSchemaMaker;
 import org.janusgraph.core.schema.EdgeLabelMaker;
 import org.janusgraph.core.schema.PropertyKeyMaker;
+import org.janusgraph.core.schema.SchemaManager;
 import org.janusgraph.core.schema.VertexLabelMaker;
 
 /**
@@ -54,5 +55,23 @@ public class DisableDefaultSchemaMaker implements DefaultSchemaMaker {
     @Override
     public boolean ignoreUndefinedQueryTypes() {
         return false;
+    }
+
+    @Override
+    public void makePropertyConstraintForEdge(EdgeLabel edgeLabel, PropertyKey key, SchemaManager manager) {
+        throw new IllegalArgumentException(
+            String.format("Property Key constraint does not exist for given Edge Label [%s] and property key [%s].", edgeLabel, key));
+    }
+
+    @Override
+    public void makePropertyConstraintForVertex(VertexLabel vertexLabel, PropertyKey key, SchemaManager manager) {
+        throw new IllegalArgumentException(
+            String.format("Property Key constraint does not exist for given Vertex Label [%s] and property key [%s].", vertexLabel, key));
+    }
+
+    @Override
+    public void makeConnectionConstraint(EdgeLabel edgeLabel, VertexLabel outVLabel, VertexLabel inVLabel, SchemaManager manager) {
+        throw new IllegalArgumentException(
+            String.format("Connection constraint does not exist for given Edge Label [%s], outgoing Vertex Label [%s] and incoming Vertex Label [%s]", edgeLabel, outVLabel, inVLabel));
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/vertices/EdgeLabelVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/vertices/EdgeLabelVertex.java
@@ -14,10 +14,22 @@
 
 package org.janusgraph.graphdb.types.vertices;
 
-import org.janusgraph.core.EdgeLabel;
-import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
-import org.janusgraph.graphdb.types.TypeDefinitionCategory;
 import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.janusgraph.core.Connection;
+import org.janusgraph.core.EdgeLabel;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.VertexLabel;
+import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
+import org.janusgraph.graphdb.types.SchemaSource;
+import org.janusgraph.graphdb.types.TypeDefinitionCategory;
+import org.janusgraph.graphdb.types.TypeDefinitionDescription;
+import org.janusgraph.graphdb.types.system.BaseKey;
+import org.janusgraph.graphdb.types.system.BaseLabel;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public class EdgeLabelVertex extends RelationTypeVertex implements EdgeLabel {
 
@@ -34,6 +46,24 @@ public class EdgeLabelVertex extends RelationTypeVertex implements EdgeLabel {
     public boolean isUnidirected() {
         return isUnidirected(Direction.OUT);
 
+    }
+
+    @Override
+    public Collection<PropertyKey> mappedProperties() {
+        return StreamSupport.stream(getRelated(TypeDefinitionCategory.PROPERTY_KEY_EDGE, Direction.OUT).spliterator(), false)
+            .map(entry -> (PropertyKey) entry.getSchemaType())
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<Connection> mappedConnections() {
+        String name = name();
+        return StreamSupport.stream(getRelated(TypeDefinitionCategory.UPDATE_CONNECTION_EDGE, Direction.OUT).spliterator(), false)
+            .map(entry -> (JanusGraphSchemaVertex) entry.getSchemaType())
+            .flatMap(s -> StreamSupport.stream(s.getEdges(TypeDefinitionCategory.CONNECTION_EDGE, Direction.OUT).spliterator(), false))
+            .map(Connection::new)
+            .filter(s -> s.getEdgeLabel().equals(name))
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphOperationCountingTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphOperationCountingTest.java
@@ -244,20 +244,22 @@ public abstract class JanusGraphOperationCountingTest extends JanusGraphBaseTest
         JanusGraphTransaction tx = graph.buildTransaction().checkExternalVertexExistence(false).groupName(metricsPrefix).start();
         v = tx.getVertex(v.longId());
         v.property("foo", "bus");
-//        printAllMetrics();
+        long numLookupPropertyConstraints = 1;
+        //printAllMetrics(metricsPrefix);
         tx.commit();
-        verifyStoreMetrics(EDGESTORE_NAME);
+        verifyStoreMetrics(EDGESTORE_NAME, ImmutableMap.of(M_GET_SLICE, numLookupPropertyConstraints));
         verifyStoreMetrics(INDEXSTORE_NAME);
         verifyStoreMetrics(METRICS_STOREMANAGER_NAME, ImmutableMap.of(M_MUTATE, 1L));
 
         tx = graph.buildTransaction().checkExternalVertexExistence(false).groupName(metricsPrefix).start();
         v = tx.getVertex(v.longId());
         v.property("foo", "band");
+        numLookupPropertyConstraints +=1;
         assertEquals("band", v.property("foo").value());
         assertEquals(1, Iterators.size(v.properties("foo")));
         assertEquals(1, Iterators.size(v.properties()));
         tx.commit();
-        verifyStoreMetrics(EDGESTORE_NAME, ImmutableMap.of(M_GET_SLICE, 2L));
+        verifyStoreMetrics(EDGESTORE_NAME, ImmutableMap.of(M_GET_SLICE, 2L + numLookupPropertyConstraints));
         verifyStoreMetrics(INDEXSTORE_NAME);
         verifyStoreMetrics(METRICS_STOREMANAGER_NAME, ImmutableMap.of(M_MUTATE, 2L));
         verifyStoreMetrics(getConfig().get(IDS_STORE_NAME));
@@ -541,7 +543,8 @@ public abstract class JanusGraphOperationCountingTest extends JanusGraphBaseTest
         System.out.println("Hits: " + (getEdgeCacheRetrievals()-getEdgeCacheMisses()));
         System.out.println("Misses: " + getEdgeCacheMisses());
         assertEquals(numReads, lookups.get());
-        assertEquals(2 * numReads + numV, getEdgeCacheRetrievals());
+        final int numLookupPropertyConstraints = numV;
+        assertEquals(2 * numReads + numV + numLookupPropertyConstraints, getEdgeCacheRetrievals());
         int minMisses = 2*numV;
         assertTrue("Min misses ["+minMisses+"] vs actual ["+getEdgeCacheMisses()+"]",minMisses<=getEdgeCacheMisses() && 4*minMisses>=getEdgeCacheMisses());
     }

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/inmemory/InMemoryGraphTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/inmemory/InMemoryGraphTest.java
@@ -19,6 +19,7 @@ import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
 import org.janusgraph.graphdb.JanusGraphTest;
 import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Map;
@@ -102,4 +103,21 @@ public class InMemoryGraphTest extends JanusGraphTest {
     @Override
     public void testClearStorage() {}
 
+    @Override
+    public void testAutoSchemaMakerForEdgePropertyConstraints() {}
+
+    @Override
+    public void testAutoSchemaMakerForVertexPropertyConstraints() {}
+
+    @Override
+    public void testAutoSchemaMakerForConnectionConstraints() {}
+
+    @Override
+    public void testSupportDirectCommitOfSchemaChangesForVertexProperties() {}
+
+    @Override
+    public void testSupportDirectCommitOfSchemaChangesForConnection() {}
+
+    @Override
+    public void testSupportDirectCommitOfSchemaChangesForEdgeProperties() {}
 }


### PR DESCRIPTION
Fixes #880.

# Design Decisions
* Extension and usage of SchemaMaker
* Connection constrains are defined using two schema edges, one between out and in Vertex and one between the edge and out vertex. The first edge has a property with the label of the edge. 

# Alternative Idea
Create a new SchemaVertex for a connection and make edges to an out-VertexLabel, an in-VertexLabel, and EdgeLabel. This alternative would allow to remove an extra step during an update, if an EdgeLabel is renamed.

# Todo
- [x] documentation (wait for review comments on current implementation)



----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.