### PR TITLE
fixing issue #1125 premature limit application when using multiple indexes in graph query

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -1258,6 +1258,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
             Iterator<JanusGraphElement> iter;
             if (!indexQuery.isEmpty()) {
                 List<QueryUtil.IndexCall<Object>> retrievals = new ArrayList<QueryUtil.IndexCall<Object>>();
+                // Leave first index for streaming, and prepare the rest for intersecting and lookup
                 for (int i = 1; i < indexQuery.size(); i++) {
                     final JointIndexQuery.Subquery subquery = indexQuery.getQuery(i);
                     retrievals.add(new QueryUtil.IndexCall<Object>() {
@@ -1277,8 +1278,10 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
                         }
                     });
                 }
+                // Constructs an iterator which lazily streams results from 1st index, and filters by looking up in the intersection of results from all other indices (if any)
+                // NOTE NO_LIMIT is passed to processIntersectingRetrievals to prevent incomplete intersections, which could lead to missed results
                 iter = new SubqueryIterator(indexQuery.getQuery(0), indexSerializer, txHandle, indexCache, indexQuery.getLimit(), getConversionFunction(query.getResultType()),
-                        retrievals.isEmpty() ? null: QueryUtil.processIntersectingRetrievals(retrievals, indexQuery.getLimit()));
+                        retrievals.isEmpty() ? null: QueryUtil.processIntersectingRetrievals(retrievals, Query.NO_LIMIT));
             } else {
                 if (config.hasForceIndexUsage()) throw new JanusGraphException("Could not find a suitable index to answer graph query and graph scans are disabled: " + query);
                 log.warn("Query requires iterating over all vertices [{}]. For better performance, use indexes", query.getCondition());

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/SubqueryIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/SubqueryIterator.java
@@ -71,7 +71,7 @@ public class SubqueryIterator implements Iterator<JanusGraphElement>, AutoClosea
                 throw new JanusGraphException("Could not call index", e.getCause());
             }
         }
-        elementIterator = stream.limit(limit).filter(e -> otherResults == null || otherResults.contains(e)).map(function).map(r -> (JanusGraphElement) r).iterator();
+        elementIterator = stream.filter(e -> otherResults == null || otherResults.contains(e)).limit(limit).map(function).map(r -> (JanusGraphElement) r).iterator();
     }
 
     @Override


### PR DESCRIPTION
This fix makes sure that we only apply limit to the query result stream when it is safe to do without a risk of losing valid results. 
Also includes a new unit test which illustrates the issue being fixed in a way easier to reproduce than originally reported on the issue #1125.