### PR TITLE
external-locking configuration parameter for CQL #1636

### DIFF
--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
@@ -65,6 +65,19 @@ public interface CQLConfigOptions {
                 "and always use LOCAL_QUORUM instead",
             ConfigOption.Type.MASKABLE, false);
 
+    ConfigOption<Boolean> USE_EXTERNAL_LOCKING = new ConfigOption<>(
+            CQL_NS,
+            "use-external-locking",
+            "True to prevent JanusGraph from using its own locking mechanism. Setting this to true eliminates " +
+            "redundant checks when using an external locking mechanism outside of JanusGraph. Be aware that " +
+            "when use-external-locking is set to true, that failure to employ a locking algorithm which locks " +
+            "all columns that participate in a transaction upfront and unlocks them when the transaction ends, " +
+            "will result in a 'read uncommitted' transaction isolation level guarantee. If set to true without " +
+            "an appropriate external locking mechanism in place side effects such as " +
+            "dirty/non-repeatable/phantom reads should be expected.",
+            ConfigOption.Type.MASKABLE,
+            false);
+
     // The number of statements in a batch
     ConfigOption<Integer> BATCH_STATEMENT_SIZE = new ConfigOption<>(
             CQL_NS,

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStore.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStore.java
@@ -365,7 +365,10 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
 
     @Override
     public void acquireLock(final StaticBuffer key, final StaticBuffer column, final StaticBuffer expectedValue, final StoreTransaction txh) throws BackendException {
-        throw new UnsupportedOperationException();
+        final boolean hasLocking = this.storeManager.getFeatures().hasLocking();
+        if (!hasLocking) {
+            throw new UnsupportedOperationException(String.format("%s doesn't support locking", getClass()));
+        }
     }
 
     @Override

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
@@ -42,6 +42,7 @@ import static org.janusgraph.diskstorage.cql.CQLConfigOptions.SSL_ENABLED;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.SSL_TRUSTSTORE_LOCATION;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.SSL_TRUSTSTORE_PASSWORD;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.WRITE_CONSISTENCY;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.USE_EXTERNAL_LOCKING;
 import static org.janusgraph.diskstorage.cql.CQLKeyColumnValueStore.EXCEPTION_MAPPER;
 import static org.janusgraph.diskstorage.cql.CQLTransaction.getTransaction;
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.AUTH_PASSWORD;
@@ -185,11 +186,14 @@ public class CQLStoreManager extends DistributedStoreManager implements KeyColum
 
         final Boolean onlyUseLocalConsistency = configuration.get(ONLY_USE_LOCAL_CONSISTENCY_FOR_SYSTEM_OPERATIONS);
 
+        final Boolean useExternalLocking = configuration.get(USE_EXTERNAL_LOCKING);
+
         final StandardStoreFeatures.Builder fb = new StandardStoreFeatures.Builder();
 
         fb.batchMutation(true).distributed(true);
         fb.timestamps(true).cellTTL(true);
         fb.keyConsistent((onlyUseLocalConsistency ? local : global), local);
+        fb.locking(useExternalLocking);
         fb.optimisticLocking(true);
         fb.multiQuery(false);
 

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLStoreTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLStoreTest.java
@@ -107,6 +107,13 @@ public class CQLStoreTest extends KeyColumnValueStoreTest {
     }
 
     @Test
+    public void testExternalLocking() throws BackendException {
+        assertFalse(this.manager.getFeatures().hasLocking());
+        assertTrue(openStorageManager(getBaseStorageConfiguration()
+                .set(USE_EXTERNAL_LOCKING, true)).getFeatures().hasLocking());
+    }
+
+    @Test
     public void testDefaultCompactStorage() throws BackendException {
         final String cf = TEST_CF_NAME + "_defaultcompact";
 


### PR DESCRIPTION
…able build-in locking mechanism in JanusGraph for the case when locking is already provided by the application.

This allows to improve performance of underlying storage (Cassandra in our case) and doesn't make it perform redundant read-before-write operation for each column participated in transaction.

Fixes #1636

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.
