### PR TITLE
Fix default option for CF_COMPACT_STORAGE and test in cassandra >= 3

### DIFF
--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
@@ -125,7 +125,8 @@ public interface CQLConfigOptions {
             "compact-storage",
             "Whether the storage backend should use compact storage on tables. This option is only available for Cassandra 2 and earlier and defaults to true.",
             ConfigOption.Type.FIXED,
-            Boolean.class);
+            Boolean.class,
+            true);
 
     // Compression
     public static final ConfigOption<Boolean> CF_COMPRESSION = new ConfigOption<>(

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLStoreTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLStoreTest.java
@@ -128,7 +128,11 @@ public class CQLStoreTest extends KeyColumnValueStoreTest {
         final CQLStoreManager cqlStoreManager = openStorageManager(config);
         cqlStoreManager.openDatabase(cf);
 
-        assertTrue(cqlStoreManager.getTableMetadata(cf).getOptions().isCompactStorage());
+        if (cqlStoreManager.isCompactStorageAllowed()) {
+            assertTrue(cqlStoreManager.getTableMetadata(cf).getOptions().isCompactStorage());
+        } else {
+            assertFalse(cqlStoreManager.getTableMetadata(cf).getOptions().isCompactStorage());
+        }
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Chris Hupman <chupman@us.ibm.com>

fixes #1595 

I added a default of true to `CF_COMPACT_STORAGE` to match its description and fix it returning null in Cassandra 3. I also added a conditional to `testUseCompactStorage()` that compact storage should only be enabled if the Cassandra version is less than 3.

I ran this update using the [.travis.yml.cassandra](https://travis-ci.org/chupman/janusgraph/builds/535092253) config in my fork to verify the fix. 

[Here's the failed CI build](https://travis-ci.org/chupman/janusgraph/builds/534967897) that originally alerted me to the issue for reference. 

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there an issue associated with this PR? Is it referenced in the commit message?
- [X] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

