### PR TITLE
Fix removal of relations in other transaction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ env:
     - MODULE='es' ARGS='-Pelasticsearch2'
     - MODULE='es' ARGS='-Pelasticsearch1'
     - MODULE='berkeleyje'
-    - MODULE='test'
+    - MODULE='test' ARGS='-Dtest.skip.tp=false'
     - MODULE='cassandra' ARGS='-Dtest=**/diskstorage/cassandra/thrift/* -Dtest.skip.unordered=true -Dtest.skip.ssl=true -Dtest.skip.serial=true'
     - MODULE='cassandra' ARGS='-Dtest=**/diskstorage/cassandra/thrift/* -Dtest.skip.ordered=true -Dtest.skip.ssl=true -Dtest.skip.serial=true'
     - MODULE='cassandra' ARGS='-Dtest=**/diskstorage/cassandra/thrift/* -Dtest.skip.unordered=true -Dtest.skip.ordered=true'

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/AbstractTypedRelation.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/AbstractTypedRelation.java
@@ -43,8 +43,7 @@ public abstract class AbstractTypedRelation extends AbstractElement implements I
 
     @Override
     public InternalRelation it() {
-        InternalVertex v = getVertex(0);
-        if (v.it().equals(v)) {
+        if (isLoadedInThisTx()) {
             return this;
         }
 
@@ -54,6 +53,11 @@ public abstract class AbstractTypedRelation extends AbstractElement implements I
         }
 
         return next;
+    }
+
+    private boolean isLoadedInThisTx() {
+        InternalVertex v = getVertex(0);
+        return v == v.it();
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/CacheVertexProperty.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/CacheVertexProperty.java
@@ -50,7 +50,7 @@ public class CacheVertexProperty extends AbstractVertexProperty {
 
         if (startVertex.hasAddedRelations() && startVertex.hasRemovedRelations()) {
             //Test whether this relation has been replaced
-            final long id = super.longId();
+            final long id = longId();
             it = Iterables.getOnlyElement(startVertex.getAddedRelations(
                 internalRelation -> (internalRelation instanceof StandardVertexProperty) && ((StandardVertexProperty) internalRelation).getPreviousID() == id), null);
         }
@@ -67,21 +67,15 @@ public class CacheVertexProperty extends AbstractVertexProperty {
     }
 
     private synchronized InternalRelation update() {
-        StandardVertexProperty copy = new StandardVertexProperty(super.longId(), propertyKey(), getVertex(0), value(), ElementLifeCycle.Loaded);
+        StandardVertexProperty copy = new StandardVertexProperty(longId(), propertyKey(), getVertex(0), value(), ElementLifeCycle.Loaded);
         copyProperties(copy);
         copy.remove();
 
         StandardVertexProperty u = (StandardVertexProperty) tx().addProperty(getVertex(0), propertyKey(), value());
-        if (type.getConsistencyModifier()!= ConsistencyModifier.FORK) u.setId(super.longId());
-        u.setPreviousID(super.longId());
+        if (type.getConsistencyModifier()!= ConsistencyModifier.FORK) u.setId(longId());
+        u.setPreviousID(longId());
         copyProperties(u);
         return u;
-    }
-
-    @Override
-    public long longId() {
-        InternalRelation it = it();
-        return (it == this) ? super.longId() : it.longId();
     }
 
     private RelationCache getPropertyMap() {
@@ -120,14 +114,14 @@ public class CacheVertexProperty extends AbstractVertexProperty {
 
     @Override
     public byte getLifeCycle() {
-        if ((getVertex(0).hasRemovedRelations() || getVertex(0).isRemoved()) && tx().isRemovedRelation(super.longId()))
+        if ((getVertex(0).hasRemovedRelations() || getVertex(0).isRemoved()) && tx().isRemovedRelation(longId()))
             return ElementLifeCycle.Removed;
         else return ElementLifeCycle.Loaded;
     }
 
     @Override
     public void remove() {
-        if (!tx().isRemovedRelation(super.longId())) {
+        if (!tx().isRemovedRelation(longId())) {
             tx().removeRelation(this);
         }// else throw InvalidElementException.removedException(this);
     }

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -2016,6 +2016,19 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
     }
 
     @Test
+    public void testPropertyIdAccessInDifferentTransaction() {
+        JanusGraphVertex v1 = graph.addVertex();
+        Object expectedId = v1.property("name", "foo").id();
+        graph.tx().commit();
+
+        VertexProperty p = getOnlyElement(v1.properties("name"));
+
+        // access property id in new transaction
+        graph.tx().commit();
+        assertEquals(expectedId, p.id());
+    }
+
+    @Test
     public void testNestedTransactions() {
         Vertex v1 = graph.addVertex();
         newTx();
@@ -5136,6 +5149,19 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
 
         e = Iterables.getOnlyElement(v3.query().direction(Direction.OUT).labels("knows").edges());
         assertEquals(222, e.<Integer>value("uid").intValue());
+    }
+
+    @Test
+    public void testRemoveEdge() {
+        JanusGraphVertex v1 = graph.addVertex();
+        JanusGraphVertex v2 = graph.addVertex();
+        JanusGraphEdge e = v1.addEdge("related", v2);
+        graph.tx().commit();
+
+        e.remove();
+        graph.tx().commit();
+
+        assertFalse(tx.query().edges().iterator().hasNext());
     }
 
    /* ==================================================================================


### PR DESCRIPTION
The vertex equality check in `AbstractTypedRelation` was used to check whether the vertex was already loaded in the current transaction. This check only works if both objects are actually the same, e.g., with
`v == v.it()`. `v.eqauals(v.it())` doesn't work as it is always true because equals() only checks whether the ids are equal. So, this check cannot be used to check whether the vertex was loaded in the transaction.

The broken check whether the relation was already loaded resulted in failures when a relation was removed in a different transaction than the transaction the relation was loaded in. This led to the TinkerPop test failures.

This reverts PR #1118 basically which introduced this problem. The `StackOverflowError` that was fixed by PR #1118 is now instead fixed by removing the unnecessary overload of `longId()` in `CacheVertexProperty`.
This overload produced the stack overflow basically like this:

1. The id of a vertex property is retrieved. This calls `CacheVertexProperty.longId()`.
2. To get the id, `it()` was called to load the property in the context of the transaction.
3. `it()` needs the id to load the property. -> return to step 1.

The added test `testPropertyIdAccessInDifferentTransaction` leads to the stack overflow if the `longId` overload is kept.
Without the `CacheVertexProperty.longId()` overload, this circle doesn't occur as the id is directly returned instead of calling `it()`.

The TinkerPop tests are now also executed on Travis, at least for the in-memory backend. This hopefully prevents such problems in the future as the TinkerPop tests are quite extensive.

Signed-off-by: Florian Hockmann <fh@florian-hockmann.de>

This fixes #1466

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [-] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [-] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [-] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [-] Have you ensured that format looks appropriate for the output in which it is rendered?
- [-] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

