### PR TITLE
No longer use COMPACT STORAGE for Cassandra 3+ with CQL backend

### DIFF
--- a/docs/basics.adoc
+++ b/docs/basics.adoc
@@ -21,7 +21,7 @@ Sets up JanusGraph to use the Cassandra persistence engine running locally and a
 
 [source, properties]
 ----
-storage.backend=cassandra
+storage.backend=cql
 storage.hostname=localhost
 
 index.search.backend=elasticsearch
@@ -70,7 +70,7 @@ There are several example configuration files in the `conf/` directory that can 
 [source, java]
 ----
 // Connect to Cassandra on localhost using a default configuration
-graph = JanusGraphFactory.open("conf/janusgraph-cassandra.properties")
+graph = JanusGraphFactory.open("conf/janusgraph-cql.properties")
 // Connect to HBase on localhost using a default configuration
 graph = JanusGraphFactory.open("conf/janusgraph-hbase.properties")
 ----
@@ -102,7 +102,7 @@ If the JanusGraph graph cluster has been previously configured and/or only the s
 
 [source, gremlin]
 ----
-graph = JanusGraphFactory.open('cassandra:localhost')
+graph = JanusGraphFactory.open('cql:localhost')
 ----
 
 [source, gremlin]
@@ -370,7 +370,7 @@ Taken together, these steps form a path-like traversal query. Each step can be d
 
 [source, gremlin]
 gremlin> g
-==>graphtraversalsource[janusgraph[cassandrathrift:127.0.0.1], standard]
+==>graphtraversalsource[janusgraph[cql:127.0.0.1], standard]
 gremlin> g.V().has('name', 'hercules')
 ==>v[24]
 gremlin> g.V().has('name', 'hercules').out('father')
@@ -536,9 +536,9 @@ The `:remote` command tells the console to configure a remote connection to Grem
 gremlin> :remote connect tinkerpop.server conf/remote.yaml
 ==>Configured localhost/127.0.0.1:8182
 gremlin> graph
-==>standardjanusgraph[cassandrathrift:[127.0.0.1]]
+==>standardjanusgraph[cql:[127.0.0.1]]
 gremlin> g
-==>graphtraversalsource[standardjanusgraph[cassandrathrift:[127.0.0.1]], standard]
+==>graphtraversalsource[standardjanusgraph[cql:[127.0.0.1]], standard]
 gremlin> g.V()
 gremlin> user = "Chris"
 ==>Chris

--- a/docs/cassandra.adoc
+++ b/docs/cassandra.adoc
@@ -14,12 +14,26 @@ over 300 TB of data in over 400 machines.
 
 The following sections outline the various ways in which JanusGraph can be used in concert with Apache Cassandra.
 
+[[cassandra-storage-backend]]
+=== Cassandra Storage Backend
+
+JanusGraph provides the following backends for use with Cassandra:
+
+* `cql` - CQL based driver. This is the recommended driver.
+* `cassandrathrift` - JanusGraph's Thrift connection pool driver
+* `cassandra` - https://github.com/Netflix/astyanax[Astyanax] driver. The Astyanax project is https://medium.com/netflix-techblog/astyanax-retiring-an-old-friend-6cca1de9ac4[retired].
+* `embeddedcassandra` - Embedded driver for running Cassandra and JanusGraph within the same JVM
+
+Cassandra has two protocols for clients to use: CQL and Thrift. Thrift was the original interface, however it was deprecated starting with Cassandra 2.1. The core of JanusGraph was originally written before the deprecation of Thrift, and it has several classes that support Thrift. With Cassandra 4.0, Thrift support will be removed in Cassandra. JanusGraph users are recommended to use the `cql` storage backend.
+
 [NOTE]
-If you are using Cassandra 2.2 or higher you need to explicitly enable thrift so that JanusGraph can connect to the cluster.
-Do so by running `./bin/nodetool enablethrift`.
+If you plan to use a Thrift-based driver and you are using Cassandra 2.2 or higher, you need to explicitly enable Thrift so that JanusGraph can connect to the cluster.
+Do so by running `./bin/nodetool enablethrift` on every Cassandra node.
+
 [NOTE]
 If security is enabled on Cassandra, the user must have `CREATE permission on <all keyspaces>`,
 otherwise the keyspace must be created ahead of time by an administrator.
+
 
 [[cassandra-local-server-mode]]
 === Local Server Mode
@@ -36,7 +50,7 @@ Now, you can create a Cassandra JanusGraph as follows::
 
 [source, java]
 JanusGraph g = JanusGraphFactory.build().
-set("storage.backend", "cassandra").
+set("storage.backend", "cql").
 set("storage.hostname", "127.0.0.1").
 open();
 
@@ -60,7 +74,7 @@ For example, suppose we have a running Cassandra cluster where one of the machin
 
 [source, java]
 JanusGraph graph = JanusGraphFactory.build().
-set("storage.backend", "cassandra").
+set("storage.backend", "cql").
 set("storage.hostname", "77.77.77.77").
 open();
 
@@ -86,7 +100,7 @@ In this case, each Gremlin Server would be configured to connect to the Cassandr
 ----
 ...
 graphs: {
-  g: conf/janusgraph-cassandra.properties}
+  g: conf/janusgraph-cql.properties}
 plugins:
   - janusgraph.imports
 ...
@@ -194,7 +208,7 @@ Launch additional EC2 instances to run JanusGraph which are either configured in
 
 * Create a configuration file with `vi janusgraph.properties` and add the following lines::
 
-      storage.backend = cassandra
+      storage.backend = cql
       storage.hostname = [IP-address-of-one-Cassandra-EC2-instance]
 
 You may add additional configuration options found on this page or in <<config-ref>>.
@@ -202,7 +216,7 @@ You may add additional configuration options found on this page or in <<config-r
 * Start the Gremlin Console again and type the following::
 
       gremlin> graph = JanusGraphFactory.open('janusgraph.properties')
-      ==>janusgraph[cassandra:[IP-address-of-one-Cassandra-EC2-instance]]
+      ==>janusgraph[cql:[IP-address-of-one-Cassandra-EC2-instance]]
 
 You have successfully connected this JanusGraph instance to the Cassandra cluster and can start to operate on the graph.
 

--- a/docs/configuredgraphfactory.adoc
+++ b/docs/configuredgraphfactory.adoc
@@ -109,7 +109,7 @@ example, look like:
 [source, properties]
 ----
 gremlin.graph=org.janusgraph.core.JanusGraphFactory
-storage.backend=cassandrathrift
+storage.backend=cql
 graph.graphname=ConfigurationManagementGraph
 storage.hostname=127.0.0.1
 ----
@@ -152,7 +152,7 @@ configurations used to open specific graphs, referenced by the
 [source, gremlin]
 ----
 map = new HashMap<String, Object>();
-map.put("storage.backend", "cassandrathrift");
+map.put("storage.backend", "cql");
 map.put("storage.hostname", "127.0.0.1");
 map.put("graph.graphname", "graph1");
 ConfiguredGraphFactory.createConfiguration(new MapConfiguration(map));
@@ -175,7 +175,7 @@ the same configuration template. For example:
 [source, gremlin]
 ----
 map = new HashMap<String, Object>();
-map.put("storage.backend", "cassandrathrift");
+map.put("storage.backend", "cql");
 map.put("storage.hostname", "127.0.0.1");
 ConfiguredGraphFactory.createTemplateConfiguration(new MapConfiguration(map));
 ----
@@ -243,7 +243,7 @@ IP address:
 [source, gremlin]
 ----
 map = new HashMap();
-map.put("storage.backend", "cassandrathrift");
+map.put("storage.backend", "cql");
 map.put("storage.hostname", "127.0.0.1");
 map.put("graph.graphname", "graph1");
 ConfiguredGraphFactory.createConfiguration(new
@@ -269,7 +269,7 @@ g1 = ConfiguredGraphFactory.open("graph1");
 [source, gremlin]
 ----
 map = new HashMap();
-map.put("storage.backend", "cassandrathrift");
+map.put("storage.backend", "cql");
 map.put("storage.hostname", "127.0.0.1");
 map.put("graph.graphname", "graph1");
 ConfiguredGraphFactory.createConfiguration(new
@@ -297,7 +297,7 @@ g1 = ConfiguredGraphFactory.open("graph1");
 [source, gremlin]
 ----
 map = new HashMap();
-map.put("storage.backend", "cassandrathrift");
+map.put("storage.backend", "cql");
 map.put("storage.hostname", "127.0.0.1");
 ConfiguredGraphFactory.createTemplateConfiguration(new
 MapConfiguration(map));
@@ -373,7 +373,7 @@ Below are some example use cases:
 [source, gremlin]
 ----
 map = new HashMap();
-map.put("storage.backend", "cassandrathrift");
+map.put("storage.backend", "cql");
 map.put("storage.hostname", "127.0.0.1");
 ConfiguredGraphFactory.createTemplateConfiguration(new
 MapConfiguration(map));
@@ -420,14 +420,14 @@ Please create a template Configuration using the
 ConfigurationManagementGraph API.
 
 gremlin> map = new HashMap();
-gremlin> map.put("storage.backend", "cassandrathrift"); 
+gremlin> map.put("storage.backend", "cql");
 gremlin> map.put("storage.hostname", "127.0.0.1");
 gremlin> map.put("GraphName", "graph1");
 gremlin> ConfiguredGraphFactory.createConfiguration(new MapConfiguration(map));
 Please include in your configuration the property "graph.graphname".
 
-gremlin> map = new HashMap(); 
-gremlin> map.put("storage.backend", "cassandrathrift");
+gremlin> map = new HashMap();
+gremlin> map.put("storage.backend", "cql");
 gremlin> map.put("storage.hostname", "127.0.0.1");
 gremlin> map.put("graph.graphname", "graph1");
 gremlin> ConfiguredGraphFactory.createConfiguration(new MapConfiguration(map));
@@ -436,7 +436,7 @@ gremlin> ConfiguredGraphFactory.createConfiguration(new MapConfiguration(map));
 gremlin> ConfiguredGraphFactory.open("graph1").vertices();
 
 gremlin> map = new HashMap(); map.put("storage.backend",
-"cassandrathrift"); map.put("storage.hostname", "127.0.0.1");
+"cql"); map.put("storage.hostname", "127.0.0.1");
 gremlin> map.put("graph.graphname", "graph1");
 gremlin> ConfiguredGraphFactory.createTemplateConfiguration(new MapConfiguration(map));
 Your template configuration may not contain the property
@@ -444,7 +444,7 @@ Your template configuration may not contain the property
 
 gremlin> map = new HashMap();
 gremlin> map.put("storage.backend",
-"cassandrathrift"); map.put("storage.hostname", "127.0.0.1");
+"cql"); map.put("storage.hostname", "127.0.0.1");
 gremlin> ConfiguredGraphFactory.createTemplateConfiguration(new MapConfiguration(map));
 ==>null
 
@@ -453,11 +453,11 @@ graphnames.
 gremlin> g1 = ConfiguredGraphFactory.open("graph1");
 gremlin> g2 = ConfiguredGraphFactory.create("graph2");
 gremlin> g3 = ConfiguredGraphFactory.create("graph3");
-gremlin> g2.addVertex(); 
+gremlin> g2.addVertex();
 gremlin> l = [];
-gremlin> l << g1.vertices().size(); 
+gremlin> l << g1.vertices().size();
 ==>0
-gremlin> l << g2.vertices().size(); 
+gremlin> l << g2.vertices().size();
 ==>1
 gremlin> l << g3.vertices().size();
 ==>0

--- a/docs/exampleconfig.adoc
+++ b/docs/exampleconfig.adoc
@@ -28,7 +28,7 @@ In addition, this configures an embedded <<elasticsearch, Elasticsearch>> index 
 
 [source, properties]
 ----
-storage.backend=cassandra
+storage.backend=cql
 storage.hostname=100.100.100.1, 100.100.100.2
 
 index.search.backend=elasticsearch

--- a/docs/hadoop.adoc
+++ b/docs/hadoop.adoc
@@ -18,7 +18,7 @@ is required when using Spark in standalone mode or when running Spark on YARN or
 
 [source, gremlin]
 ----
-bin/gremlin.sh 
+bin/gremlin.sh
 
          \,,,/
          (o o)
@@ -31,8 +31,8 @@ gremlin> :plugin use tinkerpop.spark
 gremlin> :load data/grateful-dead-janusgraph-schema.groovy
 ==>true
 ==>true
-gremlin> graph = JanusGraphFactory.open('conf/janusgraph-cassandra.properties')
-==>standardjanusgraph[cassandrathrift:[127.0.0.1]]
+gremlin> graph = JanusGraphFactory.open('conf/janusgraph-cql.properties')
+==>standardjanusgraph[cql:[127.0.0.1]]
 gremlin> defineGratefulDeadSchema(graph)
 ==>null
 gremlin> graph.close()
@@ -41,14 +41,14 @@ gremlin> if (!hdfs.exists('data/grateful-dead.kryo')) hdfs.copyFromLocal('data/g
 ==>null
 gremlin> graph = GraphFactory.open('conf/hadoop-graph/hadoop-load.properties')
 ==>hadoopgraph[gryoinputformat->nulloutputformat]
-gremlin> blvp = BulkLoaderVertexProgram.build().writeGraph('conf/janusgraph-cassandra.properties').create(graph)
+gremlin> blvp = BulkLoaderVertexProgram.build().writeGraph('conf/janusgraph-cql.properties').create(graph)
 ==>BulkLoaderVertexProgram[bulkLoader=IncrementalBulkLoader,vertexIdProperty=bulkLoader.vertex.id,userSuppliedIds=false,keepOriginalIds=true,batchSize=0]
 gremlin> graph.compute(SparkGraphComputer).program(blvp).submit().get()
 ...
 ==>result[hadoopgraph[gryoinputformat->nulloutputformat],memory[size:0]]
 gremlin> graph.close()
 ==>null
-gremlin> graph = GraphFactory.open('conf/hadoop-graph/read-cassandra.properties')
+gremlin> graph = GraphFactory.open('conf/hadoop-graph/read-cassandra-3.properties')
 ==>hadoopgraph[cassandrainputformat->gryooutputformat]
 gremlin> g = graph.traversal().withComputer(SparkGraphComputer)
 ==>graphtraversalsource[hadoopgraph[cassandrainputformat->gryooutputformat], sparkgraphcomputer]

--- a/docs/intro.adoc
+++ b/docs/intro.adoc
@@ -179,25 +179,25 @@ The `JanusGraphFactory.open() and GraphOfTheGodsFactory.load()` methods do the f
 
 Please see the https://github.com/JanusGraph/janusgraph/blob/master/janusgraph-core/src/main/java/org/janusgraph/example/GraphOfTheGodsFactory.java[GraphOfTheGodsFactory source code] for details.
 
-For those using JanusGraph/Cassandra (or JanusGraph/HBase), be sure to make use of `conf/janusgraph-cassandra-es.properties` (or `conf/janusgraph-hbase-es.properties`) and `GraphOfTheGodsFactory.load()`.
+For those using JanusGraph/Cassandra (or JanusGraph/HBase), be sure to make use of `conf/janusgraph-cql-es.properties` (or `conf/janusgraph-hbase-es.properties`) and `GraphOfTheGodsFactory.load()`.
 
 [source, gremlin]
-gremlin> graph = JanusGraphFactory.open('conf/janusgraph-cassandra-es.properties')
-==>standardjanusgraph[cassandrathrift:[127.0.0.1]]
+gremlin> graph = JanusGraphFactory.open('conf/janusgraph-cql-es.properties')
+==>standardjanusgraph[cql:[127.0.0.1]]
 gremlin> GraphOfTheGodsFactory.load(graph)
 ==>null
 gremlin> g = graph.traversal()
-==>graphtraversalsource[standardjanusgraph[cassandrathrift:[127.0.0.1]], standard]
+==>graphtraversalsource[standardjanusgraph[cql:[127.0.0.1]], standard]
 
-You may also use the `conf/janusgraph-cassandra.properties`, `conf/janusgraph-berkeleyje.properties`, or `conf/janusgraph-hbase.properties` configuration files to open a graph without an indexing backend configured. In such cases, you will need to use the `GraphOfTheGodsFactory.loadWithoutMixedIndex()` method to load the _Graph of the Gods_ so that it doesn't attempt to make use of an indexing backend.
+You may also use the `conf/janusgraph-cql.properties`, `conf/janusgraph-berkeleyje.properties`, or `conf/janusgraph-hbase.properties` configuration files to open a graph without an indexing backend configured. In such cases, you will need to use the `GraphOfTheGodsFactory.loadWithoutMixedIndex()` method to load the _Graph of the Gods_ so that it doesn't attempt to make use of an indexing backend.
 
 [source, gremlin]
-gremlin> graph = JanusGraphFactory.open('conf/janusgraph-cassandra.properties')
-==>standardjanusgraph[cassandrathrift:[127.0.0.1]]
+gremlin> graph = JanusGraphFactory.open('conf/janusgraph-cql.properties')
+==>standardjanusgraph[cql:[127.0.0.1]]
 gremlin> GraphOfTheGodsFactory.loadWithoutMixedIndex(graph, true)
 ==>null
 gremlin> g = graph.traversal()
-==>graphtraversalsource[standardjanusgraph[cassandrathrift:[127.0.0.1]], standard]
+==>graphtraversalsource[standardjanusgraph[cql:[127.0.0.1]], standard]
 
 === Global Graph Indices
 

--- a/docs/reindex.adoc
+++ b/docs/reindex.adoc
@@ -58,7 +58,7 @@ The following Gremlin snippet outlines all steps of the MapReduce reindex proces
 [source,gremlin]
 ----
 // Open a graph
-graph = JanusGraphFactory.open("conf/janusgraph-cassandra-es.properties")
+graph = JanusGraphFactory.open("conf/janusgraph-cql-es.properties")
 g = graph.traversal()
 
 // Define a property
@@ -108,7 +108,7 @@ g.V().has("desc", containsText("baz"))
 // Concerned that JanusGraph could have read cache in that last query, instead of relying on the index?
 // Start a new instance to rule out cache hits.  Now we're definitely using the index.
 graph.close()
-graph = JanusGraphFactory.open("conf/janusgraph-cassandra-es.properties")
+graph = JanusGraphFactory.open("conf/janusgraph-cql-es.properties")
 g.V().has("desc", containsText("baz"))
 ----
 
@@ -238,7 +238,7 @@ A commented code example follows in the next subsection.
 import org.janusgraph.graphdb.database.management.ManagementSystem
 
 // Load the "Graph of the Gods" sample data
-graph = JanusGraphFactory.open('conf/janusgraph-cassandra-es.properties')
+graph = JanusGraphFactory.open('conf/janusgraph-cql-es.properties')
 g = graph.traversal()
 GraphOfTheGodsFactory.load(graph)
 
@@ -291,7 +291,7 @@ The following loads some indexed sample data into a BerkeleyDB-backed JanusGraph
 import org.janusgraph.graphdb.database.management.ManagementSystem
 
 // Load the "Graph of the Gods" sample data
-graph = JanusGraphFactory.open('conf/janusgraph-cassandra-es.properties')
+graph = JanusGraphFactory.open('conf/janusgraph-cql-es.properties')
 g = graph.traversal()
 GraphOfTheGodsFactory.load(graph)
 

--- a/docs/solr.adoc
+++ b/docs/solr.adoc
@@ -358,10 +358,10 @@ bin/gremlin.sh
          \,,,/
          (o o)
 -----oOOo-(3)-oOOo-----
-gremlin> graph = JanusGraphFactory.open('conf/janusgraph-cassandra-solr.properties')
-==>janusgraph[cassandrathrift:[127.0.0.1]]
+gremlin> graph = JanusGraphFactory.open('conf/janusgraph-cql-solr.properties')
+==>janusgraph[cql:[127.0.0.1]]
 gremlin> g = graph.traversal()
-==>graphtraversalsource[janusgraph[cassandrathrift:[127.0.0.1]], standard]
+==>graphtraversalsource[janusgraph[cql:[127.0.0.1]], standard]
 gremlin>
 ----
 
@@ -394,7 +394,7 @@ SOLR_HOST=localhost:8983
 #
 # index.search.solr.http-urls=http://localhost:8983/solr/janusgraph.solr1
 #
-# The stock JanusGraph config file conf/janusgraph-cassandra-solr.properties
+# The stock JanusGraph config file conf/janusgraph-cql-solr.properties
 # ships with this http-urls value.
 
 # Upload Solr config files to DSE Search daemon
@@ -422,7 +422,7 @@ dataset.  Picking up the Gremlin Console session started above:
 
 [source, gremlin]
 ----
-// Assuming graph = JanusGraphFactory.open('conf/janusgraph-cassandra-solr.properties')...
+// Assuming graph = JanusGraphFactory.open('conf/janusgraph-cql-solr.properties')...
 gremlin> GraphOfTheGodsFactory.load(graph)
 ==>null
 ----

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
@@ -120,6 +120,13 @@ public interface CQLConfigOptions {
             ConfigOption.Type.FIXED,
             String[].class);
 
+    public static final ConfigOption<Boolean> CF_COMPACT_STORAGE = new ConfigOption<>(
+            CQL_NS,
+            "compact-storage",
+            "Whether the storage backend should use compact storage on tables. This option is only available for Cassandra 2 and earlier and defaults to true.",
+            ConfigOption.Type.FIXED,
+            Boolean.class);
+
     // Compression
     public static final ConfigOption<Boolean> CF_COMPRESSION = new ConfigOption<>(
             CQL_NS,

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
@@ -15,8 +15,9 @@
 package org.janusgraph.diskstorage.cql;
 
 import static com.datastax.driver.core.schemabuilder.SchemaBuilder.createKeyspace;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.truncate;
 import static com.datastax.driver.core.schemabuilder.SchemaBuilder.dropKeyspace;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.truncate;
 import static io.vavr.API.$;
 import static io.vavr.API.Case;
 import static io.vavr.API.Match;
@@ -92,6 +93,10 @@ import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.TableMetadata;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import com.datastax.driver.core.exceptions.QueryExecutionException;
+import com.datastax.driver.core.exceptions.QueryValidationException;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.TokenAwarePolicy;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -121,6 +126,7 @@ public class CQLStoreManager extends DistributedStoreManager implements KeyColum
     private final String keyspace;
     private final int batchSize;
     private final boolean atomicBatch;
+    private final boolean allowCompactStorage;
 
     final ExecutorService executorService;
 
@@ -154,6 +160,7 @@ public class CQLStoreManager extends DistributedStoreManager implements KeyColum
 
         this.cluster = initializeCluster();
         this.session = initializeSession(this.keyspace);
+        this.allowCompactStorage = initializeCompactStorage();
 
         final Configuration global = buildGraphConfiguration()
                 .set(READ_CONSISTENCY, CONSISTENCY_QUORUM)
@@ -284,6 +291,23 @@ public class CQLStoreManager extends DistributedStoreManager implements KeyColum
         return s;
     }
 
+    boolean initializeCompactStorage() throws PermanentBackendException {
+        try {
+            final ResultSet versionResultSet = this.session.execute(
+                select().column("release_version").from("system", "local") );
+            final String version = versionResultSet.one().getString(0);
+            final int major = Integer.parseInt(version.substring(0, version.indexOf(".")));
+            // starting with Cassandra 3 COMPACT STORAGE is deprecated and has no impact
+            return (major < 3);
+        } catch (NumberFormatException | NoHostAvailableException | QueryExecutionException | QueryValidationException e) {
+            throw new PermanentBackendException("Error determining Cassandra version", e);
+        }
+    }
+
+    boolean isCompactStorageAllowed() {
+        return this.allowCompactStorage;
+    }
+
     ExecutorService getExecutorService() {
         return this.executorService;
     }
@@ -301,6 +325,13 @@ public class CQLStoreManager extends DistributedStoreManager implements KeyColum
                 .getOrElseThrow(() -> new PermanentBackendException(String.format("Unknown keyspace '%s'", this.keyspace)));
         return Option.of(keyspaceMetadata.getTable(name))
                 .map(tableMetadata -> tableMetadata.getOptions().getCompression())
+                .getOrElseThrow(() -> new PermanentBackendException(String.format("Unknown table '%s'", name)));
+    }
+
+    TableMetadata getTableMetadata(final String name) throws BackendException {
+        final KeyspaceMetadata keyspaceMetadata = Option.of(this.cluster.getMetadata().getKeyspace(this.keyspace))
+                .getOrElseThrow(() -> new PermanentBackendException(String.format("Unknown keyspace '%s'", this.keyspace)));
+        return Option.of(keyspaceMetadata.getTable(name))
                 .getOrElseThrow(() -> new PermanentBackendException(String.format("Unknown table '%s'", name)));
     }
 
@@ -334,7 +365,7 @@ public class CQLStoreManager extends DistributedStoreManager implements KeyColum
 
     @Override
     public KeyColumnValueStore openDatabase(final String name, final Container metaData) throws BackendException {
-        return this.openStores.computeIfAbsent(name, n -> new CQLKeyColumnValueStore(this, n, getStorageConfig(), () -> this.openStores.remove(n)));
+        return this.openStores.computeIfAbsent(name, n -> new CQLKeyColumnValueStore(this, n, getStorageConfig(), () -> this.openStores.remove(n), allowCompactStorage));
     }
 
     @Override

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLStoreTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLStoreTest.java
@@ -108,6 +108,42 @@ public class CQLStoreTest extends KeyColumnValueStoreTest {
     }
 
     @Test
+    public void testDefaultCompactStorage() throws BackendException {
+        final String cf = TEST_CF_NAME + "_defaultcompact";
+
+        final CQLStoreManager cqlStoreManager = openStorageManager();
+        cqlStoreManager.openDatabase(cf);
+
+        // COMPACT STORAGE is allowed on Cassandra 2 or earlier
+        // when COMPACT STORAGE is allowed, the default is to enable it
+        assertTrue(cqlStoreManager.isCompactStorageAllowed() == cqlStoreManager.getTableMetadata(cf).getOptions().isCompactStorage());
+    }
+
+    @Test
+    public void testUseCompactStorage() throws BackendException {
+        final String cf = TEST_CF_NAME + "_usecompact";
+        final ModifiableConfiguration config = getBaseStorageConfiguration();
+        config.set(CF_COMPACT_STORAGE, true);
+
+        final CQLStoreManager cqlStoreManager = openStorageManager(config);
+        cqlStoreManager.openDatabase(cf);
+
+        assertTrue(cqlStoreManager.getTableMetadata(cf).getOptions().isCompactStorage());
+    }
+
+    @Test
+    public void testNoCompactStorage() throws BackendException {
+        final String cf = TEST_CF_NAME + "_nocompact";
+        final ModifiableConfiguration config = getBaseStorageConfiguration();
+        config.set(CF_COMPACT_STORAGE, false);
+
+        final CQLStoreManager cqlStoreManager = openStorageManager(config);
+        cqlStoreManager.openDatabase(cf);
+
+        assertFalse(cqlStoreManager.getTableMetadata(cf).getOptions().isCompactStorage());
+    }
+
+    @Test
     public void testDefaultCFCompressor() throws BackendException {
         final String cf = TEST_CF_NAME + "_snappy";
 

--- a/janusgraph-dist/src/assembly/cfilter/conf/janusgraph-cql-configurationgraph.properties
+++ b/janusgraph-dist/src/assembly/cfilter/conf/janusgraph-cql-configurationgraph.properties
@@ -1,0 +1,83 @@
+# JanusGraph configuration sample: Cassandra over a socket
+#
+# This file connects to a Cassandra daemon running on localhost via
+# CQL.  Cassandra must already be started before starting JanusGraph
+# with this file.
+
+gremlin.graph=org.janusgraph.core.ConfiguredGraphFactory
+
+# The primary persistence provider used by JanusGraph.  This is required. 
+# It should be set one of JanusGraph's built-in shorthand names for its
+# standard storage backends (shorthands: berkeleyje, cql, cassandrathrift,
+# cassandra, astyanax, embeddedcassandra, hbase, inmemory) or to the full
+# package and classname of a custom/third-party StoreManager
+# implementation.
+#
+# Default:    (no default value)
+# Data Type:  String
+# Mutability: LOCAL
+storage.backend=cql
+
+# The configuration management graph reserved for use with JanusGraphManager
+# and ConfiguredGraphFactory
+graph.graphname=ConfigurationManagementGraph
+# The hostname or comma-separated list of hostnames of storage backend
+# servers.  This is only applicable to some storage backends, such as
+# cassandra and hbase.
+#
+# Default:    127.0.0.1
+# Data Type:  class java.lang.String[]
+# Mutability: LOCAL
+storage.hostname=127.0.0.1
+
+# Whether to enable JanusGraph's database-level cache, which is shared
+# across all transactions. Enabling this option speeds up traversals by
+# holding hot graph elements in memory, but also increases the likelihood
+# of reading stale data.  Disabling it forces each transaction to
+# independently fetch graph elements from storage before reading/writing
+# them.
+#
+# Default:    false
+# Data Type:  Boolean
+# Mutability: MASKABLE
+cache.db-cache = true
+
+# How long, in milliseconds, database-level cache will keep entries after
+# flushing them.  This option is only useful on distributed storage
+# backends that are capable of acknowledging writes without necessarily
+# making them immediately visible.
+#
+# Default:    50
+# Data Type:  Integer
+# Mutability: GLOBAL_OFFLINE
+#
+# Settings with mutability GLOBAL_OFFLINE are centrally managed in
+# JanusGraph's storage backend.  After starting the database for the first
+# time, this file's copy of this setting is ignored.  Use JanusGraph's
+# Management System to read or modify this value after bootstrapping.
+cache.db-cache-clean-wait = 20
+
+# Default expiration time, in milliseconds, for entries in the
+# database-level cache. Entries are evicted when they reach this age even
+# if the cache has room to spare. Set to 0 to disable expiration (cache
+# entries live forever or until memory pressure triggers eviction when set
+# to 0).
+#
+# Default:    10000
+# Data Type:  Long
+# Mutability: GLOBAL_OFFLINE
+#
+# Settings with mutability GLOBAL_OFFLINE are centrally managed in
+# JanusGraph's storage backend.  After starting the database for the first
+# time, this file's copy of this setting is ignored.  Use JanusGraph's
+# Management System to read or modify this value after bootstrapping.
+cache.db-cache-time = 180000
+
+# Size of JanusGraph's database level cache.  Values between 0 and 1 are
+# interpreted as a percentage of VM heap, while larger values are
+# interpreted as an absolute size in bytes.
+#
+# Default:    0.3
+# Data Type:  Double
+# Mutability: MASKABLE
+cache.db-cache-size = 0.5

--- a/janusgraph-dist/src/assembly/cfilter/conf/janusgraph-cql-es.properties
+++ b/janusgraph-dist/src/assembly/cfilter/conf/janusgraph-cql-es.properties
@@ -1,0 +1,30 @@
+# JanusGraph configuration sample: Cassandra & Elasticsearch over sockets
+#
+# This file connects to Cassandra and Elasticsearch services running
+# on localhost over the CQL API and the Elasticsearch native
+# "Transport" API on their respective default ports.  The Cassandra
+# and Elasticsearch services must already be running before starting
+# JanusGraph with this file.
+
+gremlin.graph=org.janusgraph.core.JanusGraphFactory
+
+#JANUSGRAPHCFG{storage.backend=cql}
+
+#JANUSGRAPHCFG{storage.hostname=127.0.0.1}
+
+#JANUSGRAPHCFG{storage.cql.keyspace=janusgraph}
+
+#JANUSGRAPHCFG{cache.db-cache = true}
+
+#JANUSGRAPHCFG{cache.db-cache-clean-wait = 20}
+
+#JANUSGRAPHCFG{cache.db-cache-time = 180000}
+
+#JANUSGRAPHCFG{cache.db-cache-size = 0.25}
+
+# Connect to an already-running ES instance on localhost
+
+#JANUSGRAPHCFG{index.search.backend=elasticsearch}
+
+#JANUSGRAPHCFG{index.search.hostname=127.0.0.1}
+

--- a/janusgraph-dist/src/assembly/cfilter/conf/janusgraph-cql-solr.properties
+++ b/janusgraph-dist/src/assembly/cfilter/conf/janusgraph-cql-solr.properties
@@ -1,0 +1,32 @@
+# JanusGraph configuration sample: Cassandra & Solr over sockets
+#
+# This file connects to Cassandra and Solr services running on
+# localhost using the CQL API and the Solr HTTP API, respectively.
+# The Cassandra and Solr services must already be running before
+# starting JanusGraph with this file.
+
+gremlin.graph=org.janusgraph.core.JanusGraphFactory
+
+#JANUSGRAPHCFG{storage.backend=cql}
+
+#JANUSGRAPHCFG{storage.hostname=127.0.0.1}
+
+#JANUSGRAPHCFG{storage.cql.keyspace=janusgraph}
+
+#JANUSGRAPHCFG{cache.db-cache = true}
+
+#JANUSGRAPHCFG{cache.db-cache-clean-wait = 20}
+
+#JANUSGRAPHCFG{cache.db-cache-time = 180000}
+
+#JANUSGRAPHCFG{cache.db-cache-size = 0.25}
+
+# Configure a Solr backend named "search" at localhost:8983
+# and path prefix /solr/janusgraph.solr1.
+# The collection must already exist -- see the manual for info.
+
+#JANUSGRAPHCFG{index.search.backend=solr}
+
+#JANUSGRAPHCFG{index.search.solr.mode=http}
+
+#JANUSGRAPHCFG{index.search.solr.http-urls=http://localhost:8983/solr}

--- a/janusgraph-dist/src/assembly/cfilter/conf/janusgraph-cql.properties
+++ b/janusgraph-dist/src/assembly/cfilter/conf/janusgraph-cql.properties
@@ -10,6 +10,8 @@ gremlin.graph=org.janusgraph.core.JanusGraphFactory
 
 #JANUSGRAPHCFG{storage.hostname=127.0.0.1}
 
+#JANUSGRAPHCFG{storage.cql.keyspace=janusgraph}
+
 #JANUSGRAPHCFG{cache.db-cache = true}
 
 #JANUSGRAPHCFG{cache.db-cache-clean-wait = 20}

--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-configuration.yaml
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-configuration.yaml
@@ -4,7 +4,7 @@ scriptEvaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
 graphManager: org.janusgraph.graphdb.management.JanusGraphManager
 graphs: {
-  ConfigurationManagementGraph: conf/janusgraph-cassandra-configurationgraph.properties
+  ConfigurationManagementGraph: conf/janusgraph-cql-configurationgraph.properties
 }
 plugins:
   - janusgraph.imports

--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server.yaml
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server.yaml
@@ -3,7 +3,7 @@ port: 8182
 scriptEvaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
 graphs: {
-  graph: conf/gremlin-server/janusgraph-cassandra-es-server.properties
+  graph: conf/gremlin-server/janusgraph-cql-es-server.properties
 }
 plugins:
   - janusgraph.imports

--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/janusgraph-cql-es-server.properties
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/janusgraph-cql-es-server.properties
@@ -1,0 +1,140 @@
+gremlin.graph=org.janusgraph.core.JanusGraphFactory
+
+# JanusGraph configuration sample: Cassandra & Elasticsearch over sockets
+#
+# This file connects to Cassandra and Elasticsearch services running
+# on localhost over the CQL API and the Elasticsearch native
+# "Transport" API on their respective default ports.  The Cassandra
+# and Elasticsearch services must already be running before starting
+# JanusGraph with this file.
+
+# The primary persistence provider used by JanusGraph.  This is required.  It
+# should be set one of JanusGraph's built-in shorthand names for its standard
+# storage backends or to the full package and classname of a custom/third-party
+# StoreManager implementation.
+#
+# Default:    (no default value)
+# Data Type:  String
+# Mutability: LOCAL
+storage.backend=cql
+
+# The hostname or comma-separated list of hostnames of storage backend
+# servers.  This is only applicable to some storage backends, such as
+# cassandra and hbase.
+#
+# Default:    127.0.0.1
+# Data Type:  class java.lang.String[]
+# Mutability: LOCAL
+storage.hostname=127.0.0.1
+
+# The name of JanusGraph's keyspace.  It will be created if it does not
+# exist.
+#
+# Default:    janusgraph
+# Data Type:  String
+# Mutability: LOCAL
+storage.cql.keyspace=janusgraph
+
+# Whether to enable JanusGraph's database-level cache, which is shared across
+# all transactions. Enabling this option speeds up traversals by holding
+# hot graph elements in memory, but also increases the likelihood of
+# reading stale data.  Disabling it forces each transaction to
+# independently fetch graph elements from storage before reading/writing
+# them.
+#
+# Default:    false
+# Data Type:  Boolean
+# Mutability: MASKABLE
+cache.db-cache = true
+
+# How long, in milliseconds, database-level cache will keep entries after
+# flushing them.  This option is only useful on distributed storage
+# backends that are capable of acknowledging writes without necessarily
+# making them immediately visible.
+#
+# Default:    50
+# Data Type:  Integer
+# Mutability: GLOBAL_OFFLINE
+#
+# Settings with mutability GLOBAL_OFFLINE are centrally managed in JanusGraph's
+# storage backend.  After starting the database for the first time, this
+# file's copy of this setting is ignored.  Use JanusGraph's Management System
+# to read or modify this value after bootstrapping.
+cache.db-cache-clean-wait = 20
+
+# Default expiration time, in milliseconds, for entries in the
+# database-level cache. Entries are evicted when they reach this age even
+# if the cache has room to spare. Set to 0 to disable expiration (cache
+# entries live forever or until memory pressure triggers eviction when set
+# to 0).
+#
+# Default:    10000
+# Data Type:  Long
+# Mutability: GLOBAL_OFFLINE
+#
+# Settings with mutability GLOBAL_OFFLINE are centrally managed in JanusGraph's
+# storage backend.  After starting the database for the first time, this
+# file's copy of this setting is ignored.  Use JanusGraph's Management System
+# to read or modify this value after bootstrapping.
+cache.db-cache-time = 180000
+
+# Size of JanusGraph's database level cache.  Values between 0 and 1 are
+# interpreted as a percentage of VM heap, while larger values are
+# interpreted as an absolute size in bytes.
+#
+# Default:    0.3
+# Data Type:  Double
+# Mutability: MASKABLE
+cache.db-cache-size = 0.25
+
+# Connect to an already-running ES instance on localhost
+
+# The indexing backend used to extend and optimize JanusGraph's query
+# functionality. This setting is optional.  JanusGraph can use multiple
+# heterogeneous index backends.  Hence, this option can appear more than
+# once, so long as the user-defined name between "index" and "backend" is
+# unique among appearances.Similar to the storage backend, this should be
+# set to one of JanusGraph's built-in shorthand names for its standard index
+# backends (shorthands: lucene, elasticsearch, es, solr) or to the full
+# package and classname of a custom/third-party IndexProvider
+# implementation.
+#
+# Default:    elasticsearch
+# Data Type:  String
+# Mutability: GLOBAL_OFFLINE
+#
+# Settings with mutability GLOBAL_OFFLINE are centrally managed in JanusGraph's
+# storage backend.  After starting the database for the first time, this
+# file's copy of this setting is ignored.  Use JanusGraph's Management System
+# to read or modify this value after bootstrapping.
+index.search.backend=elasticsearch
+
+# The hostname or comma-separated list of hostnames of index backend
+# servers.  This is only applicable to some index backends, such as
+# elasticsearch and solr.
+#
+# Default:    127.0.0.1
+# Data Type:  class java.lang.String[]
+# Mutability: MASKABLE
+index.search.hostname=127.0.0.1
+
+# The Elasticsearch node.client option is set to this boolean value, and
+# the Elasticsearch node.data option is set to the negation of this value.
+# True creates a thin client which holds no data.  False creates a regular
+# Elasticsearch cluster node that may store data.
+#
+# Default:    true
+# Data Type:  Boolean
+# Mutability: GLOBAL_OFFLINE
+#
+# Settings with mutability GLOBAL_OFFLINE are centrally managed in JanusGraph's
+# storage backend.  After starting the database for the first time, this
+# file's copy of this setting is ignored.  Use JanusGraph's Management System
+# to read or modify this value after bootstrapping.
+index.search.elasticsearch.client-only=true
+
+# Or start ES inside the JanusGraph JVM
+#index.search.backend=elasticsearch
+#index.search.directory=db/es
+#index.search.elasticsearch.client-only=false
+#index.search.elasticsearch.local-mode=true

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <tinkerpop.version>3.2.9</tinkerpop.version>
         <junit.version>4.12</junit.version>
         <mrunit.version>1.1.0</mrunit.version>
-        <cassandra.version>2.1.18</cassandra.version>
+        <cassandra.version>2.1.20</cassandra.version>
         <jamm.version>0.3.0</jamm.version>
         <metrics2.version>2.1.2</metrics2.version>
         <metrics3.version>3.0.1</metrics3.version>


### PR DESCRIPTION
Fixes #1023

Signed-off-by: Jason Plurad <pluradj@us.ibm.com>

* Added compact storage option for Cassandra 2 and earlier only. Default is to use compact storage when using Cassandra 2 and earlier, maintaining the previous behavior.
* Updated docs to prefer CQL over Thrift going forward.
* Updated to Cassandra 2.1.20.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there an issue associated with this PR? Is it referenced in the commit message?
- [X] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you written and/or updated unit tests to verify your changes?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

