### PR TITLE
#1261 Makes Janusgraph docker run as a non-privileged user

### DIFF
--- a/janusgraph-dist/janusgraph-dist-hadoop-2/Dockerfile
+++ b/janusgraph-dist/janusgraph-dist-hadoop-2/Dockerfile
@@ -6,6 +6,15 @@ ADD ${server_zip} /var
 RUN apt-get update -y && apt-get install -y zip && \
     server_base=`basename ${server_zip} .zip` && \
     unzip -q /var/${server_base}.zip -d /var && \
-    ln -s /var/${server_base} /var/janusgraph
+    rm /var/${server_base}.zip && \
+    ln -s /var/${server_base} /var/janusgraph && \
+    groupadd -g 999 janusgraph && \
+    useradd -d /home/janusgraph -m -r -u 999 -g janusgraph janusgraph && \
+    chown -R janusgraph:janusgraph /var/${server_base} && \
+    chmod 755 /var/${server_base} && \
+    chown -R janusgraph:janusgraph /var/janusgraph && \
+    chmod 755 /var/janusgraph
+
+USER janusgraph
 
 WORKDIR /var/janusgraph


### PR DESCRIPTION
In this commit i also incorporated a small fix to the overall size by removing the zip file after extraction.

Retargeted modifictation for janusgraph 0.2 branch.
