### PR TITLE
[skip ci] Remove Seeq from the JanusGraph readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ The following users have deployed JanusGraph in production.
 * [Netflix](https://www.netflix.com) -
   [video](https://youtu.be/KSmAdtMJYEo?t=1h2m17s) and
   [slides](https://www.slideshare.net/RoopaTangirala/polyglot-persistence-netflix-cde-meetup-90955706) (graph discussion starts at #86)
-* [Seeq](https://seeq.com)
 * [Sift Security](https://siftsecurity.com)
 * [Times Internet](http://timesinternet.in) - [blog post about CMS use case](http://denmarkblog.timesinternet.in/blogs/graph/times-internet-is-using-janusgraph-as-main-database-in-cms-for-all-newsrooms/articleshow/63709837.cms) (the CMS which is serving this blog post runs on JanusGraph)
 * [Uber](https://uber.com)


### PR DESCRIPTION
Seeq is no longer using JanusGraph in production.

-----

### For all changes:
- [/] Is there an issue associated with this PR? Is it referenced in the commit message?
- [/] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For documentation related changes:
- [/] Have you ensured that format looks appropriate for the output in which it is rendered?
- [/] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?
