### PR TITLE
Improved support of ElasticSearch 6 by refactoring usage of painless scripts functionality

### DIFF
--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchConstants.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchConstants.java
@@ -24,10 +24,11 @@ public class ElasticSearchConstants {
     public static final String ES_DOC_KEY = "doc";
     public static final String ES_UPSERT_KEY = "upsert";
     public static final String ES_SCRIPT_KEY = "script";
-    public static final String ES_INLINE_KEY = "inline";
+    public static final String ES_SOURCE_KEY = "source";
+    public static final String ES_PARAMS_KEY = "params";
+    public static final String ES_PARAMS_FIELDS_KEY = "fields";
     public static final String ES_LANG_KEY = "lang";
     public static final String ES_TYPE_KEY = "type";
-    public static final String ES_INDEX_KEY = "index";
     public static final String ES_ANALYZER = "analyzer";
     public static final String ES_GEO_COORDS_KEY = "coordinates";
     public static final String CUSTOM_ALL_FIELD = "all";

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/compat/AbstractESCompat.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/compat/AbstractESCompat.java
@@ -15,9 +15,11 @@
 package org.janusgraph.diskstorage.es.compat;
 
 import static org.janusgraph.diskstorage.es.ElasticSearchConstants.ES_ANALYZER;
-import static org.janusgraph.diskstorage.es.ElasticSearchConstants.ES_INLINE_KEY;
 import static org.janusgraph.diskstorage.es.ElasticSearchConstants.ES_LANG_KEY;
+import static org.janusgraph.diskstorage.es.ElasticSearchConstants.ES_PARAMS_FIELDS_KEY;
+import static org.janusgraph.diskstorage.es.ElasticSearchConstants.ES_PARAMS_KEY;
 import static org.janusgraph.diskstorage.es.ElasticSearchConstants.ES_SCRIPT_KEY;
+import static org.janusgraph.diskstorage.es.ElasticSearchConstants.ES_SOURCE_KEY;
 import static org.janusgraph.diskstorage.es.ElasticSearchConstants.ES_TYPE_KEY;
 
 import java.util.Collections;
@@ -72,9 +74,11 @@ public abstract class AbstractESCompat {
         return "painless";
     }
 
-    public ImmutableMap.Builder prepareScript(String inline) {
-        final Map<String, String> script = ImmutableMap.of(ES_INLINE_KEY, inline, ES_LANG_KEY, scriptLang());
-        return ImmutableMap.builder().put(ES_SCRIPT_KEY, script);
+    public ImmutableMap.Builder prepareScript(String source, List<Map<String, Object>> fields) {
+        Map<String, Object> script = ImmutableMap.of(ES_SOURCE_KEY, source,
+            ES_PARAMS_KEY, ImmutableMap.of(ES_PARAMS_FIELDS_KEY, fields),
+            ES_LANG_KEY, scriptLang());
+        return ImmutableMap.<String, Object>builder().put(ES_SCRIPT_KEY, script);
     }
 
     public Map<String,Object> prepareQuery(Map<String,Object> query) {
@@ -201,5 +205,4 @@ public abstract class AbstractESCompat {
 
         return requestBody;
     }
-
 }

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/compat/ES6Compat.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/compat/ES6Compat.java
@@ -29,5 +29,4 @@ public class ES6Compat extends AbstractESCompat {
     public IndexFeatures getIndexFeatures() {
         return FEATURES;
     }
-
 }


### PR DESCRIPTION
Now painless scripts are parametrized and won't be compiled on every update and as a result load on ElasticSearch will be lower.

Fixes #1702 

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

