### PR TITLE
Add OrderPreservingSerializer on UUIDSerializer

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/serialize/attribute/UUIDSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/serialize/attribute/UUIDSerializer.java
@@ -14,17 +14,18 @@
 
 package org.janusgraph.graphdb.database.serialize.attribute;
 
-import com.google.common.base.Preconditions;
-import org.janusgraph.core.attribute.AttributeSerializer;
+import java.util.UUID;
+
 import org.janusgraph.diskstorage.ScanBuffer;
 import org.janusgraph.diskstorage.WriteBuffer;
+import org.janusgraph.graphdb.database.serialize.OrderPreservingSerializer;
 
-import java.util.UUID;
+import com.google.common.base.Preconditions;
 
 /**
  *  @author Bryn Cooke (bryn.cooke@datastax.com)
  */
-public class UUIDSerializer implements AttributeSerializer<UUID>  {
+public class UUIDSerializer implements OrderPreservingSerializer<UUID>  {
 
     @Override
     public UUID read(ScanBuffer buffer) {
@@ -47,4 +48,15 @@ public class UUIDSerializer implements AttributeSerializer<UUID>  {
         }
         return null;
     }
+
+    @Override
+    public UUID readByteOrder(ScanBuffer buffer) {
+        return read(buffer);
+    }
+
+    @Override
+    public void writeByteOrder(WriteBuffer buffer, UUID attribute) {
+        write(buffer, attribute);
+    }
+
 }

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/database/serialize/attribute/UUIDSerializerTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/database/serialize/attribute/UUIDSerializerTest.java
@@ -42,6 +42,21 @@ public class UUIDSerializerTest {
     }
 
     @Test
+    public void testRoundTripByteOrder() {
+        //Write the UUID
+        UUIDSerializer serializer = new UUIDSerializer();
+        UUID uuid1 = UUID.randomUUID();
+        WriteByteBuffer buffer = new WriteByteBuffer();
+        serializer.writeByteOrder(buffer, uuid1);
+
+        //And read it in again
+        ReadArrayBuffer readBuffer = new ReadArrayBuffer(buffer.getStaticBuffer().getBytes(0, 16));
+        UUID uuid2 = serializer.readByteOrder(readBuffer);
+
+        Assert.assertEquals(uuid1, uuid2);
+    }
+
+    @Test
     public void testConvert() {
         //Write the UUID
         UUIDSerializer serializer = new UUIDSerializer();


### PR DESCRIPTION
Issue #948

As far as I can tell, supporting "native sort order", as described in
the docs, simply means implementing `Comparable`, which UUID certainly
does. This adds support for using a UUID value in a Vertex Centric
Index.

Signed-off-by: Keith Lohnes <lohnesk@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ X ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ X ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ X ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ X ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ X ] Have you written and/or updated unit tests to verify your changes?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

