### PR TITLE
formatting fix to resolve travis-ci failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,17 +92,13 @@ matrix:
 install:
   - if [ "${TRAVIS_BRANCH}" == "${COVERITY_BRANCH_NAME}" ] && ! [ -z "${COVERITY_ONLY:-}" ]; then
       echo "Building all modules for Coverity analysis";
-      travis_retry travis_wait \
-          mvn install -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode --show-version;
+      travis_retry travis_wait mvn install -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode --show-version;
     elif [ "${TRAVIS_BRANCH}" == "${COVERITY_BRANCH_NAME}" ] || ! [ -z "${COVERITY_ONLY:-}" ]; then
       echo "Building all modules for test-compile coverage, but skipping Coverity upload";
-      travis_retry travis_wait \
-          mvn install -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode --show-version;
+      travis_retry travis_wait mvn install -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode --show-version;
     else
       echo "Building janusgraph-${MODULE} and dependencies";
-      travis_retry travis_wait \
-          mvn install --projects janusgraph-${MODULE} --also-make \
-          -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode --show-version;
+      travis_retry travis_wait mvn install --projects janusgraph-${MODULE} --also-make -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode --show-version;
     fi
 
 script:
@@ -120,8 +116,7 @@ script:
       echo "Skipping module tests on Coverity branch/job";
     else
       echo "Testing janusgraph-${MODULE}";
-      travis_retry travis_wait 50 \
-          mvn clean verify --projects janusgraph-${MODULE} -Pcoverage ${ARGS};
+      travis_retry travis_wait 50 mvn clean verify --projects janusgraph-${MODULE} -Pcoverage ${ARGS};
     fi
 
 after_success:


### PR DESCRIPTION
Signed-off-by: Chris Hupman <chupman@us.ibm.com>

After opening an issue, travis-ci/travis-ci#10111, it was pointed out that a space was getting placed before the mvn commands. 

I verified the fix on my [fork](https://travis-ci.org/chupman/janusgraph/builds/427963484)

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

