### PR TITLE
Exclude xml.releaseBackup files from headers check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,7 @@
                         <exclude>**/*.iml</exclude>
                         <exclude>**/*.json</exclude>
                         <exclude>**/*.xml</exclude>
+                        <exclude>**/*.xml.releaseBackup</exclude>
                         <exclude>docs/**</exclude>
                         <exclude>**/*.md</exclude>
                         <exclude>**/*.txt</exclude>


### PR DESCRIPTION
To correctly proceed with the release process we should exclude `pom.xml.releaseBackup` files generated by `mvn clean release:prepare` from headers checking.

This problem was introduced in #1411 

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

