### PR TITLE
Issue #1157: fix REINDEX delay on the newly created index in empty DB

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/StandardScannerExecutor.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/StandardScannerExecutor.java
@@ -145,7 +145,12 @@ class StandardScannerExecutor extends AbstractFuture<ScanMetrics> implements Jan
                     SliceResult qr = queue.poll(10,TimeUnit.MILLISECONDS); //Try very short time to see if we are done
                     if (qr==null) {
                         if (pullThreads[i].isFinished()) continue; //No more data to be expected
-                        qr = queue.poll(TIMEOUT_MS,TimeUnit.MILLISECONDS); //otherwise, give it more time
+                        // otherwise, try more times until pullThreads[i] is Finished or qr != null or reach max retryTime
+                        int retryCount = 0;
+                        while (!pullThreads[i].isFinished() && retryCount < TIMEOUT_MS / 10 && qr == null){
+                            retryCount ++;
+                            qr = queue.poll(10, TimeUnit.MILLISECONDS);
+                        }
                         if (qr==null && !pullThreads[i].isFinished())
                             throw new TemporaryBackendException("Timed out waiting for next row data - storage error likely");
                     }


### PR DESCRIPTION
### fix issue [#1157](https://github.com/JanusGraph/janusgraph/issues/1157)


fix a problem about reindex on the newly created index in empty DB, waiting for reading from a empty DB for 3 mins is Unnecessary

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

