### PR TITLE
Use new Credential DSL for authentication #1364

### DIFF
--- a/janusgraph-server/src/main/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/JanusGraphSimpleAuthenticator.java
+++ b/janusgraph-server/src/main/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/JanusGraphSimpleAuthenticator.java
@@ -17,7 +17,7 @@ package org.janusgraph.graphdb.tinkerpop.gremlin.server.auth;
 import java.net.InetAddress;
 import java.util.Map;
 
-import org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraph;
+import org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialTraversalDsl;
 import org.apache.tinkerpop.gremlin.server.auth.AuthenticatedUser;
 import org.apache.tinkerpop.gremlin.server.auth.AuthenticationException;
 import org.apache.tinkerpop.gremlin.server.auth.Authenticator;
@@ -26,7 +26,7 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 
 /**
  * A simple implementation of an {@link Authenticator} that uses a {@link Graph} instance as a credential store.
- * Management of the credential store can be handled through the {@link CredentialGraph} DSL.
+ * Management of the credential store can be handled through the {@link CredentialTraversalDsl}.
  */
 public class JanusGraphSimpleAuthenticator extends JanusGraphAbstractAuthenticator {
 
@@ -35,7 +35,6 @@ public class JanusGraphSimpleAuthenticator extends JanusGraphAbstractAuthenticat
     @Override
     public void setup(final Map<String, Object> config) {
         super.setup(config);
-        this.backingGraph.close();
         simpleAuthenticator = createSimpleAuthenticator();
         simpleAuthenticator.setup(config);
     }

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/ConfigBuilder.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/ConfigBuilder.java
@@ -1,0 +1,48 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.gremlin.server.auth;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator.CONFIG_CREDENTIALS_DB;
+
+public class ConfigBuilder {
+
+    protected final Map<String, Object> config;
+
+    protected ConfigBuilder() {
+        config = new HashMap<>();
+        config.put(CONFIG_CREDENTIALS_DB, "configCredDb");
+    }
+
+    public static ConfigBuilder build() {
+        return new ConfigBuilder();
+    }
+
+    public ConfigBuilder defaultUser(String defaultUser) {
+        config.put(HMACAuthenticator.CONFIG_DEFAULT_USER, defaultUser);
+        return this;
+    }
+
+    public ConfigBuilder defaultPassword(String defaultPassword) {
+        config.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, defaultPassword);
+        return this;
+    }
+
+    public Map<String, Object> create() {
+        return config;
+    }
+}

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/CredentialsBuilder.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/CredentialsBuilder.java
@@ -1,0 +1,57 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.gremlin.server.auth;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraphTokens.PROPERTY_PASSWORD;
+import static org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraphTokens.PROPERTY_USERNAME;
+import static org.janusgraph.graphdb.tinkerpop.gremlin.server.handler.HttpHMACAuthenticationHandler.PROPERTY_GENERATE_TOKEN;
+import static org.janusgraph.graphdb.tinkerpop.gremlin.server.handler.HttpHMACAuthenticationHandler.PROPERTY_TOKEN;
+
+public class CredentialsBuilder {
+
+    final Map<String, String> credentials = new HashMap<>();
+
+    public static CredentialsBuilder build() {
+        return new CredentialsBuilder();
+    }
+
+    public CredentialsBuilder user(final String username) {
+        credentials.put(PROPERTY_USERNAME, username);
+        return this;
+    }
+
+    public CredentialsBuilder password(final String password) {
+        credentials.put(PROPERTY_PASSWORD, password);
+        return this;
+    }
+
+    public CredentialsBuilder enableTokenGeneration() {
+        credentials.put(PROPERTY_GENERATE_TOKEN, "true");
+        return this;
+    }
+
+    public CredentialsBuilder token(final String token) {
+        credentials.put(PROPERTY_TOKEN, new String(Base64.getUrlDecoder().decode(token)));
+        return this;
+    }
+
+    public Map<String, String> create() {
+        return credentials;
+    }
+}

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/HMACAuthenticatorTest.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/HMACAuthenticatorTest.java
@@ -14,522 +14,180 @@
 
 package org.janusgraph.graphdb.tinkerpop.gremlin.server.auth;
 
-import static org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraphTokens.PROPERTY_PASSWORD;
-import static org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraphTokens.PROPERTY_USERNAME;
 import static org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator.CONFIG_CREDENTIALS_DB;
-import static org.easymock.EasyMock.eq;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.isA;
-import static org.janusgraph.graphdb.tinkerpop.gremlin.server.handler.HttpHMACAuthenticationHandler.PROPERTY_GENERATE_TOKEN;
 import static org.janusgraph.graphdb.tinkerpop.gremlin.server.handler.HttpHMACAuthenticationHandler.PROPERTY_TOKEN;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.InetAddress;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraph;
+import org.apache.tinkerpop.gremlin.server.auth.AuthenticatedUser;
 import org.apache.tinkerpop.gremlin.server.auth.AuthenticationException;
-import org.apache.tinkerpop.gremlin.structure.Transaction;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.easymock.EasyMockSupport;
-import org.janusgraph.core.Cardinality;
+import org.janusgraph.StorageSetup;
 import org.janusgraph.core.JanusGraph;
-import org.janusgraph.core.PropertyKey;
-import org.janusgraph.core.schema.JanusGraphIndex;
-import org.janusgraph.core.schema.JanusGraphManagement;
-import org.janusgraph.core.schema.PropertyKeyMaker;
-import org.janusgraph.core.schema.SchemaStatus;
-import org.janusgraph.graphdb.database.management.ManagementSystem;
 import org.junit.jupiter.api.Test;
-import org.mindrot.jbcrypt.BCrypt;
 
-public class HMACAuthenticatorTest extends EasyMockSupport {
+public class HMACAuthenticatorTest extends JanusGraphAbstractAuthenticatorTest {
 
-    @Test
-    public void testSetupNullConfig() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            final HMACAuthenticator authenticator = new HMACAuthenticator();
-            authenticator.setup(null);
-        });
+    @Override
+    public JanusGraphAbstractAuthenticator createAuthenticator() {
+        return new HMACAuthenticator();
     }
 
-    @Test
-    public void testSetupNoCredDb() {
-        assertThrows(IllegalStateException.class, () -> {
-            final HMACAuthenticator authenticator = new HMACAuthenticator();
-            authenticator.setup(new HashMap<String, Object>());
-        });
+    @Override
+    public MockedJanusGraphAuthenticatorFactory mockedAuthenticatorFactory() {
+        return new MockedHmacAuthenticatorFactory();
+    }
+
+    @Override
+    public ConfigBuilder configBuilder() {
+        return HmacConfigBuilder.build();
     }
 
     @Test
     public void testSetupNoHmacSecret() {
-        assertThrows(IllegalStateException.class, () -> {
-            final HMACAuthenticator authenticator = new HMACAuthenticator();
-            final Map<String, Object> configMap = new HashMap<String, Object>();
-            configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
-            authenticator.setup(configMap);
-        });
-    }
-
-    @Test
-    public void testSetupEmptyNoUserDefault() {
-        assertThrows(IllegalStateException.class, () -> {
-            final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
-                .addMockedMethod("openGraph")
-                .addMockedMethod("createCredentialGraph")
-                .createMock();
-            final JanusGraph graph = createMock(JanusGraph.class);
-            final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
-            final Map<String, Object> configMap = new HashMap<String, Object>();
-            configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
-            configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
-            configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
-
-            expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
-            expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
-            authenticator.setup(configMap);
-        });
-    }
-
-    @Test
-    public void testSetupEmptyCredGraphNoPassDefault() {
-        assertThrows(IllegalStateException.class, () -> {
-            final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
-                .addMockedMethod("openGraph")
-                .addMockedMethod("createCredentialGraph")
-                .createMock();
-            final JanusGraph graph = createMock(JanusGraph.class);
-            final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
-            final Map<String, Object> configMap = new HashMap<String, Object>();
-            configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
-            configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
-            configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
-
-            expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
-            expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
-            authenticator.setup(configMap);
-        });
-    }
-
-    @Test
-    public void testSetupEmptyCredGraphNoUserIndex() {
-        final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
-            .addMockedMethod("openGraph")
-            .addMockedMethod("createCredentialGraph")
-            .createMock();
-
-        final Map<String, Object> configMap = new HashMap<String, Object>();
-        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
-        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
-        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
-        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
-
-        final JanusGraph graph = createMock(JanusGraph.class);
-        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
-        final ManagementSystem mgmt = createMock(ManagementSystem.class);
-        final Transaction tx = createMock(Transaction.class);
-        final PropertyKey pk = createMock(PropertyKey.class);
-        final PropertyKeyMaker pkm = createMock(PropertyKeyMaker.class);
-        final JanusGraphManagement.IndexBuilder indexBuilder = createMock(JanusGraphManagement.IndexBuilder.class);
-        final JanusGraphIndex index = createMock(JanusGraphIndex.class);
-        final PropertyKey[] pks = {pk};
-
-        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
-        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
-        expect(credentialGraph.findUser("user")).andReturn(null);
-        expect(credentialGraph.createUser(eq("user"), eq("pass"))).andReturn(null);
-        expect(graph.openManagement()).andReturn(mgmt).times(2);
-        expect(graph.tx()).andReturn(tx);
-        expect(index.getFieldKeys()).andReturn(pks);
-        expect(index.getIndexStatus(eq(pk))).andReturn(SchemaStatus.ENABLED);
-
-        tx.rollback();
-        expectLastCall();
-
-        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(false);
-        expect(mgmt.makePropertyKey(PROPERTY_USERNAME)).andReturn(pkm);
-        expect(pkm.dataType(eq(String.class))).andReturn(pkm);
-        expect(pkm.cardinality(Cardinality.SINGLE)).andReturn(pkm);
-        expect(pkm.make()).andReturn(pk);
-        expect(mgmt.buildIndex(eq("byUsername"), eq(Vertex.class))).andReturn(indexBuilder);
-        expect(mgmt.getGraphIndex(eq("byUsername"))).andReturn(index);
-        expect(indexBuilder.addKey(eq(pk))).andReturn(indexBuilder);
-        expect(indexBuilder.unique()).andReturn(indexBuilder);
-        expect(indexBuilder.buildCompositeIndex()).andReturn(index);
-
-        mgmt.commit();
-        expectLastCall();
-
-        mgmt.rollback();
-        expectLastCall();
-
-        replayAll();
-
-        authenticator.setup(configMap);
-    }
-
-    @Test
-    public void testPassEmptyCredGraphUserIndex() {
-        final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
-            .addMockedMethod("openGraph")
-            .addMockedMethod("createCredentialGraph")
-            .createMock();
-
+        final HMACAuthenticator authenticator = new HMACAuthenticator();
         final Map<String, Object> configMap = new HashMap<>();
         configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
-        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
-        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
-        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
 
-        final JanusGraph graph = createMock(JanusGraph.class);
-        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
-        final ManagementSystem mgmt = createMock(ManagementSystem.class);
-        final Transaction tx = createMock(Transaction.class);
-
-        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
-        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
-        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
-        expect(credentialGraph.findUser("user")).andReturn(null);
-        expect(credentialGraph.createUser(eq("user"), eq("pass"))).andReturn(null);
-        expect(graph.openManagement()).andReturn(mgmt);
-        expect(graph.tx()).andReturn(tx);
-        tx.rollback();
-        expectLastCall();
-        replayAll();
-
-        authenticator.setup(configMap);
-    }
-
-    @Test
-    public void testSetupDefaultUserNonEmptyCredGraph() {
-        final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
-            .addMockedMethod("openGraph")
-            .addMockedMethod("createCredentialGraph")
-            .createMock();
-
-        final Map<String, Object> configMap = new HashMap<String, Object>();
-        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
-        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
-        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
-        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
-
-        final JanusGraph graph = createMock(JanusGraph.class);
-        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
-        final ManagementSystem mgmt = createMock(ManagementSystem.class);
-        final Transaction tx = createMock(Transaction.class);
-
-        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
-        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
-        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
-        expect(graph.openManagement()).andReturn(mgmt);
-        expect(graph.tx()).andReturn(tx);
-        expect(credentialGraph.findUser("user")).andReturn(createMock(Vertex.class));
-        tx.rollback();
-        expectLastCall();
-
-        replayAll();
-
-        authenticator.setup(configMap);
+        assertThrows(IllegalStateException.class, () -> authenticator.setup(configMap));
     }
 
     @Test
     public void testAuthenticateBasicAuthValid() throws AuthenticationException {
-        final Map<String, String> credentials = new HashMap<>();
-        credentials.put(PROPERTY_USERNAME, "user");
-        credentials.put(PROPERTY_PASSWORD, "pass");
+        final HMACAuthenticator authenticator = createMockedAuthenticator();
+        final String defaultUser = "user";
+        final String defaultPassword = "pass";
+        final Map<String, Object> config =
+            HmacConfigBuilder.build().defaultUser(defaultUser).defaultPassword(defaultPassword).create();
+        authenticator.setup(config);
+        final Map<String, String> credentials =
+            CredentialsBuilder.build().user(defaultUser).password(defaultPassword).create();
 
-        final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
-            .addMockedMethod("openGraph")
-            .addMockedMethod("createCredentialGraph")
-            .createMock();
-
-        final Map<String, Object> configMap = new HashMap<String, Object>();
-        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
-        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
-        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
-        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
-
-        final JanusGraph graph = createMock(JanusGraph.class);
-        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
-        final ManagementSystem mgmt = createMock(ManagementSystem.class);
-        final Transaction tx = createMock(Transaction.class);
-        final Vertex userVertex = createMock(Vertex.class);
-        final String bcryptedPass = BCrypt.hashpw("pass", BCrypt.gensalt(4));
-
-        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
-        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
-        expect(credentialGraph.findUser(eq("user"))).andReturn(userVertex).times(2);
-        expect(userVertex.value(eq(PROPERTY_PASSWORD))).andReturn(bcryptedPass);
-        expect(graph.openManagement()).andReturn(mgmt);
-        expect(graph.tx()).andReturn(tx);
-        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
-        tx.rollback();
-        expectLastCall();
-
-        replayAll();
-        authenticator.setup(configMap);
         authenticator.authenticate(credentials);
-        verifyAll();
     }
 
     @Test
-    public void testAuthenticateBasicAuthInvalid() throws AuthenticationException {
-        assertThrows(AuthenticationException.class, () -> {
-            final Map<String, String> credentials = new HashMap<>();
-            credentials.put(PROPERTY_USERNAME, "user");
-            credentials.put(PROPERTY_PASSWORD, "invalid");
+    public void testAuthenticateBasicAuthInvalid() {
+        final HMACAuthenticator authenticator = createMockedAuthenticator();
+        final String defaultUser = "user";
+        final String defaultPassword = "pass";
+        final Map<String, Object> config =
+            HmacConfigBuilder.build().defaultUser(defaultUser).defaultPassword(defaultPassword).create();
+        authenticator.setup(config);
+        final Map<String, String> credentials =
+            CredentialsBuilder.build().user(defaultUser).password("invalid").create();
 
-            final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
-                .addMockedMethod("openGraph")
-                .addMockedMethod("createCredentialGraph")
-                .createMock();
-
-            final Map<String, Object> configMap = new HashMap<String, Object>();
-            configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
-            configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
-            configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
-            configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
-
-            final JanusGraph graph = createMock(JanusGraph.class);
-            final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
-            final ManagementSystem mgmt = createMock(ManagementSystem.class);
-            final Transaction tx = createMock(Transaction.class);
-            final Vertex userVertex = createMock(Vertex.class);
-            final String bcryptedPass = BCrypt.hashpw("pass", BCrypt.gensalt(4));
-
-            expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
-            expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
-            expect(credentialGraph.findUser(eq("user"))).andReturn(userVertex).times(2);
-            expect(userVertex.value(eq(PROPERTY_PASSWORD))).andReturn(bcryptedPass);
-            expect(graph.tx()).andReturn(tx);
-            expect(graph.openManagement()).andReturn(mgmt);
-            expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
-            tx.rollback();
-            expectLastCall();
-
-            tx.rollback();
-            expectLastCall();
-
-            replayAll();
-            authenticator.setup(configMap);
-            authenticator.authenticate(credentials);
-            verifyAll();
-        });
+        assertThrows(AuthenticationException.class, () -> authenticator.authenticate(credentials));
     }
 
     @Test
-    public void testTokenAuth() throws AuthenticationException {
-        final Map<String, String> sharedVars = testAuthenticateGenerateToken();
-        testAuthenticateWithToken(sharedVars);
-        testFailureShortenedToken(sharedVars);
-        testTokenTimeout(sharedVars);
+    public void testAuthenticateGenerateToken() throws AuthenticationException {
+        final HMACAuthenticator authenticator = createMockedAuthenticator();
+        final String defaultUser = "user";
+        final String defaultPassword = "pass";
+        authenticator.setup(HmacConfigBuilder.build().defaultUser(defaultUser).defaultPassword(defaultPassword).create());
+        final Map<String, String> credentials = CredentialsBuilder.build().
+            user(defaultUser).
+            password(defaultPassword).
+            enableTokenGeneration().
+            create();
+
+        authenticator.authenticate(credentials);
+        assertNotNull(credentials.get(PROPERTY_TOKEN));
     }
 
-    private Map<String, String> testAuthenticateGenerateToken() throws AuthenticationException {
-        final Map<String, String> credentials = new HashMap<>();
-        credentials.put(PROPERTY_USERNAME, "user");
-        credentials.put(PROPERTY_PASSWORD, "pass");
-        credentials.put(PROPERTY_GENERATE_TOKEN, "true");
+    @Test
+    public void testAuthenticateWithToken() throws AuthenticationException {
+        final HMACAuthenticator authenticator = createMockedAuthenticator();
+        final String defaultUser = "user";
+        String token = generateTokenForAuthenticatedUser(authenticator, defaultUser);
 
-        final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
-            .addMockedMethod("openGraph")
-            .addMockedMethod("createCredentialGraph")
-            .createMock();
+        AuthenticatedUser authenticatedUser =
+            authenticator.authenticate(CredentialsBuilder.build().token(token).create());
 
-        final Map<String, Object> configMap = new HashMap<String, Object>();
-        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
-        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
-        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
-        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
-        configMap.put(HMACAuthenticator.CONFIG_HMAC_ALGO, "HmacSHA256");
-
-        final JanusGraph graph = createMock(JanusGraph.class);
-        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
-        final ManagementSystem mgmt = createMock(ManagementSystem.class);
-        final Transaction tx = createMock(Transaction.class);
-        final Vertex userVertex = createMock(Vertex.class);
-        final String bcryptedPass = BCrypt.hashpw("pass", BCrypt.gensalt(4));
-
-        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
-        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
-        expect(credentialGraph.findUser(eq("user"))).andReturn(userVertex).anyTimes();
-        expect(userVertex.value(eq(PROPERTY_PASSWORD))).andReturn(bcryptedPass).times(2);
-        expect(graph.openManagement()).andReturn(mgmt);
-        expect(graph.tx()).andReturn(tx);
-        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
-        tx.rollback();
-        expectLastCall();
-
-        replayAll();
-        authenticator.setup(configMap);
-        assertNotNull(authenticator.authenticate(credentials));
-        final String hmacToken = credentials.get(PROPERTY_TOKEN);
-        assertNotNull(hmacToken);
-        verifyAll();
-        resetAll();
-        final Map<String, String> sharedVars = new HashMap<>();
-        sharedVars.put("hmacToken", hmacToken);
-        sharedVars.put("encryptedPass", bcryptedPass);
-        return sharedVars;
+        assertEquals(defaultUser, authenticatedUser.getName());
     }
 
-    private void testFailureShortenedToken(final Map<String, String> sharedVars) throws AuthenticationException {
-        final String token = sharedVars.get("hmacToken");
-        final String bcryptedPass = sharedVars.get("encryptedPass");
-        final Map<String, String> credentials = new HashMap<>();
-        final String encodedString = new String(Base64.getUrlDecoder().decode(token));
-        final String brokenToken = encodedString.substring(0, encodedString.length() - 5);
-        credentials.put(PROPERTY_TOKEN, brokenToken);
+    @Test
+    public void testAuthenticateWithShortenedToken() throws AuthenticationException {
+        final HMACAuthenticator authenticator = createMockedAuthenticator();
+        String token = generateTokenForAuthenticatedUser(authenticator);
+        final String brokenToken = token.substring(0, token.length() - 4);
 
-        final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
-            .addMockedMethod("openGraph")
-            .addMockedMethod("createCredentialGraph")
-            .createMock();
-
-        final Map<String, Object> configMap = new HashMap<String, Object>();
-        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
-        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
-        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
-        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
-        configMap.put(HMACAuthenticator.CONFIG_HMAC_ALGO, "HmacSHA256");
-        configMap.put(HMACAuthenticator.CONFIG_TOKEN_TIMEOUT, 3600000);
-
-        final JanusGraph graph = createMock(JanusGraph.class);
-        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
-        final ManagementSystem mgmt = createMock(ManagementSystem.class);
-        final Transaction tx = createMock(Transaction.class);
-        final Vertex userVertex = createMock(Vertex.class);
-
-        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
-        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
-        expect(credentialGraph.findUser(eq("user"))).andReturn(userVertex).anyTimes();
-        expect(userVertex.value(eq(PROPERTY_PASSWORD))).andReturn(bcryptedPass);
-        expect(graph.openManagement()).andReturn(mgmt);
-        expect(graph.tx()).andReturn(tx);
-        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
-        tx.rollback();
-        expectLastCall();
-
-        replayAll();
-        authenticator.setup(configMap);
-        try {
-            authenticator.authenticate(credentials);
-            assertFalse(true);
-        } catch (AuthenticationException ex) {
-            assertNotNull(ex);
-            verifyAll();
-            resetAll();
-        }
+        assertThrows(AuthenticationException.class,
+            () -> authenticator.authenticate(CredentialsBuilder.build().token(brokenToken).create()));
     }
 
-    private void testAuthenticateWithToken(final Map<String, String> sharedVars) throws AuthenticationException {
-        final String token = sharedVars.get("hmacToken");
-        final String bcryptedPass = sharedVars.get("encryptedPass");
-        final Map<String, String> credentials = new HashMap<>();
-        credentials.put(PROPERTY_TOKEN, new String(Base64.getUrlDecoder().decode(token)));
+    @Test
+    public void testAuthenticateWithBrokenToken() throws AuthenticationException {
+        final HMACAuthenticator authenticator = createMockedAuthenticator();
+        String token = generateTokenForAuthenticatedUser(authenticator);
+        final String brokenToken = token.substring(0, token.length() - "abcdefgh".length()) + "abcdefgh";
 
-        final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
-            .addMockedMethod("openGraph")
-            .addMockedMethod("createCredentialGraph")
-            .createMock();
-
-        final Map<String, Object> configMap = new HashMap<String, Object>();
-        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
-        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
-        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
-        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
-        configMap.put(HMACAuthenticator.CONFIG_HMAC_ALGO, "HmacSHA256");
-        configMap.put(HMACAuthenticator.CONFIG_TOKEN_TIMEOUT, 3600000);
-
-        final JanusGraph graph = createMock(JanusGraph.class);
-        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
-        final ManagementSystem mgmt = createMock(ManagementSystem.class);
-        final Transaction tx = createMock(Transaction.class);
-        final Vertex userVertex = createMock(Vertex.class);
-
-        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
-        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
-        expect(credentialGraph.findUser(eq("user"))).andReturn(userVertex).anyTimes();
-        expect(userVertex.value(eq(PROPERTY_PASSWORD))).andReturn(bcryptedPass);
-        expect(graph.openManagement()).andReturn(mgmt);
-        expect(graph.tx()).andReturn(tx);
-        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
-        tx.rollback();
-        expectLastCall();
-
-        replayAll();
-        authenticator.setup(configMap);
-        assertNotNull(authenticator.authenticate(credentials));
-        verifyAll();
-        resetAll();
+        assertThrows(AuthenticationException.class,
+            () -> authenticator.authenticate(CredentialsBuilder.build().token(brokenToken).create()));
     }
 
-    private void testTokenTimeout(final Map<String, String> sharedVars) {
-        final String token = sharedVars.get("hmacToken");
-        final String bcryptedPass = sharedVars.get("encryptedPass");
-        final Map<String, String> credentials = new HashMap<>();
-        credentials.put(PROPERTY_TOKEN, new String(Base64.getUrlDecoder().decode(token)));
+    private String generateTokenForAuthenticatedUser(final HMACAuthenticator authenticator) throws AuthenticationException {
+        return generateTokenForAuthenticatedUser(authenticator, "user");
+    }
 
-        final HMACAuthenticator authenticator = createMockBuilder(HMACAuthenticator.class)
-            .addMockedMethod("openGraph")
-            .addMockedMethod("createCredentialGraph")
-            .createMock();
+    private String generateTokenForAuthenticatedUser(final HMACAuthenticator authenticator, final String defaultUser) throws AuthenticationException {
+        final String defaultPassword = "pass";
+        ConfigBuilder.build().defaultUser(defaultUser).create();
+        authenticator.setup(HmacConfigBuilder.build().defaultUser(defaultUser).defaultPassword(defaultPassword).create());
+        final Map<String, String> credentials = CredentialsBuilder.build().
+            user(defaultUser).
+            password(defaultPassword).
+            enableTokenGeneration().
+            create();
+        authenticator.authenticate(credentials);
+        return credentials.get(PROPERTY_TOKEN);
+    }
 
-        final Map<String, Object> configMap = new HashMap<String, Object>();
-        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
-        configMap.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
-        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
-        configMap.put(HMACAuthenticator.CONFIG_DEFAULT_USER, "user");
-        configMap.put(HMACAuthenticator.CONFIG_HMAC_ALGO, "HmacSHA256");
-        configMap.put(HMACAuthenticator.CONFIG_TOKEN_TIMEOUT, 1);
+    @Test
+    public void testAuthenticateWithTimedOutToken() throws AuthenticationException, InterruptedException {
+        final HMACAuthenticator authenticator = createMockedAuthenticator();
+        final String defaultPassword = "pass";
+        final String defaultUser = "user";
+        ConfigBuilder.build().defaultUser(defaultUser).create();
+        final int tokenTimeoutInMs = 1;
+        final Map<String, Object> config = HmacConfigBuilder.build().
+            tokenTimeout(tokenTimeoutInMs).
+            defaultUser(defaultUser).
+            defaultPassword(defaultPassword).
+            create();
+        authenticator.setup(config);
+        final Map<String, String> credentials = CredentialsBuilder.build().
+            user(defaultUser).
+            password(defaultPassword).
+            enableTokenGeneration().
+            create();
+        authenticator.authenticate(credentials);
+        String token =  credentials.get(PROPERTY_TOKEN);
+        Thread.sleep(tokenTimeoutInMs);
 
-        final JanusGraph graph = createMock(JanusGraph.class);
-        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
-        final ManagementSystem mgmt = createMock(ManagementSystem.class);
-        final Transaction tx = createMock(Transaction.class);
-        final Vertex userVertex = createMock(Vertex.class);
+        assertThrows(AuthenticationException.class,
+            () -> authenticator.authenticate(CredentialsBuilder.build().token(token).create()));
+    }
 
-        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
-        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
-        expect(credentialGraph.findUser(eq("user"))).andReturn(userVertex).anyTimes();
-        expect(userVertex.value(eq(PROPERTY_PASSWORD))).andReturn(bcryptedPass);
-        expect(graph.openManagement()).andReturn(mgmt);
-        expect(graph.tx()).andReturn(tx);
-        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
-        tx.rollback();
-        expectLastCall();
-
-        replayAll();
-        authenticator.setup(configMap);
-        AuthenticationException ae = null;
-        try {
-            authenticator.authenticate(credentials);
-        } catch (AuthenticationException e) {
-            ae = e;
-        }
-        assertNotNull(ae);
-        verifyAll();
-
+    private HMACAuthenticator createMockedAuthenticator() {
+        final JanusGraph graph = StorageSetup.getInMemoryGraph();
+        return new MockedHmacAuthenticatorFactory().createInitializedAuthenticator(graph);
     }
 
     @Test
     public void testNewSaslNegotiatorOfInetAddr() {
-        assertThrows(RuntimeException.class, () -> {
-            final HMACAuthenticator authenticator = new HMACAuthenticator();
-            authenticator.newSaslNegotiator(createMock(InetAddress.class));
-        });
+        final HMACAuthenticator authenticator = new HMACAuthenticator();
+        assertThrows(RuntimeException.class, () -> authenticator.newSaslNegotiator(createMock(InetAddress.class)));
     }
 
     @Test
     public void testNewSaslNegotiator() {
-        assertThrows(RuntimeException.class, () -> {
-            final HMACAuthenticator authenticator = new HMACAuthenticator();
-            authenticator.newSaslNegotiator();
-        });
+        final HMACAuthenticator authenticator = new HMACAuthenticator();
+        assertThrows(RuntimeException.class, () -> authenticator.newSaslNegotiator());
     }
 }
+

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/HmacConfigBuilder.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/HmacConfigBuilder.java
@@ -1,4 +1,4 @@
-// Copyright 2017 JanusGraph Authors
+// Copyright 2019 JanusGraph Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,20 +14,18 @@
 
 package org.janusgraph.graphdb.tinkerpop.gremlin.server.auth;
 
-public class JanusGraphSimpleAuthenticatorTest extends JanusGraphAbstractAuthenticatorTest {
-
-    @Override
-    public JanusGraphAbstractAuthenticator createAuthenticator() {
-        return new JanusGraphSimpleAuthenticator();
+public class HmacConfigBuilder extends ConfigBuilder {
+    public HmacConfigBuilder() {
+        super();
+        config.put(HMACAuthenticator.CONFIG_HMAC_SECRET, "secret");
     }
 
-    @Override
-    public MockedJanusGraphAuthenticatorFactory mockedAuthenticatorFactory() {
-        return new MockedSimpleAuthenticatorFactory();
+    public ConfigBuilder tokenTimeout(int timeoutInMs) {
+        config.put(HMACAuthenticator.CONFIG_TOKEN_TIMEOUT, timeoutInMs);
+        return this;
     }
 
-    @Override
-    public ConfigBuilder configBuilder() {
-        return ConfigBuilder.build();
+    public static HmacConfigBuilder build() {
+        return new HmacConfigBuilder();
     }
 }

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/JanusGraphAbstractAuthenticatorTest.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/JanusGraphAbstractAuthenticatorTest.java
@@ -1,0 +1,146 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.gremlin.server.auth;
+
+import org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraphTokens;
+import org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.easymock.EasyMockSupport;
+import org.janusgraph.StorageSetup;
+import org.janusgraph.core.Cardinality;
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.JanusGraphIndex;
+import org.janusgraph.core.schema.SchemaStatus;
+import org.janusgraph.graphdb.database.management.ManagementSystem;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public abstract class JanusGraphAbstractAuthenticatorTest extends EasyMockSupport {
+
+    public abstract JanusGraphAbstractAuthenticator createAuthenticator();
+
+    public abstract MockedJanusGraphAuthenticatorFactory mockedAuthenticatorFactory();
+
+    public abstract ConfigBuilder configBuilder();
+
+    @Test
+    public void testSetupNullConfig() {
+        final JanusGraphAbstractAuthenticator authenticator = createAuthenticator();
+
+        assertThrows(IllegalArgumentException.class, () -> authenticator.setup(null));
+    }
+
+    @Test
+    public void testSetupNoCredDb() {
+        final JanusGraphAbstractAuthenticator authenticator = createAuthenticator();
+
+        assertThrows(IllegalStateException.class, () -> authenticator.setup(new HashMap<>()));
+    }
+
+    @Test
+    public void testSetupNoUserDefault() {
+        final JanusGraphAbstractAuthenticator authenticator = createAuthenticator();
+        final Map<String, Object> configMap = configBuilder().defaultPassword("pass").create();
+
+        assertThrows(IllegalStateException.class, () -> authenticator.setup(configMap));
+    }
+
+    @Test
+    public void testSetupNoPassDefault() {
+        final JanusGraphAbstractAuthenticator authenticator = createAuthenticator();
+        final Map<String, Object> configMap = configBuilder().defaultUser("user").create();
+
+        assertThrows(IllegalStateException.class, () -> authenticator.setup(configMap));
+    }
+
+    @Test
+    public void testSetupEmptyCredentialsGraphCreateDefaultUser() {
+        final String defaultUser = "user";
+        final String defaultPassword = "pass";
+        final Map<String, Object> configMap =
+            configBuilder().defaultUser(defaultUser).defaultPassword(defaultPassword).create();
+        final JanusGraph graph = StorageSetup.getInMemoryGraph();
+        final JanusGraphAbstractAuthenticator authenticator = createInitializedAuthenticator(configMap, graph);
+
+        authenticator.setup(configMap);
+
+        CredentialTraversalSource credentialSource = graph.traversal(CredentialTraversalSource.class);
+        List<Vertex> users = credentialSource.users(defaultUser).toList();
+        assertEquals(1, users.size());
+    }
+
+    @Test
+    public void testSetupEmptyCredentialsGraphCreateUsernamePropertyKey() {
+        final Map<String, Object> configMap = createConfig();
+        final JanusGraph graph = StorageSetup.getInMemoryGraph();
+        final JanusGraphAbstractAuthenticator authenticator = createInitializedAuthenticator(configMap, graph);
+
+        authenticator.setup(configMap);
+
+        final ManagementSystem mgmt = (ManagementSystem) graph.openManagement();
+        final PropertyKey username = mgmt.getPropertyKey(CredentialGraphTokens.PROPERTY_USERNAME);
+        assertEquals(String.class, username.dataType());
+        assertEquals(Cardinality.SINGLE, username.cardinality());
+    }
+
+    @Test
+    public void testSetupEmptyCredentialsGraphCreateUsernameIndex() {
+        final Map<String, Object> configMap = createConfig();
+        final JanusGraph graph = StorageSetup.getInMemoryGraph();
+        final JanusGraphAbstractAuthenticator authenticator = createInitializedAuthenticator(configMap, graph);
+
+        authenticator.setup(configMap);
+
+        final ManagementSystem mgmt = (ManagementSystem) graph.openManagement();
+        assertTrue(mgmt.containsGraphIndex(JanusGraphSimpleAuthenticator.USERNAME_INDEX_NAME));
+        final JanusGraphIndex index = mgmt.getGraphIndex(JanusGraphSimpleAuthenticator.USERNAME_INDEX_NAME);
+        final PropertyKey username = mgmt.getPropertyKey(CredentialGraphTokens.PROPERTY_USERNAME);
+        assertTrue(index.getIndexStatus(username).equals(SchemaStatus.ENABLED));
+    }
+
+    @Test
+    public void testSetupCredentialsGraphWithDefaultUserDontCreateUserAgain() {
+        final String defaultUser = "user";
+        final String defaultPassword = "pass";
+        final Map<String, Object> configMap =
+            configBuilder().defaultUser(defaultUser).defaultPassword(defaultPassword).create();
+        final JanusGraph graph = StorageSetup.getInMemoryGraph();
+        JanusGraphAbstractAuthenticator authenticator = createInitializedAuthenticator(configMap, graph);
+        authenticator.setup(configMap);
+        authenticator = createInitializedAuthenticator(configMap, graph);
+
+        // set up again:
+        authenticator.setup(configMap);
+
+        CredentialTraversalSource credentialSource = graph.traversal(CredentialTraversalSource.class);
+        List<Vertex> users = credentialSource.users(defaultUser).toList();
+        assertEquals(1, users.size());
+    }
+
+    protected JanusGraphAbstractAuthenticator createInitializedAuthenticator(final Map<String, Object> config,
+                                                                           final JanusGraph graph) {
+        return mockedAuthenticatorFactory().createInitializedAuthenticator(config, graph);
+    }
+
+    private Map<String, Object> createConfig() {
+        return configBuilder().defaultUser("testUser").defaultPassword("testPassword").create();
+    }
+}

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/MockedHmacAuthenticatorFactory.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/MockedHmacAuthenticatorFactory.java
@@ -1,0 +1,41 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.gremlin.server.auth;
+
+import org.janusgraph.core.JanusGraph;
+
+import java.util.Map;
+
+import static org.easymock.EasyMock.createMockBuilder;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.isA;
+import static org.easymock.EasyMock.replay;
+
+public class MockedHmacAuthenticatorFactory implements MockedJanusGraphAuthenticatorFactory {
+
+    public JanusGraphAbstractAuthenticator createInitializedAuthenticator(final Map<String, Object> config,
+                                                                             final JanusGraph graph) {
+        return createInitializedAuthenticator(graph);
+    }
+
+    public HMACAuthenticator createInitializedAuthenticator(final JanusGraph graph) {
+        final HMACAuthenticator hmacAuthenticator = createMockBuilder(HMACAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .createMock();
+        expect(hmacAuthenticator.openGraph(isA(String.class))).andReturn(graph);
+        replay(hmacAuthenticator);
+        return hmacAuthenticator;
+    }
+}

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/MockedJanusGraphAuthenticatorFactory.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/MockedJanusGraphAuthenticatorFactory.java
@@ -1,4 +1,4 @@
-// Copyright 2017 JanusGraph Authors
+// Copyright 2019 JanusGraph Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,20 +14,11 @@
 
 package org.janusgraph.graphdb.tinkerpop.gremlin.server.auth;
 
-public class JanusGraphSimpleAuthenticatorTest extends JanusGraphAbstractAuthenticatorTest {
+import org.janusgraph.core.JanusGraph;
 
-    @Override
-    public JanusGraphAbstractAuthenticator createAuthenticator() {
-        return new JanusGraphSimpleAuthenticator();
-    }
+import java.util.Map;
 
-    @Override
-    public MockedJanusGraphAuthenticatorFactory mockedAuthenticatorFactory() {
-        return new MockedSimpleAuthenticatorFactory();
-    }
-
-    @Override
-    public ConfigBuilder configBuilder() {
-        return ConfigBuilder.build();
-    }
+public interface MockedJanusGraphAuthenticatorFactory {
+    JanusGraphAbstractAuthenticator createInitializedAuthenticator(final Map<String, Object> config,
+                                                                   final JanusGraph graph);
 }

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/MockedSaslAndHmacAuthenticatorFactory.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/MockedSaslAndHmacAuthenticatorFactory.java
@@ -1,0 +1,50 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.gremlin.server.auth;
+
+import org.janusgraph.core.JanusGraph;
+
+import java.util.Map;
+
+import static org.easymock.EasyMock.createMockBuilder;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.isA;
+import static org.easymock.EasyMock.replay;
+
+public class MockedSaslAndHmacAuthenticatorFactory implements MockedJanusGraphAuthenticatorFactory {
+
+    final private MockedHmacAuthenticatorFactory hmacFactory = new MockedHmacAuthenticatorFactory();
+    final private MockedSimpleAuthenticatorFactory saslFactory = new MockedSimpleAuthenticatorFactory();
+
+    public JanusGraphAbstractAuthenticator createInitializedAuthenticator(final Map<String, Object> config,
+                                                                             final JanusGraph graph) {
+        final JanusGraphSimpleAuthenticator jsa =
+            (JanusGraphSimpleAuthenticator) saslFactory.createInitializedAuthenticator(config, graph);
+        final HMACAuthenticator hmacAuthenticator =
+            (HMACAuthenticator) hmacFactory.createInitializedAuthenticator(config, graph);
+
+        SaslAndHMACAuthenticator authenticator = createMockBuilder(SaslAndHMACAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createSimpleAuthenticator")
+            .addMockedMethod("createHMACAuthenticator")
+            .createMock();
+
+        expect(authenticator.createSimpleAuthenticator()).andReturn(jsa);
+        expect(authenticator.createHMACAuthenticator()).andReturn(hmacAuthenticator);
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        replay(authenticator);
+        return authenticator;
+    }
+}

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/MockedSimpleAuthenticatorFactory.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/MockedSimpleAuthenticatorFactory.java
@@ -1,0 +1,43 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.gremlin.server.auth;
+
+import org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator;
+import org.janusgraph.core.JanusGraph;
+
+import java.util.Map;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.createMockBuilder;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.isA;
+import static org.easymock.EasyMock.replay;
+
+public class MockedSimpleAuthenticatorFactory implements MockedJanusGraphAuthenticatorFactory {
+
+    public JanusGraphAbstractAuthenticator createInitializedAuthenticator(final Map<String, Object> config,
+                                                                          final JanusGraph graph) {
+        final JanusGraphSimpleAuthenticator authenticator = createMockBuilder(JanusGraphSimpleAuthenticator.class)
+            .addMockedMethod("openGraph")
+            .addMockedMethod("createSimpleAuthenticator")
+            .createMock();
+        final SimpleAuthenticator sa = createMock(SimpleAuthenticator.class);
+        expect(authenticator.createSimpleAuthenticator()).andReturn(sa);
+        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
+        sa.setup(config);
+        replay(authenticator);
+        return authenticator;
+    }
+}

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/SaslAndHMACAuthenticatorTest.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/auth/SaslAndHMACAuthenticatorTest.java
@@ -14,35 +14,28 @@
 
 package org.janusgraph.graphdb.tinkerpop.gremlin.server.auth;
 
-import static org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraphTokens.PROPERTY_USERNAME;
-import static org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator.CONFIG_CREDENTIALS_DB;
-import static org.easymock.EasyMock.eq;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.isA;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.InetAddress;
-import java.util.HashMap;
-import java.util.Map;
 
-import org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.CredentialGraph;
-import org.apache.tinkerpop.gremlin.server.auth.AuthenticationException;
-import org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator;
-import org.apache.tinkerpop.gremlin.structure.Transaction;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.easymock.EasyMockSupport;
-import org.janusgraph.core.Cardinality;
-import org.janusgraph.core.JanusGraph;
-import org.janusgraph.core.PropertyKey;
-import org.janusgraph.core.schema.JanusGraphIndex;
-import org.janusgraph.core.schema.JanusGraphManagement;
-import org.janusgraph.core.schema.PropertyKeyMaker;
-import org.janusgraph.core.schema.SchemaStatus;
-import org.janusgraph.graphdb.database.management.ManagementSystem;
 import org.junit.jupiter.api.Test;
 
-public class SaslAndHMACAuthenticatorTest extends EasyMockSupport {
+public class SaslAndHMACAuthenticatorTest extends JanusGraphAbstractAuthenticatorTest {
+
+    @Override
+    public JanusGraphAbstractAuthenticator createAuthenticator() {
+        return new SaslAndHMACAuthenticator();
+    }
+
+    @Override
+    public MockedJanusGraphAuthenticatorFactory mockedAuthenticatorFactory() {
+        return new MockedSaslAndHmacAuthenticatorFactory();
+    }
+
+    @Override
+    public ConfigBuilder configBuilder() {
+        return HmacConfigBuilder.build();
+    }
 
     @Test
     public void testNewSaslNegotiator() {
@@ -51,224 +44,12 @@ public class SaslAndHMACAuthenticatorTest extends EasyMockSupport {
 
     @Test
     public void testNewSaslNegotiatorInet() {
-        assertThrows(RuntimeException.class, () -> {
-            final InetAddress inet = createMock(InetAddress.class);
-            new SaslAndHMACAuthenticator().newSaslNegotiator(inet);
-        });
+        final InetAddress inet = createMock(InetAddress.class);
+        assertThrows(RuntimeException.class, () -> new SaslAndHMACAuthenticator().newSaslNegotiator(inet));
     }
 
     @Test
-    public void testAuthenticate() throws AuthenticationException {
+    public void testAuthenticate() {
         assertThrows(IllegalStateException.class, () -> new SaslAndHMACAuthenticator().authenticate(null));
     }
-
-    @Test
-    public void testSetupNullConfig() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            final SaslAndHMACAuthenticator authenticator = new SaslAndHMACAuthenticator();
-            authenticator.setup(null);
-        });
-    }
-
-    @Test
-    public void testSetupNoCredDb() {
-        assertThrows(IllegalStateException.class, () -> {
-            final SaslAndHMACAuthenticator authenticator = new SaslAndHMACAuthenticator();
-            authenticator.setup(new HashMap<String, Object>());
-        });
-    }
-
-    @Test
-    public void testSetupEmptyNoUserDefault() {
-        assertThrows(IllegalStateException.class, () -> {
-            final SaslAndHMACAuthenticator authenticator = createMockBuilder(SaslAndHMACAuthenticator.class)
-                .addMockedMethod("openGraph")
-                .addMockedMethod("createCredentialGraph")
-                .createMock();
-            final JanusGraph graph = createMock(JanusGraph.class);
-            final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
-            final Map<String, Object> configMap = new HashMap<String, Object>();
-            configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
-            configMap.put(SaslAndHMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
-
-            expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
-            expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
-            authenticator.setup(configMap);
-        });
-    }
-
-    @Test
-    public void testSetupEmptyCredGraphNoPassDefault() {
-        assertThrows(IllegalStateException.class, () -> {
-            final SaslAndHMACAuthenticator authenticator = createMockBuilder(SaslAndHMACAuthenticator.class)
-                .addMockedMethod("openGraph")
-                .addMockedMethod("createCredentialGraph")
-                .createMock();
-            final JanusGraph graph = createMock(JanusGraph.class);
-            final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
-            final Map<String, Object> configMap = new HashMap<String, Object>();
-            configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
-            configMap.put(SaslAndHMACAuthenticator.CONFIG_DEFAULT_USER, "user");
-
-            expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
-            expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
-            authenticator.setup(configMap);
-        });
-    }
-
-    @Test
-    public void testSetupEmptyCredGraphNoUserIndex() {
-        final SaslAndHMACAuthenticator authenticator = createMockBuilder(SaslAndHMACAuthenticator.class)
-            .addMockedMethod("openGraph")
-            .addMockedMethod("createCredentialGraph")
-            .addMockedMethod("createSimpleAuthenticator")
-            .addMockedMethod("createHMACAuthenticator")
-            .createMock();
-
-        final Map<String, Object> configMap = new HashMap<String, Object>();
-        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
-        configMap.put(SaslAndHMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
-        configMap.put(SaslAndHMACAuthenticator.CONFIG_DEFAULT_USER, "user");
-
-        final JanusGraph graph = createMock(JanusGraph.class);
-        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
-        final ManagementSystem mgmt = createMock(ManagementSystem.class);
-        final JanusGraphSimpleAuthenticator janusSimpleAuthenticator = createMock(JanusGraphSimpleAuthenticator.class);
-        final HMACAuthenticator hmacAuthenticator = createMock(HMACAuthenticator.class);
-        final SimpleAuthenticator simpleAuthenticator = createMock(SimpleAuthenticator.class);
-        final Transaction tx = createMock(Transaction.class);
-        final PropertyKey pk = createMock(PropertyKey.class);
-        final PropertyKeyMaker pkm = createMock(PropertyKeyMaker.class);
-        final JanusGraphManagement.IndexBuilder indexBuilder = createMock(JanusGraphManagement.IndexBuilder.class);
-        final JanusGraphIndex index = createMock(JanusGraphIndex.class);
-        final PropertyKey[] pks = {pk};
-
-        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
-        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
-        expect(authenticator.createSimpleAuthenticator()).andReturn(janusSimpleAuthenticator);
-        expect(authenticator.createHMACAuthenticator()).andReturn(hmacAuthenticator);
-        hmacAuthenticator.setup(configMap);
-        expectLastCall();
-        expect(janusSimpleAuthenticator.createSimpleAuthenticator()).andReturn(simpleAuthenticator);
-        simpleAuthenticator.setup(configMap);
-        expectLastCall();
-
-        expect(credentialGraph.findUser("user")).andReturn(null);
-        expect(credentialGraph.createUser(eq("user"), eq("pass"))).andReturn(null);
-        expect(graph.openManagement()).andReturn(mgmt).times(2);
-        expect(graph.tx()).andReturn(tx);
-        expect(index.getFieldKeys()).andReturn(pks);
-        expect(index.getIndexStatus(eq(pk))).andReturn(SchemaStatus.ENABLED);
-
-        tx.rollback();
-        expectLastCall();
-
-        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(false);
-        expect(mgmt.makePropertyKey(PROPERTY_USERNAME)).andReturn(pkm);
-        expect(pkm.dataType(eq(String.class))).andReturn(pkm);
-        expect(pkm.cardinality(Cardinality.SINGLE)).andReturn(pkm);
-        expect(pkm.make()).andReturn(pk);
-        expect(mgmt.buildIndex(eq("byUsername"), eq(Vertex.class))).andReturn(indexBuilder);
-        expect(mgmt.getGraphIndex(eq("byUsername"))).andReturn(index);
-        expect(indexBuilder.addKey(eq(pk))).andReturn(indexBuilder);
-        expect(indexBuilder.unique()).andReturn(indexBuilder);
-        expect(indexBuilder.buildCompositeIndex()).andReturn(index);
-
-        mgmt.commit();
-        expectLastCall();
-
-        mgmt.rollback();
-        expectLastCall();
-
-        replayAll();
-
-        authenticator.setup(configMap);
-    }
-
-    @Test
-    public void testPassEmptyCredGraphUserIndex() {
-        final SaslAndHMACAuthenticator authenticator = createMockBuilder(SaslAndHMACAuthenticator.class)
-            .addMockedMethod("openGraph")
-            .addMockedMethod("createCredentialGraph")
-            .addMockedMethod("createSimpleAuthenticator")
-            .addMockedMethod("createHMACAuthenticator")
-            .createMock();
-
-        final Map<String, Object> configMap = new HashMap<>();
-        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
-        configMap.put(SaslAndHMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
-        configMap.put(SaslAndHMACAuthenticator.CONFIG_DEFAULT_USER, "user");
-
-        final JanusGraph graph = createMock(JanusGraph.class);
-        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
-        final ManagementSystem mgmt = createMock(ManagementSystem.class);
-        final HMACAuthenticator hmacAuthenticator = createMock(HMACAuthenticator.class);
-        final JanusGraphSimpleAuthenticator janusSimpleAuthenticator = createMock(JanusGraphSimpleAuthenticator.class);
-        final SimpleAuthenticator simpleAuthenticator = createMock(SimpleAuthenticator.class);
-        final Transaction tx = createMock(Transaction.class);
-
-        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
-        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
-        expect(authenticator.createSimpleAuthenticator()).andReturn(janusSimpleAuthenticator);
-        expect(authenticator.createHMACAuthenticator()).andReturn(hmacAuthenticator);
-        hmacAuthenticator.setup(configMap);
-        expectLastCall();
-        expect(janusSimpleAuthenticator.createSimpleAuthenticator()).andReturn(simpleAuthenticator);
-        simpleAuthenticator.setup(configMap);
-        expectLastCall();
-        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
-        expect(credentialGraph.findUser("user")).andReturn(null);
-        expect(credentialGraph.createUser(eq("user"), eq("pass"))).andReturn(null);
-        expect(graph.openManagement()).andReturn(mgmt);
-        expect(graph.tx()).andReturn(tx);
-        tx.rollback();
-        expectLastCall();
-        replayAll();
-
-        authenticator.setup(configMap);
-    }
-
-    @Test
-    public void testSetupDefaultUserNonEmptyCredGraph() {
-        final SaslAndHMACAuthenticator authenticator = createMockBuilder(SaslAndHMACAuthenticator.class)
-            .addMockedMethod("openGraph")
-            .addMockedMethod("createCredentialGraph")
-            .addMockedMethod("createSimpleAuthenticator")
-            .addMockedMethod("createHMACAuthenticator")
-            .createMock();
-
-        final Map<String, Object> configMap = new HashMap<String, Object>();
-        configMap.put(CONFIG_CREDENTIALS_DB, "configCredDb");
-        configMap.put(SaslAndHMACAuthenticator.CONFIG_DEFAULT_PASSWORD, "pass");
-        configMap.put(SaslAndHMACAuthenticator.CONFIG_DEFAULT_USER, "user");
-
-        final JanusGraph graph = createMock(JanusGraph.class);
-        final CredentialGraph credentialGraph = createMock(CredentialGraph.class);
-        final ManagementSystem mgmt = createMock(ManagementSystem.class);
-        final JanusGraphSimpleAuthenticator janusSimpleAuthenticator = createMock(JanusGraphSimpleAuthenticator.class);
-        final HMACAuthenticator hmacAuthenticator = createMock(HMACAuthenticator.class);
-        final SimpleAuthenticator simpleAuthenticator = createMock(SimpleAuthenticator.class);
-        final Transaction tx = createMock(Transaction.class);
-
-        expect(authenticator.openGraph(isA(String.class))).andReturn(graph);
-        expect(authenticator.createCredentialGraph(isA(JanusGraph.class))).andReturn(credentialGraph);
-        expect(authenticator.createSimpleAuthenticator()).andReturn(janusSimpleAuthenticator);
-        expect(authenticator.createHMACAuthenticator()).andReturn(hmacAuthenticator);
-        hmacAuthenticator.setup(configMap);
-        expectLastCall();
-        expect(janusSimpleAuthenticator.createSimpleAuthenticator()).andReturn(simpleAuthenticator);
-        simpleAuthenticator.setup(configMap);
-        expectLastCall();
-        expect(mgmt.containsGraphIndex(eq("byUsername"))).andReturn(true);
-        expect(graph.openManagement()).andReturn(mgmt);
-        expect(graph.tx()).andReturn(tx);
-        expect(credentialGraph.findUser("user")).andReturn(createMock(Vertex.class));
-        tx.rollback();
-        expectLastCall();
-
-        replayAll();
-
-        authenticator.setup(configMap);
-    }
-
 }


### PR DESCRIPTION
TinkerPop [deprecated](http://tinkerpop.apache.org/docs/3.4.0/upgrade/#_credential_dsl_changes) the old `CredentialGraph` with version 3.3.3 and it will be removed completely in version 3.4.0. Instead, the new Credential traversal DSL should be used.
So, this is a precondition for the upgrade to TinkerPop 3.4.0.

The tests made extensive use of mocking of the `CredentialGraph` which is now not possible any more. Since they were quite complex in general and contained a lot of duplicated code, I decided to refactor them completely instead of trying to fix them as that would have been probably even more work.
During the refactoring of the tests I also noticed some minor issues in the code which I also fixed.

I tested manually that authentication with the `JanusGraphSimpleAuthenticator` still works and that it can also use credentials stored in Cassandra that were created with JanusGraph 0.3.1.

Part of #1364.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [-] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [-] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [-] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [-] Have you ensured that format looks appropriate for the output in which it is rendered?
- [-] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

