### PR TITLE
Only check the global configuration for graph.titan-version

### DIFF
--- a/docs/migrating.adoc
+++ b/docs/migrating.adoc
@@ -5,14 +5,8 @@ This page describes some of the Configuration options that JanusGraph provides t
 
 === Configuration
 
-When connecting to an existing Titan data store the `graph.titan-version` property should be set to the Titan version used to create that store.
+When connecting to an existing Titan data store the `graph.titan-version` property should already be set in the global configuration to Titan version `1.0.0`. The ID store name in JanusGraph is configurable via the `ids.store-name` property whereas in Titan it was a constant. If the `graph.titan-version` has been set in the existing global configuration, then you do **not** need to explicitly set the ID store as it will default to `titan_ids`.
 
-[source, properties]
-----
-graph.titan-version=1.0.0
-----
-
-The ID store name in JanusGraph is configurable via the `ids.store-name` property whereas in Titan it was a constant. If the `graph.titan-version` has been set, as in the example above, then you do **not** need to explicitly set this value as it will default to `titan_ids`.
 
 === Cassandra
 
@@ -20,7 +14,6 @@ The default keyspace used by Titan was `titan` and in order to reuse that existi
 
 [source, properties]
 ----
-graph.titan-version=1.0.0
 storage.cassandra.keyspace=titan
 ----
 
@@ -32,7 +25,6 @@ The name of the table used by Titan was `titan` and in order to reuse that exist
 
 [source, properties]
 ----
-graph.titan-version=1.0.0
 storage.hbase.table=titan
 ----
 

--- a/docs/upgrade.adoc
+++ b/docs/upgrade.adoc
@@ -19,10 +19,8 @@ your code and configuration accordingly:
   duplicate a word, e.g., `TitanGraph` is simply `JanusGraph` rather than
   `JanusGraphGraph`
 
-*IMPORTANT* If you are pointing JanusGraph at an existing Titan database you will
-need to set the `graph.titan-version` property. For more information on how to
-configure JanusGraph to read data which had previously been written by Titan
-refer to <<migrating-titan>>.
+For more information on how to configure JanusGraph to read data which had
+previously been written by Titan refer to <<migrating-titan>>.
 
 === Upgrading from JanusGraph 0.1.z
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -1533,7 +1533,7 @@ public class GraphDatabaseConfiguration {
         preLoadConfiguration();
     }
 
-    private void checkBackwardCompatibilityWithTitan(ModifiableConfiguration globalWrite, BasicConfiguration localbc, KCVSConfiguration kcvsConfig, ModifiableConfiguration overwrite) {
+    private void checkBackwardCompatibilityWithTitan(ModifiableConfiguration globalWrite, BasicConfiguration localBasicConfiguration, KCVSConfiguration keyColumnValueStoreConfiguration, ModifiableConfiguration overwrite) {
         String version = globalWrite.get(TITAN_COMPATIBLE_VERSIONS);
         Preconditions.checkArgument(version!=null,"JanusGraph version nor Titan compatibility have not been initialized");
         if (!JanusGraphConstants.TITAN_COMPATIBLE_VERSIONS.contains(version)) {
@@ -1541,19 +1541,17 @@ public class GraphDatabaseConfiguration {
         }
 
         // When connecting to a store created by Titan the ID store name will not be in the
-        // global configuration. To ensure compatibility override the default to titan_ids.
-        boolean localTitanConfigured = localbc.get(TITAN_COMPATIBLE_VERSIONS) != null;
-        boolean localIdStoreIsDefault = JanusGraphConstants.JANUSGRAPH_ID_STORE_NAME.equals(localbc.get(IDS_STORE_NAME));
+        // global configuration as it was not something which was configurable with Titan.
+        // So to ensure compatibility override the default to titan_ids.
+        boolean localIdStoreIsDefault = JanusGraphConstants.JANUSGRAPH_ID_STORE_NAME.equals(localBasicConfiguration.get(IDS_STORE_NAME));
 
-        if (localTitanConfigured == true) {
-            boolean usingTitanIdStore = localIdStoreIsDefault == true || JanusGraphConstants.TITAN_ID_STORE_NAME.equals(localbc.get(IDS_STORE_NAME));
-            boolean existingKeyStore = kcvsConfig.get(IDS_STORE_NAME.getName(), IDS_STORE_NAME.getDatatype()) != null;
+        boolean usingTitanIdStore = localIdStoreIsDefault || JanusGraphConstants.TITAN_ID_STORE_NAME.equals(localBasicConfiguration.get(IDS_STORE_NAME));
+        boolean existingKeyStore = keyColumnValueStoreConfiguration.get(IDS_STORE_NAME.getName(), IDS_STORE_NAME.getDatatype()) != null;
 
-        	Preconditions.checkArgument(usingTitanIdStore,"ID store for Titan compatibility has not been initialized to: " + JanusGraphConstants.TITAN_ID_STORE_NAME);
-            if (existingKeyStore == false) {
-                log.info("Setting {} to {} for Titan compatibility", IDS_STORE_NAME.getName(), JanusGraphConstants.TITAN_ID_STORE_NAME);
-                overwrite.set(IDS_STORE_NAME, JanusGraphConstants.TITAN_ID_STORE_NAME);
-            }
+        Preconditions.checkArgument(usingTitanIdStore,"ID store for Titan compatibility has not been initialized to: " + JanusGraphConstants.TITAN_ID_STORE_NAME);
+        if (!existingKeyStore) {
+            log.info("Setting {} to {} for Titan compatibility", IDS_STORE_NAME.getName(), JanusGraphConstants.TITAN_ID_STORE_NAME);
+            overwrite.set(IDS_STORE_NAME, JanusGraphConstants.TITAN_ID_STORE_NAME);
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Scott McQuillan <scott.mcquillan@uk.ibm.com>

-----

**Note:** This pull request is targeted at 0.2 and replaces #977 which had been targeted at master 


This pull request has been raised following the discussions around pull request #843 the suggested fix for which would not have worked as expected, as it would have caused JanusGraph to create a second ID store named `janusgraph_ids` in addition to the existing one created by Titan and named `titan_ids`. 


Given that you must first populate Cassandra with data from Titan in order to reproduce the problem I wasn't able to create a unit test. But here's a walk through of how to re-create the problem:


### 1) Use Titan 1.0 to create a graph in Cassandra:

```
gremlin>  graph = TitanFactory.open('conf/titan-cassandra.properties')
==>standardtitangraph[cassandrathrift:[127.0.0.1]]
gremlin> GraphOfTheGodsFactory.loadWithoutMixedIndex(graph, true)
==>null
gremlin> g = graph.traversal()
==>graphtraversalsource[standardtitangraph[cassandrathrift:[127.0.0.1]], standard]
gremlin> saturn = g.V().has('name', 'saturn').next()
==>v[4200]
gremlin> 
```

### 2) JanusGraph CAN read if graph.titan-version is set in the local config

create a test config with `graph.titan-version` included:
```
cp janusgraph-cassandra.properties test.properties
echo "storage.cassandra.keyspace = titan" >> test.properties 
echo "graph.titan-version = 1.0.0" >> test.properties
```
And then connect:

```
gremlin>  graph = JanusGraphFactory.open('conf/test.properties')
==>standardjanusgraph[cassandrathrift:[127.0.0.1]]
gremlin>  g = graph.traversal()
==>graphtraversalsource[standardjanusgraph[cassandrathrift:[127.0.0.1]], standard]
gremlin> saturn = g.V().has('name', 'saturn').next()
==>v[4200]
gremlin> 
````

### 3) JanusGraph CAN'T read if graph.titan-version is omitted from local config

create a test config with `graph.titan-version` omitted:
```
cp janusgraph-cassandra.properties test.properties
echo "storage.cassandra.keyspace = titan" >> test.properties 
```
JanusGraph will now fail to connect with an exception:
```
gremlin>  graph = JanusGraphFactory.open('conf/test.properties')
Need to set configuration value: root.graph.titan-version
Type ':help' or ':h' for help.
Display stack trace? [yN]y
java.lang.IllegalStateException: Need to set configuration value: root.graph.titan-version
	at com.google.common.base.Preconditions.checkState(Preconditions.java:197)
	at org.janusgraph.diskstorage.configuration.ConfigOption.get(ConfigOption.java:229)
	at org.janusgraph.diskstorage.configuration.BasicConfiguration.get(BasicConfiguration.java:69)
	at org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.checkBackwardCompatibilityWithTitan(GraphDatabaseConfiguration.java:1402)
	at org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.<init>(GraphDatabaseConfiguration.java:1298)
	at org.janusgraph.core.JanusGraphFactory.open(JanusGraphFactory.java:160)
```


### Summary

JanusGraph can currently only read Titan data if you explicitly specify `graph.titan-version` in the configuration when connecting.  This pull request removes the check of of `graph.titan-version` from the local configuration as its not really needed as the one that actually counts is the one already persisted in the global configuration.

Also, if you ignore white space with [?w=1](https://github.com/JanusGraph/janusgraph/pull/977/files?w=1) reviewing the changes it's clearer what's been changed.

