### PR TITLE
Fixing issue 1333

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/StandardVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/StandardVertex.java
@@ -33,7 +33,8 @@ import java.util.List;
 
 public class StandardVertex extends AbstractVertex {
 
-    private byte lifecycle;
+    private Object lifecycleMutex = new Object();
+    private volatile byte lifecycle;
     private volatile AddedRelationsContainer addedRelations=AddedRelationsContainer.EMPTY;
 
     public StandardVertex(final StandardJanusGraphTx tx, final long id, byte lifecycle) {
@@ -41,8 +42,10 @@ public class StandardVertex extends AbstractVertex {
         this.lifecycle=lifecycle;
     }
 
-    public synchronized final void updateLifeCycle(ElementLifeCycle.Event event) {
-        this.lifecycle = ElementLifeCycle.update(lifecycle,event);
+    public final void updateLifeCycle(ElementLifeCycle.Event event) {
+        synchronized(lifecycleMutex) {
+            this.lifecycle = ElementLifeCycle.update(lifecycle,event);
+        }
     }
 
     @Override


### PR DESCRIPTION
Created a new mutex to lock during the updateLifeCycle method. Not sure what the original intention of having this method be synchronized was, but this should ensure the behavior is the same without the risk of deadlock.

Also marked lifecycle as volatile since it can be updated and read by different threads.

Issue #1333 
