### PR TITLE
Issue #71: Various Gremlin query patterns throw NPE when query.batch=true

### DIFF
--- a/janusgraph-berkeleyje/src/test/java/org/janusgraph/blueprints/BerkeleyMultiQueryGraphProvider.java
+++ b/janusgraph-berkeleyje/src/test/java/org/janusgraph/blueprints/BerkeleyMultiQueryGraphProvider.java
@@ -1,0 +1,30 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.blueprints;
+
+import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+
+/**
+ * @author Ted Wilmes (twilmes@gmail.com)
+ */
+public class BerkeleyMultiQueryGraphProvider extends BerkeleyGraphProvider {
+
+    @Override
+    public ModifiableConfiguration getJanusGraphConfiguration(String graphName, Class<?> test, String testMethodName) {
+        return super.getJanusGraphConfiguration(graphName, test, testMethodName)
+            .set(GraphDatabaseConfiguration.USE_MULTIQUERY, true);
+    }
+}

--- a/janusgraph-berkeleyje/src/test/java/org/janusgraph/blueprints/process/BerkeleyMultiQueryJanusGraphProcessTest.java
+++ b/janusgraph-berkeleyje/src/test/java/org/janusgraph/blueprints/process/BerkeleyMultiQueryJanusGraphProcessTest.java
@@ -1,0 +1,29 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.blueprints.process;
+
+import org.apache.tinkerpop.gremlin.GraphProviderClass;
+import org.apache.tinkerpop.gremlin.process.ProcessStandardSuite;
+import org.janusgraph.blueprints.BerkeleyMultiQueryGraphProvider;
+import org.janusgraph.core.JanusGraph;
+import org.junit.runner.RunWith;
+
+/**
+* @author Ted Wilmes (twilmes@gmail.com)
+*/
+@RunWith(ProcessStandardSuite.class)
+@GraphProviderClass(provider = BerkeleyMultiQueryGraphProvider.class, graph = JanusGraph.class)
+public class BerkeleyMultiQueryJanusGraphProcessTest {
+}

--- a/janusgraph-cassandra/src/test/java/org/janusgraph/blueprints/thrift/ThriftMultiQueryGraphProvider.java
+++ b/janusgraph-cassandra/src/test/java/org/janusgraph/blueprints/thrift/ThriftMultiQueryGraphProvider.java
@@ -1,0 +1,34 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.blueprints.thrift;
+
+import org.janusgraph.CassandraStorageSetup;
+import org.janusgraph.blueprints.AbstractJanusGraphProvider;
+import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+
+/**
+ * @author Ted Wilmes (twilmes@gmail.com)
+ */
+public class ThriftMultiQueryGraphProvider extends AbstractJanusGraphProvider {
+
+    @Override
+    public ModifiableConfiguration getJanusGraphConfiguration(String graphName, Class<?> test, String testMethodName) {
+        CassandraStorageSetup.startCleanEmbedded();
+        return CassandraStorageSetup.getCassandraThriftConfiguration(graphName)
+            .set(GraphDatabaseConfiguration.USE_MULTIQUERY, true);
+    }
+
+}

--- a/janusgraph-cassandra/src/test/java/org/janusgraph/blueprints/thrift/process/ThriftMultiQueryProcessTest.java
+++ b/janusgraph-cassandra/src/test/java/org/janusgraph/blueprints/thrift/process/ThriftMultiQueryProcessTest.java
@@ -1,0 +1,29 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.blueprints.thrift.process;
+
+import org.apache.tinkerpop.gremlin.GraphProviderClass;
+import org.apache.tinkerpop.gremlin.process.ProcessStandardSuite;
+import org.janusgraph.blueprints.thrift.ThriftMultiQueryGraphProvider;
+import org.janusgraph.core.JanusGraph;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Ted Wilmes (twilmese@gmail.com)
+ */
+@RunWith(ProcessStandardSuite.class)
+@GraphProviderClass(provider = ThriftMultiQueryGraphProvider.class, graph = JanusGraph.class)
+public class ThriftMultiQueryProcessTest {
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphVertexStep.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphVertexStep.java
@@ -81,7 +81,9 @@ public class JanusGraphVertexStep<E extends Element> extends VertexStep<E> imple
         assert !initialized;
         initialized = true;
         if (useMultiQuery) {
-            if (!starts.hasNext()) throw FastNoSuchElementException.instance();
+            if (!starts.hasNext()) {
+                throw FastNoSuchElementException.instance();
+            }
             JanusGraphMultiVertexQuery mquery = JanusGraphTraversalUtil.getTx(traversal).multiQuery();
             List<Traverser.Admin<Vertex>> vertices = new ArrayList<>();
             starts.forEachRemaining(v -> {

--- a/janusgraph-cql/src/test/java/org/janusgraph/blueprints/cql/CQLMultiQueryGraphProvider.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/blueprints/cql/CQLMultiQueryGraphProvider.java
@@ -1,0 +1,34 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.blueprints.cql;
+
+import org.janusgraph.blueprints.AbstractJanusGraphProvider;
+import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
+import org.janusgraph.diskstorage.cql.CassandraStorageSetup;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+
+/**
+ * @author Ted Wilmes (twilmes@gmail.com)
+ */
+public class CQLMultiQueryGraphProvider extends AbstractJanusGraphProvider {
+
+    @Override
+    public ModifiableConfiguration getJanusGraphConfiguration(String graphName, Class<?> test, String testMethodName) {
+        CassandraStorageSetup.startCleanEmbedded();
+        return CassandraStorageSetup.getCQLConfiguration(graphName)
+            .set(GraphDatabaseConfiguration.USE_MULTIQUERY, true);
+    }
+
+}

--- a/janusgraph-cql/src/test/java/org/janusgraph/blueprints/cql/process/CQLMultiQueryProcessTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/blueprints/cql/process/CQLMultiQueryProcessTest.java
@@ -1,0 +1,29 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.blueprints.cql.process;
+
+import org.apache.tinkerpop.gremlin.GraphProviderClass;
+import org.apache.tinkerpop.gremlin.process.ProcessStandardSuite;
+import org.janusgraph.blueprints.cql.CQLMultiQueryGraphProvider;
+import org.janusgraph.core.JanusGraph;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Ted Wilmes (twilmes@gmail.com)
+ */
+@RunWith(ProcessStandardSuite.class)
+@GraphProviderClass(provider = CQLMultiQueryGraphProvider.class, graph = JanusGraph.class)
+public class CQLMultiQueryProcessTest {
+}

--- a/janusgraph-hbase-parent/janusgraph-hbase-core/src/test/java/org/janusgraph/blueprints/HBaseMultiQueryGraphProvider.java
+++ b/janusgraph-hbase-parent/janusgraph-hbase-core/src/test/java/org/janusgraph/blueprints/HBaseMultiQueryGraphProvider.java
@@ -1,0 +1,45 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.blueprints;
+
+import org.janusgraph.HBaseStorageSetup;
+import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+
+import java.io.IOException;
+
+/**
+ * @author Ted Wilmes (twilmes@gmail.com)
+ */
+public class HBaseMultiQueryGraphProvider extends AbstractJanusGraphProvider {
+
+    @Override
+    public ModifiableConfiguration getJanusGraphConfiguration(String graphName, Class<?> test, String testMethodName) {
+        return HBaseStorageSetup.getHBaseConfiguration(graphName)
+            .set(GraphDatabaseConfiguration.USE_MULTIQUERY, true);
+    }
+
+    @Override
+    public Graph openTestGraph(final Configuration config) {
+        try {
+            HBaseStorageSetup.startHBase();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return super.openTestGraph(config);
+    }
+}

--- a/janusgraph-hbase-parent/janusgraph-hbase-core/src/test/java/org/janusgraph/blueprints/process/HBaseMultiQueryProcessTest.java
+++ b/janusgraph-hbase-parent/janusgraph-hbase-core/src/test/java/org/janusgraph/blueprints/process/HBaseMultiQueryProcessTest.java
@@ -1,0 +1,51 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.blueprints.process;
+
+import org.janusgraph.HBaseStorageSetup;
+import org.janusgraph.blueprints.HBaseMultiQueryGraphProvider;
+import org.janusgraph.core.JanusGraph;
+import org.apache.hadoop.hbase.util.VersionInfo;
+import org.apache.tinkerpop.gremlin.GraphProviderClass;
+import org.apache.tinkerpop.gremlin.process.ProcessStandardSuite;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+/**
+ * @author Ted Wilmese (twilmes@gmail.com)
+ */
+@RunWith(ProcessStandardSuite.class)
+@GraphProviderClass(provider = HBaseMultiQueryGraphProvider.class, graph = JanusGraph.class)
+public class HBaseMultiQueryProcessTest {
+
+    @BeforeClass
+    public static void startHBase() {
+        try {
+            HBaseStorageSetup.startHBase();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @AfterClass
+    public static void stopHBase() {
+        // Workaround for https://issues.apache.org/jira/browse/HBASE-10312
+        if (VersionInfo.getVersion().startsWith("0.96"))
+            HBaseStorageSetup.killIfRunning();
+    }
+}

--- a/janusgraph-test/src/test/java/org/janusgraph/blueprints/InMemoryMultiQueryGraphProvider.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/blueprints/InMemoryMultiQueryGraphProvider.java
@@ -1,0 +1,30 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.blueprints;
+
+import org.janusgraph.StorageSetup;
+import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+
+/**
+ * @author Ted Wilmes (twilmes@gmail.com)
+ */
+public class InMemoryMultiQueryGraphProvider extends AbstractJanusGraphProvider {
+    @Override
+    public ModifiableConfiguration getJanusGraphConfiguration(String graphName, Class<?> test, String testMethodName) {
+        return StorageSetup.getInMemoryConfiguration()
+            .set(GraphDatabaseConfiguration.USE_MULTIQUERY, true);
+    }
+}

--- a/janusgraph-test/src/test/java/org/janusgraph/blueprints/InMemoryMultiQueryJanusGraphProcessTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/blueprints/InMemoryMultiQueryJanusGraphProcessTest.java
@@ -1,0 +1,28 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.blueprints;
+
+import org.janusgraph.core.JanusGraph;
+import org.apache.tinkerpop.gremlin.GraphProviderClass;
+import org.apache.tinkerpop.gremlin.process.ProcessStandardSuite;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Ted Wilmes (twilmes@gmail.com)
+ */
+@RunWith(ProcessStandardSuite.class)
+@GraphProviderClass(provider = InMemoryMultiQueryGraphProvider.class, graph = JanusGraph.class)
+public class InMemoryMultiQueryJanusGraphProcessTest {
+}


### PR DESCRIPTION
Storage adapter tests were added to exercise all backends in `query.batch` mode.
The `JanusGraphLocalQueryOptimizerStrategy` was updated to disable multiquery on Janus specific steps that are nested within `RepeatStep`, `MatchStep`, and `BranchSteps`.

These steps cause difficulties with the barrier step nature of the batched query multiquery enabled steps. We should still be able to get at least some level of batched backend retrieval working with these but it will be a more involved effort. The intent of this PR is to un-break the `query.batch` option for users and to allow them to benefit from the decreased latencies in other common query patterns and to lay down a foundation for testing out further multiquery optimizations.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

