### PR TITLE
Stop using deprecated TinkerPop methods for upgrade to TinkerPop 3.4.0 #1364

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/core/InvalidElementException.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/InvalidElementException.java
@@ -53,9 +53,9 @@ public class InvalidElementException extends JanusGraphException {
     }
 
     public static IllegalStateException removedException(JanusGraphElement element) {
-        Class elementClass = Vertex.class.isAssignableFrom(element.getClass())?Vertex.class:
-                (Edge.class.isAssignableFrom(element.getClass())?Edge.class:VertexProperty.class);
-        return Element.Exceptions.elementAlreadyRemoved(elementClass, element.id());
+        Class elementClass = Vertex.class.isAssignableFrom(element.getClass()) ? Vertex.class :
+            (Edge.class.isAssignableFrom(element.getClass()) ? Edge.class : VertexProperty.class);
+        return new IllegalStateException(String.format("%s with id %s was removed.", elementClass.getSimpleName(), element.id()));
     }
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/AdjacentVertexFilterOptimizerStrategy.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/AdjacentVertexFilterOptimizerStrategy.java
@@ -88,9 +88,9 @@ public class AdjacentVertexFilterOptimizerStrategy extends AbstractTraversalStra
                                 && (direction == Direction.BOTH || direction.equals(vertexStep.getDirection().opposite()))) {
                             //Now replace the step with a has condition
                             TraversalHelper.replaceStep(originalStep,
-                                    new HasStep(traversal,
-                                            HasContainer.makeHasContainers(ImplicitKey.ADJACENT_ID.name(), P.eq(vertex))),
-                                    traversal);
+                                new HasStep(traversal,
+                                    new HasContainer(ImplicitKey.ADJACENT_ID.name(), P.eq(vertex))),
+                                traversal);
                         }
                     }
 


### PR DESCRIPTION
The following methods were deprecated in TinkerPop 3.3.z and removed in TinkerPop 3.4.0:

- `org.apache.tinkerpop.gremlin.structure.Element.Exceptions#elementAlreadyRemoved(Class, Object)`
- `org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer#makeHasContainers(String, P)`

I just inlined these methods in the two places where they were called.

There were two more deprecated methods we're using that were removed in TinkerPop 3.4.0, but we can only remove them together with the upgrade to 3.4.0 as they're part of the `GraphManager` interface until 3.4.0, so we still have to implement them until 3.4.0:

- `org.apache.tinkerpop.gremlin.server.GraphManager#getGraphs()`
- `org.apache.tinkerpop.gremlin.server.GraphManager#getTraversalSources()`

Part of #1364

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [-] Have you written and/or updated unit tests to verify your changes?
- [-] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [-] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [-] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [-] Have you ensured that format looks appropriate for the output in which it is rendered?
- [-] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

