### PR TITLE
Update Transaction Log docs [skip ci]

### DIFF
--- a/docs/basics.adoc
+++ b/docs/basics.adoc
@@ -1391,7 +1391,7 @@ totalHumansAdded = new AtomicInteger(0);
 totalGodsAdded = new AtomicInteger(0);
 logProcessor.addLogProcessor("addedPerson").
         setProcessorIdentifier("addedPersonCounter").
-        setStartTime(System.currentTimeMillis(), TimeUnit.MILLISECONDS).
+        setStartTimeNow().
         addProcessor(new ChangeProcessor() {
             @Override
             public void process(JanusGraphTransaction tx, TransactionId txId, ChangeState changeState) {
@@ -1425,7 +1425,7 @@ One cannot add or remove change processor from a running log processor. In other
 [source, gremlin]
 logProcessor.addLogProcessor("battle").
         setProcessorIdentifier("battleTimer").
-        setStartTime(System.currentTimeMillis(), TimeUnit.MILLISECONDS).
+        setStartTimeNow().
         addProcessor(new ChangeProcessor() {
             @Override
             public void process(JanusGraphTransaction tx, TransactionId txId, ChangeState changeState) {


### PR DESCRIPTION
The transaction log docs are still using the old versions of the
setStartTime method that took a long and a TimeUnit. Switched it to
use setStartTimeNow() instead

Signed-off-by: Keith Lohnes <lohnesk@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there an issue associated with this PR? Is it referenced in the commit message?
- [X] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [X] Is your initial contribution a single, squashed commit?

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered?
- [X] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

