### PR TITLE
issue #1482 initial contribution of production in-memory backend

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/StaticArrayBuffer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/StaticArrayBuffer.java
@@ -1,4 +1,4 @@
-// Copyright 2017 JanusGraph Authors
+// Copyright 2019 JanusGraph Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -106,7 +106,7 @@ public class StaticArrayBuffer implements StaticBuffer {
     ############## BULK READING ################
      */
 
-    void copyTo(byte[] dest, int destOffset) {
+    public void copyTo(byte[] dest, int destOffset) {
         System.arraycopy(array,offset,dest,destOffset,length());
     }
 
@@ -378,6 +378,10 @@ public class StaticArrayBuffer implements StaticBuffer {
 
     public int compareTo(StaticArrayBuffer other) {
         return compareTo(array, offset, limit, other.array, other.offset, other.limit);
+    }
+
+    public int compareTo(byte[] otherBuffer, int otherOffset, int otherLimit) {
+        return compareTo(array, offset, limit, otherBuffer, otherOffset, otherLimit);
     }
 
     protected int compareTo(int length, StaticBuffer buffer, int bufferLen) {

--- a/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/BufferPage.java
+++ b/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/BufferPage.java
@@ -1,0 +1,241 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.inmemory;
+
+import com.google.common.base.Preconditions;
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.util.StaticArrayBuffer;
+import org.janusgraph.diskstorage.util.StaticArrayEntry;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is a single page of a paged column value store, which essentially has the same structure as the original store,
+ * i.e. it holds a sorted array of Entries
+ * <p>
+ * However, instead of storing incoming Entry objects directly, it strips out the raw byte data and stores all entries in a single shared byte array,
+ * thus removing the overhead of Entry wrappers and individual byte arrays in each entry.
+ *
+ * This requires much less heap to store the same data for reasonably well populated store.
+ *
+ * The maximum saving is achieved when the page is full i.e. has reached the maximum number of entries
+ */
+
+class BufferPage {
+    public static final int[] EMPTY_INDEX = new int[]{};
+    public static final byte[] EMPTY_DATA = new byte[]{};
+
+    private int[] offsetIndex;
+    private byte[] rawData;
+
+    BufferPage(final int[] indices, final byte[] data) {
+        this.offsetIndex = indices;
+        this.rawData = data;
+    }
+
+    protected int[] getOffsetIndex() {
+        return offsetIndex;
+    }
+
+    protected byte[] getRawData() {
+        return rawData;
+    }
+
+    protected void setRawData(final byte[] rawData) {
+        this.rawData = rawData;
+    }
+
+    protected void setOffsetIndex(final int[] offsetIndex) {
+        this.offsetIndex = offsetIndex;
+    }
+
+    public boolean isEmpty() {
+        return offsetIndex.length == 0;
+    }
+
+    public int getIndex(final StaticBuffer column) {
+        //binary search on column names
+        int low = 0;
+        int high = offsetIndex.length - 1;
+        int compare;
+        int mid;
+
+        while (low <= high) {
+            mid = (low + high) >>> 1;
+
+            //NOTE: we used to do getColumn(mid).compareTo(column), where compareTo internally asserts that column is a StaticARRAYBuffer, so
+            // apparently we don't have to worry about column name being in anything but array-backed buffer
+            //So we can compare relevant array parts directly, avoiding the churn of new StaticArrayBuffers created by getColumn()
+            Preconditions.checkArgument(column instanceof StaticArrayBuffer);
+            compare = -((StaticArrayBuffer) column).compareTo(rawData, offsetIndex[mid] + 1, offsetIndex[mid] + 1 + rawData[offsetIndex[mid]]);
+
+            if (compare < 0) {
+                low = mid + 1;
+            } else if (compare > 0) {
+                high = mid - 1;
+            } else {
+                return mid; // key found
+            }
+        }
+        return -(low + 1);  // key not found.
+    }
+
+    private int getEntryLength(final int index) {
+        if (index < offsetIndex.length - 1) {
+            return offsetIndex[index + 1] - offsetIndex[index];
+        } else {
+            return rawData.length - offsetIndex[index];
+        }
+    }
+
+    private int getEntryEndOffset(final int index) {
+        if (index < offsetIndex.length - 1) {
+            return offsetIndex[index + 1];
+        } else {
+            return rawData.length;
+        }
+    }
+
+    public Entry get(final int index) {
+        final int entryBufLen = getEntryLength(index);
+
+        final ByteBuffer entryBuffer = ByteBuffer.wrap(rawData, offsetIndex[index], entryBufLen);
+
+        final byte valPos = entryBuffer.get();
+
+        final byte[] col = new byte[valPos];
+        entryBuffer.get(col);
+
+        final byte[] val = new byte[entryBufLen - valPos - 1];
+        entryBuffer.get(val);
+
+        return StaticArrayEntry.of(StaticArrayBuffer.of(col), StaticArrayBuffer.of(val));
+    }
+
+    public Entry getNoCopy(final int index) {
+        return new StaticArrayEntry(rawData, offsetIndex[index] + 1, getEntryEndOffset(index), rawData[offsetIndex[index]]);
+    }
+
+    public int numEntries() {
+        return offsetIndex.length;
+    }
+
+    public int byteSize() {
+        return rawData.length + offsetIndex.length * Integer.BYTES + 16;
+    }
+
+    public static List<BufferPage> merge(List<BufferPage> pagesToMerge, int maxPageSize) {
+        if (pagesToMerge == null || pagesToMerge.size() < 1) {
+            return pagesToMerge;
+        }
+
+        //NOTE: instead of constructing all Entries and then rebuilding offsetIndex and rawData,
+        // it could use arraycopy to copy parts of existing buffers into new ones
+        // it is possible to do in one pass, but rather complex as we'd need to keep track of current offset in new buffer,
+        // current page and offset within that page etc. In practice, this is required seldom enough to create any noticeable deficiencies.
+
+        // Just extracts all Entries from all fragmented pages into a single list, then create new full pages
+        int totalCount = 0;
+        for (BufferPage p : pagesToMerge) {
+            totalCount += p.numEntries();
+        }
+
+        Entry[] newdata = new Entry[totalCount];
+
+        totalCount = 0;
+        for (BufferPage p : pagesToMerge) {
+            for (int i = 0; i < p.numEntries(); i++) {
+                newdata[totalCount++] = p.getNoCopy(i);
+            }
+        }
+
+        int numNewPages = newdata.length / maxPageSize;
+        if (newdata.length % maxPageSize > 0) {
+            numNewPages++;
+        }
+
+        List<BufferPage> newPages = new ArrayList<>(numNewPages);
+        for (int i = 0; i < numNewPages; i++) {
+            newPages.add(BufferPageUtils.buildFromEntryArray(newdata, i * maxPageSize, Math.min(newdata.length, (i + 1) * maxPageSize)));
+        }
+
+        return newPages;
+    }
+
+    public List<BufferPage> merge(Entry[] add, int iaddp, int addLimit, Entry[] del, int idelp, int delLimit, int maxPageSize) {
+        int iadd = iaddp;
+        int idel = idelp;
+        Entry[] newdata = new Entry[numEntries() + addLimit - iadd];
+
+        // Merge sort
+        int i = 0;
+        int iold = 0;
+        while (iold < numEntries()) {
+            Entry e = getNoCopy(iold);
+            iold++;
+            // Compare with additions
+            if (iadd < addLimit) {
+                int compare = e.compareTo(add[iadd]);
+                if (compare >= 0) {
+                    e = add[iadd];
+                    iadd++;
+                    // Skip duplicates
+                    while (iadd < addLimit && e.equals(add[iadd])) {
+                        iadd++;
+                    }
+                }
+                if (compare > 0) {
+                    iold--;
+                }
+            }
+            // Compare with deletions
+            if (idel < delLimit) {
+                int compare = e.compareTo(del[idel]);
+                if (compare == 0) {
+                    e = null;
+                }
+                if (compare >= 0) {
+                    idel++;
+                }
+            }
+            if (e != null) {
+                newdata[i] = e;
+                i++;
+            }
+        }
+        while (iadd < addLimit) {
+            newdata[i] = add[iadd];
+            i++;
+            iadd++;
+        }
+
+        int newDataEnd = i;
+        int numNewPages = newDataEnd / maxPageSize;
+        if (newDataEnd % maxPageSize > 0) {
+            numNewPages++;
+        }
+
+        List<BufferPage> newPages = new ArrayList<>(numNewPages);
+
+        for (i = 0; i < numNewPages; i++) {
+            newPages.add(BufferPageUtils.buildFromEntryArray(newdata, i * maxPageSize, Math.min(newDataEnd, (i + 1) * maxPageSize)));
+        }
+
+        return newPages;
+    }
+}

--- a/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/BufferPageUtils.java
+++ b/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/BufferPageUtils.java
@@ -1,0 +1,150 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.inmemory;
+
+import com.google.common.base.Preconditions;
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.util.StaticArrayBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is a collection of static methods to help read a BufferPage from a stream it was previously dumped to
+ */
+public final class BufferPageUtils {
+
+    private static final Logger log = LoggerFactory.getLogger(BufferPageUtils.class);
+
+    public static BufferPage readPage(DataInputStream in) throws IOException {
+        int numEntries = in.readInt();
+        if (log.isDebugEnabled()) {
+            log.debug("page numentries is " + numEntries);
+        }
+
+        if (numEntries > 0) {
+            int[] index = new int[numEntries];
+            //NOTE: again, no way to read int[] as a block of bytes apparently... relying on buffering
+            for (int i = 0; i < index.length; i++) {
+                index[i] = in.readInt();
+            }
+
+            int dataLength = in.readInt();
+            if (log.isDebugEnabled()) {
+                log.debug("page data size is " + dataLength);
+            }
+
+            byte[] data = new byte[dataLength];
+            readWholeArray(in, data);
+
+            return new BufferPage(index, data);
+        } else
+            return new BufferPage(BufferPage.EMPTY_INDEX, BufferPage.EMPTY_DATA);
+    }
+
+    public static void readWholeArray(DataInputStream in, byte[] data) throws IOException {
+        int offset = 0;
+        do {
+            int bytesRead = in.read(data, offset, data.length - offset);
+            if (bytesRead < 0) {
+                throw new IllegalStateException("Premature end of file while reading, expected to read " + data.length);
+            }
+            offset += bytesRead;
+        }
+        while (offset < data.length);
+    }
+
+    public static SharedEntryBuffer readFrom(DataInputStream in) throws IOException {
+        int numPages = in.readInt();
+
+        if (log.isDebugEnabled()) {
+            log.debug("number of pages in column store is " + numPages);
+        }
+
+        if (numPages == 1) {
+            BufferPage p = readPage(in);
+
+            return new SinglePageEntryBuffer(p.getOffsetIndex(), p.getRawData());
+        } else {
+            List<BufferPage> pages = new ArrayList<>(numPages);
+            for (int i = 0; i < numPages; i++) {
+                BufferPage p = readPage(in);
+                pages.add(p);
+            }
+            return new MultiPageEntryBuffer(pages);
+        }
+    }
+
+    public static BufferPage buildFromEntryArray(final Entry[] array, final int start, final int end) {
+        Preconditions.checkArgument(start >= 0 && end <= array.length);
+        final int size = end - start;
+
+        //compute the size of the raw byte storage and the offsets of individual entries inside it
+        int[] offsetIndex = new int[size];
+        int rawSize = 0;
+        for (int i = 0; i < size; i++) {
+            offsetIndex[i] = rawSize;
+            rawSize += array[start + i].length() + 1; //extra 1 byte for valuePosition
+        }
+        byte[] rawData = new byte[rawSize];
+
+        for (int i = 0; i < size; i++) {
+            //this assumes that the key size will never be > 127 bytes, thus saving 3 out of 4 bytes to store the value position within the buffer
+            Preconditions.checkArgument(array[start + i].getValuePosition() <= 127);
+            final byte entryValPos = (byte) array[start + i].getValuePosition();
+            rawData[offsetIndex[i]] = entryValPos;
+
+            if (array[start + i] instanceof StaticArrayBuffer) {
+                final StaticArrayBuffer arrayBuffer = (StaticArrayBuffer) array[start + i];
+                arrayBuffer.copyTo(rawData, offsetIndex[i] + 1);
+            } else {
+                final byte[] entryData = array[start + i].getBytes(0, array[start + i].length());
+                System.arraycopy(entryData, 0, rawData, offsetIndex[i] + 1, entryData.length);
+            }
+        }
+        return new BufferPage(offsetIndex, rawData);
+    }
+
+    public static BufferPage buildFromEntryArray(final Entry[] array, final int size) {
+        return buildFromEntryArray(array, 0, size);
+    }
+
+    public static void dumpTo(BufferPage page, DataOutputStream out) throws IOException {
+        //page dump format is: index size aka numEntries, (offsetIndex, dataSize, rawData -- if numentries > 0)
+        if (log.isDebugEnabled()) {
+            log.debug("page index numEntries is " + page.getOffsetIndex().length + ", byte size is " + page.getOffsetIndex().length * Integer.BYTES);
+        }
+        out.writeInt(page.getOffsetIndex().length);
+
+        if (page.getOffsetIndex().length > 0) {
+            //NOTE: looks like there is no other way to write out an int[] without copying it?.. no IntBuffer.asByteBuffer(endianness) or smth...
+            // will rely on buffering here
+            for (int i : page.getOffsetIndex()) {
+                out.writeInt(i);
+            }
+
+            out.writeInt(page.getRawData().length);
+            out.write(page.getRawData());
+            if (log.isDebugEnabled()) {
+                log.debug("page data length is " + page.getRawData().length + ", byte size is " + page.getRawData().length * Integer.BYTES);
+            }
+        }
+    }
+}

--- a/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/InMemoryKeyColumnValueStore.java
+++ b/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/InMemoryKeyColumnValueStore.java
@@ -1,4 +1,4 @@
-// Copyright 2017 JanusGraph Authors
+// Copyright 2019 JanusGraph Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package org.janusgraph.diskstorage.inmemory;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.Entry;
@@ -24,26 +25,56 @@ import org.janusgraph.diskstorage.StaticBuffer;
 import org.janusgraph.diskstorage.keycolumnvalue.*;
 import org.janusgraph.diskstorage.util.RecordIterator;
 import org.apache.commons.lang.StringUtils;
+import org.janusgraph.diskstorage.util.StaticArrayBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.*;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterInputStream;
+
+import static java.util.zip.Deflater.BEST_SPEED;
+import static org.janusgraph.diskstorage.StaticBuffer.ARRAY_FACTORY;
 
 /**
  * An in-memory implementation of {@link KeyColumnValueStore}.
  * This implementation is thread-safe. All data is held in memory, which means that the capacity of this store is
  * determined by the available heap space. No data is persisted and all data lost when the jvm terminates or store closed.
  *
- * @author Matthias Broecheler (me@matthiasb.com)
+ * The implementation also provides basic dump/restore capabilities, so that a "snapshot" of its contents can be saved to filesystem
+ * and loaded back.
+ *
+ * Finally, it provides a means to assess the fragmentation of the data across allocated memory storage, and to defragment it if required.
+ * NOTE: with usual "populate then query" and "add only" use cases, fragmentation is of no concern. Only if your application performs
+ * a lot of deletes interleaved with additions for a prolong periods of time, and if you are experiencing a "bigger than expected" memory
+ * footprint, is it worth looking at fragmentation report.
+ *
  */
 
 public class InMemoryKeyColumnValueStore implements KeyColumnValueStore {
 
+    private static final boolean USE_COMPRESSION = true;
+    private static final int READ_BUFFER_SIZE = 1024 * 1024 * 8;
+    private static final int WRITE_BUFFER_SIZE = READ_BUFFER_SIZE;
+
+    private static final Logger log = LoggerFactory.getLogger(InMemoryKeyColumnValueStore.class);
+
     private final String name;
-    private final ConcurrentNavigableMap<StaticBuffer, ColumnValueStore> kcv;
+    private final ConcurrentNavigableMap<StaticBuffer, InMemoryColumnValueStore> kcv;
 
     public InMemoryKeyColumnValueStore(final String name) {
         Preconditions.checkArgument(StringUtils.isNotBlank(name));
@@ -53,7 +84,7 @@ public class InMemoryKeyColumnValueStore implements KeyColumnValueStore {
 
     @Override
     public EntryList getSlice(KeySliceQuery query, StoreTransaction txh) throws BackendException {
-        ColumnValueStore cvs = kcv.get(query.getKey());
+        InMemoryColumnValueStore cvs = kcv.get(query.getKey());
         if (cvs == null) return EntryList.EMPTY_LIST;
         else return cvs.getSlice(query, txh);
     }
@@ -67,9 +98,9 @@ public class InMemoryKeyColumnValueStore implements KeyColumnValueStore {
 
     @Override
     public void mutate(StaticBuffer key, List<Entry> additions, List<StaticBuffer> deletions, StoreTransaction txh) throws BackendException {
-        ColumnValueStore cvs = kcv.get(key);
+        InMemoryColumnValueStore cvs = kcv.get(key);
         if (cvs == null) {
-            kcv.putIfAbsent(key, new ColumnValueStore());
+            kcv.putIfAbsent(key, new InMemoryColumnValueStore());
             cvs = kcv.get(key);
         }
         cvs.mutate(additions, deletions, txh);
@@ -104,17 +135,225 @@ public class InMemoryKeyColumnValueStore implements KeyColumnValueStore {
         kcv.clear();
     }
 
+    public InMemoryKeyColumnValueStoreFragmentationReport createFragmentationReport(StoreTransaction txh) throws BackendException {
+        int totalPageCount = 0;
+        int numMultipageStores = 0;
+        int[] pageLevels = new int[]{0, 1, 3, 5, 10, 100, 500};
+        int[] pageCounts = new int[pageLevels.length + 1];
+        int[] compressablePageLevels = new int[]{0, 1, 3, 5, 10, 100, 500};
+        int[] compressablePageCounts = new int[compressablePageLevels.length + 1];
+        int[] reductionLevels = new int[]{0, 1, 3, 5, 10, 100, 500};
+        int[] reductionCounts = new int[reductionLevels.length + 1];
+        int[] entryLevels = new int[]{3, 5, 10, 100, 500, 5000, 20000, 100000, 500000, 1000000};
+        int[] entryCounts = new int[entryLevels.length + 1];
+        List<InMemoryColumnValueStore> storesToDefragment = new ArrayList<>(0);
+
+        int keysByteSize = 0;
+        int numFragmentedStores = 0;
+        int totalFragmentedPages = 0;
+        int numCompressableStores = 0;
+        int totalCompressablePages = 0;
+        int totalAchievablePageReduction = 0;
+
+        for (Map.Entry<StaticBuffer, InMemoryColumnValueStore> e : kcv.entrySet()) {
+            keysByteSize += e.getKey().length();
+            int i;
+            int numEntries = e.getValue().numEntries(txh);
+            for (i = 0; i < entryLevels.length; i++) {
+                if (numEntries <= entryLevels[i]) {
+                    break;
+                }
+            }
+            entryCounts[i]++;
+            if (e.getValue() instanceof InMemoryColumnValueStore) {
+                InMemoryColumnValueStore pbCvs = (InMemoryColumnValueStore) e.getValue();
+                SharedEntryBufferFragmentationReport fr = pbCvs.createFragmentationReport(txh);
+                int pageCount = fr.getPageCount();
+                totalPageCount += pageCount;
+                if (pageCount > 1) {
+                    numMultipageStores++;
+                }
+                for (i = 0; i < pageLevels.length; i++) {
+                    if (pageCount <= pageLevels[i]) {
+                        break;
+                    }
+                }
+                pageCounts[i]++;
+                if (fr.getFragmentedPageCount() > 0) {
+                    numFragmentedStores++;
+                    totalFragmentedPages += fr.getFragmentedPageCount();
+                    if (fr.getCompressableChunksCount() > 0) {
+                        numCompressableStores++;
+                        totalCompressablePages += fr.getCompressablePageCount();
+                        totalAchievablePageReduction += fr.getAchievablePageReduction();
+                        storesToDefragment.add(pbCvs);
+
+                        for (i = 0; i < compressablePageLevels.length; i++) {
+                            if (fr.getCompressablePageCount() <= compressablePageLevels[i]) {
+                                break;
+                            }
+                        }
+                        compressablePageCounts[i]++;
+
+                        for (i = 0; i < reductionLevels.length; i++) {
+                            if (fr.getAchievablePageReduction() <= reductionLevels[i]) {
+                                break;
+                            }
+                        }
+                        reductionCounts[i]++;
+                    }
+                }
+
+            }
+        }
+
+        return new InMemoryKeyColumnValueStoreFragmentationReport.Builder().name(name)
+        .numStores(kcv.size())
+        .numMultipageStores(numMultipageStores)
+        .totalPageCount(totalPageCount)
+        .numFragmentedStores(numFragmentedStores)
+        .totalFragmentedPages(totalFragmentedPages)
+        .numCompressableStores(numCompressableStores)
+        .totalCompressablePages(totalCompressablePages)
+        .totalAchievablePageReduction(totalAchievablePageReduction)
+        .keysByteSize(keysByteSize)
+
+        .entryLevels(entryLevels)
+        .entryCounts(entryCounts)
+
+        .pageLevels(pageLevels)
+        .pageCounts(pageCounts)
+
+        .compressablePageLevels(compressablePageLevels)
+        .compressablePageCounts(compressablePageCounts)
+
+        .reductionLevels(reductionLevels)
+        .reductionCounts(reductionCounts)
+
+        .storesToDefragment(storesToDefragment)
+        .build();
+    }
+
+    public void quickDefragment(Collection<InMemoryColumnValueStore> stores, StoreTransaction txh) throws BackendException {
+        for (InMemoryColumnValueStore cvs : stores) {
+            cvs.quickDefragment(txh);
+        }
+    }
+
+    public void quickDefragment(StoreTransaction txh) throws BackendException {
+        quickDefragment(kcv.values(), txh);
+    }
+
+    private static OutputStream compressedOutputStream(OutputStream streamToWrap) {
+        return new DeflaterOutputStream(streamToWrap, new Deflater(BEST_SPEED, true), true);
+    }
+
+    private static InputStream compressedInputStream(InputStream streamToWrap) {
+        return new InflaterInputStream(streamToWrap, new Inflater(true));
+    }
+
+    public void dumpTo(Path storePath, ForkJoinPool parallelOperationsExecutor) {
+        if (kcv.size() < 1)
+            return;
+
+        int numChunks = Runtime.getRuntime().availableProcessors() * 2;
+
+        int chunkSize = kcv.size() > 1000 ? kcv.size() / numChunks : kcv.size();
+
+        ArrayList<List<Map.Entry<StaticBuffer, InMemoryColumnValueStore>>> chunks = Lists.newArrayList(Iterators.partition(kcv.entrySet().iterator(), chunkSize));
+
+        IntStream.range(0, chunks.size()).mapToObj(i ->
+        {
+            Path filePath = Paths.get(storePath.toString(), getName() + "_" + i);
+
+            return parallelOperationsExecutor.submit(() -> dumpChunk(filePath, chunks.get(i)));
+        }).collect(Collectors.toList()) //collecting here to make sure all tasks are submitted eagerly
+            .stream().map(ForkJoinTask::join).collect(Collectors.toList());
+    }
+
+    private void dumpChunk(Path filePath, List<Map.Entry<StaticBuffer, InMemoryColumnValueStore>> chunk) {
+        if (log.isDebugEnabled()) {
+            log.debug("number of column stores in chunk " + filePath + ": " + chunk.size() + " " + Thread.currentThread().getName());
+        }
+        try (OutputStream rawStream = Files.newOutputStream(filePath, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+             BufferedOutputStream bufferedStream = new BufferedOutputStream(rawStream, WRITE_BUFFER_SIZE);
+             OutputStream compressedStream = USE_COMPRESSION ? compressedOutputStream(bufferedStream) : null;
+             DataOutputStream out = new DataOutputStream(USE_COMPRESSION ? compressedStream : bufferedStream)) {
+            //write number of kcvs
+            out.writeInt(chunk.size());
+
+            for (Map.Entry<StaticBuffer, InMemoryColumnValueStore> e : chunk) {
+                //write key length then actual key bytes
+                out.writeInt(e.getKey().length());
+
+                out.write(e.getKey().as(ARRAY_FACTORY));
+
+                InMemoryColumnValueStore sbKcv = (InMemoryColumnValueStore) e.getValue();
+                sbKcv.dumpTo(out);
+            }
+
+            if (log.isDebugEnabled()) {
+                log.debug("finished writing chunk " + filePath + " " + Thread.currentThread().getName());
+            }
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public static InMemoryKeyColumnValueStore readFrom(Path storePath, String name, ForkJoinPool parallelOperationsExecutor) throws IOException {
+        InMemoryKeyColumnValueStore store = new InMemoryKeyColumnValueStore(name);
+
+        Files.list(storePath).map(p -> parallelOperationsExecutor.submit(() -> readChunkFrom(p, store)))
+            .collect(Collectors.toList()).stream() //force it to submit all tasks
+            .map(ForkJoinTask::join).collect(Collectors.toList());
+
+        return store;
+    }
+
+    private static int readChunkFrom(Path filePath, InMemoryKeyColumnValueStore store) {
+        try (InputStream rawStream = Files.newInputStream(filePath, StandardOpenOption.READ);
+             BufferedInputStream bufferedStream = new BufferedInputStream(rawStream, READ_BUFFER_SIZE);
+             InputStream compressedStream = USE_COMPRESSION ? compressedInputStream(bufferedStream) : null;
+             DataInputStream in = new DataInputStream(USE_COMPRESSION ? compressedStream : bufferedStream)) {
+            int numKcvs = in.readInt();
+
+            if (log.isDebugEnabled()) {
+                log.debug("number of column stores in chunk " + filePath + ": " + numKcvs + " " + Thread.currentThread().getName());
+            }
+
+            for (int i = 0; i < numKcvs; i++) {
+                int keyLength = in.readInt();
+                if (log.isDebugEnabled()) {
+                    log.debug("column " + i + " key size is " + keyLength);
+                }
+                byte[] keyData = new byte[keyLength];
+                BufferPageUtils.readWholeArray(in, keyData);
+
+                //NOTE: here we know that kcv is a concurrent map so safe to put in parallel from different chunks
+                store.kcv.put(StaticArrayBuffer.of(keyData), InMemoryColumnValueStore.readFrom(in));
+            }
+
+            if (log.isDebugEnabled()) {
+                log.debug("finished reading chunk " + filePath + " " + Thread.currentThread().getName());
+            }
+
+            return numKcvs;
+        } catch (Exception ex) {
+            throw new RuntimeException("Problem while reading chunk " + filePath + " of store " + store.getName(), ex);
+        }
+    }
+
 
     private static class RowIterator implements KeyIterator {
-        private final Iterator<Map.Entry<StaticBuffer, ColumnValueStore>> rows;
+        private final Iterator<Map.Entry<StaticBuffer, InMemoryColumnValueStore>> rows;
         private final SliceQuery columnSlice;
         private final StoreTransaction transaction;
 
-        private Map.Entry<StaticBuffer, ColumnValueStore> currentRow;
-        private Map.Entry<StaticBuffer, ColumnValueStore> nextRow;
+        private Map.Entry<StaticBuffer, InMemoryColumnValueStore> currentRow;
+        private Map.Entry<StaticBuffer, InMemoryColumnValueStore> nextRow;
         private boolean isClosed;
 
-        public RowIterator(Iterator<Map.Entry<StaticBuffer, ColumnValueStore>> rows,
+        public RowIterator(Iterator<Map.Entry<StaticBuffer, InMemoryColumnValueStore>> rows,
                            @Nullable SliceQuery columns,
                            final StoreTransaction transaction) {
             this.rows = Iterators.filter(rows, entry -> entry != null && !entry.getValue().isEmpty(transaction));

--- a/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/InMemoryKeyColumnValueStoreFragmentationReport.java
+++ b/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/InMemoryKeyColumnValueStoreFragmentationReport.java
@@ -1,0 +1,383 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.inmemory;
+
+import java.util.List;
+
+public class InMemoryKeyColumnValueStoreFragmentationReport {
+    private String name;
+    private int numStores;
+    private int numMultipageStores;
+    private int totalPageCount;
+    private int[] pageLevels;
+    private int[] pageCounts;
+    private int[] compressablePageLevels;
+    private int[] compressablePageCounts;
+    private int[] reductionLevels;
+    private int[] reductionCounts;
+    private int[] entryLevels;
+    private int[] entryCounts;
+    private int keysByteSize;
+    private int numFragmentedStores;
+    private int totalFragmentedPages;
+    private int numCompressableStores;
+    private int totalCompressablePages;
+    private int totalAchievablePageReduction;
+    private List<InMemoryColumnValueStore> storesToDefragment;
+
+    private InMemoryKeyColumnValueStoreFragmentationReport(Builder builder) {
+        setName(builder.name);
+        setNumStores(builder.numStores);
+        setNumMultipageStores(builder.numMultipageStores);
+        setTotalPageCount(builder.totalPageCount);
+        setPageLevels(builder.pageLevels);
+        setPageCounts(builder.pageCounts);
+        setCompressablePageLevels(builder.compressablePageLevels);
+        setCompressablePageCounts(builder.compressablePageCounts);
+        setReductionLevels(builder.reductionLevels);
+        setReductionCounts(builder.reductionCounts);
+        setEntryLevels(builder.entryLevels);
+        setEntryCounts(builder.entryCounts);
+        setKeysByteSize(builder.keysByteSize);
+        setNumFragmentedStores(builder.numFragmentedStores);
+        setTotalFragmentedPages(builder.totalFragmentedPages);
+        setNumCompressableStores(builder.numCompressableStores);
+        setTotalCompressablePages(builder.totalCompressablePages);
+        setTotalAchievablePageReduction(builder.totalAchievablePageReduction);
+        setStoresToDefragment(builder.storesToDefragment);
+    }
+
+    public List<InMemoryColumnValueStore> getStoresToDefragment() {
+        return storesToDefragment;
+    }
+
+    public void setStoresToDefragment(List<InMemoryColumnValueStore> storesToDefragment) {
+        this.storesToDefragment = storesToDefragment;
+    }
+
+    public int getTotalAchievablePageReduction() {
+        return totalAchievablePageReduction;
+    }
+
+    public void setTotalAchievablePageReduction(int totalAchievablePageReduction) {
+        this.totalAchievablePageReduction = totalAchievablePageReduction;
+    }
+
+    public int[] getReductionCounts() {
+        return reductionCounts;
+    }
+
+    public void setReductionCounts(int[] reductionCounts) {
+        this.reductionCounts = reductionCounts;
+    }
+
+    public int[] getReductionLevels() {
+        return reductionLevels;
+    }
+
+    public void setReductionLevels(int[] reductionLevels) {
+        this.reductionLevels = reductionLevels;
+    }
+
+    public int getNumMultipageStores() {
+        return numMultipageStores;
+    }
+
+    public void setNumMultipageStores(int numMultipageStores) {
+        this.numMultipageStores = numMultipageStores;
+    }
+
+    public int getNumStores() {
+        return numStores;
+    }
+
+    public void setNumStores(int numStores) {
+        this.numStores = numStores;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String storeName) {
+        this.name = storeName;
+    }
+
+    public int getTotalPageCount() {
+        return totalPageCount;
+    }
+
+    public void setTotalPageCount(int totalPageCount) {
+        this.totalPageCount = totalPageCount;
+    }
+
+    public int[] getPageLevels() {
+        return pageLevels;
+    }
+
+    public void setPageLevels(int[] pageLevels) {
+        this.pageLevels = pageLevels;
+    }
+
+    public int[] getPageCounts() {
+        return pageCounts;
+    }
+
+    public void setPageCounts(int[] pageCounts) {
+        this.pageCounts = pageCounts;
+    }
+
+    public int[] getCompressablePageLevels() {
+        return compressablePageLevels;
+    }
+
+    public void setCompressablePageLevels(int[] compressablePageLevels) {
+        this.compressablePageLevels = compressablePageLevels;
+    }
+
+    public int[] getCompressablePageCounts() {
+        return compressablePageCounts;
+    }
+
+    public void setCompressablePageCounts(int[] compressablePageCounts) {
+        this.compressablePageCounts = compressablePageCounts;
+    }
+
+    public int[] getEntryLevels() {
+        return entryLevels;
+    }
+
+    public void setEntryLevels(int[] entryLevels) {
+        this.entryLevels = entryLevels;
+    }
+
+    public int[] getEntryCounts() {
+        return entryCounts;
+    }
+
+    public void setEntryCounts(int[] entryCounts) {
+        this.entryCounts = entryCounts;
+    }
+
+    public int getKeysByteSize() {
+        return keysByteSize;
+    }
+
+    public void setKeysByteSize(int keysByteSize) {
+        this.keysByteSize = keysByteSize;
+    }
+
+    public int getNumFragmentedStores() {
+        return numFragmentedStores;
+    }
+
+    public void setNumFragmentedStores(int numFragmentedStores) {
+        this.numFragmentedStores = numFragmentedStores;
+    }
+
+    public int getTotalFragmentedPages() {
+        return totalFragmentedPages;
+    }
+
+    public void setTotalFragmentedPages(int totalFragmentedPages) {
+        this.totalFragmentedPages = totalFragmentedPages;
+    }
+
+    public int getNumCompressableStores() {
+        return numCompressableStores;
+    }
+
+    public void setNumCompressableStores(int numCompressableStores) {
+        this.numCompressableStores = numCompressableStores;
+    }
+
+    public int getTotalCompressablePages() {
+        return totalCompressablePages;
+    }
+
+    public void setTotalCompressablePages(int totalCompressablePages) {
+        this.totalCompressablePages = totalCompressablePages;
+    }
+
+    private void printHistogram(StringBuilder sb, int[] levels, int[] counts) {
+        int i;
+        for (i = 0; i < levels.length; i++) {
+            if (counts[i] > 0) {
+                sb.append("<=" + levels[i] + ": " + counts[i] + "; ");
+            }
+        }
+        if (counts[i] > 0) {
+            sb.append(">" + levels[i - 1] + ": " + counts[i] + "; ").append(System.lineSeparator());
+        }
+    }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder(System.lineSeparator());
+
+        sb.append("KCVS name: ").append(name).append(System.lineSeparator());
+        sb.append("Total number of CVS: ").append(numStores).append(System.lineSeparator());
+        sb.append("Total number of multi-page CVS: ").append(numMultipageStores).append(System.lineSeparator());
+        sb.append("Total number of pages: ").append(totalPageCount).append(System.lineSeparator());
+        sb.append(System.lineSeparator());
+        sb.append("Number of fragmented CVS: ").append(numFragmentedStores).append(System.lineSeparator());
+        sb.append("Total number of fragmented pages: ").append(totalFragmentedPages).append(System.lineSeparator());
+        sb.append(System.lineSeparator());
+        sb.append("Number of compressible CVS: ").append(numCompressableStores).append(System.lineSeparator());
+        sb.append("Total number of compressible pages: ").append(totalCompressablePages).append(System.lineSeparator());
+        sb.append("Total achievable page reduction: ").append(totalAchievablePageReduction).append(System.lineSeparator());
+        sb.append(System.lineSeparator());
+        sb.append("Total row keys bytesize: ").append(keysByteSize).append(System.lineSeparator());
+        sb.append(System.lineSeparator());
+
+        sb.append("Number of CVS by #entries: ").append(System.lineSeparator());
+        printHistogram(sb, entryLevels, entryCounts);
+        sb.append(System.lineSeparator());
+
+        sb.append("Number of CVS by #pages: ").append(System.lineSeparator());
+        printHistogram(sb, pageLevels, pageCounts);
+        sb.append(System.lineSeparator());
+
+        sb.append("Number of CVS by #compressable pages: ").append(System.lineSeparator());
+        printHistogram(sb, compressablePageLevels, compressablePageCounts);
+        sb.append(System.lineSeparator());
+
+        sb.append("Number of CVS by achievable page reduction: ").append(System.lineSeparator());
+        printHistogram(sb, reductionLevels, reductionCounts);
+        sb.append(System.lineSeparator());
+
+        return sb.toString();
+    }
+
+    public static final class Builder {
+        private String name;
+        private int numStores;
+        private int numMultipageStores;
+        private int totalPageCount;
+        private int[] pageLevels;
+        private int[] pageCounts;
+        private int[] compressablePageLevels;
+        private int[] compressablePageCounts;
+        private int[] reductionLevels;
+        private int[] reductionCounts;
+        private int[] entryLevels;
+        private int[] entryCounts;
+        private int keysByteSize;
+        private int numFragmentedStores;
+        private int totalFragmentedPages;
+        private int numCompressableStores;
+        private int totalCompressablePages;
+        private int totalAchievablePageReduction;
+        private List<InMemoryColumnValueStore> storesToDefragment;
+
+        public Builder name(String val) {
+            name = val;
+            return this;
+        }
+
+        public Builder numStores(int val) {
+            numStores = val;
+            return this;
+        }
+
+        public Builder numMultipageStores(int val) {
+            numMultipageStores = val;
+            return this;
+        }
+
+        public Builder totalPageCount(int val) {
+            totalPageCount = val;
+            return this;
+        }
+
+        public Builder pageLevels(int[] val) {
+            pageLevels = val;
+            return this;
+        }
+
+        public Builder pageCounts(int[] val) {
+            pageCounts = val;
+            return this;
+        }
+
+        public Builder compressablePageLevels(int[] val) {
+            compressablePageLevels = val;
+            return this;
+        }
+
+        public Builder compressablePageCounts(int[] val) {
+            compressablePageCounts = val;
+            return this;
+        }
+
+        public Builder reductionLevels(int[] val) {
+            reductionLevels = val;
+            return this;
+        }
+
+        public Builder reductionCounts(int[] val) {
+            reductionCounts = val;
+            return this;
+        }
+
+        public Builder entryLevels(int[] val) {
+            entryLevels = val;
+            return this;
+        }
+
+        public Builder entryCounts(int[] val) {
+            entryCounts = val;
+            return this;
+        }
+
+        public Builder keysByteSize(int val) {
+            keysByteSize = val;
+            return this;
+        }
+
+        public Builder numFragmentedStores(int val) {
+            numFragmentedStores = val;
+            return this;
+        }
+
+        public Builder totalFragmentedPages(int val) {
+            totalFragmentedPages = val;
+            return this;
+        }
+
+        public Builder numCompressableStores(int val) {
+            numCompressableStores = val;
+            return this;
+        }
+
+        public Builder totalCompressablePages(int val) {
+            totalCompressablePages = val;
+            return this;
+        }
+
+        public Builder totalAchievablePageReduction(int val) {
+            totalAchievablePageReduction = val;
+            return this;
+        }
+
+        public Builder storesToDefragment(List<InMemoryColumnValueStore> val) {
+            storesToDefragment = val;
+            return this;
+        }
+
+        public InMemoryKeyColumnValueStoreFragmentationReport build() {
+            return new InMemoryKeyColumnValueStoreFragmentationReport(this);
+        }
+    }
+}

--- a/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/MemoryEntryList.java
+++ b/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/MemoryEntryList.java
@@ -1,0 +1,43 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.inmemory;
+
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.EntryList;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+public class MemoryEntryList extends ArrayList<Entry> implements EntryList {
+
+    public MemoryEntryList(int size) {
+        super(size);
+    }
+
+    @Override
+    public Iterator<Entry> reuseIterator() {
+        return iterator();
+    }
+
+    @Override
+    public int getByteSize() {
+        int size = 48;
+        for (Entry e : this) {
+            size += 8 + 16 + 8 + 8 + e.length();
+        }
+
+        return size;
+    }
+}

--- a/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/MultiPageEntryBuffer.java
+++ b/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/MultiPageEntryBuffer.java
@@ -1,0 +1,406 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.inmemory;
+
+import com.google.common.base.Preconditions;
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.EntryList;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.keycolumnvalue.KeySliceQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.janusgraph.diskstorage.inmemory.BufferPageUtils.buildFromEntryArray;
+
+/**
+ * "Multi-page" implementation of SharedEntryBuffer.
+ * Maintains a list of pages, each containing a shared byte buffer for maxPageSize Entries. Dividing the buffer into
+ * pages helps maintain performance in the case of very big stores. This is because when mutating, instead of re-copying
+ * all the entries in a single byte buffer, we only locate and modify a few pages, skipping those not affected by the mutation.
+ * <p>
+ * Since only a limited number of stores actually get very big, the parent store switches from SinglePageEntryBuffer
+ * to this implementation when a mutation brings the max number of entries beyond maxPageSize threshold.
+ */
+public class MultiPageEntryBuffer implements SharedEntryBuffer {
+    private static int INITIAL_CAPACITY = 2;
+
+    private static final Logger log = LoggerFactory.getLogger(BufferPageUtils.class);
+
+    //NOTE: tracking pages in a list, which internally maintains an array, creates additional overhead;
+    // if we maintain our page list in an array directly, this will save this overhead at the cost of some more boilerplate code here
+    // However in practice the number of multi-page buffers is usually relatively small, so at the moment it seems to be
+    // a reasonable price for having less code
+    private ArrayList<BufferPage> pages;
+
+    public MultiPageEntryBuffer(BufferPage initialPage) {
+        this.pages = new ArrayList<>(INITIAL_CAPACITY);
+        if (initialPage instanceof SinglePageEntryBuffer) {
+            pages.add(new BufferPage(initialPage.getOffsetIndex(), initialPage.getRawData()));
+        } else
+            pages.add(initialPage);
+    }
+
+    MultiPageEntryBuffer(List<BufferPage> allPages) {
+        this.pages = new ArrayList<>(allPages);
+    }
+
+    @Override
+    public int numPages() {
+        return pages.size();
+    }
+
+    @Override
+    public int numEntries() {
+        if (pages == null) {
+            return 0;
+        }
+
+        int numEntries = 0;
+
+        for (BufferPage p : pages) {
+            numEntries += p.numEntries();
+        }
+        return numEntries;
+    }
+
+    @Override
+    public int byteSize() {
+        if (pages == null) {
+            return 0;
+        }
+
+        int byteSize = 0;
+        for (BufferPage p : pages) {
+            byteSize += p.byteSize() + 16;
+        }
+        return byteSize;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return pages.isEmpty();
+    }
+
+    private int getPageIndex(StaticBuffer column) {
+        //binary search for correct page on column name
+        int low = 0;
+        int high = pages.size() - 1;
+
+        while (low <= high) {
+            int mid = (low + high) >>> 1;
+
+            BufferPage midPage = pages.get(mid);
+
+            int idx = midPage.getIndex(column);
+
+            if (idx >= 0) {
+                return mid; //key found in this page
+            }
+
+            //key not found, idx contains nearest index, negated
+            idx = (-idx - 1);
+
+            if (idx <= 0) //key is smaller than the first key in this page - search previous pages
+            {
+                high = mid - 1;
+            } else if (idx >= midPage.numEntries()) //key is bigger than the last in this page - search following pages
+            {
+                low = mid + 1;
+            } else //key was not found in this page, but the nearest key found is in this page
+            {
+                return mid;
+            }
+        }
+        return -(low + 1);  //key not found in any of the pages, and is outside the range of current pages - return the nearest page
+    }
+
+    @Override
+    public EntryList getSlice(KeySliceQuery query) {
+        if (pages == null || pages.size() == 0) {
+            return EntryList.EMPTY_LIST;
+        }
+
+        int startPageIdx = getPageIndex(query.getSliceStart());
+        if (startPageIdx < 0) {
+            startPageIdx = (-startPageIdx - 1);
+        }
+
+        int endPageLimit = getPageIndex(query.getSliceEnd());
+        if (endPageLimit < 0) {
+            endPageLimit = (-endPageLimit - 1);
+        } else {
+            endPageLimit++; //we want "insertion point" like in case when it wasn't found
+        }
+
+        if (startPageIdx < endPageLimit) {
+            int startIndex = pages.get(startPageIdx).getIndex(query.getSliceStart());
+            if (startIndex < 0) {
+                startIndex = (-startIndex - 1);
+            }
+
+            int endIndex = pages.get(endPageLimit - 1).getIndex(query.getSliceEnd());
+            if (endIndex < 0) {
+                endIndex = (-endIndex - 1);
+            }
+
+            MemoryEntryList result = new MemoryEntryList(0);
+            for (int i = startPageIdx; i < endPageLimit; i++) {
+                if (query.hasLimit() && result.size() >= query.getLimit()) {
+                    break;
+                }
+
+                BufferPage page = pages.get(i);
+                int start = (i == startPageIdx) ? startIndex : 0;
+                int end = (i == endPageLimit - 1) ? endIndex : page.numEntries();
+                for (int j = start; j < end; j++) {
+                    if (query.hasLimit() && result.size() >= query.getLimit()) {
+                        break;
+                    }
+
+                    //using getNoCopy here means the old page buffer will not be collected until the last of the Entries it used to hold is collected
+                    //however, since all Entries we return are managed by a single transaction and not presented to user code, this should not be a problem
+                    result.add(page.getNoCopy(j));
+                }
+            }
+
+            return result;
+        } else {
+            return EntryList.EMPTY_LIST;
+        }
+    }
+
+    @Override
+    public void mutate(Entry[] add, Entry[] del, int maxPageSize) {
+        int pageHits = 0;
+        int oldPageCount = pages.size();
+
+        // Merge sort:
+        //  iterate through pages,
+        //  skip those pages which are not hit by any adds or deletes,
+        //  rebuild those which are hit, merging existing data with all adds/deletes up to next page margin
+        //  if new page is going to hit max size - insert new one
+        if (pages.size() == 0) {
+            pages.add(buildFromEntryArray(new Entry[]{}, 0));
+        }
+
+        int iadd = 0;
+        int idel = 0;
+        //NOTE: if it finds min of first add/first delete via getPageIndex (binary search), jumps straight to that page
+        // - could be better for big stores updated sparsely. However in practice it doesn't seem to be any noticeable bottleneck
+        int currPageNo = 0;
+
+        while (currPageNo < pages.size() && (iadd < add.length || idel < del.length)) {
+            BufferPage currPage = pages.get(currPageNo);
+            BufferPage nextPage = (currPageNo + 1 < pages.size()) ? pages.get(currPageNo + 1) : null;
+
+            //assumes there will be no pages with zero entries - i.e. we will delete a page if it contains no data
+            Preconditions.checkArgument(nextPage == null || nextPage.numEntries() > 0);
+            StaticBuffer nextPageStart = nextPage == null ? null : nextPage.getNoCopy(0);
+
+            boolean pageNeedsMerging = false;
+
+            // Compare with additions
+            if (iadd < add.length) //still have things to add
+            {
+                pageNeedsMerging = nextPageStart == null; //if there's no next page then we definitely need to merge into this page
+
+                if (!pageNeedsMerging) {
+                    //if next page start is bigger than the key we need to add, this means we need to merge this page
+                    //if next page start is smaller, then we can skip this page - we will merge one of the next pages we see
+                    int compare = nextPageStart.compareTo(add[iadd]);
+                    pageNeedsMerging = compare >= 0;
+                }
+            }
+            // Compare with deletions
+            if (!pageNeedsMerging && idel < del.length) //still have things to delete, and still not sure if we need to merge this page
+            {
+                //if this page end is bigger than the key we need to delete, this means we need to merge this page
+                //if it is smaller, then we won't find anything to delete in this page anyway
+                StaticBuffer thisPageEnd = currPage.getNoCopy(currPage.numEntries() - 1);
+                int compare = thisPageEnd.compareTo(del[idel]);
+                pageNeedsMerging = compare >= 0;
+            }
+
+            if (pageNeedsMerging) {
+                int addLimit;
+                int delLimit;
+                if (nextPageStart == null) //this is the last page, everything we still need to add/delete applies to it
+                {
+                    addLimit = add.length;
+                    delLimit = del.length;
+                } else //this is not the last page, we need to determine which adds/deletes go to this page, and which go to next page(s)
+                {
+                    //NOTE: for long mutation lists, it could be better to do binary search here,
+                    // otherwise it could be up to maxPageSize linear comparisons.
+                    // However it was not seen as a bottleneck in practice so far
+                    addLimit = iadd;
+                    while (addLimit < add.length && nextPageStart.compareTo(add[addLimit]) > 0) {
+                        addLimit++;
+                    }
+
+                    delLimit = idel;
+                    while (delLimit < del.length && nextPageStart.compareTo(del[delLimit]) > 0) {
+                        delLimit++;
+                    }
+                }
+
+                List<BufferPage> mergedPages = currPage.merge(add, iadd, addLimit, del, idel, delLimit, maxPageSize);
+                if (mergedPages.size() == 0) //there was no data left in the page as a result of merge - remove old page
+                {
+                    pages.remove(currPageNo);
+                    //do NOT increase currPageNo here as the next page moved in to this place
+                } else //there is at least one page as a result of merge - replace the current one and insert any additional overflow pages
+                {
+                    pages.set(currPageNo, mergedPages.get(0)); //replace the currPage with the newly merged version
+                    currPageNo++; //move to next page
+                    if (mergedPages.size() > 1) //more than one page as a result of merge - insert all additional ones
+                    {
+                        mergedPages.remove(0);
+                        pages.addAll(currPageNo, mergedPages);
+
+                        //skip over the pages we just added as they cannot contain any work we might still need to do
+                        currPageNo += mergedPages.size();
+                        pageHits += mergedPages.size();
+                    }
+                }
+
+                iadd = addLimit;
+                idel = delLimit;
+
+                pageHits++;
+            } else {
+                currPageNo++;
+            }
+        }
+
+        if (oldPageCount >= pages.size()) {
+            //it grew before but not this time, assume it stopped growing for now and trim to size to save memory
+            pages.trimToSize();
+        }
+    }
+
+    @Override
+    public boolean isPaged() {
+        return true;
+    }
+
+    @Override
+    public SharedEntryBufferFragmentationReport createFragmentationReport(int maxPageSize) {
+        SharedEntryBufferFragmentationReport.Builder report = new SharedEntryBufferFragmentationReport.Builder();
+
+        report.pageCount(pages.size());
+        if (pages.size() < 2) {
+            //not fragmented;
+            return report.build();
+        }
+        //We try to identify chunks of 2 or more adjacent non-full pages.
+        //Such chunks are easily "compactable" by merging into one or more full pages.
+        //this is different from doing "full defragmentation", which would require moving contents of full pages as well
+        int compressableChunksCount = 0;
+        int fragmentedPageCount = 0;
+        int currCompressableCount = 0;
+        int totalCompressableCount = 0;
+        int currChunkNumEntries = 0;
+        int achievablePageReduction = 0;
+        for (int i = 0; i < pages.size(); i++) {
+            BufferPage page = pages.get(i);
+            if (page.numEntries() < maxPageSize) {
+                fragmentedPageCount++;
+                currCompressableCount++;
+                currChunkNumEntries += page.numEntries();
+            } else {
+                int numPagesAfterCompression = getNumPagesRequired(currChunkNumEntries, maxPageSize);
+                if (numPagesAfterCompression < currCompressableCount) {
+                    compressableChunksCount++;
+                    totalCompressableCount += currCompressableCount;
+                    achievablePageReduction += currCompressableCount - numPagesAfterCompression;
+                }
+                currCompressableCount = 0;
+                currChunkNumEntries = 0;
+            }
+        }
+
+        if (currCompressableCount > 1) {
+            compressableChunksCount++;
+            totalCompressableCount += currCompressableCount;
+            achievablePageReduction += currCompressableCount - getNumPagesRequired(currChunkNumEntries, maxPageSize);
+        }
+
+        return report.fragmentedPageCount(fragmentedPageCount)
+            .compressableChunksCount(compressableChunksCount)
+            .compressablePageCount(totalCompressableCount)
+            .achievablePageReduction(achievablePageReduction).build();
+    }
+
+    @Override
+    public void quickDefragment(int maxPageSize) {
+        List<BufferPage> currChunkToDefragment = new ArrayList<>();
+        int currChunkStart = -1;
+        int currChunkNumEntries = 0;
+        for (int i = 0; i < pages.size(); i++) {
+            BufferPage page = pages.get(i);
+            if (page.numEntries() < maxPageSize) {
+                if (currChunkStart < 0) {
+                    currChunkStart = i;
+                }
+                currChunkNumEntries += page.numEntries();
+                currChunkToDefragment.add(page);
+            } else {
+                //if we can get less pages back by compacting the current chunk then proceed
+                if (currChunkToDefragment.size() > 1 && getNumPagesRequired(currChunkNumEntries, maxPageSize) < currChunkToDefragment.size()) {
+                    defragmentAndReplaceChunk(maxPageSize, currChunkToDefragment, currChunkStart);
+                }
+
+                currChunkToDefragment.clear();
+                currChunkStart = -1;
+                currChunkNumEntries = 0;
+            }
+        }
+        if (currChunkToDefragment.size() > 1 && getNumPagesRequired(currChunkNumEntries, maxPageSize) < currChunkToDefragment.size()) {
+            defragmentAndReplaceChunk(maxPageSize, currChunkToDefragment, currChunkStart);
+        }
+    }
+
+    @Override
+    public void dumpTo(DataOutputStream out) throws IOException {
+        //the dump format is: numPages, (pagedump)*
+
+        if (log.isDebugEnabled()) {
+            log.debug("number of pages in multipage buffer is " + numPages());
+        }
+        out.writeInt(numPages());
+
+        for (BufferPage page : pages) {
+            BufferPageUtils.dumpTo(page, out);
+        }
+    }
+
+    private int getNumPagesRequired(int currChunkNumEntries, int maxPageSize) {
+        return currChunkNumEntries / maxPageSize + (currChunkNumEntries % maxPageSize > 0 ? 1 : 0);
+    }
+
+    private void defragmentAndReplaceChunk(int maxPageSize, List<BufferPage> currChunkToDefragment, int currChunkStart) {
+        List<BufferPage> mergedPages = BufferPage.merge(currChunkToDefragment, maxPageSize);
+        for (int j = currChunkToDefragment.size() - 1; j >= 0; j--) {
+            pages.remove(currChunkStart + j);
+        }
+        pages.addAll(currChunkStart, mergedPages);
+    }
+}

--- a/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/SharedEntryBuffer.java
+++ b/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/SharedEntryBuffer.java
@@ -1,0 +1,49 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.inmemory;
+
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.EntryList;
+import org.janusgraph.diskstorage.keycolumnvalue.KeySliceQuery;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * This is a common interface which allows CompactInMemoryColumnValueStore to switch between single- and multi-page
+ * implementations based on number of entries at runtime.
+ */
+public interface SharedEntryBuffer {
+    int numPages();
+
+    int numEntries();
+
+    int byteSize();
+
+    boolean isEmpty();
+
+    EntryList getSlice(KeySliceQuery query);
+
+    void mutate(Entry[] add, Entry[] del, int maxPageSize);
+
+    boolean isPaged();
+
+    SharedEntryBufferFragmentationReport createFragmentationReport(int maxPageSize);
+
+    void quickDefragment(int maxPageSize);
+
+    void dumpTo(DataOutputStream out) throws IOException;
+
+}

--- a/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/SharedEntryBufferFragmentationReport.java
+++ b/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/SharedEntryBufferFragmentationReport.java
@@ -1,0 +1,108 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.inmemory;
+
+public class SharedEntryBufferFragmentationReport {
+    private int pageCount;
+    private int fragmentedPageCount;
+    private int compressableChunksCount;
+    private int compressablePageCount;
+    private int achievablePageReduction;
+
+    private SharedEntryBufferFragmentationReport(Builder builder) {
+        setPageCount(builder.pageCount);
+        setFragmentedPageCount(builder.fragmentedPageCount);
+        setCompressableChunksCount(builder.compressableChunksCount);
+        setCompressablePageCount(builder.compressablePageCount);
+        setAchievablePageReduction(builder.achievablePageReduction);
+    }
+
+    public int getPageCount() {
+        return pageCount;
+    }
+
+    public void setPageCount(int pageCount) {
+        this.pageCount = pageCount;
+    }
+
+    public int getFragmentedPageCount() {
+        return fragmentedPageCount;
+    }
+
+    public void setFragmentedPageCount(int fragmentedPageCount) {
+        this.fragmentedPageCount = fragmentedPageCount;
+    }
+
+    public int getCompressableChunksCount() {
+        return compressableChunksCount;
+    }
+
+    public void setCompressableChunksCount(int compressableChunksCount) {
+        this.compressableChunksCount = compressableChunksCount;
+    }
+
+    public int getCompressablePageCount() {
+        return compressablePageCount;
+    }
+
+    public void setCompressablePageCount(int compressablePageCount) {
+        this.compressablePageCount = compressablePageCount;
+    }
+
+    public int getAchievablePageReduction() {
+        return achievablePageReduction;
+    }
+
+    public void setAchievablePageReduction(int achievablePageReduction) {
+        this.achievablePageReduction = achievablePageReduction;
+    }
+
+    public static final class Builder {
+        private int pageCount;
+        private int fragmentedPageCount;
+        private int compressableChunksCount;
+        private int compressablePageCount;
+        private int achievablePageReduction;
+
+        public Builder pageCount(int val) {
+            pageCount = val;
+            return this;
+        }
+
+        public Builder fragmentedPageCount(int val) {
+            fragmentedPageCount = val;
+            return this;
+        }
+
+        public Builder compressableChunksCount(int val) {
+            compressableChunksCount = val;
+            return this;
+        }
+
+        public Builder compressablePageCount(int val) {
+            compressablePageCount = val;
+            return this;
+        }
+
+        public Builder achievablePageReduction(int val) {
+            achievablePageReduction = val;
+            return this;
+        }
+
+        public SharedEntryBufferFragmentationReport build() {
+            return new SharedEntryBufferFragmentationReport(this);
+        }
+    }
+}

--- a/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/SinglePageEntryBuffer.java
+++ b/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/SinglePageEntryBuffer.java
@@ -1,0 +1,124 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.inmemory;
+
+import com.google.common.base.Preconditions;
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.EntryList;
+import org.janusgraph.diskstorage.keycolumnvalue.KeySliceQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * "Single page" implementation of SharedEntryBuffer.
+ * <p>
+ * It extends BufferPage and complements it with the methods required to make a page look like a complete buffer.
+ * In essence, it just makes a page mutable by reassigning merge results to the same buffer + index refs
+ * <p>
+ * This saves a lot of overhead because 90% of stores fit into one page, as we don't have to keep track of a list of pages etc
+ */
+public class SinglePageEntryBuffer extends BufferPage implements SharedEntryBuffer {
+
+    private static final Logger log = LoggerFactory.getLogger(BufferPageUtils.class);
+
+    public SinglePageEntryBuffer() {
+        super(EMPTY_INDEX, EMPTY_DATA);
+    }
+
+    SinglePageEntryBuffer(final int[] index, final byte[] data) {
+        super(index, data);
+    }
+
+    @Override
+    public int numPages() {
+        return 1;
+    }
+
+    @Override
+    public EntryList getSlice(KeySliceQuery query) {
+        int start = getIndex(query.getSliceStart());
+        if (start < 0) {
+            start = (-start - 1);
+        }
+        int end = getIndex(query.getSliceEnd());
+        if (end < 0) {
+            end = (-end - 1);
+        }
+        if (start < end) {
+            MemoryEntryList result = new MemoryEntryList(end - start);
+            for (int i = start; i < end; i++) {
+                if (query.hasLimit() && result.size() >= query.getLimit()) {
+                    break;
+                }
+
+                //using getNoCopy here as well, means the old common buffer will not be collected until the last of the Entries it used to hold is collected
+                //however, since all Entries in an array are managed by a single transaction and not presented to user code, this should not be a problem
+                result.add(getNoCopy(i));
+            }
+            return result;
+        } else {
+            return EntryList.EMPTY_LIST;
+        }
+    }
+
+    @Override
+    public void mutate(Entry[] add, Entry[] del, int maxPageSize) {
+        //call "immutable" merge method with "unlimited" max page size (ignoring the one passed), to obtain new offset and rawData arrays
+        List<BufferPage> res = merge(add, 0, add.length, del, 0, del.length, Integer.MAX_VALUE);
+
+        //now reassign this instance's index and rawData
+        if (res.isEmpty()) {
+            this.setOffsetIndex(EMPTY_INDEX);
+            this.setRawData(EMPTY_DATA);
+        } else {
+            Preconditions.checkArgument(res.size() == 1); //page size is "unlimited" so we should get exactly 1 page
+            final BufferPage resPage = res.get(0);
+
+            this.setRawData(resPage.getRawData());
+            this.setOffsetIndex(resPage.getOffsetIndex());
+        }
+    }
+
+    @Override
+    public boolean isPaged() {
+        return false;
+    }
+
+    @Override
+    public SharedEntryBufferFragmentationReport createFragmentationReport(int maxPageSize) {
+        return new SharedEntryBufferFragmentationReport.Builder().pageCount(1).build();
+        //rest is 0 by default
+    }
+
+    @Override
+    public void quickDefragment(int maxPageSize) {
+        //do nothing - single buffer is not fragmented by construction
+    }
+
+    @Override
+    public void dumpTo(DataOutputStream out) throws IOException {
+        //the dump format is: numPages, (pagedump)*
+        if (log.isDebugEnabled()) {
+            log.debug("number of pages in single page buffer is " + numPages());
+        }
+        out.writeInt(numPages());
+
+        BufferPageUtils.dumpTo(this, out); //call dumpTo for Page since this is basically a single page anyway
+    }
+}

--- a/janusgraph-inmemory/src/test/java/org/janusgraph/diskstorage/inmemory/BufferPageTest.java
+++ b/janusgraph-inmemory/src/test/java/org/janusgraph/diskstorage/inmemory/BufferPageTest.java
@@ -1,0 +1,148 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.inmemory;
+
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.util.StaticArrayBuffer;
+import org.janusgraph.diskstorage.util.StaticArrayEntry;
+import org.junit.jupiter.api.Test;
+
+import static org.janusgraph.diskstorage.inmemory.BufferPageUtils.buildFromEntryArray;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+public class BufferPageTest
+{
+    private static final String COL_START = "00colStart";
+    private static final String COL_END = "99colEnd";
+    private static final String VERY_END = "zz";
+
+    static StaticArrayBuffer makeStaticBuffer(String value) {
+        return StaticArrayBuffer.of(value.getBytes());
+    }
+
+    static Entry makeEntry(String column, String value) {
+        return StaticArrayEntry.of(makeStaticBuffer(column), makeStaticBuffer(column));
+    }
+
+    @Test
+    public void testGetIndex()
+    {
+        Entry[] entries = new Entry[]
+                {
+                    makeEntry(COL_START, "valStart"),
+                    makeEntry("01col1", "val1"),
+                    makeEntry("02col2", "val2"),
+                    makeEntry("03col3", "val3"),
+                    makeEntry("04emptycol", ""),
+                    makeEntry(COL_END, "valEnd"),
+                }; //must be pre-sorted
+
+        BufferPage bp = buildFromEntryArray(entries, entries.length);
+
+        for(int i=0; i<entries.length; i++)
+        {
+            assertEquals(i, bp.getIndex(entries[i].getColumn()));
+        }
+
+        assertEquals(-1, bp.getIndex(StaticArrayBuffer.of(COL_START.substring(0, 1).getBytes())));
+        assertEquals(-entries.length - 1, bp.getIndex(StaticArrayBuffer.of(VERY_END.getBytes())));
+    }
+
+    @Test
+    public void testMerge()
+    {
+        Entry[] entries = new Entry[]
+                {
+                        makeEntry(COL_START, "valStart"),
+                        makeEntry("01col1", "val1"),
+                        makeEntry("02col2", "val2"),
+                        makeEntry("03col3", "val3"),
+                        makeEntry("04emptycol", ""),
+                        makeEntry(COL_END, "valEnd"),
+                }; //must be pre-sorted
+
+        Entry[] adds = new Entry[]
+                {
+                        makeEntry("03col3", "val3-2"), //update?
+                        makeEntry("06col6", "val6"), //new val
+                        makeEntry("19col19", "val19"), //new val
+                }; //must be pre-sorted
+
+        Entry[] dels = new Entry[]
+                {
+                        makeEntry("01col1", "val1"), //existing val
+                        makeEntry("11col11", "val11"), //non-existing val
+                }; //must be pre-sorted
+
+        List<BufferPage> mergedPages;
+
+        int maxPageSize = 100;
+
+        BufferPage bp = buildFromEntryArray(entries, entries.length);
+        //additions only
+        mergedPages =  bp.merge(adds,0,adds.length, new Entry[]{}, 0, 0, maxPageSize);
+        assertEquals(1, mergedPages.size());
+        assertEquals(entries.length + 2, mergedPages.get(0).numEntries());
+
+        //deletions only
+        mergedPages =  bp.merge(new Entry[]{}, 0, 0, dels, 0, dels.length, maxPageSize);
+        assertEquals(1, mergedPages.size());
+        assertEquals(entries.length - 1, mergedPages.get(0).numEntries());
+
+        //adds+deletes
+        mergedPages =  bp.merge(adds,0,adds.length, dels, 0, dels.length, maxPageSize);
+        assertEquals(1, mergedPages.size());
+        assertEquals(entries.length + 2 - 1, mergedPages.get(0).numEntries());
+
+        //now do the same for smaller page size - should result in multiple pages
+        maxPageSize = 3;
+        bp = buildFromEntryArray(entries, entries.length);
+        mergedPages =  bp.merge(adds,0,adds.length, new Entry[]{}, 0, 0, maxPageSize);
+        //we expect 8 entries after merge, so not exactly divisible
+        assertEquals(3, mergedPages.size());
+        assertEquals(3, mergedPages.get(0).numEntries());
+        assertEquals(3, mergedPages.get(1).numEntries());
+        assertEquals(2, mergedPages.get(2).numEntries());
+
+
+        maxPageSize = 2;
+        bp = buildFromEntryArray(entries, entries.length);
+        mergedPages =  bp.merge(adds,0,adds.length, new Entry[]{}, 0, 0, maxPageSize);
+        //we expect 8 entries after merge, exactly divisible
+        assertEquals(4, mergedPages.size());
+        assertEquals(2, mergedPages.get(0).numEntries());
+        assertEquals(2, mergedPages.get(1).numEntries());
+        assertEquals(2, mergedPages.get(2).numEntries());
+        assertEquals(2, mergedPages.get(3).numEntries());
+
+
+        //complete removal of page
+        mergedPages = mergedPages.get(0).merge(new Entry[]{},0,0,new Entry[]{mergedPages.get(0).getNoCopy(0), mergedPages.get(0).getNoCopy(1)},0,2, maxPageSize);
+        assertEquals(0, mergedPages.size());
+
+        maxPageSize = 2;
+        bp = buildFromEntryArray(entries, entries.length);
+        mergedPages =  bp.merge(adds,0,adds.length-1, new Entry[]{}, 0, 0, maxPageSize);
+        //we expect 7 entries after merge
+        assertEquals(4, mergedPages.size());
+        assertEquals(2, mergedPages.get(0).numEntries());
+        assertEquals(2, mergedPages.get(1).numEntries());
+        assertEquals(2, mergedPages.get(2).numEntries());
+        assertEquals(1, mergedPages.get(3).numEntries());
+    }
+
+}

--- a/janusgraph-inmemory/src/test/java/org/janusgraph/diskstorage/inmemory/InMemoryColumnValueStoreTest.java
+++ b/janusgraph-inmemory/src/test/java/org/janusgraph/diskstorage/inmemory/InMemoryColumnValueStoreTest.java
@@ -1,0 +1,517 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.inmemory;
+
+import org.janusgraph.diskstorage.BaseTransactionConfig;
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.EntryList;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.keycolumnvalue.KeySliceQuery;
+import org.janusgraph.diskstorage.keycolumnvalue.StoreTransaction;
+import org.janusgraph.diskstorage.locking.TemporaryLockingException;
+import org.janusgraph.diskstorage.util.StaticArrayBuffer;
+import org.junit.jupiter.api.Test;
+
+import static org.janusgraph.diskstorage.inmemory.BufferPageTest.makeEntry;
+import static org.janusgraph.diskstorage.inmemory.BufferPageTest.makeStaticBuffer;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.STORAGE_TRANSACTIONAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * This is a unit test for custom override of JanusGraph ColumnValueStore. Required to verify the added logic and
+ * the correctness of its integration with standard logic
+ */
+public class InMemoryColumnValueStoreTest
+{
+    public static final String VERY_START = Character.valueOf((char)0).toString();
+    public static final String COL_START = "00colStart";
+    public static final String COL_END = "99colEnd";
+    public static final String VERY_END = "zz";
+
+    @Test
+    public void testRoundtrip()
+    {
+        InMemoryColumnValueStore[] cvStores = new InMemoryColumnValueStore[] {
+                new InMemoryColumnValueStore(),
+                //same as above but page size = 3 to catch multi-page cases which otherwise
+                // go untested with default page size of 500 due to small sample data set
+                new TestPagedBufferColumnValueStore(3)
+        };
+
+        //first, add some columns
+        List<Entry> additions1 = Arrays.asList(
+                makeEntry("02col2", "val2"),
+                makeEntry("01col1", "val1"),
+                makeEntry("03col3", "val3"),
+                makeEntry(COL_END, "valEnd"),
+                makeEntry(COL_START, "valStart"),
+                makeEntry("04emptycol", "")
+        );
+
+        List<StaticBuffer> deletions1 = Collections.emptyList();
+
+        StoreTransaction txh = mock(StoreTransaction.class);
+        BaseTransactionConfig mockConfig = mock(BaseTransactionConfig.class);
+        when(txh.getConfiguration()).thenReturn(mockConfig);
+        when(mockConfig.getCustomOption(eq(STORAGE_TRANSACTIONAL))).thenReturn(true);
+
+        for(InMemoryColumnValueStore cvs : cvStores)
+        {
+            cvs.mutate(additions1, deletions1, txh);
+        }
+
+        EntryList[] results = new EntryList[cvStores.length];
+
+        //check the added/retrieved columns against originals
+        for(int i=0; i<cvStores.length; i++)
+        {
+            results[i] = cvStores[i].getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                    makeStaticBuffer(COL_START), makeStaticBuffer(VERY_END)),
+                    txh //if we pass COL_END, it doesn't get included
+            );
+
+            assertEquals(additions1.size(), results[i].size());
+        }
+
+        //we'll get the results back sorted, so we sort the initial entries as well, for ease of comparison
+        additions1.sort(Comparator.naturalOrder());
+
+        for(int j=0; j<cvStores.length; j++)
+        {
+            for (int i=0; i< results[j].size(); i++)
+            {
+                assertEquals(additions1.get(i), results[j].get(i));
+                assertEquals(additions1.get(i), results[j].get(i));
+                assertEquals(additions1.get(i).getColumn(), results[j].get(i).getColumn());
+                assertEquals(additions1.get(i).getValue(), results[j].get(i).getValue());
+            }
+        }
+
+        //now delete and update some columns
+        List<Entry> additions2 = Arrays.asList(
+                makeEntry("02col2", "val2_updated"),
+                makeEntry("03col3", "val3_updated")
+        );
+
+        List<StaticBuffer> deletions2 = Arrays.asList(
+            makeStaticBuffer("01col1"),
+            makeStaticBuffer("02col2")
+        );
+
+        for(InMemoryColumnValueStore cvs : cvStores)
+        {
+            cvs.mutate(additions2, deletions2, txh);
+        }
+
+        for(int i=0; i<cvStores.length; i++)
+        {
+            results[i] = cvStores[i].getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                    makeStaticBuffer(COL_START), makeStaticBuffer(VERY_END)),
+                    txh //if we pass COL_END, it doesn't get included
+            );
+
+            //col2 was in both deletes AND updates, JanusGraph logic is to honour update over delete, so we expect only col1 to be deleted
+            assertEquals(additions1.size()-1, results[i].size());
+        }
+
+        for(int i=0; i<cvStores.length; i++)
+        {
+            final Map<StaticBuffer, StaticBuffer> seenValues = new HashMap<>(additions1.size()-1);
+
+            StaticArrayBuffer expectDeleted = makeStaticBuffer("01col1");
+
+            results[i].forEach(entry -> seenValues.put(entry.getColumn(), entry.getValue()));
+
+            assertFalse(seenValues.containsKey(expectDeleted));
+
+            additions2.forEach(entry ->
+            {
+                assertTrue(seenValues.containsKey(entry.getColumn()));
+                assertEquals(seenValues.get(entry.getColumn()), entry.getValue());
+            });
+        }
+
+
+        for(int i=0; i<cvStores.length; i++)
+        {
+            results[i] = cvStores[i].getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                    additions1.get(1).getColumn(),
+                    additions1.get(3).getColumn()),
+                    txh //if we pass COL_END, it doesn't get included
+            );
+
+            assertEquals(1, results[i].size());
+        }
+
+    }
+
+    @Test
+    public void testVolumeSlidingWindows() throws TemporaryLockingException
+    {
+        int pageSize = InMemoryColumnValueStore.DEF_PAGE_SIZE;
+        int maxNumEntries = 7*pageSize + pageSize/2;
+
+        StoreTransaction txh = mock(StoreTransaction.class);
+        BaseTransactionConfig mockConfig = mock(BaseTransactionConfig.class);
+        when(txh.getConfiguration()).thenReturn(mockConfig);
+        when(mockConfig.getCustomOption(eq(STORAGE_TRANSACTIONAL))).thenReturn(true);
+
+        InMemoryColumnValueStore cvs = new InMemoryColumnValueStore();
+
+        for(int numEntries=1;numEntries<maxNumEntries;numEntries+=pageSize + pageSize/3)
+        {
+            List<Entry> additions = generateEntries(0, numEntries,"orig");
+
+            cvs.mutate(additions, Collections.emptyList(), txh);
+
+            EntryList result = cvs.getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                    makeStaticBuffer(VERY_START), makeStaticBuffer(VERY_END)), //if we pass COL_END, it doesn't get included
+                    txh
+                 );
+
+            assertEquals(additions.size(), result.size());
+
+            int stepSize = numEntries < 100 ? 1 : 21;
+
+            for (int windowSize=0; windowSize<numEntries; windowSize+=stepSize)
+            {
+                for (int windowStart=0; windowStart<numEntries; windowStart+=stepSize)
+                {
+                    int windowEnd = Math.min(windowStart+windowSize, numEntries-1);
+                    result = cvs.getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                            additions.get(windowStart).getColumn(),
+                            additions.get(windowEnd).getColumn()
+                    ),
+                           txh);
+                    assertEquals(windowEnd - windowStart, result.size());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testMultipageSlicing() throws TemporaryLockingException
+    {
+        int numEntries = 502;
+        int windowStart = 494;
+        int windowEnd = 501;
+
+        StoreTransaction txh = mock(StoreTransaction.class);
+        BaseTransactionConfig mockConfig = mock(BaseTransactionConfig.class);
+        when(txh.getConfiguration()).thenReturn(mockConfig);
+        when(mockConfig.getCustomOption(eq(STORAGE_TRANSACTIONAL))).thenReturn(true);
+
+        InMemoryColumnValueStore cvs = new InMemoryColumnValueStore();
+        //ColumnValueStore cvs = new DeflatedEntryColumnValueStore(false);
+        List<Entry> additions = generateEntries(0, numEntries,"orig");
+
+        cvs.mutate(additions, Collections.emptyList(), txh);
+
+        EntryList result = cvs.getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                makeStaticBuffer(VERY_START),
+                makeStaticBuffer(VERY_END)), txh //if we pass COL_END, it doesn't get included
+                );
+
+        assertEquals(additions.size(), result.size());
+
+        //this getSlice spans two pages and doesn't retrieve either page in full
+        result = cvs.getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                additions.get(windowStart).getColumn(),
+                additions.get(windowEnd).getColumn()
+                ), txh);
+
+        assertEquals(windowEnd - windowStart, result.size());
+    }
+
+    @Test
+    public void testMultipageDelete() throws TemporaryLockingException
+    {
+        int numEntries = 1001;
+
+        StoreTransaction txh = mock(StoreTransaction.class);
+        BaseTransactionConfig mockConfig = mock(BaseTransactionConfig.class);
+        when(txh.getConfiguration()).thenReturn(mockConfig);
+        when(mockConfig.getCustomOption(eq(STORAGE_TRANSACTIONAL))).thenReturn(true);
+
+        InMemoryColumnValueStore cvs = new InMemoryColumnValueStore();
+        //ColumnValueStore cvs = new DeflatedEntryColumnValueStore(false);
+        List<Entry> additions = generateEntries(0, numEntries,"orig");
+
+        cvs.mutate(additions, Collections.emptyList(), txh);
+
+        EntryList result = cvs.getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                makeStaticBuffer(VERY_START), makeStaticBuffer(VERY_END)), //if we pass COL_END, it doesn't get included
+            txh);
+
+        assertEquals(additions.size(), result.size());
+
+        int windowStart = 494;
+        int windowEnd = 501;
+
+        List<StaticBuffer> deletions = new ArrayList<>(windowEnd-windowStart);
+
+        deletions.addAll(additions.subList(windowStart,windowEnd).stream().map(Entry::getColumn).collect(Collectors.toList()));
+
+        cvs.mutate(Collections.emptyList(), deletions, txh);
+
+        result = cvs.getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                makeStaticBuffer(VERY_START), makeStaticBuffer(VERY_END)), //if we pass COL_END, it doesn't get included
+            txh);
+
+        assertEquals(additions.size()-deletions.size(), result.size());
+
+    }
+
+    @Test
+    public void testMultipageUpdateDelete() throws TemporaryLockingException
+    {
+        int numEntries = 2511;
+
+        StoreTransaction txh = mock(StoreTransaction.class);
+        BaseTransactionConfig mockConfig = mock(BaseTransactionConfig.class);
+        when(txh.getConfiguration()).thenReturn(mockConfig);
+        when(mockConfig.getCustomOption(eq(STORAGE_TRANSACTIONAL))).thenReturn(true);
+
+        InMemoryColumnValueStore cvs = new InMemoryColumnValueStore();
+        //ColumnValueStore cvs = new DeflatedEntryColumnValueStore(false);
+        List<Entry> additions = generateEntries(0, numEntries,"orig");
+
+        cvs.mutate(additions, Collections.emptyList(), txh);
+
+        EntryList result = cvs.getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                makeStaticBuffer(VERY_START), makeStaticBuffer(VERY_END)), //if we pass COL_END, it doesn't get included
+            txh);
+
+        assertEquals(additions.size(), result.size());
+
+        int windowStart = 494;
+        int windowEnd = 2002;
+
+        //update
+        List<Entry> updates = generateEntries(windowStart, windowEnd, "updated");
+
+        cvs.mutate(updates, Collections.emptyList(), txh);
+
+        result = cvs.getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                makeStaticBuffer(VERY_START), makeStaticBuffer(VERY_END)), //if we pass COL_END, it doesn't get included
+            txh);
+
+        assertEquals(additions.size(), result.size());
+
+        for(int i=0; i<result.size(); i++)
+        {
+            if (windowStart < i && i < windowEnd)
+            {
+                assertEquals(updates.get(i-windowStart), result.get(i));
+            }
+            else
+            {
+                assertEquals(additions.get(i), result.get(i));
+            }
+        }
+
+        //delete
+        List<StaticBuffer> deletions = new ArrayList<>(windowEnd-windowStart);
+        deletions.addAll(additions.subList(windowStart,windowEnd).stream().map(Entry::getColumn).collect(Collectors.toList()));
+        cvs.mutate(Collections.emptyList(), deletions, txh);
+
+        result = cvs.getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                makeStaticBuffer(VERY_START), makeStaticBuffer(VERY_END)), //if we pass COL_END, it doesn't get included
+            txh);
+
+        assertEquals(additions.size()-deletions.size(), result.size());
+    }
+
+    @Test
+    public void testAddInterleaved() throws TemporaryLockingException
+    {
+        int pageSize = InMemoryColumnValueStore.DEF_PAGE_SIZE;
+
+        StoreTransaction txh = mock(StoreTransaction.class);
+        BaseTransactionConfig mockConfig = mock(BaseTransactionConfig.class);
+        when(txh.getConfiguration()).thenReturn(mockConfig);
+        when(mockConfig.getCustomOption(eq(STORAGE_TRANSACTIONAL))).thenReturn(true);
+
+        InMemoryColumnValueStore cvs = new InMemoryColumnValueStore();
+
+        List<Entry> additions1 = generateEntries(0, pageSize*2 + pageSize/2,"orig");
+        cvs.mutate(additions1, Collections.emptyList(), txh);
+
+        List<Entry> additions2 = generateEntries(pageSize*10, pageSize*10 + pageSize*2 + pageSize/2,"orig");
+        cvs.mutate(additions2, Collections.emptyList(), txh);
+
+        List<Entry> additions3 = generateEntries(pageSize*5, pageSize*5 + pageSize*2 + pageSize/2,"orig");
+        cvs.mutate(additions3, Collections.emptyList(), txh);
+
+        EntryList result = cvs.getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                makeStaticBuffer(VERY_START), makeStaticBuffer(VERY_END)), //if we pass COL_END, it doesn't get included
+            txh);
+
+        assertEquals(additions1.size()+additions2.size()+additions3.size(), result.size());
+
+        for(int i=0; i< result.size() -1; i++)
+        {
+            assertTrue(result.get(i).compareTo(result.get(i+1)) < 0);
+        }
+    }
+
+    @Test
+    public void testPagingAndFragmentation() throws TemporaryLockingException
+    {
+        int pageSize = InMemoryColumnValueStore.DEF_PAGE_SIZE;
+
+        StoreTransaction txh = mock(StoreTransaction.class);
+        BaseTransactionConfig mockConfig = mock(BaseTransactionConfig.class);
+        when(txh.getConfiguration()).thenReturn(mockConfig);
+        when(mockConfig.getCustomOption(eq(STORAGE_TRANSACTIONAL))).thenReturn(true);
+
+        InMemoryColumnValueStore cvs = new InMemoryColumnValueStore();
+
+        List<Entry> additions = generateEntries(0, pageSize*5 + pageSize/2,"orig");
+        cvs.mutate(additions, Collections.emptyList(), txh);
+        //We inserted more than pagesize in one go, so the store should switch to multipage buffer - but, as currently implemented,
+        // this doesn't get immediately broken up into multiple pages, instead it will hold a single "oversized" page.
+        //The break-up will only happen if there is a consequent update
+        assertEquals(1, cvs.numPages(txh));
+
+        //emulate update so that the single "oversized" page will be broken up into multiple pages of correct size
+        cvs.mutate(additions.subList(1, 3), Collections.emptyList(), txh);
+        assertEquals(6, cvs.numPages(txh));
+
+        int numDeleted = 0;
+
+        int windowStart = pageSize - pageSize/3;
+        int windowEnd = pageSize + pageSize/3;
+        //this should remove parts of page0 and page1
+        List<StaticBuffer> deletions = new ArrayList<>(windowEnd-windowStart);
+        deletions.addAll(additions.subList(windowStart,windowEnd).stream().map(Entry::getColumn).collect(Collectors.toList()));
+        cvs.mutate(Collections.emptyList(), deletions, txh);
+
+        numDeleted += windowEnd - windowStart;
+        EntryList result = cvs.getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                makeStaticBuffer(VERY_START), makeStaticBuffer(VERY_END)), //if we pass COL_END, it doesn't get included
+            txh);
+
+        assertEquals(additions.size() - numDeleted, result.size());
+
+        SharedEntryBufferFragmentationReport report = cvs.createFragmentationReport(txh);
+        assertEquals(6, report.getPageCount());
+        assertEquals(3, report.getFragmentedPageCount());
+        //since only 1/3 of each page is removed, the remains won't fit into one page anyway, so not deemed compressable
+        assertEquals(0, report.getCompressableChunksCount());
+        assertEquals(0, report.getCompressablePageCount());
+
+        windowStart = pageSize * 4 - pageSize/3;
+        windowEnd = pageSize * 4 + pageSize/3;
+        //this should remove  parts of page3 and page 4
+        deletions.clear();
+        deletions.addAll(additions.subList(windowStart,windowEnd).stream().map(Entry::getColumn).collect(Collectors.toList()));
+        cvs.mutate(Collections.emptyList(), deletions, txh);
+
+        numDeleted += windowEnd - windowStart;
+        result = cvs.getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                makeStaticBuffer(VERY_START), makeStaticBuffer(VERY_END)), //if we pass COL_END, it doesn't get included
+            txh);
+        assertEquals(additions.size() - numDeleted, result.size());
+
+        report = cvs.createFragmentationReport(txh);
+        assertEquals(6, report.getPageCount());
+        assertEquals(5, report.getFragmentedPageCount());
+        //we now have pages 3 & 4 which are 2/3 full, PLUS page 5 which is half full => 3 pages compressable into 2
+        assertEquals(1, report.getCompressableChunksCount());
+        assertEquals(3, report.getCompressablePageCount());
+        assertEquals(1, report.getAchievablePageReduction());
+
+        cvs.quickDefragment(txh);
+
+        EntryList result2 = cvs.getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                makeStaticBuffer(VERY_START), makeStaticBuffer(VERY_END)), //if we pass COL_END, it doesn't get included
+            txh);
+        assertEquals(additions.size() - numDeleted, result2.size());
+        for(int i=0; i< result2.size(); i++)
+        {
+            assertEquals(result.get(i), result2.get(i));
+        }
+
+        //after quick defrag, we should have 5 pages in total, page 0 & 1 still fragmented, page 4 also not full
+        report = cvs.createFragmentationReport(txh);
+        assertEquals(5, report.getPageCount());
+        assertEquals(3, report.getFragmentedPageCount());
+        assertEquals(0, report.getCompressableChunksCount());
+        assertEquals(0, report.getCompressablePageCount());
+        assertEquals(0, report.getAchievablePageReduction());
+
+        windowStart = pageSize - pageSize/2;
+        windowEnd = pageSize + pageSize/2+1;
+        //this should remove half of page0 and page1 each
+        deletions.clear();
+        deletions.addAll(additions.subList(windowStart,windowEnd).stream().map(Entry::getColumn).collect(Collectors.toList()));
+        cvs.mutate(Collections.emptyList(), deletions, txh);
+
+        numDeleted += (pageSize/2 - pageSize/3) * 2 + 1;
+        result = cvs.getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                makeStaticBuffer(VERY_START), makeStaticBuffer(VERY_END)), //if we pass COL_END, it doesn't get included
+            txh);
+        assertEquals(additions.size() - numDeleted, result.size());
+
+        //now two first pages should become collapsible into one
+        report = cvs.createFragmentationReport(txh);
+        assertEquals(5, report.getPageCount());
+        assertEquals(3, report.getFragmentedPageCount());
+        assertEquals(1, report.getCompressableChunksCount());
+        assertEquals(2, report.getCompressablePageCount());
+        assertEquals(1, report.getAchievablePageReduction());
+
+        cvs.quickDefragment(txh);
+
+        result2 = cvs.getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                makeStaticBuffer(VERY_START), makeStaticBuffer(VERY_END)), //if we pass COL_END, it doesn't get included
+            txh);
+        assertEquals(additions.size() - numDeleted, result2.size());
+        for(int i=0; i< result2.size(); i++)
+        {
+            assertEquals(result.get(i), result2.get(i));
+        }
+
+        //two first pages collapsed into one which is one entry short of full
+        report = cvs.createFragmentationReport(txh);
+        assertEquals(4, report.getPageCount());
+        assertEquals(2, report.getFragmentedPageCount());
+        assertEquals(0, report.getCompressableChunksCount());
+        assertEquals(0, report.getCompressablePageCount());
+        assertEquals(0, report.getAchievablePageReduction());
+    }
+
+    public static List<Entry> generateEntries(int start, int end, String suffix)
+    {
+        List<Entry> entries = new ArrayList<>(end-start);
+        for(int i=start; i<end; i++)
+        {
+            entries.add(makeEntry(String.format("%012dcol",i),
+                    String.format("val%d_%s",i,suffix)));
+        }
+
+        return entries;
+    }
+}

--- a/janusgraph-inmemory/src/test/java/org/janusgraph/diskstorage/inmemory/InMemoryStoreManagerTest.java
+++ b/janusgraph-inmemory/src/test/java/org/janusgraph/diskstorage/inmemory/InMemoryStoreManagerTest.java
@@ -1,0 +1,142 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.inmemory;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.SystemUtils;
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.EntryList;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.keycolumnvalue.KCVMutation;
+import org.janusgraph.diskstorage.keycolumnvalue.KeyColumnValueStore;
+import org.janusgraph.diskstorage.keycolumnvalue.KeySliceQuery;
+import org.janusgraph.diskstorage.keycolumnvalue.StoreTransaction;
+import org.janusgraph.diskstorage.util.StandardBaseTransactionConfig;
+import org.janusgraph.diskstorage.util.time.TimestampProviders;
+import org.junit.jupiter.api.Test;
+
+import static org.janusgraph.diskstorage.inmemory.BufferPageTest.makeEntry;
+import static org.janusgraph.diskstorage.inmemory.BufferPageTest.makeStaticBuffer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.util.*;
+import java.util.concurrent.ForkJoinPool;
+
+public class InMemoryStoreManagerTest
+{
+    @Test
+    public void testStoreCycle() throws Exception
+    {
+        InMemoryStoreManager imsm = new InMemoryStoreManager();
+
+        KeyColumnValueStore kcvs1 = imsm.openDatabase("testStore1");
+        KeyColumnValueStore kcvs2 = imsm.openDatabase("testStore2");
+
+        assertEquals("testStore1", kcvs1.getName());
+        assertEquals("testStore2", kcvs2.getName());
+
+        StoreTransaction txh = imsm.beginTransaction(StandardBaseTransactionConfig.of(TimestampProviders.MICRO, imsm.getFeatures().getKeyConsistentTxConfig()));
+
+        Map<String, Map<StaticBuffer, KCVMutation>> allMut= new HashMap<>();
+        Map<StaticBuffer, KCVMutation> store1Mut = new HashMap<>();
+        Map<StaticBuffer, KCVMutation> store2Mut = new HashMap<>();
+        allMut.put("testStore1", store1Mut);
+        allMut.put("testStore2", store2Mut);
+
+        //first, add some columns
+        List<Entry> additions1 = Arrays.asList(
+                makeEntry("02col2", "val2"),
+                makeEntry("01col1", "val1"),
+                makeEntry("03col3", "val3"),
+                makeEntry(InMemoryColumnValueStoreTest.COL_END, "valEnd"),
+                makeEntry(InMemoryColumnValueStoreTest.COL_START, "valStart"),
+                makeEntry("04emptycol", "")
+        );
+
+        KCVMutation kcvMut1 = new KCVMutation(additions1, Collections.EMPTY_LIST);
+        store1Mut.put(makeStaticBuffer("row1"), kcvMut1);
+
+        List<Entry> additions2 = Arrays.asList(
+                makeEntry("01col1", "val1"),
+                makeEntry("03col3", "val3")
+        );
+        KCVMutation kcvMut2 = new KCVMutation(additions2, Collections.EMPTY_LIST);
+        store2Mut.put(makeStaticBuffer("row1"), kcvMut2);
+
+        imsm.mutateMany(allMut, txh);
+
+        EntryList result1 = kcvs1.getSlice(new KeySliceQuery(makeStaticBuffer("row1"),
+                    makeStaticBuffer(InMemoryColumnValueStoreTest.COL_START),
+                    makeStaticBuffer(InMemoryColumnValueStoreTest.VERY_END)
+                ),
+                txh);
+
+        Map<StaticBuffer, EntryList> result2 = kcvs2.getSlice(
+                Arrays.asList(makeStaticBuffer("row1"), makeStaticBuffer("row2")),
+                new KeySliceQuery(makeStaticBuffer("row1"),
+                makeStaticBuffer(InMemoryColumnValueStoreTest.COL_START),
+                makeStaticBuffer(InMemoryColumnValueStoreTest.VERY_END)
+                ),
+                txh);
+
+        assertEquals(2, result2.size());
+
+        assertEquals(additions1.size(), result1.size());
+        assertEquals(additions2.size(), result2.get(makeStaticBuffer("row1")).size());
+        assertEquals(0, result2.get(makeStaticBuffer("row2")).size());
+
+        for (boolean rollbackIfFailed : new boolean[] {true, false})
+        {
+            File testSnapshotDir = new File(SystemUtils.JAVA_IO_TMPDIR, Long.toString(System.currentTimeMillis()));
+            testSnapshotDir.deleteOnExit();
+
+            try
+            {
+                imsm.makeSnapshot(testSnapshotDir, ForkJoinPool.commonPool());
+
+                imsm.clearStorage(); //to make the fact that the previous contents were cleared visible
+
+                imsm.restoreFromSnapshot(testSnapshotDir, rollbackIfFailed, ForkJoinPool.commonPool());
+
+                kcvs1 = imsm.openDatabase("testStore1");
+                kcvs2 = imsm.openDatabase("testStore2");
+
+                EntryList result1AfterRestore = kcvs1.getSlice(new KeySliceQuery(makeStaticBuffer("row1"),
+                                makeStaticBuffer(InMemoryColumnValueStoreTest.COL_START),
+                                makeStaticBuffer(InMemoryColumnValueStoreTest.VERY_END)
+                        ),
+                        txh);
+
+                Map<StaticBuffer, EntryList> result2AfterRestore = kcvs2.getSlice(
+                    Arrays.asList(makeStaticBuffer("row1"), makeStaticBuffer("row2")),
+                        new KeySliceQuery(makeStaticBuffer("row1"),
+                                makeStaticBuffer(InMemoryColumnValueStoreTest.COL_START),
+                                makeStaticBuffer(InMemoryColumnValueStoreTest.VERY_END)
+                        ),
+                        txh);
+
+                assertEquals(result1, result1AfterRestore);
+                assertEquals(result2, result2AfterRestore);
+            } finally
+            {
+                FileUtils.cleanDirectory(testSnapshotDir);
+                testSnapshotDir.delete();
+            }
+        }
+
+        imsm.close();
+    }
+}

--- a/janusgraph-inmemory/src/test/java/org/janusgraph/diskstorage/inmemory/MultiPageEntryBufferTest.java
+++ b/janusgraph-inmemory/src/test/java/org/janusgraph/diskstorage/inmemory/MultiPageEntryBufferTest.java
@@ -1,0 +1,76 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.inmemory;
+
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.keycolumnvalue.KeySliceQuery;
+import org.junit.jupiter.api.Test;
+
+import static org.janusgraph.diskstorage.inmemory.BufferPageTest.makeStaticBuffer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MultiPageEntryBufferTest
+{
+
+    @Test
+    public void testBuffer() throws Exception
+    {
+        SinglePageEntryBuffer singlePage = new SinglePageEntryBuffer();
+        MultiPageEntryBuffer buffer = new MultiPageEntryBuffer(singlePage);
+
+        int maxPageSize = 50;
+
+        Entry[] empty = new Entry[0];
+
+        Entry[] add1 = InMemoryColumnValueStoreTest.generateEntries(0,123,"qq").toArray(empty);
+        Entry[] add2 = InMemoryColumnValueStoreTest.generateEntries(113,347,"qq").toArray(empty);
+        Entry[] add3 = InMemoryColumnValueStoreTest.generateEntries(340,497,"qq").toArray(empty);
+        Entry[] del1 = new Entry[] {};
+        Entry[] del2 = InMemoryColumnValueStoreTest.generateEntries(3,43,"qq").toArray(empty);
+        Entry[] del3 = InMemoryColumnValueStoreTest.generateEntries(55,99,"qq").toArray(empty);
+        Entry[] del4 = InMemoryColumnValueStoreTest.generateEntries(415,446,"qq").toArray(empty);
+        Entry[] del5 = InMemoryColumnValueStoreTest.generateEntries(453,495,"qq").toArray(empty);
+
+        buffer.mutate(add1, del1, maxPageSize);
+
+        assertEquals(3, buffer.numPages());
+
+        buffer.getSlice(new KeySliceQuery(makeStaticBuffer("someRow"),
+                                          makeStaticBuffer(InMemoryColumnValueStoreTest.VERY_START),
+                                          makeStaticBuffer(InMemoryColumnValueStoreTest.VERY_END)));
+
+        buffer.mutate(add2, del1, maxPageSize);
+        assertEquals(7, buffer.numPages());
+        buffer.mutate(add3, del1, maxPageSize);
+        assertEquals(10, buffer.numPages());
+        buffer.mutate(new Entry[]{}, del2, maxPageSize);
+        assertEquals(10, buffer.numPages());
+        buffer.mutate(new Entry[]{}, del3, maxPageSize);
+        assertEquals(10, buffer.numPages());
+        buffer.mutate(new Entry[]{}, del4, maxPageSize);
+        assertEquals(10, buffer.numPages());
+        buffer.mutate(new Entry[]{}, del5, maxPageSize);
+        assertEquals(10, buffer.numPages());
+
+
+        buffer.isEmpty();
+        buffer.isPaged();
+        buffer.numEntries();
+        buffer.createFragmentationReport(maxPageSize);
+        buffer.quickDefragment(maxPageSize);
+        assertEquals(8, buffer.numPages());
+        buffer.createFragmentationReport(maxPageSize);
+    }
+}

--- a/janusgraph-inmemory/src/test/java/org/janusgraph/diskstorage/inmemory/TestPagedBufferColumnValueStore.java
+++ b/janusgraph-inmemory/src/test/java/org/janusgraph/diskstorage/inmemory/TestPagedBufferColumnValueStore.java
@@ -1,0 +1,37 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.inmemory;
+
+/**
+* This is a test version of SharedBufferColumnValueStore which overrides getMaxPageSize() to make page size configurable at runtime.
+ * The "production" SharedBufferColumnValueStore doesn't allow this in order to reduce overhead of storing current page size
+ * Changing page size to a different value is handy for modeling edge cases on smaller test data.
+*/
+class TestPagedBufferColumnValueStore extends InMemoryColumnValueStore
+{
+    private final int maxPageSize;
+
+    public TestPagedBufferColumnValueStore(int maxPageSize)
+    {
+        super();
+        this.maxPageSize = maxPageSize;
+    }
+
+    @Override
+    public int getMaxPageSize()
+    {
+        return maxPageSize;
+    }
+}


### PR DESCRIPTION
We would like to contribute an improved implementation of in-memory backend for JanusGraph.

Please see issue #1482 for rationale and some comparative analysis vs existing "test-only" in-memory backend.

**_NOTE_**: This PR currently suggests adding the new backend rather than modifying the existing one, as it seemed cleaner and easier to compare performance within one codebase branch.
However, having read recent discussions about adding more backends into main repository vs maintenance costs, I am starting to think that actually modifying the existing in-memory backend could be a better idea.
This is because:

- the modifications are fairly straightforward and do not change the general structure of existing backend
- don’t add too much extra code or any external dependencies
- don’t require any additional documentation or setup instructions, at least initially
- all existing (and a few extra) integrity tests pass and using it in place of current version is unlikely to create any issues for current (test-only) uses
- the same backend will simply be fit for production use, no new backends to maintain

Thoughts?