### PR TITLE
fix issue 1314 g.E().hasId() not returning right result

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphStep.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphStep.java
@@ -14,6 +14,7 @@
 
 package org.janusgraph.graphdb.tinkerpop.optimize;
 
+import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.janusgraph.core.JanusGraphEdge;
 import org.janusgraph.core.JanusGraphElement;
@@ -75,6 +76,9 @@ public class JanusGraphStep<S, E extends Element> extends GraphStep<S, E> implem
             }
             else if (this.ids.length > 0) {
                 final Graph graph = (Graph)traversal.asAdmin().getGraph().get();
+                if(Edge.class.isAssignableFrom(returnClass)){
+                    return iteratorList((Iterator) graph.edges(this.ids));
+                }
                 return iteratorList((Iterator)graph.vertices(this.ids));
             }
             if (hasLocalContainers.isEmpty()) {

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CqlGetEdgeByHasIdTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CqlGetEdgeByHasIdTest.java
@@ -1,0 +1,34 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.cql;
+
+import org.janusgraph.CassandraStorageSetup;
+import org.janusgraph.diskstorage.configuration.WriteConfiguration;
+import org.janusgraph.graphdb.GetEdgeByHasIdTest;
+import org.junit.BeforeClass;
+
+public class CqlGetEdgeByHasIdTest extends GetEdgeByHasIdTest {
+
+    @BeforeClass
+    public static void startCassandra() {
+        org.janusgraph.diskstorage.cql.CassandraStorageSetup.startCleanEmbedded();
+    }
+
+
+    @Override
+    public WriteConfiguration getConfiguration() {
+        return CassandraStorageSetup.getAstyanaxGraphConfiguration(getClass().getSimpleName());
+    }
+}

--- a/janusgraph-hbase-parent/janusgraph-hbase-core/src/test/java/org/janusgraph/graphdb/hbase/HBaseGetEdgeByHasIdTest.java
+++ b/janusgraph-hbase-parent/janusgraph-hbase-core/src/test/java/org/janusgraph/graphdb/hbase/HBaseGetEdgeByHasIdTest.java
@@ -1,0 +1,46 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.hbase;
+
+import org.apache.hadoop.hbase.util.VersionInfo;
+import org.janusgraph.HBaseStorageSetup;
+import org.janusgraph.diskstorage.configuration.WriteConfiguration;
+import org.janusgraph.graphdb.GetEdgeByHasIdTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+
+public class HBaseGetEdgeByHasIdTest extends GetEdgeByHasIdTest {
+
+
+    @BeforeClass
+    public static void startHBase() throws IOException {
+        HBaseStorageSetup.startHBase();
+    }
+
+    @AfterClass
+    public static void stopHBase() {
+        // Workaround for https://issues.apache.org/jira/browse/HBASE-10312
+        if (VersionInfo.getVersion().startsWith("0.96"))
+            HBaseStorageSetup.killIfRunning();
+    }
+
+
+    @Override
+    public WriteConfiguration getConfiguration() {
+        return HBaseStorageSetup.getHBaseGraphConfiguration();
+    }
+}

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/GetEdgeByHasIdTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/GetEdgeByHasIdTest.java
@@ -1,0 +1,48 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb;
+
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.janusgraph.graphdb.relations.RelationIdentifier;
+import org.junit.Test;
+
+public abstract class GetEdgeByHasIdTest extends JanusGraphBaseTest {
+
+    @Test
+    public void getEdgeByHasId() {
+        GraphTraversalSource g = graph.traversal();
+
+        g.addV("community").property("name","first").as("firstCommunity").
+            addV("community").property("name","second").as("secondCommunity").
+            addV("person").addE("follows").to("firstCommunity").
+            addV("person").addE("follows").to("firstCommunity").
+            addV("person").addE("follows").to("secondCommunity").iterate();
+
+        RelationIdentifier eid = (RelationIdentifier) g.E().id().next();
+
+        GraphTraversal<Edge, Edge> t1 = g.E().hasId(eid);
+        GraphTraversal<Edge, Edge> t2 = g.E(eid);
+
+
+        Edge e1 = t1.next();
+
+        Edge e2 = t2.next();
+
+        assert e1 != null && e1.equals(e2);
+
+    }
+}


### PR DESCRIPTION
Issue fix 1314 that g.E().hasId() didn't return the right result. [issue 1314](https://github.com/JanusGraph/janusgraph/issues/1314). I have commited this before, using another [PR](https://github.com/JanusGraph/janusgraph/pull/1317) which is wrong used because I didn't try to fix it with a new branch.
-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

