### PR TITLE
Support CQL for OLAP

### DIFF
--- a/janusgraph-cql/pom.xml
+++ b/janusgraph-cql/pom.xml
@@ -309,6 +309,19 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>pack-test-jar</id>
+                        <!-- prepare-package instead of package forces it to get signed -->
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStore.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStore.java
@@ -103,9 +103,9 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
     private static final String TTL_FUNCTION_NAME = "ttl";
     private static final String WRITETIME_FUNCTION_NAME = "writetime";
 
-    static final String KEY_COLUMN_NAME = "key";
-    static final String COLUMN_COLUMN_NAME = "column1";
-    static final String VALUE_COLUMN_NAME = "value";
+    public static final String KEY_COLUMN_NAME = "key";
+    public static final String COLUMN_COLUMN_NAME = "column1";
+    public static final String VALUE_COLUMN_NAME = "value";
     static final String WRITETIME_COLUMN_NAME = "writetime";
     static final String TTL_COLUMN_NAME = "ttl";
 

--- a/janusgraph-dist/src/assembly/static/conf/hadoop-graph/read-cql.properties
+++ b/janusgraph-dist/src/assembly/static/conf/hadoop-graph/read-cql.properties
@@ -1,0 +1,44 @@
+# Copyright 2019 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Hadoop Graph Configuration
+#
+gremlin.graph=org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph
+gremlin.hadoop.graphReader=org.janusgraph.hadoop.formats.cql.CqlInputFormat
+gremlin.hadoop.graphWriter=org.apache.tinkerpop.gremlin.hadoop.structure.io.gryo.GryoOutputFormat
+
+gremlin.hadoop.jarsInDistributedCache=true
+gremlin.hadoop.inputLocation=none
+gremlin.hadoop.outputLocation=output
+
+#
+# JanusGraph Cassandra InputFormat configuration
+#
+janusgraphmr.ioformat.conf.storage.backend=cql
+janusgraphmr.ioformat.conf.storage.hostname=localhost
+janusgraphmr.ioformat.conf.storage.port=9042
+janusgraphmr.ioformat.conf.storage.cassandra.keyspace=janusgraph
+
+#
+# Apache Cassandra InputFormat configuration
+#
+cassandra.input.partitioner.class=org.apache.cassandra.dht.Murmur3Partitioner
+
+#
+# SparkGraphComputer Configuration
+#
+spark.master=local[4]
+spark.serializer=org.apache.spark.serializer.KryoSerializer
+spark.kryo.registrator=org.janusgraph.hadoop.serialize.JanusGraphKryoRegistrator

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/pom.xml
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/pom.xml
@@ -62,6 +62,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>janusgraph-cql</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>janusgraph-es</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cql/CqlBinaryInputFormat.java
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cql/CqlBinaryInputFormat.java
@@ -1,0 +1,97 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.hadoop.formats.cql;
+
+import org.apache.cassandra.hadoop.ConfigHelper;
+import org.apache.cassandra.hadoop.cql3.CqlInputFormat;
+import org.apache.cassandra.hadoop.cql3.CqlRecordReader;
+import org.apache.cassandra.thrift.SlicePredicate;
+import org.apache.cassandra.thrift.SliceRange;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.cql.CQLConfigOptions;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.janusgraph.hadoop.config.JanusGraphHadoopConfiguration;
+import org.janusgraph.hadoop.formats.util.AbstractBinaryInputFormat;
+import org.janusgraph.hadoop.formats.util.input.JanusGraphHadoopSetupCommon;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+
+public class CqlBinaryInputFormat extends AbstractBinaryInputFormat {
+
+    private static final Logger log = LoggerFactory.getLogger(CqlBinaryInputFormat.class);
+
+    // Copied these private constants from Cassandra's ConfigHelper circa 2.0.9
+    private static final String INPUT_WIDEROWS_CONFIG = "cassandra.input.widerows";
+    private static final String RANGE_BATCH_SIZE_CONFIG = "cassandra.range.batch.size";
+
+    private final CqlInputFormat  cqlInputFormat = new CqlInputFormat();
+
+    @Override
+    public List<InputSplit> getSplits(JobContext jobContext) throws IOException {
+        return cqlInputFormat.getSplits(jobContext);
+    }
+
+    @Override
+    public RecordReader<StaticBuffer, Iterable<Entry>> createRecordReader(InputSplit inputSplit, TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
+        CqlRecordReader recordReader = (CqlRecordReader) cqlInputFormat.createRecordReader(inputSplit, taskAttemptContext);
+        CqlBinaryRecordReader reader = new CqlBinaryRecordReader(recordReader);
+
+        return reader;
+    }
+
+    @Override
+    public void setConf(final Configuration config) {
+        super.setConf(config);
+
+        // Copy some JanusGraph configuration keys to the Hadoop Configuration keys used by Cassandra's ColumnFamilyInputFormat
+        ConfigHelper.setInputInitialAddress(config, janusgraphConf.get(GraphDatabaseConfiguration.STORAGE_HOSTS)[0]);
+        if (janusgraphConf.has(GraphDatabaseConfiguration.STORAGE_PORT))
+            ConfigHelper.setInputRpcPort(config, String.valueOf(janusgraphConf.get(GraphDatabaseConfiguration.STORAGE_PORT)));
+        if (janusgraphConf.has(GraphDatabaseConfiguration.AUTH_USERNAME))
+            ConfigHelper.setInputKeyspaceUserName(config, janusgraphConf.get(GraphDatabaseConfiguration.AUTH_USERNAME));
+        if (janusgraphConf.has(GraphDatabaseConfiguration.AUTH_PASSWORD))
+            ConfigHelper.setInputKeyspacePassword(config, janusgraphConf.get(GraphDatabaseConfiguration.AUTH_PASSWORD));
+
+        // Copy keyspace, force the CF setting to edgestore, honor widerows when set
+        final boolean wideRows = config.getBoolean(INPUT_WIDEROWS_CONFIG, false);
+        // Use the setInputColumnFamily overload that includes a widerows argument; using the overload without this argument forces it false
+        ConfigHelper.setInputColumnFamily(config, janusgraphConf.get(CQLConfigOptions.KEYSPACE),
+            mrConf.get(JanusGraphHadoopConfiguration.COLUMN_FAMILY_NAME), wideRows);
+        log.debug("Set keyspace: {}", janusgraphConf.get(CQLConfigOptions.KEYSPACE));
+
+        // Set the column slice bounds via Faunus' vertex query filter
+        final SlicePredicate predicate = new SlicePredicate();
+        final int rangeBatchSize = config.getInt(RANGE_BATCH_SIZE_CONFIG, Integer.MAX_VALUE);
+        predicate.setSlice_range(getSliceRange(rangeBatchSize)); // TODO stop slicing the whole row
+        ConfigHelper.setInputSlicePredicate(config, predicate);
+    }
+
+    private SliceRange getSliceRange(final int limit) {
+        final SliceRange sliceRange = new SliceRange();
+        sliceRange.setStart(JanusGraphHadoopSetupCommon.DEFAULT_SLICE_QUERY.getSliceStart().asByteBuffer());
+        sliceRange.setFinish(JanusGraphHadoopSetupCommon.DEFAULT_SLICE_QUERY.getSliceEnd().asByteBuffer());
+        sliceRange.setCount(Math.min(limit, JanusGraphHadoopSetupCommon.DEFAULT_SLICE_QUERY.getLimit()));
+        return sliceRange;
+    }
+}

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cql/CqlBinaryRecordReader.java
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cql/CqlBinaryRecordReader.java
@@ -1,0 +1,119 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.hadoop.formats.cql;
+
+import com.datastax.driver.core.Row;
+import org.apache.cassandra.hadoop.cql3.CqlRecordReader;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.cql.CQLKeyColumnValueStore;
+import org.janusgraph.diskstorage.util.StaticArrayBuffer;
+import org.janusgraph.diskstorage.util.StaticArrayEntry;
+import java.io.IOException;
+import java.util.ArrayList;
+
+public class CqlBinaryRecordReader extends RecordReader<StaticBuffer, Iterable<Entry>> {
+    private KV currentKV;
+    private KV incompleteKV;
+
+    private final CqlRecordReader reader;
+
+    public CqlBinaryRecordReader(CqlRecordReader reader) {
+        this.reader = reader;
+    }
+
+    @Override
+    public void initialize(final InputSplit inputSplit, final TaskAttemptContext taskAttemptContext) throws IOException {
+        reader.initialize(inputSplit, taskAttemptContext);
+    }
+
+    @Override
+    public boolean nextKeyValue() throws IOException {
+        return null != (currentKV = completeNextKV());
+    }
+
+    private KV completeNextKV() throws IOException {
+        KV completedKV = null;
+        boolean hasNext;
+        do {
+            hasNext = reader.nextKeyValue();
+
+            if (!hasNext) {
+                completedKV = incompleteKV;
+                incompleteKV = null;
+            } else {
+                Row row = reader.getCurrentValue();
+                StaticArrayBuffer key = StaticArrayBuffer.of(row.getBytesUnsafe(CQLKeyColumnValueStore.KEY_COLUMN_NAME));
+                StaticBuffer column1 = StaticArrayBuffer.of(row.getBytesUnsafe(CQLKeyColumnValueStore.COLUMN_COLUMN_NAME));
+                StaticBuffer value = StaticArrayBuffer.of(row.getBytesUnsafe(CQLKeyColumnValueStore.VALUE_COLUMN_NAME));
+                Entry entry = StaticArrayEntry.of(column1, value);
+
+                if (null == incompleteKV) {
+                    // Initialization; this should happen just once in an instance's lifetime
+                    incompleteKV = new KV(key);
+                } else if (!incompleteKV.key.equals(key)) {
+                    // The underlying Cassandra reader has just changed to a key we haven't seen yet
+                    // This implies that there will be no more entries for the prior key
+                    completedKV = incompleteKV;
+                    incompleteKV = new KV(key);
+                }
+
+                incompleteKV.addEntry(entry);
+            }
+            /* Loop ends when either
+             * A) the cassandra reader ran out of data
+             * or
+             * B) the cassandra reader switched keys, thereby completing a KV */
+        } while (hasNext && null == completedKV);
+
+        return completedKV;
+    }
+
+    @Override
+    public StaticBuffer getCurrentKey() {
+        return currentKV.key;
+    }
+
+    @Override
+    public Iterable<Entry> getCurrentValue() {
+        return currentKV.entries;
+    }
+
+    @Override
+    public void close() {
+        reader.close();
+    }
+
+    @Override
+    public float getProgress() {
+        return reader.getProgress();
+    }
+
+    private static class KV {
+        private final StaticArrayBuffer key;
+        private ArrayList<Entry> entries = new ArrayList<>();
+
+        public KV(StaticArrayBuffer key) {
+            this.key = key;
+        }
+
+        public void addEntry(Entry toAdd) {
+            entries.add(toAdd);
+        }
+    }
+}

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cql/CqlInputFormat.java
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/main/java/org/janusgraph/hadoop/formats/cql/CqlInputFormat.java
@@ -1,0 +1,23 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.hadoop.formats.cql;
+
+import org.janusgraph.hadoop.formats.util.HadoopInputFormat;
+
+public class CqlInputFormat extends HadoopInputFormat {
+    public CqlInputFormat() {
+        super(new CqlBinaryInputFormat());
+    }
+}

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/test/java/org/janusgraph/hadoop/CqlInputFormatIT.java
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/test/java/org/janusgraph/hadoop/CqlInputFormatIT.java
@@ -1,0 +1,57 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.hadoop;
+
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.util.GraphFactory;
+import org.janusgraph.diskstorage.cql.CassandraStorageSetup;
+import org.janusgraph.diskstorage.configuration.WriteConfiguration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.STORAGE_HOSTS;
+
+public class CqlInputFormatIT extends AbstractInputFormatIT {
+
+    @BeforeAll
+    public static void start(){
+        CassandraStorageSetup.startCleanEmbedded();
+    }
+
+    private PropertiesConfiguration getGraphConfiguration() throws ConfigurationException, IOException {
+        final PropertiesConfiguration config = new PropertiesConfiguration("target/test-classes/cql-read.properties");
+        Path baseOutDir = Paths.get((String) config.getProperty("gremlin.hadoop.outputLocation"));
+        baseOutDir.toFile().mkdirs();
+        String outDir = Files.createTempDirectory(baseOutDir, null).toAbsolutePath().toString();
+        config.setProperty("gremlin.hadoop.outputLocation", outDir);
+        return config;
+    }
+
+    @Override
+    public WriteConfiguration getConfiguration() {
+        return CassandraStorageSetup.getCQLConfiguration("cqlinputformatit").set(STORAGE_HOSTS, new String[]{"127.0.0.1"}).getConfiguration();
+    }
+
+    @Override
+    protected Graph getGraph() throws ConfigurationException, IOException {
+        return GraphFactory.open(getGraphConfiguration());
+    }
+}

--- a/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/test/resources/cql-read.properties
+++ b/janusgraph-hadoop-parent/janusgraph-hadoop-core/src/test/resources/cql-read.properties
@@ -1,0 +1,35 @@
+# Copyright 2019 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+gremlin.graph=org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph
+gremlin.hadoop.graphReader=org.janusgraph.hadoop.formats.cql.CqlInputFormat
+gremlin.hadoop.graphWriter=org.apache.hadoop.mapreduce.lib.output.NullOutputFormat
+gremlin.hadoop.jarsInDistributedCache=true
+gremlin.hadoop.inputLocation=none
+gremlin.hadoop.outputLocation=target/output
+
+janusgraphmr.ioformat.conf.storage.backend=cql
+janusgraphmr.ioformat.conf.storage.cql.keyspace=cqlinputformatit
+janusgraphmr.ioformat.conf.storage.hostname=localhost
+janusgraphmr.ioformat.conf.storage.port=9042
+
+####################################
+# SparkGraphComputer Configuration #
+####################################
+spark.master=local[4]
+spark.executor.memory=1g
+spark.serializer=org.apache.spark.serializer.KryoSerializer
+spark.kryo.registrator=org.janusgraph.hadoop.serialize.JanusGraphKryoRegistrator
+cassandra.input.partitioner.class=org.apache.cassandra.dht.Murmur3Partitioner
+cassandra.input.widerows=true

--- a/janusgraph-hadoop-parent/pom.xml
+++ b/janusgraph-hadoop-parent/pom.xml
@@ -96,9 +96,10 @@
         </dependency>
         <dependency>
             <groupId>org.janusgraph</groupId>
-            <artifactId>janusgraph-cassandra</artifactId>
+            <artifactId>janusgraph-cql</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
+            <classifier>tests</classifier>
         </dependency>
         <dependency>
             <groupId>org.janusgraph</groupId>
@@ -324,6 +325,7 @@
                             <configuration>
                                 <includes>
                                     <include>**/*Cassandra*IT.java</include>
+                                    <include>**/*Cql*IT.java</include>
                                 </includes>
                                 <excludes>
                                     <exclude>**/*Cassandra3*IT.java</exclude>
@@ -344,6 +346,7 @@
                             <configuration>
                                 <includes>
                                     <include>**/*Cassandra3*IT.java</include>
+                                    <include>**/*Cql*IT.java</include>
                                 </includes>
                                 <skipTests>${skipCassandra3}</skipTests>
                                 <reuseForks>false</reuseForks>


### PR DESCRIPTION
This adds a `CqlInputFormat` to enable Spark with CQL without relying on Thrift any more.

@farodin91 and I worked together on this one.

We already tested this in production with our graph with ~250 M vertices and could successfully execute some traversals on our Scylla backend with Spark.

Fixes #985.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [-] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [-] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [-] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [-] Have you ensured that format looks appropriate for the output in which it is rendered?
- [-] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

