### PR TITLE
Use shared cache by default for berkeleydb

### DIFF
--- a/docs/basics/janusgraph-cfg.md
+++ b/docs/basics/janusgraph-cfg.md
@@ -356,6 +356,7 @@ BerkeleyDB JE configuration options
 | storage.berkeleyje.cache-percentage | Percentage of JVM heap reserved for BerkeleyJE's cache | Integer | 65 | MASKABLE |
 | storage.berkeleyje.isolation-level | The isolation level used by transactions | String | REPEATABLE_READ | MASKABLE |
 | storage.berkeleyje.lock-mode | The BDB record lock mode used for read operations | String | LockMode.DEFAULT | MASKABLE |
+| storage.berkeleyje.shared-cache | If true, the shared cache is used for all graph instances | Boolean | true | MASKABLE |
 
 ### storage.cassandra
 Cassandra storage backend options

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -78,6 +78,10 @@ which will tell JanusGraph to use mapping types for ElasticSearch version 7.
 Due to the drop of support for 5.x version, deprecated multi-type indices are no more supported. 
 Parameter `use-deprecated-multitype-index` is no more supported by JanusGraph.
 
+##### BerkeleyDB
+
+BerkeleyDB storage configured with [SHARED_CACHE](https://docs.oracle.com/cd/E17277_02/html/java/com/sleepycat/je/EnvironmentConfig.html#SHARED_CACHE) for better memory usage.
+
 ### Version 0.4.0 (Release Date: July 1, 2019)
 Legacy documentation: <https://old-docs.janusgraph.org/0.4.0/index.html>
 

--- a/docs/storage-backend/bdb.md
+++ b/docs/storage-backend/bdb.md
@@ -42,7 +42,10 @@ BerkeleyDB Specific Configuration
 
 Refer to [Configuration Reference](../basics/configuration-reference.md) for a complete listing of all BerkeleyDB
 specific configuration options in addition to the general JanusGraph
-configuration options.
+configuration options. BerkeleyDB configured with
+[SHARED_CACHE](https://docs.oracle.com/cd/E17277_02/html/java/com/sleepycat/je/EnvironmentConfig.html#SHARED_CACHE)
+those multiple graphs will make better use of memory because the cache LRU algorithm is applied across all
+information in all graphs sharing the cache.
 
 When configuring BerkeleyDB it is recommended to consider the following
 BerkeleyDB specific configuration options:

--- a/janusgraph-berkeleyje/src/main/java/org/janusgraph/diskstorage/berkeleyje/BerkeleyJEStoreManager.java
+++ b/janusgraph-berkeleyje/src/main/java/org/janusgraph/diskstorage/berkeleyje/BerkeleyJEStoreManager.java
@@ -56,6 +56,11 @@ public class BerkeleyJEStoreManager extends LocalStoreManager implements Ordered
             "Percentage of JVM heap reserved for BerkeleyJE's cache",
             ConfigOption.Type.MASKABLE, 65, ConfigOption.positiveInt());
 
+    public static final ConfigOption<Boolean> SHARED_CACHE =
+        new ConfigOption<>(BERKELEY_NS, "shared-cache",
+            "If true, the shared cache is used for all graph instances",
+            ConfigOption.Type.MASKABLE, true);
+
     public static final ConfigOption<String> LOCK_MODE =
             new ConfigOption<>(BERKELEY_NS, "lock-mode",
             "The BDB record lock mode used for read operations",
@@ -77,7 +82,8 @@ public class BerkeleyJEStoreManager extends LocalStoreManager implements Ordered
         stores = new HashMap<>();
 
         int cachePercentage = configuration.get(JVM_CACHE);
-        initialize(cachePercentage);
+        boolean sharedCache = configuration.get(SHARED_CACHE);
+        initialize(cachePercentage, sharedCache);
 
         features = new StandardStoreFeatures.Builder()
                     .orderedScan(true)
@@ -90,26 +96,15 @@ public class BerkeleyJEStoreManager extends LocalStoreManager implements Ordered
                     .supportsInterruption(false)
                     .optimisticLocking(false)
                     .build();
-
-//        features = new StoreFeatures();
-//        features.supportsOrderedScan = true;
-//        features.supportsUnorderedScan = false;
-//        features.supportsBatchMutation = false;
-//        features.supportsTxIsolation = transactional;
-//        features.supportsConsistentKeyOperations = true;
-//        features.supportsLocking = true;
-//        features.isKeyOrdered = true;
-//        features.isDistributed = false;
-//        features.hasLocalKeyPartition = false;
-//        features.supportsMultiQuery = false;
     }
 
-    private void initialize(int cachePercent) throws BackendException {
+    private void initialize(int cachePercent, final boolean sharedCache) throws BackendException {
         try {
             EnvironmentConfig envConfig = new EnvironmentConfig();
             envConfig.setAllowCreate(true);
             envConfig.setTransactional(transactional);
             envConfig.setCachePercent(cachePercent);
+            envConfig.setSharedCache(sharedCache);
 
             if (batchLoading) {
                 envConfig.setConfigParam(EnvironmentConfig.ENV_RUN_CHECKPOINTER, "false");
@@ -118,7 +113,6 @@ public class BerkeleyJEStoreManager extends LocalStoreManager implements Ordered
 
             //Open the environment
             environment = new Environment(directory, envConfig);
-
 
         } catch (DatabaseException e) {
             throw new PermanentBackendException("Error during BerkeleyJE initialization: ", e);


### PR DESCRIPTION
When I want create two instance of berkeleydb with default configuration it lead to out of memory - default configuration 60% memory for instance

I can't proper set [MAX_MEMORY_PERCENT](https://docs.oracle.com/cd/E17277_02/html/java/com/sleepycat/je/EnvironmentConfig.html#MAX_MEMORY_PERCENT) because number of instance is unknown

Bdb has [SHARED_CACHE](https://docs.oracle.com/cd/E17277_02/html/java/com/sleepycat/je/EnvironmentConfig.html#SHARED_CACHE) it will manage shared cache by ourself

I think it would be better as default settings

Signed-off-by: Pavel Ershov <owner.mad.epa@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

