### PR TITLE
Ensure deleted Elements remain in volatile tx cache map

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/vertexcache/GuavaVertexCache.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/vertexcache/GuavaVertexCache.java
@@ -50,7 +50,7 @@ public class GuavaVertexCache implements VertexCache {
                     //Should only get evicted based on size constraint or replaced through add
                     assert (notification.getCause() == RemovalCause.SIZE || notification.getCause() == RemovalCause.REPLACED) : "Cause: " + notification.getCause();
                     final InternalVertex v = notification.getValue();
-                    if (((AbstractVertex) v).isTxOpen() && v.isModified()) {
+                    if (((AbstractVertex) v).isTxOpen() && (v.isModified() || v.isRemoved())) {
                         volatileVertices.putIfAbsent(notification.getKey(), v);
                     }
                 })


### PR DESCRIPTION
The idea is to included deleted vertices in the `GuavaVertexCache` volatile map, in addition to  modified vertices. It can currently appear that `.remove()` operations can be lost on vertices.

To see this, take the following example: Obtain an instance of `CacheVertex` `V`, and delete it. Do a bunch of other read operations that fill the `GuavaVertexCache` and evicts our vertex `V`. When re-reading `V`, we get a new `CacheVertex` instance for which `V.isRemoved()` is `false`.

Happy to include a unit test if the community deems necessary and agrees with this change.
-----

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

