### PR TITLE
Issue #1200: Update traversal source map in JanusGraphManager when new graph is dynamically created

### DIFF
--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/JanusGraphChannelizerTest.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/JanusGraphChannelizerTest.java
@@ -16,6 +16,9 @@ package org.janusgraph.graphdb.tinkerpop;
 
 import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Cluster;
+import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import java.util.concurrent.ExecutionException;
 
 import org.junit.Test;
@@ -56,6 +59,9 @@ public class JanusGraphChannelizerTest extends AbstractGremlinServerIntegrationT
             //assert newGraph_traversal is bound and the graphs are equivalent
             assertEquals("newGraph", client.submit("newGraph_traversal.getGraph().getGraphName()").all().get().get(0).getString());
 
+            // Ensure that we can open a remote graph traversal source against the created graph, and execute traversals
+            GraphTraversalSource newGraphTraversal = EmptyGraph.instance().traversal().withRemote(DriverRemoteConnection.using(cluster, "newGraph_traversal"));
+            assertEquals(0, newGraphTraversal.V().count().next().longValue());
         } finally {
             cluster.close();
         }


### PR DESCRIPTION
Fixes issue #1200  

@dpitera When a new graph is created using the JanusGraphManager, the graph and its traversal source are added to the script engine's global variable bindings, but the traversal is not added to the graph manager's map of registered traversal sources; this prevents a client from creating a remote traversal object (using `GraphTraversalSource.withRemote()`) or from creating an aliased Gremlin Server client (using `Client.alias()`). This PR addresses that.

(Aside) I'm just getting the CLA process started on my end, so it may be some time for that to get addressed.

Signed-off-by: Paul Khermouch <paul.khermouch@civitaslearning.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

