### PR TITLE
Remove stale values when updating ElasticSearch index

### DIFF
--- a/docs/elasticsearch.adoc
+++ b/docs/elasticsearch.adoc
@@ -222,6 +222,9 @@ For example https://www.elastic.co/guide/en/elasticsearch/reference/current/date
 
 See https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html[ingest documentation] for more information about ingest pipelines and https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-processors.html[processors documentation] for more information about ingest processors.
 
+==== Handling Updates on Non-Singular Property Values
+For properties with non-singular cardinality (such as Cardinality.LIST), the default behavior when updating the value of such a property is to preserve the old value(s) and insert the new value into the list. This is not always desirable in implementations where the entire attribute list is updated in one transaction, in which case the previous attribute list should be overwritten. This can lead to invalid search results, such as when a property's attribute list has been updated and a query run for a value from the old list still returns that property as a match. The config option `replace-stale-values` can be set to true so that when a property is updated, any previous/stale values for that property are removed and only the new attribute list is preserved.
+
 === Secure Elasticsearch
 
 Elasticsearch does not perform authentication or authorization. A client that can connect to Elasticsearch is trusted by Elasticsearch. When Elasticsearch runs on an unsecured or public network, particularly the Internet, it should be deployed with some type of external security. This is generally done with a combination of firewalling, tunneling of Elasticsearch's ports or by using Elasticsearch extensions such as https://www.elastic.co/guide/en/x-pack/current/index.html[X-Pack]. Elasticsearch has two client-facing ports to consider:


### PR DESCRIPTION
ElasticSearchIndex has the same issue with retaining stale values as SolrIndex. This is a very similar fix to the one I made for SolrIndex in a previous PR.

See issue https://github.com/JanusGraph/janusgraph/issues/1050 and PR https://github.com/JanusGraph/janusgraph/pull/1547 for more details.

Signed-off-by: Erin Cornett <erin.cornett@ibm.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

