### PR TITLE
Issue #1066 - Fixed automatic type detection issue for edge properties

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/AbstractTypedRelation.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/AbstractTypedRelation.java
@@ -116,7 +116,7 @@ public abstract class AbstractTypedRelation extends AbstractElement implements I
     public <V> Property<V> property(final String key, final V value) {
         verifyAccess();
 
-        PropertyKey pkey = tx().getOrCreatePropertyKey(key);
+        PropertyKey pkey = tx().getOrCreatePropertyKey(key, value);
         Object normalizedValue = tx().verifyAttribute(pkey,value);
         it().setPropertyDirect(pkey,normalizedValue);
         return new SimpleJanusGraphProperty<V>(this,pkey,value);

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -147,6 +147,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.Date;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -5335,4 +5336,34 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         d = v2.value("~ttl");
         assertEquals(Duration.ZERO, d);
     }
+
+    @Test
+    public void testAutoSchemaMakerForVertexPropertyDataType(){
+        JanusGraphVertex v1 = tx.addVertex("user");
+        v1.property("id", 10);
+        v1.property("created", new Date());
+
+        PropertyKey idPropertyKey = tx.getPropertyKey("id");
+        assertEquals("Data type not identified correctly by auto schema maker",
+            Integer.class, idPropertyKey.dataType());
+        PropertyKey createdPropertyKey = tx.getPropertyKey("created");
+        assertEquals("Data type not identified properly by auto schema maker",
+            Date.class, createdPropertyKey.dataType());
+
+    }
+
+    @Test
+    public void testAutoSchemaMakerForEdgePropertyDataType(){
+        JanusGraphVertex v1 = tx.addVertex("user");
+        JanusGraphVertex v2 = tx.addVertex("user");
+        v1.addEdge("knows", v2, "id", 10, "created", new Date());
+
+        PropertyKey idPropertyKey = tx.getPropertyKey("id");
+        assertEquals("Data type not identified correctly by auto schema maker",
+            Integer.class, idPropertyKey.dataType());
+        PropertyKey createdPropertyKey = tx.getPropertyKey("created");
+        assertEquals("Data type not identified correctly by auto schema maker",
+            Date.class, createdPropertyKey.dataType());
+    }
+
 }


### PR DESCRIPTION
Issue #1066 

1.  getOrCreatePropertyKey was getting called without the value and hence the code in the following file was not getting executed - [JanusGraphDefaultSchemaMaker.java#L44](https://github.com/JanusGraph/janusgraph/blob/037f8af5471f5e0a2becc2cb331c822936e7d01a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphDefaultSchemaMaker.java#L44). This resulted in the edge properties not having automatic type detection.

2. Added JUNIT tests for vertex and edge properties to verify auto data type detection

Signed-off-by: Prithvi Nambiar <prithvinambiar@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [x] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
- [x] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

