### PR TITLE
Optimise open and close graph using CQL driver

### DIFF
--- a/janusgraph-berkeleyje/src/test/java/org/janusgraph/graphdb/berkeleyje/BerkeleyGraphTest.java
+++ b/janusgraph-berkeleyje/src/test/java/org/janusgraph/graphdb/berkeleyje/BerkeleyGraphTest.java
@@ -66,7 +66,7 @@ public class BerkeleyGraphTest extends JanusGraphTest {
         config.set(ConfigElement.getPath(GraphDatabaseConfiguration.DROP_ON_CLEAR), true);
         Backend backend = getBackend(config, false);
         assertTrue(backend.getStoreManager().exists(), "graph should exist before clearing storage");
-        clearGraph(config);
+        backend.clearStorage();
         backend.close();
         backend = getBackend(config, false);
         assertFalse(backend.getStoreManager().exists(), "graph should not exist after clearing storage");

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/Backend.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/Backend.java
@@ -138,10 +138,13 @@ public class Backend implements LockerProvider, AutoCloseable {
 
     private final Configuration configuration;
 
-    public Backend(Configuration configuration) {
+    public Backend(Configuration configuration){
+        this(configuration, getStorageManager(configuration));
+    }
+
+    public Backend(Configuration configuration, KeyColumnValueStoreManager manager) {
         this.configuration = configuration;
 
-        KeyColumnValueStoreManager manager = getStorageManager(configuration);
         if (configuration.get(BASIC_METRICS)) {
             storeManager = new MetricInstrumentedStoreManager(manager,METRICS_STOREMANAGER_NAME,configuration.get(METRICS_MERGE_STORES),METRICS_MERGED_STORE);
         } else {
@@ -220,16 +223,15 @@ public class Backend implements LockerProvider, AutoCloseable {
     /**
      * Initializes this backend with the given configuration. Must be called before this Backend can be used
      *
-     * @param config
      */
-    public void initialize(Configuration config) {
+    public void initialize() {
         try {
             //EdgeStore & VertexIndexStore
-            KeyColumnValueStore idStore = storeManager.openDatabase(config.get(IDS_STORE_NAME));
+            KeyColumnValueStore idStore = storeManager.openDatabase(configuration.get(IDS_STORE_NAME));
 
             idAuthority = null;
             if (storeFeatures.isKeyConsistent()) {
-                idAuthority = new ConsistentKeyIDAuthority(idStore, storeManager, config);
+                idAuthority = new ConsistentKeyIDAuthority(idStore, storeManager, configuration);
             } else {
                 throw new IllegalStateException("Store needs to support consistent key or transactional operations for ID manager to guarantee proper id allocations");
             }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/backend/builder/KCVSConfigurationBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/backend/builder/KCVSConfigurationBuilder.java
@@ -42,8 +42,8 @@ public class KCVSConfigurationBuilder {
                 }
 
                 @Override
-                public void close() throws BackendException {
-                    manager.close();
+                public void close() {
+                    //Do nothing, storeManager is shared with Backend which will close it explicitly
                 }
             },manager.openDatabase(SYSTEM_PROPERTIES_STORE_NAME),config);
         } catch (BackendException e) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -1229,11 +1229,12 @@ public class GraphDatabaseConfiguration {
     private StoreFeatures storeFeatures = null;
 
     public GraphDatabaseConfiguration(ReadConfiguration configurationAtOpen, ModifiableConfiguration localConfiguration,
-                                      String uniqueGraphId, Configuration configuration) {
+                                      String uniqueGraphId, Configuration configuration, StoreFeatures storeFeatures) {
         this.configurationAtOpen = configurationAtOpen;
         this.localConfiguration = localConfiguration;
         this.uniqueGraphId = uniqueGraphId;
         this.configuration = configuration;
+        this.storeFeatures = storeFeatures;
         preLoadConfiguration();
     }
 
@@ -1348,19 +1349,11 @@ public class GraphDatabaseConfiguration {
         return configuration;
     }
 
-    public Backend getBackend() {
-        Backend backend = new Backend(configuration);
-        backend.initialize(configuration);
-        storeFeatures = backend.getStoreFeatures();
-        return backend;
-    }
-
     public String getGraphName() {
         return getConfigurationAtOpen().getString(GRAPH_NAME.toStringWithoutRoot());
     }
 
     public StoreFeatures getStoreFeatures() {
-        Preconditions.checkArgument(storeFeatures != null, "Cannot retrieve store features before the storage backend has been initialized");
         return storeFeatures;
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/StandardJanusGraph.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/StandardJanusGraph.java
@@ -136,10 +136,10 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
 
     private final String name;
 
-    public StandardJanusGraph(GraphDatabaseConfiguration configuration) {
+    public StandardJanusGraph(GraphDatabaseConfiguration configuration, Backend backend) {
 
         this.config = configuration;
-        this.backend = configuration.getBackend();
+        this.backend = backend;
 
         this.name = configuration.getGraphName();
 

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
@@ -374,7 +374,7 @@ public class CQLStoreManager extends DistributedStoreManager implements KeyColum
             this.session.close();
         } finally {
             try {
-                this.cluster.close();
+                this.cluster.closeAsync();
             } finally {
                 this.executorService.shutdownNow();
             }

--- a/janusgraph-hbase-parent/janusgraph-hbase-core/src/test/java/org/janusgraph/diskstorage/hbase/HBaseStoreManagerConfigTest.java
+++ b/janusgraph-hbase-parent/janusgraph-hbase-core/src/test/java/org/janusgraph/diskstorage/hbase/HBaseStoreManagerConfigTest.java
@@ -94,7 +94,7 @@ public class HBaseStoreManagerConfigTest {
         // Set backend to hbase
         config.set(GraphDatabaseConfiguration.STORAGE_BACKEND, "hbase");
         // Instantiate a GraphDatabaseConfiguration based on the above
-        GraphDatabaseConfiguration graphConfig = new GraphDatabaseConfigurationBuilder().build(config.getConfiguration());
+        GraphDatabaseConfiguration graphConfig = GraphDatabaseConfigurationBuilder.build(config.getConfiguration());
         // Check the TIMESTAMP_PROVIDER has been set to the hbase preferred MILLI
         TimestampProviders provider = graphConfig.getConfiguration().get(GraphDatabaseConfiguration.TIMESTAMP_PROVIDER);
         assertEquals(HBaseStoreManager.PREFERRED_TIMESTAMPS, provider);

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/GraphDatabaseConfigurationInstanceIdTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/GraphDatabaseConfigurationInstanceIdTest.java
@@ -20,8 +20,8 @@ import java.util.Map;
 import java.util.HashMap;
 import org.apache.commons.configuration.MapConfiguration;
 import org.janusgraph.core.JanusGraphException;
+import org.janusgraph.core.JanusGraphFactory;
 import org.janusgraph.diskstorage.configuration.backend.CommonsConfiguration;
-import org.janusgraph.graphdb.configuration.builder.GraphDatabaseConfigurationBuilder;
 import org.janusgraph.graphdb.database.StandardJanusGraph;
 import org.junit.jupiter.api.Test;
 
@@ -41,12 +41,12 @@ public class GraphDatabaseConfigurationInstanceIdTest {
         map.put(UNIQUE_INSTANCE_ID.toStringWithoutRoot(), "not-unique");
         map.put(REPLACE_INSTANCE_IF_EXISTS.toStringWithoutRoot(), true);
         final MapConfiguration config = new MapConfiguration(map);
-        final StandardJanusGraph graph1 = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
+        final StandardJanusGraph graph1 = (StandardJanusGraph) JanusGraphFactory.open(new CommonsConfiguration(config));
 
         assertEquals(graph1.openManagement().getOpenInstances().size(), 1);
         assertEquals(graph1.openManagement().getOpenInstances().toArray()[0], "not-unique");
 
-        final StandardJanusGraph graph2 = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
+        final StandardJanusGraph graph2 = (StandardJanusGraph) JanusGraphFactory.open(new CommonsConfiguration(config));
 
         assertEquals(graph1.openManagement().getOpenInstances().size(), 1);
         assertEquals(graph1.openManagement().getOpenInstances().toArray()[0], "not-unique");
@@ -62,13 +62,14 @@ public class GraphDatabaseConfigurationInstanceIdTest {
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
         map.put(UNIQUE_INSTANCE_ID.toStringWithoutRoot(), "not-unique");
         final MapConfiguration config = new MapConfiguration(map);
-        final StandardJanusGraph graph1 = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
+        final StandardJanusGraph graph1 = (StandardJanusGraph) JanusGraphFactory.open(new CommonsConfiguration(config));
 
         assertEquals(graph1.openManagement().getOpenInstances().size(), 1);
         assertEquals(graph1.openManagement().getOpenInstances().toArray()[0], "not-unique");
         JanusGraphException janusGraphException = assertThrows(JanusGraphException.class, () -> {
-            final StandardJanusGraph graph2 = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
+            final StandardJanusGraph graph2 = (StandardJanusGraph) JanusGraphFactory.open(new CommonsConfiguration(config));
             graph1.close();
+            graph2.close();
         });
         assertEquals("A JanusGraph graph with the same instance id [not-unique] is already open. Might required forced shutdown.", janusGraphException.getMessage());
     }
@@ -79,7 +80,7 @@ public class GraphDatabaseConfigurationInstanceIdTest {
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
         map.put(UNIQUE_INSTANCE_ID_HOSTNAME.toStringWithoutRoot(), true);
         final MapConfiguration config = new MapConfiguration(map);
-        final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
+        final StandardJanusGraph graph = (StandardJanusGraph) JanusGraphFactory.open(new CommonsConfiguration(config));
         assertEquals(graph.openManagement().getOpenInstances().size(), 1);
         assertEquals(graph.openManagement().getOpenInstances().toArray()[0], Inet4Address.getLocalHost().getHostName());
 				graph.close();
@@ -92,7 +93,7 @@ public class GraphDatabaseConfigurationInstanceIdTest {
         map.put(UNIQUE_INSTANCE_ID_HOSTNAME.toStringWithoutRoot(), true);
         map.put(UNIQUE_INSTANCE_ID_SUFFIX.toStringWithoutRoot(), 1);
 				final MapConfiguration config = new MapConfiguration(map);
-        final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
+        final StandardJanusGraph graph = (StandardJanusGraph) JanusGraphFactory.open(new CommonsConfiguration(config));
         assertEquals(graph.openManagement().getOpenInstances().size(), 1);
         assertEquals(graph.openManagement().getOpenInstances().toArray()[0], Inet4Address.getLocalHost().getHostName() + "1");
 				graph.close();

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphBaseTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphBaseTest.java
@@ -87,7 +87,7 @@ public abstract class JanusGraphBaseTest {
         adjustedConfig.set(GraphDatabaseConfiguration.UNIQUE_INSTANCE_ID, "inst");
         final Backend backend = new Backend(adjustedConfig);
         if (initialize) {
-            backend.initialize(adjustedConfig);
+            backend.initialize();
         }
         return backend;
     }

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphEventualGraphTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphEventualGraphTest.java
@@ -51,7 +51,7 @@ public abstract class JanusGraphEventualGraphTest extends JanusGraphBaseTest {
 
     @Test
     public void verifyEligibility() {
-        Preconditions.checkArgument(!graph.getConfiguration().getBackend().getStoreFeatures().hasTxIsolation(),
+        Preconditions.checkArgument(!graph.getBackend().getStoreFeatures().hasTxIsolation(),
                 "This test suite only applies to eventually consistent data stores");
     }
 

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphIndexTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphIndexTest.java
@@ -1771,16 +1771,10 @@ public abstract class JanusGraphIndexTest extends JanusGraphBaseTest {
         // approach might implement different methods/assertions depending on
         // whether the store is capable of deadlocking or detecting conflicting
         // writes and aborting a transaction.
-        Backend b = null;
-        try {
-            b = graph.getConfiguration().getBackend();
-            if (b.getStoreFeatures().hasTxIsolation()) {
-                log.info("Skipping " + getClass().getSimpleName() + "." + testInfo.getTestMethod().toString());
-                return;
-            }
-        } finally {
-            if (null != b)
-                b.close();
+        Backend b = graph.getBackend();
+        if (b.getStoreFeatures().hasTxIsolation()) {
+            log.info("Skipping " + getClass().getSimpleName() + "." + testInfo.getTestMethod().toString());
+            return;
         }
 
         final String propName = "foo";

--- a/janusgraph-test/src/test/java/org/janusgraph/core/ConfiguredGraphFactoryTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/core/ConfiguredGraphFactoryTest.java
@@ -14,7 +14,6 @@
 
 package org.janusgraph.core;
 
-import org.janusgraph.graphdb.configuration.builder.GraphDatabaseConfigurationBuilder;
 import org.janusgraph.graphdb.management.JanusGraphManager;
 import org.janusgraph.graphdb.management.ConfigurationManagementGraph;
 import org.janusgraph.graphdb.management.utils.ConfigurationManagementGraphNotEnabledException;
@@ -40,7 +39,7 @@ public class ConfiguredGraphFactoryTest {
         final Map<String, Object> map = new HashMap<>();
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
         final MapConfiguration config = new MapConfiguration(map);
-        final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
+        final StandardJanusGraph graph = (StandardJanusGraph) JanusGraphFactory.open(new CommonsConfiguration(config));
         // Instantiate the ConfigurationManagementGraph Singleton
         new ConfigurationManagementGraph(graph);
     }

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/management/ConfigurationManagementGraphTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/management/ConfigurationManagementGraphTest.java
@@ -14,7 +14,6 @@
 
 package org.janusgraph.graphdb.management;
 
-import org.janusgraph.graphdb.configuration.builder.GraphDatabaseConfigurationBuilder;
 import org.janusgraph.core.schema.JanusGraphManagement;
 import static org.janusgraph.core.schema.SchemaStatus.ENABLED;
 import org.janusgraph.core.schema.JanusGraphIndex;
@@ -48,7 +47,7 @@ public class ConfigurationManagementGraphTest {
         final Map<String, Object> map = new HashMap<>();
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
         final MapConfiguration config = new MapConfiguration(map);
-        final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
+        final StandardJanusGraph graph = (StandardJanusGraph) JanusGraphFactory.open(new CommonsConfiguration(config));
 
         final String propertyKeyName = "Created_Using_Template";
         final Class dataType = Boolean.class;

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/management/ManagementLoggerGraphCacheEvictionTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/management/ManagementLoggerGraphCacheEvictionTest.java
@@ -14,8 +14,8 @@
 
 package org.janusgraph.graphdb.management;
 
+import org.janusgraph.core.JanusGraphFactory;
 import org.janusgraph.diskstorage.configuration.backend.CommonsConfiguration;
-import org.janusgraph.graphdb.configuration.builder.GraphDatabaseConfigurationBuilder;
 import org.janusgraph.graphdb.database.StandardJanusGraph;
 import org.janusgraph.graphdb.database.management.ManagementSystem;
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.GRAPH_NAME;
@@ -43,7 +43,7 @@ public class ManagementLoggerGraphCacheEvictionTest {
         final Map<String, Object> map = new HashMap<>();
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
         final MapConfiguration config = new MapConfiguration(map);
-        final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
+        final StandardJanusGraph graph = (StandardJanusGraph) JanusGraphFactory.open(new CommonsConfiguration(config));
         final ManagementSystem mgmt = (ManagementSystem) graph.openManagement();
         mgmt.evictGraphFromCache();
         mgmt.commit();
@@ -62,7 +62,7 @@ public class ManagementLoggerGraphCacheEvictionTest {
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
         map.put(GRAPH_NAME.toStringWithoutRoot(), "graph1");
         final MapConfiguration config = new MapConfiguration(map);
-        final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
+        final StandardJanusGraph graph = (StandardJanusGraph) JanusGraphFactory.open(new CommonsConfiguration(config));
         jgm.putGraph("graph1", graph);
         assertEquals("graph1", ((StandardJanusGraph) JanusGraphManager.getInstance().getGraph("graph1")).getGraphName());
 


### PR DESCRIPTION
When switching from Thrift to CQL driver we noticed how all our tests started timing out,
after some digging we noticed that `storeManager` (which physically connects to the Cassandra backend) is initialised twice every time a new graph is created.

In this PR we change the behaviour of instantiation of a graph: store manager only gets created once and used to read global configuration and then used to create a `Backend` which is in turn used by the new Graph.

List of changes contained in this PR:

- `ConfiguredGraphFactory` and `JanusGraphFactory` now instantiate both `StoreManager` and `Backend` which are then injected in the components that need them.

- `static JanusGraph open(ReadConfiguration configuration, String backupName)` is now a *private* method as the associated Javadoc states: "This method shouldn't be called by end users;"

- `GraphDatabaseConfiguration` is no longer used as a `Backend` factory, instead the Graph object is used to fetch the associated Backend

- `GraphDatabaseConfigurationBuilder` is now a static class, as it does not hold any state

- `CQLStoreManager` uses the native `closeAsync` instead of the synchronous `close`, this saves at least 2 seconds every time a graph gets closed

- updated tests

Possibly related to this: https://github.com/JanusGraph/janusgraph/issues/1249


Signed-off-by: Marco Scoppetta <marco@grakn.ai>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

