### PR TITLE
Repackaging of PR 362 NPE fix and test

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/CacheVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/CacheVertex.java
@@ -63,7 +63,7 @@ public class CacheVertex extends StandardVertex {
         if (result == null) {
             //First check for super
             Map.Entry<SliceQuery, EntryList> superset = getSuperResultSet(query);
-            if (superset == null) {
+            if (superset == null || superset.getValue() == null) {
                 result = lookup.get(query);
             } else {
                 result = query.getSubset(superset.getKey(), superset.getValue());

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/vertices/CacheVertexTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/vertices/CacheVertexTest.java
@@ -1,0 +1,55 @@
+// Copyright 2018 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.vertices;
+
+import org.easymock.EasyMockSupport;
+import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
+import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
+import org.janusgraph.util.datastructures.Retriever;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.isA;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+
+public class CacheVertexTest extends EasyMockSupport {
+
+    @Test
+    public void testLoadRelationsWithNullSuperSetValue() {
+        final SliceQuery mockSliceQuery = createMock(SliceQuery.class);
+        final Retriever mockRetriever = createMock(Retriever.class);
+
+        expect(mockSliceQuery.subsumes(isA(SliceQuery.class))).andReturn(true);
+        expect(mockRetriever.get(isA(SliceQuery.class))).andReturn(null);
+
+        replayAll();
+
+        final CacheVertex cacheVertex = createMockBuilder(CacheVertex.class)
+            .withConstructor(createMock(StandardJanusGraphTx.class), 0l, (byte) 0)
+            .addMockedMethod("isNew")
+            .createMock();
+
+        expect(cacheVertex.isNew()).andReturn(false);
+
+        replay(cacheVertex);
+
+        cacheVertex.addToQueryCache(mockSliceQuery, null);
+        cacheVertex.loadRelations(createMock(SliceQuery.class), mockRetriever);
+
+        verify(mockRetriever);
+    }
+
+}


### PR DESCRIPTION
I spent a couple hours digging into this issue today. I went through and confirmed that the new test [will fail](https://travis-ci.org/chupman/janusgraph/jobs/532023315) without the  code change. 

Fixes #357. Includes the commit from PR #362. Also includes the commit with the test created by @sjudeng.

[link to the test.](https://github.com/sjudeng/janusgraph/commit/c0df7b6f1a1a6083a11e9ac32961be1ba5255ef4) 
-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there an issue associated with this PR? Is it referenced in the commit message?
- [X] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you written and/or updated unit tests to verify your changes?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [X] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [X] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

