### PR TITLE
Un-deprecate multiQuery #984 and pre-fetch properties to cache

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphMultiVertexQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphMultiVertexQuery.java
@@ -122,6 +122,10 @@ public interface JanusGraphMultiVertexQuery<Q extends JanusGraphMultiVertexQuery
      */
     Map<JanusGraphVertex, Iterable<JanusGraphVertexProperty>> properties();
 
+    /**
+     * Makes a call to properties to pre-fetch the properties into the vertex cache
+     */
+    void preFetch();
 
     /**
      * Returns an iterable over all incident relations that match this query for each vertex

--- a/janusgraph-core/src/main/java/org/janusgraph/core/Transaction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/Transaction.java
@@ -80,14 +80,12 @@ public interface Transaction extends Graph, SchemaManager {
      * @return
      * @see JanusGraph#multiQuery(org.janusgraph.core.JanusGraphVertex...)
      */
-    @Deprecated
     JanusGraphMultiVertexQuery<? extends JanusGraphMultiVertexQuery> multiQuery(JanusGraphVertex... vertices);
 
     /**
      * @return
      * @see JanusGraph#multiQuery(java.util.Collection)
      */
-    @Deprecated
     JanusGraphMultiVertexQuery<? extends JanusGraphMultiVertexQuery> multiQuery(Collection<JanusGraphVertex> vertices);
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -264,6 +264,12 @@ public class GraphDatabaseConfiguration {
                     "performance improvement if there is a non-trivial latency to the backend.",
             ConfigOption.Type.MASKABLE, false);
 
+    public static final ConfigOption<Boolean> BATCH_PROPERTY_PREFETCHING = new ConfigOption<>(QUERY_NS,"batch-property-prefetch",
+            "Whether to do a batched pre-fetch of all properties on adjacent vertices against the storage backend prior to evaluating a has condition against those vertices. " +
+                    "Because these vertex properties will be loaded into the transaction-level cache of recently-used vertices when the condition is evaluated this can " +
+                    "lead to significant performance improvement if there are many edges to adjacent vertices and there is a non-trivial latency to the backend.",
+            ConfigOption.Type.MASKABLE, false);
+
     // ################ SCHEMA #######################
     // ################################################
 
@@ -1214,6 +1220,7 @@ public class GraphDatabaseConfiguration {
     private Boolean propertyPrefetching;
     private boolean adjustQueryLimit;
     private Boolean useMultiQuery;
+    private Boolean batchPropertyPrefetching;
     private boolean allowVertexIdSetting;
     private boolean logTransactions;
     private String metricsPrefix;
@@ -1298,6 +1305,10 @@ public class GraphDatabaseConfiguration {
 
     public boolean useMultiQuery() {
         return useMultiQuery;
+    }
+
+    public boolean batchPropertyPrefetching() {
+        return batchPropertyPrefetching;
     }
 
     public boolean adjustQueryLimit() {
@@ -1410,6 +1421,7 @@ public class GraphDatabaseConfiguration {
 
         propertyPrefetching = configuration.get(PROPERTY_PREFETCHING);
         useMultiQuery = configuration.get(USE_MULTIQUERY);
+        batchPropertyPrefetching = configuration.get(BATCH_PROPERTY_PREFETCHING);
         adjustQueryLimit = configuration.get(ADJUST_LIMIT);
         allowVertexIdSetting = configuration.get(ALLOW_SETTING_VERTEX_ID);
         logTransactions = configuration.get(SYSTEM_LOG_TRANSACTIONS);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/QueryProfiler.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/QueryProfiler.java
@@ -30,6 +30,7 @@ public interface QueryProfiler {
     String LIMIT_ANNOTATION = "limit";
 
     String MULTIQUERY_ANNOTATION = "multi";
+    String MULTIPREFETCH_ANNOTATION = "multiPreFetch";
     String NUMVERTICES_ANNOTATION = "vertices";
     String PARTITIONED_VERTEX_ANNOTATION = "partitioned";
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/MultiVertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/MultiVertexCentricQueryBuilder.java
@@ -141,6 +141,12 @@ public class MultiVertexCentricQueryBuilder extends BasicVertexCentricQueryBuild
     }
 
     @Override
+    public void preFetch() {
+        profiler.setAnnotation(QueryProfiler.MULTIPREFETCH_ANNOTATION, true);
+        properties();
+    }
+
+    @Override
     public Map<JanusGraphVertex, Iterable<JanusGraphRelation>> relations() {
         return (Map)(isImplicitKeyQuery(RelationCategory.RELATION)?
                 executeImplicitKeyQuery():

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphBlueprintsGraph.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphBlueprintsGraph.java
@@ -181,13 +181,11 @@ public abstract class JanusGraphBlueprintsGraph implements JanusGraph {
     }
 
     @Override
-    @Deprecated
     public JanusGraphMultiVertexQuery multiQuery(JanusGraphVertex... vertices) {
         return getAutoStartTx().multiQuery(vertices);
     }
 
     @Override
-    @Deprecated
     public JanusGraphMultiVertexQuery multiQuery(Collection<JanusGraphVertex> vertices) {
         return getAutoStartTx().multiQuery(vertices);
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphEdgeVertexStep.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphEdgeVertexStep.java
@@ -1,0 +1,111 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.optimize;
+
+import org.janusgraph.core.JanusGraphMultiVertexQuery;
+import org.janusgraph.graphdb.query.profile.QueryProfiler;
+import org.janusgraph.graphdb.query.vertex.BasicVertexCentricQueryBuilder;
+import org.janusgraph.graphdb.tinkerpop.profile.TP3ProfileWrapper;
+
+import com.google.common.collect.Sets;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.Profiling;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeVertexStep;
+import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
+import org.apache.tinkerpop.gremlin.process.traversal.util.MutableMetrics;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A JanusGraphEdgeVertexStep is identical to a {@link EdgeVertexStep}. The only difference
+ * being that it can use multiQuery to pre-fetch the vertex properties prior to the execution
+ * of any subsequent has steps and so eliminate the need for a network trip for each vertex.
+ * It implements the optimisation enabled via the query.batch-property-prefetch config option.
+ */
+public class JanusGraphEdgeVertexStep extends EdgeVertexStep implements Profiling {
+
+    private boolean initialized = false;
+    private QueryProfiler queryProfiler = QueryProfiler.NO_OP;
+    private final int txVertexCacheSize;
+
+    public JanusGraphEdgeVertexStep(EdgeVertexStep originalStep, int txVertexCacheSize) {
+        super(originalStep.getTraversal(), originalStep.getDirection());
+        originalStep.getLabels().forEach(this::addLabel);
+        this.txVertexCacheSize = txVertexCacheSize;
+    }
+
+    private void initialize() {
+        assert !initialized;
+        initialized = true;
+
+        if (!starts.hasNext()) {
+            throw FastNoSuchElementException.instance();
+        }
+        List<Traverser.Admin<Edge>> edges = new ArrayList<>();
+        Set<Vertex> vertices = Sets.newHashSet();
+        starts.forEachRemaining(e -> {
+            edges.add(e);
+
+            if (vertices.size() < txVertexCacheSize) {
+                if (Direction.IN.equals(direction) || Direction.BOTH.equals(direction)) {
+                    vertices.add(e.get().inVertex());
+                }
+                if (Direction.OUT.equals(direction) || Direction.BOTH.equals(direction)) {
+                    vertices.add(e.get().outVertex());
+                }
+            }
+        });
+
+        // If there are multiple vertices then fetch the properties for all of them in a single multiQuery to
+        // populate the vertex cache so subsequent queries of properties don't have to go to the storage back end
+        if (vertices.size() > 1) {
+            JanusGraphMultiVertexQuery multiQuery = JanusGraphTraversalUtil.getTx(traversal).multiQuery();
+            ((BasicVertexCentricQueryBuilder) multiQuery).profiler(queryProfiler);
+            multiQuery.addAllVertices(vertices).preFetch();
+        }
+
+        starts.add(edges.iterator());
+    }
+
+    @Override
+    protected Traverser.Admin<Vertex> processNextStart() {
+        if (!initialized) initialize();
+        return super.processNextStart();
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        this.initialized = false;
+    }
+
+    @Override
+    public JanusGraphEdgeVertexStep clone() {
+        final JanusGraphEdgeVertexStep clone = (JanusGraphEdgeVertexStep) super.clone();
+        clone.initialized = false;
+        return clone;
+    }
+
+    @Override
+    public void setMetrics(MutableMetrics metrics) {
+        queryProfiler = new TP3ProfileWrapper(metrics);
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphPropertiesStep.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphPropertiesStep.java
@@ -82,7 +82,6 @@ public class JanusGraphPropertiesStep<E> extends PropertiesStep<E> implements Ha
         return (Iterator<E>) Iterators.transform(iterable.iterator(), Property::value);
     }
 
-    @SuppressWarnings("deprecation")
     private void initialize() {
         assert !initialized;
         initialized = true;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -1085,7 +1085,6 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
     }
 
     @Override
-    @Deprecated
     public JanusGraphMultiVertexQuery multiQuery(JanusGraphVertex... vertices) {
         MultiVertexCentricQueryBuilder builder = new MultiVertexCentricQueryBuilder(this);
         for (JanusGraphVertex v : vertices) builder.addVertex(v);
@@ -1093,7 +1092,6 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
     }
 
     @Override
-    @Deprecated
     public JanusGraphMultiVertexQuery multiQuery(Collection<JanusGraphVertex> vertices) {
         MultiVertexCentricQueryBuilder builder = new MultiVertexCentricQueryBuilder(this);
         builder.addAllVertices(vertices);

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -2001,7 +2001,6 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
      * are bound to single-threaded graph transactions
      */
     @Test
-    @SuppressWarnings("deprecation")
     public void testThreadBoundTx() {
         PropertyKey t = mgmt.makePropertyKey("type").dataType(Integer.class).make();
         mgmt.buildIndex("etype", Edge.class).addKey(t).buildCompositeIndex();
@@ -2757,7 +2756,6 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         testVertexCentricQuery(10000 /*noVertices*/);
     }
 
-    @SuppressWarnings("deprecation")
     public void testVertexCentricQuery(int noVertices) {
         makeVertexIndexedUniqueKey("name", String.class);
         PropertyKey time = makeKey("time", Integer.class);
@@ -3978,7 +3976,6 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         }
 
         Traversal t;
-        TraversalMetrics metrics;
         GraphTraversalSource gts = graph.traversal();
 
         //Edge
@@ -4029,6 +4026,30 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertNumStep(superV * 10, 2, gts.V().has("id", sid).local(__.outE("knows").has("weight", P.gte(1)).has("weight", P.lt(3)).limit(10)), JanusGraphStep.class, JanusGraphVertexStep.class);
         assertNumStep(superV * 10, 1, gts.V().has("id", sid).local(__.outE("knows").has("weight", P.between(1, 3)).order().by("weight", decr).limit(10)), JanusGraphStep.class);
         assertNumStep(superV * 10, 0, gts.V().has("id", sid).local(__.outE("knows").has("weight", P.between(1, 3)).order().by("weight", decr).limit(10)), LocalStep.class);
+
+        // Verify that the batch property pre-fetching is not applied when the configuration option is not set
+        t = gts.V().has("id", sid).outE("knows").has("weight", P.between(1, 3)).inV().has("weight", P.between(1, 3)).profile("~metrics");
+        assertNumStep(superV * (numV / 5 * 2), 2, (GraphTraversal)t, JanusGraphStep.class, JanusGraphVertexStep.class);
+        assertFalse(queryProfilerAnnotationIsPresent(t, QueryProfiler.MULTIPREFETCH_ANNOTATION));
+
+        clopen(option(BATCH_PROPERTY_PREFETCHING), true);
+        gts = graph.traversal();
+
+        // This tests an edge property before inV and will trigger the multiQuery property pre-fetch optimisation in JanusGraphEdgeVertexStep
+        t = gts.V().has("id", sid).outE("knows").has("weight", P.between(1, 3)).inV().has("weight", P.between(1, 3)).profile("~metrics");
+        assertNumStep(superV * (numV / 5 * 2), 2, (GraphTraversal)t, JanusGraphStep.class, JanusGraphVertexStep.class);
+        assertTrue(queryProfilerAnnotationIsPresent(t, QueryProfiler.MULTIPREFETCH_ANNOTATION));
+
+        // This tests a vertex property after inV and will trigger the multiQuery property pre-fetch optimisation in JanusGraphVertexStep
+        t = gts.V().has("id", sid).outE("knows").inV().has("weight", P.between(1, 3)).profile("~metrics");
+        assertNumStep(superV * (numV / 5 * 2), 2, (GraphTraversal)t, JanusGraphStep.class, JanusGraphVertexStep.class);
+        assertTrue(queryProfilerAnnotationIsPresent(t, QueryProfiler.MULTIPREFETCH_ANNOTATION));
+
+        // As above but with a limit after the has step meaning property pre-fetch won't know how much to fetch and so should not be used
+        t = gts.V().has("id", sid).outE("knows").inV().has("weight", P.between(1, 3)).limit(1000).profile("~metrics");
+        assertNumStep(superV * (numV / 5 * 2), 2, (GraphTraversal)t, JanusGraphStep.class, JanusGraphVertexStep.class);
+        assertFalse(queryProfilerAnnotationIsPresent(t, QueryProfiler.MULTIPREFETCH_ANNOTATION));
+
         clopen(option(USE_MULTIQUERY), true);
         gts = graph.traversal();
 
@@ -4042,12 +4063,12 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         //Verify traversal metrics when all reads are from cache (i.e. no backend queries)
         t = gts.V().has("id", sid).local(__.outE("knows").has("weight", P.between(1, 3)).order().by("weight", decr).limit(10)).profile("~metrics");
         assertCount(superV * 10, t);
-        metrics = t.asAdmin().getSideEffects().get("~metrics");
+        assertTrue(queryProfilerAnnotationIsPresent(t, QueryProfiler.MULTIQUERY_ANNOTATION));
 
         //Verify that properties also use multi query
         t = gts.V().has("id", sid).values("names").profile("~metrics");
         assertCount(superV * numV, t);
-        metrics = t.asAdmin().getSideEffects().get("~metrics");
+        assertTrue(queryProfilerAnnotationIsPresent(t, QueryProfiler.MULTIQUERY_ANNOTATION));
 
         clopen(option(USE_MULTIQUERY), true);
         gts = graph.traversal();
@@ -4055,13 +4076,17 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         //Verify traversal metrics when having to read from backend [same query as above]
         t = gts.V().has("id", sid).local(__.outE("knows").has("weight", P.gte(1)).has("weight", P.lt(3)).order().by("weight", decr).limit(10)).profile("~metrics");
         assertCount(superV * 10, t);
-        metrics = t.asAdmin().getSideEffects().get("~metrics");
+        assertTrue(queryProfilerAnnotationIsPresent(t, QueryProfiler.MULTIQUERY_ANNOTATION));
 
         //Verify that properties also use multi query [same query as above]
         t = gts.V().has("id", sid).values("names").profile("~metrics");
         assertCount(superV * numV, t);
-        metrics = t.asAdmin().getSideEffects().get("~metrics");
+        assertTrue(queryProfilerAnnotationIsPresent(t, QueryProfiler.MULTIQUERY_ANNOTATION));
+    }
 
+    private static boolean queryProfilerAnnotationIsPresent(Traversal t, String queryProfilerAnnotation) {
+        TraversalMetrics metrics = t.asAdmin().getSideEffects().get("~metrics");
+        return metrics.toString().contains(queryProfilerAnnotation + "=true");
     }
 
     private static void assertNumStep(int expectedResults, int expectedSteps, GraphTraversal traversal, Class<? extends Step>... expectedStepTypes) {


### PR DESCRIPTION
Signed-off-by: Scott McQuillan <scott.mcquillan@uk.ibm.com>

Pull request  to un-deprecates multiQuery for issue #984 

In addition it adds an optimisation to use multiQuery to pre-fetch properties for multiple vertices into the cache if the next step of the query is a `has` step. For queries following large number of edges this eliminates many network trips to the storage backend for the vertex properties and can give significant performance improvements, see the issue for an example.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x ] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.