### PR TITLE
[skip ci] JanusGraphVertexProperty interface comments

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphVertexProperty.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphVertexProperty.java
@@ -18,8 +18,8 @@ package org.janusgraph.core;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 
 /**
- * JanusGraphProperty is a {@link JanusGraphRelation} connecting a vertex to a value.
- * JanusGraphProperty extends {@link JanusGraphRelation}, with methods for retrieving the property's value and key.
+ * JanusGraphVertexProperty is a {@link JanusGraphRelation} connecting a vertex to a value.
+ * JanusGraphVertexProperty extends {@link JanusGraphRelation}, with methods for retrieving the property's value and key.
  *
  * @author Matthias Br&ouml;cheler (me@matthiasb.com);
  * @see JanusGraphRelation


### PR DESCRIPTION
The JanusGraphVertexProperty comments says JanusGraphProperty which should be JanusGraphVertexProperty.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

