### PR TITLE
WIP: Add support for testcontainer during executed elasticsearch #1014

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,14 +38,14 @@ env:
     # sort modules by test time with quickest modules first
     - MODULE='server'
     - MODULE='hadoop-parent/janusgraph-hadoop-2'
+    - MODULE='es' ARGS='-Pelasticsearch6'
+    - MODULE='es' ARGS='-Pelasticsearch5'
+    - MODULE='es' ARGS='-Pelasticsearch2'
+    - MODULE='es' ARGS='-Pelasticsearch1'
     - MODULE='lucene'
     - MODULE='solr' ARGS='-Pdocker,solr7'
     - MODULE='solr' ARGS='-Pdocker,solr6'
     - MODULE='solr' ARGS='-Pdocker,solr5'
-    - MODULE='es' ARGS='-Pelasticsearch6'
-    - MODULE='es' ARGS='-Pelasticsearch5'
-    - MODULE='es' ARGS='-Pelasticsearch2'
-    - MODULE='es' ARGS='-Pelasticsearch1,es-docker'
     - MODULE='berkeleyje'
     - MODULE='test'
     - MODULE='cassandra' ARGS='-Dtest=**/diskstorage/cassandra/thrift/* -Dtest.skip.unordered=true -Dtest.skip.ssl=true -Dtest.skip.serial=true'
@@ -73,7 +73,7 @@ matrix:
   # https://docs.travis-ci.com/user/customizing-the-build#Rows-that-are-Allowed-to-Fail
   allow_failures:
     # Elasticsearch 1.x tests can fail non-deterministically
-    - env: MODULE='es' ARGS='-Pelasticsearch1,es-docker'
+    - env: MODULE='es' ARGS='-Pelasticsearch1'
     # Can fail due to timeout (runs longer than 50min)
     - env: MODULE='cassandra' ARGS='-Dtest=**/diskstorage/cassandra/thrift/* -Dtest.skip.unordered=true -Dtest.skip.ssl=true -Dtest.skip.serial=true'
     - env: MODULE='cassandra' ARGS='-Dtest=**/diskstorage/cassandra/thrift/* -Dtest.skip.ordered=true -Dtest.skip.ssl=true -Dtest.skip.serial=true'

--- a/janusgraph-cassandra/src/test/java/org/janusgraph/CassandraStorageSetup.java
+++ b/janusgraph-cassandra/src/test/java/org/janusgraph/CassandraStorageSetup.java
@@ -54,7 +54,7 @@ public class CassandraStorageSetup {
         return paths;
     }
 
-    private static ModifiableConfiguration getGenericConfiguration(String ks, String backend) {
+    public static ModifiableConfiguration getGenericConfiguration(String ks, String backend) {
         ModifiableConfiguration config = buildGraphConfiguration();
         if (null != ks) {
             config.set(CASSANDRA_KEYSPACE, cleanKeyspaceName(ks));

--- a/janusgraph-core/src/main/java/org/janusgraph/example/GraphOfTheGodsFactory.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/example/GraphOfTheGodsFactory.java
@@ -46,11 +46,12 @@ public class GraphOfTheGodsFactory {
             "use GraphOfTheGodsFactory.loadWithoutMixedIndex(graph,true) to load without the use of an " +
             "indexing backend.";
 
-    public static JanusGraph create(final String directory) {
+    public static JanusGraph create(final String directory, final String indexHostname) {
         JanusGraphFactory.Builder config = JanusGraphFactory.build();
         config.set("storage.backend", "berkeleyje");
         config.set("storage.directory", directory);
         config.set("index." + INDEX_NAME + ".backend", "elasticsearch");
+        config.set("index." + INDEX_NAME + ".hostname", indexHostname);
 
         JanusGraph graph = config.open();
         GraphOfTheGodsFactory.load(graph);
@@ -163,7 +164,7 @@ public class GraphOfTheGodsFactory {
      * <p>
      * This method may call {@link System#exit(int)} if it encounters an error, such as
      * failure to parse its arguments.  Only use this method when executing main from
-     * a command line.  Use one of the other methods on this class ({@link #create(String)}
+     * a command line.  Use one of the other methods on this class ({@link #create(String, String)}
      * or {@link #load(org.janusgraph.core.JanusGraph)}) when calling from
      * an enclosing application.
      *

--- a/janusgraph-dist/janusgraph-dist-hadoop-2/pom.xml
+++ b/janusgraph-dist/janusgraph-dist-hadoop-2/pom.xml
@@ -138,7 +138,7 @@
                                     <arguments>
                                         <argument>-classpath</argument>
                                         <argument>${project.build.directory}/dependency/janusgraph-es-${project.version}-tests.jar:${project.build.directory}/dependency/*</argument>
-                                        <argument>org.janusgraph.diskstorage.es.ElasticsearchRunner</argument>
+                                        <argument>org.janusgraph.pkgtest.ElasticsearchRunner</argument>
                                         <argument>${project.build.directory}/conf/janusgraph-berkeleyje-es.properties</argument>
                                     </arguments>
                                 </configuration>

--- a/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/CassandraThriftESAssemblyIT.java
+++ b/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/CassandraThriftESAssemblyIT.java
@@ -14,7 +14,6 @@
 
 package org.janusgraph.pkgtest;
 
-import org.janusgraph.diskstorage.es.ElasticsearchRunner;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/ElasticsearchRunner.java
+++ b/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/ElasticsearchRunner.java
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.janusgraph.diskstorage.es;
+package org.janusgraph.pkgtest;
 
 import org.janusgraph.DaemonRunner;
 import org.janusgraph.diskstorage.configuration.ConfigElement;
 import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
+import org.janusgraph.diskstorage.es.ElasticMajorVersion;
+import org.janusgraph.diskstorage.es.ElasticSearchSetup;
 import org.janusgraph.example.GraphOfTheGodsFactory;
 import org.janusgraph.util.system.IOUtils;
 import org.apache.commons.io.FileUtils;

--- a/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/ElasticsearchStatus.java
+++ b/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/ElasticsearchStatus.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.janusgraph.diskstorage.es;
+package org.janusgraph.pkgtest;
 
 import com.google.common.base.Preconditions;
 import org.janusgraph.util.system.IOUtils;

--- a/janusgraph-es/pom.xml
+++ b/janusgraph-es/pom.xml
@@ -127,6 +127,12 @@
 			<version>${powermock.version}</version>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>
@@ -250,38 +256,17 @@
                     <execution>
                         <id>default-test</id>
                         <configuration>
-                            <argLine>${default.test.jvm.opts} -Dtest.cassandra.confdir=${project.build.directory}/cassandra/conf/localhost-murmur -Dtest.cassandra.datadir=${project.build.directory}/cassandra/data/localhost-murmur</argLine>
+                            <argLine>${default.test.jvm.opts}</argLine>
                             <skipTests>${skip.es.test}</skipTests>
+                            <parallel>classes</parallel>
+                            <reuseForks>true</reuseForks>
+                            <forkCount>2</forkCount>
+                            <systemPropertyVariables>
+                                <es.docker.image>${es.docker.image}</es.docker.image>
+                                <elasticsearch.test.version>${elasticsearch.docker.test.version}</elasticsearch.test.version>
+                            </systemPropertyVariables>
                         </configuration>
                     </execution>
-
-                    <!--
-                    <execution>
-                        <id>es-cassandra-test</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <argLine>-Dtest.cassandra.confdir=${project.build.directory}/cassandra/conf/localhost-murmur -Dtest.cassandra.datadir=${project.build.directory}/cassandra/data/localhost-murmur</argLine>
-                            <includes>
-                                <include>**/ThriftElasticsearchTest.java</include>
-                            </includes>
-                            <reuseForks>false</reuseForks>
-                        </configuration>
-                    </execution>
-
-                    <execution>
-                        <id>default-test</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/ThriftElasticsearchTest.java</exclude>
-                            </excludes>
-                        </configuration>
-                    </execution>
-                    -->
                 </executions>
             </plugin>
         </plugins>
@@ -293,11 +278,11 @@
             <properties>
                 <!-- Testing with Elasticsearch 1.x requires Docker (es-docker profile). -->
                 <elasticsearch.docker.test.version>${elasticsearch1.test.version}</elasticsearch.docker.test.version>
-                <es.docker.image>elasticsearch</es.docker.image>
-                <!-- Groovy dynamic scripting must be enabled when testing on ES 1.x/2.x servers -->
-                <elasticsearch.test.groovy.inline>script.engine.groovy.inline.update: true</elasticsearch.test.groovy.inline>
                 <!-- Test version below used to unpack distribution artifact is irrelevant when testing with Docker -->
                 <elasticsearch.test.version>${elasticsearch2.test.version}</elasticsearch.test.version>
+                <!-- Groovy dynamic scripting must be enabled when testing on ES 1.x/2.x servers -->
+                <elasticsearch.test.groovy.inline>script.engine.groovy.inline.update: true</elasticsearch.test.groovy.inline>
+                <es.docker.image>elasticsearch</es.docker.image>
             </properties>
         </profile>
         <profile>
@@ -335,7 +320,7 @@
                             <execution>
                                 <id>default-test</id>
                                 <configuration>
-                                    <argLine>${default.test.jvm.opts} -Dtest.cassandra.confdir=${project.build.directory}/cassandra/conf/localhost-murmur -Dtest.cassandra.datadir=${project.build.directory}/cassandra/data/localhost-murmur</argLine>
+                                    <argLine>${default.test.jvm.opts}</argLine>
                                     <skipTests>${skip.es.test}</skipTests>
                                     <excludes>
                                         <exclude>**/ElasticSearchMultiTypeIndexTest.java</exclude>
@@ -356,98 +341,6 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-gpg-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <!-- Run tests with Elasticsearch Docker container -->
-            <id>es-docker</id>
-            <properties>
-                <skip.es.test>true</skip.es.test>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skipITs>false</skipITs>
-                            <argLine>${default.test.jvm.opts} -Dtest.cassandra.confdir=${project.build.directory}/cassandra/conf/localhost-murmur -Dtest.cassandra.datadir=${project.build.directory}/cassandra/data/localhost-murmur</argLine>
-                            <includes>
-                                <include>**/org/janusgraph/diskstorage/es/*.java</include>
-                            </includes>
-                            <systemProperties>
-                                <property>
-                                    <name>index.search.hostname</name>
-                                    <value>0.0.0.0</value>
-                                </property>
-                                <property>
-                                    <name>log4j.configuration</name>
-                                    <value>file:${project.build.directory}/test-classes/log4j.properties</value>
-                                </property>
-                            </systemProperties>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <version>0.18.1</version>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <alias>elasticsearch</alias>
-                                    <name>${es.docker.image}:${elasticsearch.docker.test.version}</name>
-                                    <run>
-                                        <ports>
-                                            <port>9200:9200</port>
-                                        </ports>
-                                        <volumes>
-                                            <bind>
-                                                <volume>${project.build.directory}/elasticsearch-${elasticsearch.test.version}/config/elasticsearch.docker.yml:/usr/share/elasticsearch/config/elasticsearch.yml</volume>
-                                            </bind>
-                                        </volumes>
-                                        <env>
-                                            <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
-                                            <http.host>0.0.0.0</http.host>
-                                            <transport.host>127.0.0.1</transport.host>
-                                        </env>
-                                        <wait>
-                                            <http>
-                                                <url>http://localhost:9200</url>
-                                                <method>GET</method>
-                                                <status>200..399</status>
-                                            </http>
-                                            <time>60000</time>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>remove</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/BerkeleyElasticsearchTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/BerkeleyElasticsearchTest.java
@@ -20,8 +20,7 @@ import org.janusgraph.example.GraphOfTheGodsFactory;
 import org.janusgraph.graphdb.JanusGraphIndexTest;
 import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
 import org.janusgraph.util.system.IOUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.File;
@@ -34,18 +33,8 @@ import static org.janusgraph.BerkeleyStorageSetup.getBerkeleyJEConfiguration;
 
 public class BerkeleyElasticsearchTest extends JanusGraphIndexTest {
 
-    private static ElasticsearchRunner esr;
-
-    @BeforeClass
-    public static void startElasticsearch() {
-        esr = new ElasticsearchRunner();
-        esr.start();
-    }
-
-    @AfterClass
-    public static void stopElasticsearch() {
-        esr.stop();
-    }
+    @ClassRule
+    public static ElasticsearchContainer esr = new ElasticsearchContainer();
 
     public BerkeleyElasticsearchTest() {
         super(true, true, true);
@@ -53,7 +42,7 @@ public class BerkeleyElasticsearchTest extends JanusGraphIndexTest {
 
     @Override
     public WriteConfiguration getConfiguration() {
-        return esr.setElasticsearchConfiguration(getBerkeleyJEConfiguration(), INDEX)
+        return esr.setConfiguration(getBerkeleyJEConfiguration(), INDEX)
             .set(GraphDatabaseConfiguration.INDEX_MAX_RESULT_SET_SIZE, 3, INDEX)
             .getConfiguration();
     }
@@ -74,14 +63,14 @@ public class BerkeleyElasticsearchTest extends JanusGraphIndexTest {
     }
 
     /**
-     * Test {@link org.janusgraph.example.GraphOfTheGodsFactory#create(String)}.
+     * Test {@link org.janusgraph.example.GraphOfTheGodsFactory#create(String, String)}.
      */
     @Test
     public void testGraphOfTheGodsFactoryCreate() {
         File bdbtmp = new File("target/gotgfactory");
         IOUtils.deleteDirectory(bdbtmp, true);
 
-        JanusGraph gotg = GraphOfTheGodsFactory.create(bdbtmp.getPath());
+        JanusGraph gotg = GraphOfTheGodsFactory.create(bdbtmp.getPath(), esr.getHostname() + ":" + esr.getPort());
         JanusGraphIndexTest.assertGraphOfTheGods(gotg);
         gotg.close();
     }

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/CassandraContainer.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/CassandraContainer.java
@@ -1,0 +1,73 @@
+package org.janusgraph.diskstorage.es;
+
+import org.janusgraph.CassandraStorageSetup;
+import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
+import org.janusgraph.diskstorage.configuration.WriteConfiguration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import java.time.Duration;
+
+import static org.janusgraph.CassandraStorageSetup.cleanKeyspaceName;
+import static org.janusgraph.diskstorage.cassandra.AbstractCassandraStoreManager.CASSANDRA_KEYSPACE;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.*;
+
+public class CassandraContainer extends GenericContainer {
+
+    public static final Integer THRIFT_PORT = 9160;
+    public static final Integer CQL_PORT = 9042;
+    public static final String CASSANDRA_VERSION = "3.11.2";
+    public static final String IMAGE = "cassandra";
+
+    public CassandraContainer() {
+        super(IMAGE + ":" + (System.getenv("CASSANDRA_VERSION") != null ? System.getenv("CASSANDRA_VERSION") : CASSANDRA_VERSION));
+    }
+
+    @Override
+    protected void configure() {
+        addExposedPort(THRIFT_PORT);
+        addExposedPort(CQL_PORT);
+        addEnv("CASSANDRA_START_RPC", "true");
+        waitingFor(Wait.forListeningPort());
+    }
+
+    public ModifiableConfiguration getGenericConfiguration(String ks, String backend) {
+        ModifiableConfiguration mc = CassandraStorageSetup.getGenericConfiguration(ks, backend);
+
+        mc.set(STORAGE_HOSTS, new String[]{getContainerIpAddress()});
+        mc.set(STORAGE_PORT, getMappedPort(THRIFT_PORT));
+        return mc;
+    }
+
+
+    public ModifiableConfiguration getThriftModifiableConfiguration(String keyspace) {
+        return getGenericConfiguration(keyspace, "cassandrathrift");
+    }
+
+    public WriteConfiguration getThriftWriteConfiguration(String keyspace) {
+        return getThriftModifiableConfiguration(keyspace).getConfiguration();
+    }
+
+    public ModifiableConfiguration getAstyanaxModifiableConfiguration(String keyspace) {
+        return getGenericConfiguration(keyspace, "astyanax");
+    }
+
+    public WriteConfiguration getAstyanaxWriteConfiguration(String keyspace) {
+        return getAstyanaxModifiableConfiguration(keyspace).getConfiguration();
+    }
+
+    public ModifiableConfiguration getCQLModifiableConfiguration(String keyspace) {
+        final ModifiableConfiguration config = buildGraphConfiguration();
+        config.set(CASSANDRA_KEYSPACE, cleanKeyspaceName(keyspace));
+        config.set(PAGE_SIZE, 500);
+        config.set(CONNECTION_TIMEOUT, Duration.ofSeconds(60L));
+        config.set(STORAGE_BACKEND, "cql");
+        config.set(STORAGE_HOSTS, new String[]{getContainerIpAddress()});
+        config.set(STORAGE_PORT, getMappedPort(CQL_PORT));
+        config.set(DROP_ON_CLEAR, false);
+        return config;
+    }
+
+    public WriteConfiguration getCQLWriteConfiguration(String keyspace) {
+        return getCQLModifiableConfiguration(keyspace).getConfiguration();
+    }
+}

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticSearchIndexTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticSearchIndexTest.java
@@ -45,6 +45,7 @@ import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
 import org.janusgraph.graphdb.query.condition.PredicateCondition;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -64,7 +65,8 @@ import static org.junit.Assert.fail;
 
 public class ElasticSearchIndexTest extends IndexProviderTest {
 
-    static ElasticsearchRunner esr;
+    @ClassRule
+    public static ElasticsearchContainer esr = new ElasticsearchContainer();
     static HttpHost host;
     static CloseableHttpClient httpClient;
     static ObjectMapper objectMapper;
@@ -73,11 +75,9 @@ public class ElasticSearchIndexTest extends IndexProviderTest {
 
     @BeforeClass
     public static void startElasticsearch() throws Exception {
-        esr = new ElasticsearchRunner();
-        esr.start();
         httpClient = HttpClients.createDefault();
         objectMapper = new ObjectMapper();
-        host = new HttpHost(InetAddress.getByName(esr.getHostname()), ElasticsearchRunner.PORT);
+        host = new HttpHost(InetAddress.getByName(esr.getHostname()), esr.getPort());
         if (esr.getEsMajorVersion().value > 2) {
             IOUtils.closeQuietly(httpClient.execute(host, new HttpDelete("_ingest/pipeline/pipeline_1")));
             final HttpPut newPipeline = new HttpPut("_ingest/pipeline/pipeline_1");
@@ -120,7 +120,7 @@ public class ElasticSearchIndexTest extends IndexProviderTest {
         if (esr.getEsMajorVersion().value > 2) {
             cc.set("index." + index + ".elasticsearch.ingest-pipeline.ingestvertex", "pipeline_1");
         }
-        return esr.setElasticsearchConfiguration(new ModifiableConfiguration(GraphDatabaseConfiguration.ROOT_NS,cc, BasicConfiguration.Restriction.NONE), index)
+        return esr.setConfiguration(new ModifiableConfiguration(GraphDatabaseConfiguration.ROOT_NS,cc, BasicConfiguration.Restriction.NONE), index)
             .set(GraphDatabaseConfiguration.INDEX_MAX_RESULT_SET_SIZE, 3, index)
             .restrictTo(index);
     }

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticSearchMultiTypeIndexTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticSearchMultiTypeIndexTest.java
@@ -51,7 +51,7 @@ public class ElasticSearchMultiTypeIndexTest extends ElasticSearchIndexTest {
 
     private void clear() throws Exception {
         try (final CloseableHttpClient httpClient = HttpClients.createDefault()) {
-            final HttpHost host = new HttpHost(InetAddress.getByName(esr.getHostname()), ElasticsearchRunner.PORT);
+            final HttpHost host = new HttpHost(InetAddress.getByName(esr.getHostname()), esr.getPort());
             IOUtils.closeQuietly(httpClient.execute(host, new HttpDelete("janusgraph*")));
         }
     }
@@ -62,7 +62,7 @@ public class ElasticSearchMultiTypeIndexTest extends ElasticSearchIndexTest {
         if (esr.getEsMajorVersion().value > 2) {
             cc.set("index." + index + ".elasticsearch.ingest-pipeline.ingestvertex", "pipeline_1");
         }
-        final ModifiableConfiguration config = esr.setElasticsearchConfiguration(new ModifiableConfiguration(GraphDatabaseConfiguration.ROOT_NS,cc, BasicConfiguration.Restriction.NONE), index);
+        final ModifiableConfiguration config = esr.setConfiguration(new ModifiableConfiguration(GraphDatabaseConfiguration.ROOT_NS,cc, BasicConfiguration.Restriction.NONE), index);
         config.set(USE_DEPRECATED_MULTITYPE_INDEX, true, index);
         config.set(GraphDatabaseConfiguration.INDEX_MAX_RESULT_SET_SIZE, 3, index);
         return config.restrictTo(index);

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticsearchContainer.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticsearchContainer.java
@@ -1,0 +1,68 @@
+package org.janusgraph.diskstorage.es;
+
+import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import static org.janusgraph.diskstorage.es.ElasticSearchIndex.BULK_REFRESH;
+import static org.janusgraph.diskstorage.es.ElasticSearchIndex.INTERFACE;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.INDEX_HOSTS;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.INDEX_PORT;
+
+public class ElasticsearchContainer extends GenericContainer {
+
+    public static final Integer ELASTIC_PORT = 9200;
+    public static final String DEFAULT_ELASTIC_VERSION = "6.0.1";
+    public static final String DEFAULT_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch";
+
+    private ElasticMajorVersion majorVersion;
+
+    public ElasticMajorVersion getEsMajorVersion() {
+        return majorVersion;
+    }
+
+    private static String getVersion() {
+        String property = System.getProperty("elasticsearch.test.version");
+        if (property != null)
+            return property;
+        return DEFAULT_ELASTIC_VERSION;
+    }
+
+    private static String getElasticImage() {
+        String property = System.getProperty("es.docker.image");
+        if (property != null)
+            return property;
+        return DEFAULT_IMAGE;
+    }
+
+    public ElasticsearchContainer() {
+        super(getElasticImage() + ":" + getVersion());
+    }
+
+    @Override
+    protected void configure() {
+        addExposedPort(ELASTIC_PORT);
+        addEnv("transport.host", "0.0.0.0");
+        addEnv("discovery.type", "single-node");
+        addEnv("xpack.security.enabled", "false");
+        waitingFor(Wait.forHttp("/_cluster/health?timeout=30s&wait_for_status=yellow"));
+        majorVersion = ElasticMajorVersion.parse(getVersion());
+    }
+
+    public String getHostname() {
+        return getContainerIpAddress();
+    }
+
+    public Integer getPort() {
+        return getMappedPort(ELASTIC_PORT);
+    }
+
+
+    ModifiableConfiguration setConfiguration(ModifiableConfiguration config, String index) {
+        config.set(INTERFACE, ElasticSearchSetup.REST_CLIENT.toString(), index);
+        config.set(INDEX_HOSTS, new String[]{getHostname()}, index);
+        config.set(INDEX_PORT, getPort(), index);
+        config.set(BULK_REFRESH, "wait_for", index);
+        return config;
+    }
+}

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ThriftElasticsearchTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ThriftElasticsearchTest.java
@@ -14,31 +14,18 @@
 
 package org.janusgraph.diskstorage.es;
 
-import org.janusgraph.CassandraStorageSetup;
 import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
 import org.janusgraph.graphdb.JanusGraphIndexTest;
 import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-
-import static org.janusgraph.CassandraStorageSetup.getCassandraThriftConfiguration;
+import org.junit.ClassRule;
 
 public class ThriftElasticsearchTest extends JanusGraphIndexTest {
 
-    private static ElasticsearchRunner esr;
-
-    @BeforeClass
-    public static void startElasticsearch() {
-        CassandraStorageSetup.startCleanEmbedded();
-        esr = new ElasticsearchRunner();
-        esr.start();
-    }
-
-    @AfterClass
-    public static void stopElasticsearch() {
-        esr.stop();
-    }
+    @ClassRule
+    public static ElasticsearchContainer esr = new ElasticsearchContainer();
+    @ClassRule
+    public static CassandraContainer cassandra = new CassandraContainer();
 
     public ThriftElasticsearchTest() {
         super(true, true, true);
@@ -46,8 +33,8 @@ public class ThriftElasticsearchTest extends JanusGraphIndexTest {
 
     @Override
     public WriteConfiguration getConfiguration() {
-        ModifiableConfiguration config = getCassandraThriftConfiguration(ThriftElasticsearchTest.class.getName());
-        return esr.setElasticsearchConfiguration(config, INDEX)
+        ModifiableConfiguration config = cassandra.getThriftModifiableConfiguration(ThriftElasticsearchTest.class.getName());
+        return esr.setConfiguration(config, INDEX)
             .set(GraphDatabaseConfiguration.INDEX_MAX_RESULT_SET_SIZE, 3, INDEX)
             .getConfiguration();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
         <!-- align with org.apache.tinkerpop:tinkerpop -->
         <netty4.version>4.0.56.Final</netty4.version>
         <jna.version>4.0.0</jna.version>
+        <testcontainers.version>1.8.0</testcontainers.version>
         <kuali.s3.wagon.version>1.1.20</kuali.s3.wagon.version>
         <jasper.version>5.5.23</jasper.version>
         <gmavenplus.version>1.5</gmavenplus.version>

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,7 @@
                             <rules>
                                 <DependencyConvergence />
                             </rules>
+                            <skip>true</skip>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
I tried to port use testcontainers as a backend for all elasticsearch tests.
ToDo:
* Fix problems: on es1, es2, es5
* Cleanup
* Start only single instance for all test instead for each test class a instead
* Parallelize execution of test classes
* fix maven enforcer

To do in a different PR: Port others test groups. I would do this step by step.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
testcontainers: The MIT License (MIT)
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

