### PR TITLE
Prevent deadlock when vertices are removed in parallel

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/StandardVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/StandardVertex.java
@@ -33,7 +33,8 @@ import java.util.List;
 
 public class StandardVertex extends AbstractVertex {
 
-    private byte lifecycle;
+    private final Object lifecycleMutex = new Object();
+    private volatile byte lifecycle;
     private volatile AddedRelationsContainer addedRelations=AddedRelationsContainer.EMPTY;
 
     public StandardVertex(final StandardJanusGraphTx tx, final long id, byte lifecycle) {
@@ -41,8 +42,10 @@ public class StandardVertex extends AbstractVertex {
         this.lifecycle=lifecycle;
     }
 
-    public synchronized final void updateLifeCycle(ElementLifeCycle.Event event) {
-        this.lifecycle = ElementLifeCycle.update(lifecycle,event);
+    public final void updateLifeCycle(ElementLifeCycle.Event event) {
+        synchronized(lifecycleMutex) {
+            this.lifecycle = ElementLifeCycle.update(lifecycle,event);
+        }
     }
 
     @Override


### PR DESCRIPTION
Hi,

Based on the comment by @FlorianHockmann for PR #1334 I am creating a new pull request on top of the 0.2 branch. Sorry if this is not the correct way to do it but I'm not a git expert and I couldn't figure out how to update the existing pull request.

Just merge this one and I can delete the other one I guess.

Fixes #1333 

Thanks,
Mike

---

Created a new mutex to lock during the updateLifyCycle method. Not sure what the origional intention of having this method be synchronized was,
but this should ensure the behavior is the same without the risk of
deadlock.

Also marked lifecycle as volatile since it can be updated and read by
different threads.

Signed-off-by: Mike Beaubien <mbbeaubi@umich.edu>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

