### PR TITLE
Update CQL driver version to 4.2.0

### DIFF
--- a/janusgraph-cql/pom.xml
+++ b/janusgraph-cql/pom.xml
@@ -33,9 +33,26 @@
         </dependency>
 
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
-            <artifactId>cassandra-driver-core</artifactId>
+            <groupId>com.datastax.oss</groupId>
+            <artifactId>java-driver-core</artifactId>
             <version>${cassandra-driver.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.jnr</groupId>
+                    <artifactId>jnr-ffi</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.datastax.oss</groupId>
+            <artifactId>java-driver-query-builder</artifactId>
+            <version>${cassandra-driver.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.jnr</groupId>
+                    <artifactId>jnr-ffi</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLColValGetter.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLColValGetter.java
@@ -14,11 +14,11 @@
 
 package org.janusgraph.diskstorage.cql;
 
+import com.datastax.oss.driver.api.core.cql.Row;
 import org.janusgraph.diskstorage.EntryMetaData;
 import org.janusgraph.diskstorage.StaticBuffer;
 import org.janusgraph.diskstorage.util.StaticArrayEntry.GetColVal;
 
-import com.datastax.driver.core.Row;
 
 import io.vavr.Tuple3;
 

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
@@ -39,11 +39,11 @@ public interface CQLConfigOptions {
             "janusgraph");
 
     ConfigOption<Integer> PROTOCOL_VERSION = new ConfigOption<>(
-            CQL_NS,
-            "protocol-version",
-            "The protocol version used to connect to the Cassandra database.  If no value is supplied then the driver will negotiate with the server.",
-            ConfigOption.Type.LOCAL,
-            0);
+        CQL_NS,
+        "protocol-version",
+        "The protocol version used to connect to the Cassandra database.  If no value is supplied then the driver will negotiate with the server.",
+        ConfigOption.Type.LOCAL,
+        0);
 
     ConfigOption<String> READ_CONSISTENCY = new ConfigOption<>(
             CQL_NS,
@@ -165,20 +165,6 @@ public interface CQLConfigOptions {
             ConfigOption.Type.FIXED,
             64);
 
-    ConfigOption<Integer> LOCAL_CORE_CONNECTIONS_PER_HOST = new ConfigOption<>(
-            CQL_NS,
-            "local-core-connections-per-host",
-            "The number of connections initially created and kept open to each host for local datacenter",
-            ConfigOption.Type.FIXED,
-            1);
-
-    ConfigOption<Integer> REMOTE_CORE_CONNECTIONS_PER_HOST = new ConfigOption<>(
-            CQL_NS,
-            "remote-core-connections-per-host",
-            "The number of connections initially created and kept open to each host for remote datacenter",
-            ConfigOption.Type.FIXED,
-            1);
-
     ConfigOption<Integer> LOCAL_MAX_CONNECTIONS_PER_HOST = new ConfigOption<>(
             CQL_NS,
             "local-max-connections-per-host",
@@ -193,19 +179,13 @@ public interface CQLConfigOptions {
             ConfigOption.Type.FIXED,
             1);
 
-    ConfigOption<Integer> LOCAL_MAX_REQUESTS_PER_CONNECTION = new ConfigOption<>(
+    ConfigOption<Integer> MAX_REQUESTS_PER_CONNECTION = new ConfigOption<>(
             CQL_NS,
-            "local-max-requests-per-connection",
-            "The maximum number of requests per connection for local datacenter",
+            "max-requests-per-connection",
+            "The maximum number of requests that can be executed concurrently on a connection.",
             ConfigOption.Type.FIXED,
             1024);
 
-    ConfigOption<Integer> REMOTE_MAX_REQUESTS_PER_CONNECTION = new ConfigOption<>(
-            CQL_NS,
-            "remote-max-requests-per-connection",
-            "The maximum number of requests per connection for remote datacenter",
-            ConfigOption.Type.FIXED,
-            256);
 
     // SSL
     ConfigNamespace SSL_NS = new ConfigNamespace(
@@ -239,13 +219,14 @@ public interface CQLConfigOptions {
             ConfigOption.Type.LOCAL,
             "");
 
-    // Other options
-    ConfigOption<String> CLUSTER_NAME = new ConfigOption<>(
-            CQL_NS,
-            "cluster-name",
-            "Default name for the Cassandra cluster",
-            ConfigOption.Type.MASKABLE,
-            "JanusGraph Cluster");
+    //Other options
+
+    ConfigOption<String> SESSION_NAME = new ConfigOption<>(
+        CQL_NS,
+        "session-name",
+        "Default name for the Cassandra session",
+        ConfigOption.Type.MASKABLE,
+        "JanusGraph Session");
 
     ConfigOption<String> LOCAL_DATACENTER = new ConfigOption<>(
             CQL_NS,
@@ -258,6 +239,7 @@ public interface CQLConfigOptions {
              * the same Cassandra DC.
              */
             ConfigOption.Type.MASKABLE,
-            String.class);
+            String.class,
+            "datacenter1");
 
 }

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStore.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStore.java
@@ -14,46 +14,28 @@
 
 package org.janusgraph.diskstorage.cql;
 
-import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.column;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.delete;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.gte;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.lt;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.lte;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.timestamp;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.token;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.ttl;
-import static com.datastax.driver.core.schemabuilder.SchemaBuilder.createTable;
-import static com.datastax.driver.core.schemabuilder.SchemaBuilder.dateTieredStrategy;
-import static com.datastax.driver.core.schemabuilder.SchemaBuilder.deflate;
-import static com.datastax.driver.core.schemabuilder.SchemaBuilder.leveledStrategy;
-import static com.datastax.driver.core.schemabuilder.SchemaBuilder.lz4;
-import static com.datastax.driver.core.schemabuilder.SchemaBuilder.noCompression;
-import static com.datastax.driver.core.schemabuilder.SchemaBuilder.sizedTieredStategy;
-import static com.datastax.driver.core.schemabuilder.SchemaBuilder.snappy;
-import static io.vavr.API.$;
-import static io.vavr.API.Case;
-import static io.vavr.API.Match;
-import static io.vavr.Predicates.instanceOf;
-import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CF_COMPACT_STORAGE;
-import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CF_COMPRESSION;
-import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CF_COMPRESSION_BLOCK_SIZE;
-import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CF_COMPRESSION_TYPE;
-import static org.janusgraph.diskstorage.cql.CQLConfigOptions.COMPACTION_OPTIONS;
-import static org.janusgraph.diskstorage.cql.CQLConfigOptions.COMPACTION_STRATEGY;
-import static org.janusgraph.diskstorage.cql.CQLTransaction.getTransaction;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.function.Function;
-import java.util.function.Supplier;
-
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.BatchableStatement;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.metadata.TokenMap;
+import com.datastax.oss.driver.api.core.servererrors.QueryValidationException;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.querybuilder.relation.Relation;
+import com.datastax.oss.driver.api.querybuilder.schema.CreateTableWithOptions;
+import com.datastax.oss.driver.api.querybuilder.schema.compaction.CompactionStrategy;
+import com.datastax.oss.driver.internal.core.cql.ResultSets;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import io.vavr.Lazy;
+import io.vavr.Tuple;
+import io.vavr.Tuple3;
+import io.vavr.collection.Array;
+import io.vavr.collection.Iterator;
+import io.vavr.concurrent.Future;
+import io.vavr.control.Try;
 import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.Entry;
 import org.janusgraph.diskstorage.EntryList;
@@ -70,30 +52,35 @@ import org.janusgraph.diskstorage.keycolumnvalue.KeySliceQuery;
 import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
 import org.janusgraph.diskstorage.keycolumnvalue.StoreTransaction;
 import org.janusgraph.diskstorage.util.StaticArrayBuffer;
-import org.janusgraph.diskstorage.util.StaticArrayEntry.GetColVal;
+import org.janusgraph.diskstorage.util.StaticArrayEntry;
 import org.janusgraph.diskstorage.util.StaticArrayEntryList;
 
-import com.datastax.driver.core.DataType;
-import com.datastax.driver.core.Metadata;
-import com.datastax.driver.core.PreparedStatement;
-import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.Row;
-import com.datastax.driver.core.Session;
-import com.datastax.driver.core.Statement;
-import com.datastax.driver.core.exceptions.QueryValidationException;
-import com.datastax.driver.core.exceptions.UnsupportedFeatureException;
-import com.datastax.driver.core.schemabuilder.Create.Options;
-import com.datastax.driver.core.schemabuilder.TableOptions.CompactionOptions;
-import com.datastax.driver.core.schemabuilder.TableOptions.CompressionOptions;
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
 
-import io.vavr.Lazy;
-import io.vavr.Tuple;
-import io.vavr.Tuple3;
-import io.vavr.collection.Array;
-import io.vavr.collection.Iterator;
-import io.vavr.concurrent.Future;
-import io.vavr.control.Try;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.deleteFrom;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.selectFrom;
+import static com.datastax.oss.driver.api.querybuilder.SchemaBuilder.createTable;
+import static com.datastax.oss.driver.api.querybuilder.SchemaBuilder.leveledCompactionStrategy;
+import static com.datastax.oss.driver.api.querybuilder.SchemaBuilder.timeWindowCompactionStrategy;
+import static com.datastax.oss.driver.api.querybuilder.select.Selector.column;
+import static io.vavr.API.$;
+import static io.vavr.API.Case;
+import static io.vavr.API.Match;
+import static io.vavr.Predicates.instanceOf;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CF_COMPACT_STORAGE;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CF_COMPRESSION;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CF_COMPRESSION_BLOCK_SIZE;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CF_COMPRESSION_TYPE;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.COMPACTION_OPTIONS;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.COMPACTION_STRATEGY;
+import static org.janusgraph.diskstorage.cql.CQLTransaction.getTransaction;
 
 /**
  * An implementation of {@link KeyColumnValueStore} which stores the data in a CQL connected backend.
@@ -122,12 +109,11 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
 
     static final Function<? super Throwable, BackendException> EXCEPTION_MAPPER = cause -> Match(cause).of(
             Case($(instanceOf(QueryValidationException.class)), PermanentBackendException::new),
-            Case($(instanceOf(UnsupportedFeatureException.class)), PermanentBackendException::new),
             Case($(), TemporaryBackendException::new));
 
     private final CQLStoreManager storeManager;
     private final ExecutorService executorService;
-    private final Session session;
+    private final CqlSession session;
     private final String tableName;
     private final CQLColValGetter getter;
     private final Runnable closer;
@@ -146,10 +132,9 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
      * @param tableName the name of the database table for storing the key/column/values
      * @param configuration data used in creating this store
      * @param closer callback used to clean up references to this store in the store manager
-     * @param allowCompactStorage whether to use compact storage is allowed (true only for Cassandra 2 and earlier)
-     * @param shouldInitializeTable if true is provided the table gets initialized
      */
-    public CQLKeyColumnValueStore(final CQLStoreManager storeManager, final String tableName, final Configuration configuration, final Runnable closer, final boolean allowCompactStorage, final Supplier<Boolean> shouldInitializeTable) {
+    public CQLKeyColumnValueStore(final CQLStoreManager storeManager, final String tableName, final Configuration configuration, final Runnable closer) {
+
         this.storeManager = storeManager;
         this.executorService = this.storeManager.getExecutorService();
         this.tableName = tableName;
@@ -157,112 +142,141 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
         this.session = this.storeManager.getSession();
         this.getter = new CQLColValGetter(storeManager.getMetaDataSchema(this.tableName));
 
-        if(shouldInitializeTable.get()) {
-            initializeTable(this.session, this.storeManager.getKeyspaceName(), tableName, configuration, allowCompactStorage);
+        if(shouldInitializeTable()) {
+            initializeTable(this.session, this.storeManager.getKeyspaceName(), tableName, configuration, this.storeManager.isCompactStorageAllowed());
         }
 
         // @formatter:off
-        this.getSlice = this.session.prepare(select()
+        this.getSlice = this.session.prepare(selectFrom(this.storeManager.getKeyspaceName(), this.tableName)
                 .column(COLUMN_COLUMN_NAME)
                 .column(VALUE_COLUMN_NAME)
-                .fcall(WRITETIME_FUNCTION_NAME, column(VALUE_COLUMN_NAME)).as(WRITETIME_COLUMN_NAME)
-                .fcall(TTL_FUNCTION_NAME, column(VALUE_COLUMN_NAME)).as(TTL_COLUMN_NAME)
-                .from(this.storeManager.getKeyspaceName(), this.tableName)
-                .where(eq(KEY_COLUMN_NAME, bindMarker(KEY_BINDING)))
-                .and(gte(COLUMN_COLUMN_NAME, bindMarker(SLICE_START_BINDING)))
-                .and(lt(COLUMN_COLUMN_NAME, bindMarker(SLICE_END_BINDING)))
-                .limit(bindMarker(LIMIT_BINDING)));
+                .function(WRITETIME_FUNCTION_NAME, column(VALUE_COLUMN_NAME)).as(WRITETIME_COLUMN_NAME)
+                .function(TTL_FUNCTION_NAME, column(VALUE_COLUMN_NAME)).as(TTL_COLUMN_NAME)
+                .where(
+                    Relation.column(KEY_COLUMN_NAME).isEqualTo(bindMarker(KEY_BINDING)),
+                    Relation.column(COLUMN_COLUMN_NAME).isGreaterThanOrEqualTo(bindMarker(SLICE_START_BINDING)),
+                    Relation.column(COLUMN_COLUMN_NAME).isLessThan(bindMarker(SLICE_END_BINDING))
+                )
+                .limit(bindMarker(LIMIT_BINDING)).build());
 
-        this.getKeysRanged = this.session.prepare(select()
+        this.getKeysRanged = this.session.prepare(selectFrom(this.storeManager.getKeyspaceName(), this.tableName)
                 .column(KEY_COLUMN_NAME)
                 .column(COLUMN_COLUMN_NAME)
                 .column(VALUE_COLUMN_NAME)
-                .fcall(WRITETIME_FUNCTION_NAME, column(VALUE_COLUMN_NAME)).as(WRITETIME_COLUMN_NAME)
-                .fcall(TTL_FUNCTION_NAME, column(VALUE_COLUMN_NAME)).as(TTL_COLUMN_NAME)
-                .from(this.storeManager.getKeyspaceName(), this.tableName)
+                .function(WRITETIME_FUNCTION_NAME, column(VALUE_COLUMN_NAME)).as(WRITETIME_COLUMN_NAME)
+                .function(TTL_FUNCTION_NAME, column(VALUE_COLUMN_NAME)).as(TTL_COLUMN_NAME)
                 .allowFiltering()
-                .where(gte(token(KEY_COLUMN_NAME), bindMarker(KEY_START_BINDING)))
-                .and(lt(token(KEY_COLUMN_NAME), bindMarker(KEY_END_BINDING)))
-                .and(gte(COLUMN_COLUMN_NAME, bindMarker(SLICE_START_BINDING)))
-                .and(lte(COLUMN_COLUMN_NAME, bindMarker(SLICE_END_BINDING))));
+                .where(
+                    Relation.token(KEY_COLUMN_NAME).isGreaterThanOrEqualTo(bindMarker(KEY_START_BINDING)),
+                    Relation.token(KEY_COLUMN_NAME).isLessThan(bindMarker(KEY_END_BINDING))
+                )
+                .whereColumn(COLUMN_COLUMN_NAME).isGreaterThanOrEqualTo(bindMarker(SLICE_START_BINDING))
+                .whereColumn(COLUMN_COLUMN_NAME).isLessThanOrEqualTo(bindMarker(SLICE_END_BINDING))
+                .build());
 
-        this.getKeysAll = this.session.prepare(select()
+        this.getKeysAll = this.session.prepare(selectFrom(this.storeManager.getKeyspaceName(), this.tableName)
                 .column(KEY_COLUMN_NAME)
                 .column(COLUMN_COLUMN_NAME)
                 .column(VALUE_COLUMN_NAME)
-                .fcall(WRITETIME_FUNCTION_NAME, column(VALUE_COLUMN_NAME)).as(WRITETIME_COLUMN_NAME)
-                .fcall(TTL_FUNCTION_NAME, column(VALUE_COLUMN_NAME)).as(TTL_COLUMN_NAME)
-                .from(this.storeManager.getKeyspaceName(), this.tableName)
+                .function(WRITETIME_FUNCTION_NAME, column(VALUE_COLUMN_NAME)).as(WRITETIME_COLUMN_NAME)
+                .function(TTL_FUNCTION_NAME, column(VALUE_COLUMN_NAME)).as(TTL_COLUMN_NAME)
                 .allowFiltering()
-                .where(gte(COLUMN_COLUMN_NAME, bindMarker(SLICE_START_BINDING)))
-                .and(lte(COLUMN_COLUMN_NAME, bindMarker(SLICE_END_BINDING))));
+                .whereColumn(COLUMN_COLUMN_NAME).isGreaterThanOrEqualTo(bindMarker(SLICE_START_BINDING))
+                .whereColumn(COLUMN_COLUMN_NAME).isLessThan(bindMarker(SLICE_END_BINDING))
+                .build());
 
-        this.deleteColumn = this.session.prepare(delete()
-                .from(this.storeManager.getKeyspaceName(), this.tableName)
-                .where(eq(KEY_COLUMN_NAME, bindMarker(KEY_BINDING)))
-                .and(eq(COLUMN_COLUMN_NAME, bindMarker(COLUMN_BINDING)))
-                .using(timestamp(bindMarker(TIMESTAMP_BINDING))));
+        this.deleteColumn = this.session.prepare(deleteFrom(this.storeManager.getKeyspaceName(), this.tableName)
+                .usingTimestamp(bindMarker(TIMESTAMP_BINDING))
+                .whereColumn(KEY_COLUMN_NAME).isEqualTo(bindMarker(KEY_BINDING))
+                .whereColumn(COLUMN_COLUMN_NAME).isEqualTo(bindMarker(COLUMN_BINDING))
+                .build());
 
         this.insertColumn = this.session.prepare(insertInto(this.storeManager.getKeyspaceName(), this.tableName)
                 .value(KEY_COLUMN_NAME, bindMarker(KEY_BINDING))
                 .value(COLUMN_COLUMN_NAME, bindMarker(COLUMN_BINDING))
                 .value(VALUE_COLUMN_NAME, bindMarker(VALUE_BINDING))
-                .using(timestamp(bindMarker(TIMESTAMP_BINDING))));
+                .usingTimestamp(bindMarker(TIMESTAMP_BINDING)).build());
 
         this.insertColumnWithTTL = this.session.prepare(insertInto(this.storeManager.getKeyspaceName(), this.tableName)
                 .value(KEY_COLUMN_NAME, bindMarker(KEY_BINDING))
                 .value(COLUMN_COLUMN_NAME, bindMarker(COLUMN_BINDING))
                 .value(VALUE_COLUMN_NAME, bindMarker(VALUE_BINDING))
-                .using(timestamp(bindMarker(TIMESTAMP_BINDING)))
-                .and(ttl(bindMarker(TTL_BINDING))));
+                .usingTimestamp(bindMarker(TIMESTAMP_BINDING))
+                .usingTtl(bindMarker(TTL_BINDING)).build());
         // @formatter:on
     }
 
-    private static void initializeTable(final Session session, final String keyspaceName, final String tableName, final Configuration configuration, final boolean allowCompactStorage) {
-        final Options createTable = createTable(keyspaceName, tableName)
+    /**
+     * Check if the current table should be initialized.
+     * NOTE: This additional check is needed when Cassandra security is enabled, for more info check issue #1103
+     * @return true if table already exists in current keyspace, false otherwise
+     */
+    private boolean shouldInitializeTable() {
+        return storeManager.getSession().getMetadata()
+            .getKeyspace(storeManager.getKeyspaceName()).map(k -> !k.getTable(this.tableName).isPresent())
+            .orElse(true);
+    }
+
+    private static void initializeTable(final CqlSession session, final String keyspaceName, final String tableName, final Configuration configuration, final boolean allowCompactStorage) {
+        CreateTableWithOptions createTable = createTable(keyspaceName, tableName)
                 .ifNotExists()
-                .addPartitionKey(KEY_COLUMN_NAME, DataType.blob())
-                .addClusteringColumn(COLUMN_COLUMN_NAME, DataType.blob())
-                .addColumn(VALUE_COLUMN_NAME, DataType.blob())
-                .withOptions()
-                .compressionOptions(compressionOptions(configuration))
-                .compactionOptions(compactionOptions(configuration));
+                .withPartitionKey(KEY_COLUMN_NAME, DataTypes.BLOB)
+                .withClusteringColumn(COLUMN_COLUMN_NAME, DataTypes.BLOB)
+                .withColumn(VALUE_COLUMN_NAME, DataTypes.BLOB);
+
+
+        createTable = compactionOptions(createTable, configuration);
         // COMPACT STORAGE is allowed on Cassandra 2 or earlier
         // when COMPACT STORAGE is allowed, the default is to enable it
-        final boolean useCompactStorage =
+        boolean useCompactStorage =
             (allowCompactStorage && configuration.has(CF_COMPACT_STORAGE))
             ? configuration.get(CF_COMPACT_STORAGE)
             : allowCompactStorage;
-        session.execute(useCompactStorage ? createTable.compactStorage() : createTable);
+
+        if(useCompactStorage){
+            createTable = createTable.withCompactStorage();
+        }
+
+        createTable = compressionOptions(createTable, configuration, allowCompactStorage);
+
+
+        session.execute(createTable.build());
     }
 
-    private static CompressionOptions compressionOptions(final Configuration configuration) {
+    private static CreateTableWithOptions compressionOptions(final CreateTableWithOptions createTable, final Configuration configuration, boolean allowCompactStorage) {
         if (!configuration.get(CF_COMPRESSION)) {
             // No compression
-            return noCompression();
+            return createTable.withNoCompression();
         }
+        String compressionType = configuration.get(CF_COMPRESSION_TYPE);
+        int chunkLengthInKb = configuration.get(CF_COMPRESSION_BLOCK_SIZE);
+        // AllowCompactStorage is true only when using Cassandra 2.x, which uses 'sstable_compression' instead of 'class' to refer to
+        // the compression type Class
+        String compressionKey = (allowCompactStorage) ? "sstable_compression" : "class";
 
-        return Match(configuration.get(CF_COMPRESSION_TYPE)).of(
-                Case($("LZ4Compressor"), lz4()),
-                Case($("SnappyCompressor"), snappy()),
-                Case($("DeflateCompressor"), deflate()))
-                .withChunkLengthInKb(configuration.get(CF_COMPRESSION_BLOCK_SIZE));
+        return createTable.withOption("compression",
+                ImmutableMap.of(compressionKey, compressionType, "chunk_length_kb", chunkLengthInKb));
+
     }
 
-    private static CompactionOptions<?> compactionOptions(final Configuration configuration) {
+    private static CreateTableWithOptions compactionOptions(CreateTableWithOptions createTable, final Configuration configuration) {
         if (!configuration.has(COMPACTION_STRATEGY)) {
-            return null;
+            return createTable;
         }
 
-        final CompactionOptions<?> compactionOptions = Match(configuration.get(COMPACTION_STRATEGY))
+        CompactionStrategy<?> compactionStrategy = Match(configuration.get(COMPACTION_STRATEGY))
                 .of(
-                        Case($("SizeTieredCompactionStrategy"), sizedTieredStategy()),
-                        Case($("DateTieredCompactionStrategy"), dateTieredStrategy()),
-                        Case($("LeveledCompactionStrategy"), leveledStrategy()));
-        Array.of(configuration.get(COMPACTION_OPTIONS))
-                .grouped(2)
-                .forEach(keyValue -> compactionOptions.freeformOption(keyValue.get(0), keyValue.get(1)));
-        return compactionOptions;
+                        Case($("SizeTieredCompactionStrategy"), leveledCompactionStrategy()),
+                        Case($("TimeWindowCompactionStrategy"), timeWindowCompactionStrategy()),
+                        Case($("LeveledCompactionStrategy"), leveledCompactionStrategy()));
+        Iterator<Array<String>> groupedOptions = Array.of(configuration.get(COMPACTION_OPTIONS))
+            .grouped(2);
+
+        for(Array<String> keyValue: groupedOptions){
+            compactionStrategy = compactionStrategy.withOption(keyValue.get(0), keyValue.get(1));
+        }
+
+        return createTable.withCompaction(compactionStrategy);
     }
 
     @Override
@@ -280,11 +294,12 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
         final Future<EntryList> result = Future.fromJavaFuture(
                 this.executorService,
                 this.session.executeAsync(this.getSlice.bind()
-                        .setBytes(KEY_BINDING, query.getKey().asByteBuffer())
-                        .setBytes(SLICE_START_BINDING, query.getSliceStart().asByteBuffer())
-                        .setBytes(SLICE_END_BINDING, query.getSliceEnd().asByteBuffer())
+                        .setByteBuffer(KEY_BINDING, query.getKey().asByteBuffer())
+                        .setByteBuffer(SLICE_START_BINDING, query.getSliceStart().asByteBuffer())
+                        .setByteBuffer(SLICE_END_BINDING, query.getSliceEnd().asByteBuffer())
                         .setInt(LIMIT_BINDING, query.getLimit())
-                        .setConsistencyLevel(getTransaction(txh).getReadConsistencyLevel())))
+                        .setConsistencyLevel(getTransaction(txh).getReadConsistencyLevel()))
+                        .toCompletableFuture())
                 .map(resultSet -> fromResultSet(resultSet, this.getter));
         interruptibleWait(result);
         return result.getValue().get().getOrElseThrow(EXCEPTION_MAPPER);
@@ -299,7 +314,7 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
      * VAVR Future.await will throw InterruptedException wrapped in a FatalException. If the Thread was in Object.wait, the interrupted
      * flag will be cleared as a side effect and needs to be reset. This method checks that the underlying cause of the FatalException is
      * InterruptedException and resets the interrupted flag.
-     * 
+     *
      * @param result the future to wait on
      * @throws PermanentBackendException if the thread was interrupted while waiting for the future result
      */
@@ -307,23 +322,24 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
         try {
             result.await();
         } catch (Exception e) {
-            if (e instanceof InterruptedException) {
+            if (e.getCause() instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            throw new PermanentBackendException(e);
+            throw new PermanentBackendException(e.getCause());
         }
     }
 
-    private static EntryList fromResultSet(final ResultSet resultSet, final GetColVal<Tuple3<StaticBuffer, StaticBuffer, Row>, StaticBuffer> getter) {
-        final Lazy<ArrayList<Row>> lazyList = Lazy.of(() -> Lists.newArrayList(resultSet));
+    private static EntryList fromResultSet(final AsyncResultSet resultSet, final StaticArrayEntry.GetColVal<Tuple3<StaticBuffer, StaticBuffer, Row>, StaticBuffer> getter) {
+        final Lazy<ArrayList<Row>> lazyList = Lazy.of(() -> Lists.newArrayList(ResultSets.newInstance(resultSet)));
+
         // Use the Iterable overload of ofByteBuffer as it's able to allocate
         // the byte array up front.
         // To ensure that the Iterator instance is recreated, it is created
         // within the closure otherwise
         // the same iterator would be reused and would be exhausted.
         return StaticArrayEntryList.ofStaticBuffer(() -> Iterator.ofAll(lazyList.get()).map(row -> Tuple.of(
-                        StaticArrayBuffer.of(row.getBytes(COLUMN_COLUMN_NAME)),
-                        StaticArrayBuffer.of(row.getBytes(VALUE_COLUMN_NAME)),
+                        StaticArrayBuffer.of(row.getByteBuffer(COLUMN_COLUMN_NAME)),
+                        StaticArrayBuffer.of(row.getByteBuffer(VALUE_COLUMN_NAME)),
                         row)),
                 getter);
     }
@@ -331,30 +347,30 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
     /*
      * Used from CQLStoreManager
      */
-    Statement deleteColumn(final StaticBuffer key, final StaticBuffer column, final long timestamp) {
+    BatchableStatement<BoundStatement> deleteColumn(final StaticBuffer key, final StaticBuffer column, final long timestamp) {
         return this.deleteColumn.bind()
-                .setBytes(KEY_BINDING, key.asByteBuffer())
-                .setBytes(COLUMN_BINDING, column.asByteBuffer())
+                .setByteBuffer(KEY_BINDING, key.asByteBuffer())
+                .setByteBuffer(COLUMN_BINDING, column.asByteBuffer())
                 .setLong(TIMESTAMP_BINDING, timestamp);
     }
 
     /*
      * Used from CQLStoreManager
      */
-    Statement insertColumn(final StaticBuffer key, final Entry entry, final long timestamp) {
+    BatchableStatement<BoundStatement> insertColumn(final StaticBuffer key, final Entry entry, final long timestamp) {
         final Integer ttl = (Integer) entry.getMetaData().get(EntryMetaData.TTL);
         if (ttl != null) {
             return this.insertColumnWithTTL.bind()
-                    .setBytes(KEY_BINDING, key.asByteBuffer())
-                    .setBytes(COLUMN_BINDING, entry.getColumn().asByteBuffer())
-                    .setBytes(VALUE_BINDING, entry.getValue().asByteBuffer())
+                    .setByteBuffer(KEY_BINDING, key.asByteBuffer())
+                    .setByteBuffer(COLUMN_BINDING, entry.getColumn().asByteBuffer())
+                    .setByteBuffer(VALUE_BINDING, entry.getValue().asByteBuffer())
                     .setLong(TIMESTAMP_BINDING, timestamp)
                     .setInt(TTL_BINDING, ttl);
         }
         return this.insertColumn.bind()
-                .setBytes(KEY_BINDING, key.asByteBuffer())
-                .setBytes(COLUMN_BINDING, entry.getColumn().asByteBuffer())
-                .setBytes(VALUE_BINDING, entry.getValue().asByteBuffer())
+                .setByteBuffer(KEY_BINDING, key.asByteBuffer())
+                .setByteBuffer(COLUMN_BINDING, entry.getColumn().asByteBuffer())
+                .setByteBuffer(VALUE_BINDING, entry.getValue().asByteBuffer())
                 .setLong(TIMESTAMP_BINDING, timestamp);
     }
 
@@ -377,16 +393,16 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
             throw new PermanentBackendException("This operation is only allowed when the byteorderedpartitioner is used.");
         }
 
-        final Metadata metadata = this.session.getCluster().getMetadata();
+        TokenMap tokenMap = this.session.getMetadata().getTokenMap().get();
         return Try.of(() -> new CQLResultSetKeyIterator(
                 query,
                 this.getter,
                 this.session.execute(this.getKeysRanged.bind()
-                        .setToken(KEY_START_BINDING, metadata.newToken(query.getKeyStart().asByteBuffer()))
-                        .setToken(KEY_END_BINDING, metadata.newToken(query.getKeyEnd().asByteBuffer()))
-                        .setBytes(SLICE_START_BINDING, query.getSliceStart().asByteBuffer())
-                        .setBytes(SLICE_END_BINDING, query.getSliceEnd().asByteBuffer())
-                        .setFetchSize(this.storeManager.getPageSize())
+                        .setToken(KEY_START_BINDING, tokenMap.newToken(query.getKeyStart().asByteBuffer()))
+                        .setToken(KEY_END_BINDING, tokenMap.newToken(query.getKeyEnd().asByteBuffer()))
+                        .setByteBuffer(SLICE_START_BINDING, query.getSliceStart().asByteBuffer())
+                        .setByteBuffer(SLICE_END_BINDING, query.getSliceEnd().asByteBuffer())
+                        .setPageSize(this.storeManager.getPageSize())
                         .setConsistencyLevel(getTransaction(txh).getReadConsistencyLevel()))))
                 .getOrElseThrow(EXCEPTION_MAPPER);
     }
@@ -401,9 +417,9 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
                 query,
                 this.getter,
                 this.session.execute(this.getKeysAll.bind()
-                        .setBytes(SLICE_START_BINDING, query.getSliceStart().asByteBuffer())
-                        .setBytes(SLICE_END_BINDING, query.getSliceEnd().asByteBuffer())
-                        .setFetchSize(this.storeManager.getPageSize())
+                        .setByteBuffer(SLICE_START_BINDING, query.getSliceStart().asByteBuffer())
+                        .setByteBuffer(SLICE_END_BINDING, query.getSliceEnd().asByteBuffer())
+                        .setPageSize(this.storeManager.getPageSize())
                         .setConsistencyLevel(getTransaction(txh).getReadConsistencyLevel()))))
                 .getOrElseThrow(EXCEPTION_MAPPER);
     }

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLTransaction.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLTransaction.java
@@ -14,14 +14,15 @@
 
 package org.janusgraph.diskstorage.cql;
 
-import static org.janusgraph.diskstorage.cql.CQLConfigOptions.*;
-
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
+import com.google.common.base.Preconditions;
 import org.janusgraph.diskstorage.BaseTransactionConfig;
 import org.janusgraph.diskstorage.common.AbstractStoreTransaction;
 import org.janusgraph.diskstorage.keycolumnvalue.StoreTransaction;
 
-import com.datastax.driver.core.ConsistencyLevel;
-import com.google.common.base.Preconditions;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.READ_CONSISTENCY;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.WRITE_CONSISTENCY;
 
 /**
  * This class manages the translation of read and write consistency configuration values to CQL API {@link ConsistencyLevel} types.
@@ -33,8 +34,8 @@ public class CQLTransaction extends AbstractStoreTransaction {
 
     public CQLTransaction(final BaseTransactionConfig config) {
         super(config);
-        this.readConsistencyLevel = ConsistencyLevel.valueOf(getConfiguration().getCustomOption(READ_CONSISTENCY));
-        this.writeConsistencyLevel = ConsistencyLevel.valueOf(getConfiguration().getCustomOption(WRITE_CONSISTENCY));
+        this.readConsistencyLevel = DefaultConsistencyLevel.valueOf(getConfiguration().getCustomOption(READ_CONSISTENCY));
+        this.writeConsistencyLevel = DefaultConsistencyLevel.valueOf(getConfiguration().getCustomOption(WRITE_CONSISTENCY));
     }
 
     ConsistencyLevel getReadConsistencyLevel() {

--- a/janusgraph-cql/src/test/java/org/janusgraph/JanusGraphCassandraContainer.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/JanusGraphCassandraContainer.java
@@ -31,8 +31,18 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.time.Duration;
 
-import static org.janusgraph.diskstorage.cql.CQLConfigOptions.*;
-import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.*;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.KEYSPACE;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.MAX_REQUESTS_PER_CONNECTION;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.SSL_ENABLED;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.SSL_TRUSTSTORE_LOCATION;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.SSL_TRUSTSTORE_PASSWORD;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.CONNECTION_TIMEOUT;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.DROP_ON_CLEAR;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.PAGE_SIZE;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.STORAGE_BACKEND;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.STORAGE_HOSTS;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.STORAGE_PORT;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.buildGraphConfiguration;
 
 public class JanusGraphCassandraContainer extends CassandraContainer<JanusGraphCassandraContainer> {
     private static final Logger LOGGER = LoggerFactory.getLogger(JanusGraphCassandraContainer.class);
@@ -149,7 +159,7 @@ public class JanusGraphCassandraContainer extends CassandraContainer<JanusGraphC
         config.set(STORAGE_PORT, getMappedPort(CQL_PORT));
         config.set(STORAGE_HOSTS, new String[]{getContainerIpAddress()});
         config.set(DROP_ON_CLEAR, false);
-        config.set(REMOTE_MAX_REQUESTS_PER_CONNECTION, 1024);
+        config.set(MAX_REQUESTS_PER_CONNECTION, 1024);
         if (useSSL() && useDynamicConfig()) {
             config.set(SSL_ENABLED, true);
             config.set(SSL_TRUSTSTORE_LOCATION,

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLResultSetKeyIteratorTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLResultSetKeyIteratorTest.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Random;
 
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
 import org.janusgraph.diskstorage.Entry;
 import org.janusgraph.diskstorage.EntryMetaData;
 import org.janusgraph.diskstorage.StaticBuffer;
@@ -30,9 +32,6 @@ import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
 import org.janusgraph.diskstorage.util.BufferUtil;
 import org.janusgraph.diskstorage.util.RecordIterator;
 import org.junit.jupiter.api.Test;
-
-import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.Row;
 
 import io.vavr.Function1;
 import io.vavr.Tuple;
@@ -49,9 +48,9 @@ public class CQLResultSetKeyIteratorTest {
     public void testIterator() throws IOException {
         final Array<Row> rows = Array.rangeClosed(1, 100).map(idx -> {
             final Row row = mock(Row.class);
-            when(row.getBytes("key")).thenReturn(ByteBuffer.wrap(Integer.toString(idx / 5).getBytes()));
-            when(row.getBytes("column1")).thenReturn(ByteBuffer.wrap(Integer.toString(idx % 5).getBytes()));
-            when(row.getBytes("value")).thenReturn(ByteBuffer.wrap(Integer.toString(idx).getBytes()));
+            when(row.getByteBuffer("key")).thenReturn(ByteBuffer.wrap(Integer.toString(idx / 5).getBytes()));
+            when(row.getByteBuffer("column1")).thenReturn(ByteBuffer.wrap(Integer.toString(idx % 5).getBytes()));
+            when(row.getByteBuffer("value")).thenReturn(ByteBuffer.wrap(Integer.toString(idx).getBytes()));
             return row;
         });
 
@@ -69,9 +68,9 @@ public class CQLResultSetKeyIteratorTest {
                     final Row row = rows.get(i++);
                     final Entry entry = entries.next();
 
-                    assertEquals(row.getBytes("key"), next.asByteBuffer());
-                    assertEquals(row.getBytes("column1"), entry.getColumn().asByteBuffer());
-                    assertEquals(row.getBytes("value"), entry.getValue().asByteBuffer());
+                    assertEquals(row.getByteBuffer("key"), next.asByteBuffer());
+                    assertEquals(row.getByteBuffer("column1"), entry.getColumn().asByteBuffer());
+                    assertEquals(row.getByteBuffer("value"), entry.getValue().asByteBuffer());
                 }
             }
         }
@@ -189,9 +188,9 @@ public class CQLResultSetKeyIteratorTest {
     private ResultSet generateMockedResultSet(Array<Tuple2<ByteBuffer, Array<Tuple2<ByteBuffer, ByteBuffer>>>> keysMap){
         final Seq<Row> rows = keysMap.flatMap(tuple -> tuple._2.map(columnAndValue -> {
             final Row row = mock(Row.class);
-            when(row.getBytes("key")).thenReturn(tuple._1);
-            when(row.getBytes("column1")).thenReturn(columnAndValue._1);
-            when(row.getBytes("value")).thenReturn(columnAndValue._2);
+            when(row.getByteBuffer("key")).thenReturn(tuple._1);
+            when(row.getByteBuffer("column1")).thenReturn(columnAndValue._1);
+            when(row.getByteBuffer("value")).thenReturn(columnAndValue._2);
             return row;
         }));
 

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLStoreTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLStoreTest.java
@@ -14,7 +14,11 @@
 
 package org.janusgraph.diskstorage.cql;
 
-import com.datastax.driver.core.*;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.Statement;
+import com.datastax.oss.driver.api.core.metadata.Metadata;
+import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
+import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
 import org.janusgraph.JanusGraphCassandraContainer;
 import org.janusgraph.TestCategory;
 import org.janusgraph.diskstorage.BackendException;
@@ -39,10 +43,14 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @ExtendWith(MockitoExtension.class)
 @Testcontainers
@@ -52,7 +60,13 @@ public class CQLStoreTest extends KeyColumnValueStoreTest {
 
     private static final String TEST_CF_NAME = "testcf";
     private static final String DEFAULT_COMPRESSOR_PACKAGE = "org.apache.cassandra.io.compress";
-    private static final String TEST_KEYSPACE_NAME = "test_keyspace";
+    private final String TEST_KEYSPACE_NAME = getClass().getSimpleName();
+
+    @Mock
+    private CqlSession session;
+
+    @InjectMocks
+    private CQLStoreManager mockManager = new CQLStoreManager(getBaseStorageConfiguration());
 
     @Container
     public static final JanusGraphCassandraContainer cqlContainer = new JanusGraphCassandraContainer();
@@ -61,7 +75,7 @@ public class CQLStoreTest extends KeyColumnValueStoreTest {
     }
 
     protected ModifiableConfiguration getBaseStorageConfiguration() {
-        return cqlContainer.getConfiguration(getClass().getSimpleName());
+        return cqlContainer.getConfiguration(TEST_KEYSPACE_NAME);
     }
 
     private CQLStoreManager openStorageManager(final Configuration c) throws BackendException {
@@ -122,7 +136,7 @@ public class CQLStoreTest extends KeyColumnValueStoreTest {
 
         // COMPACT STORAGE is allowed on Cassandra 2 or earlier
         // when COMPACT STORAGE is allowed, the default is to enable it
-        assertTrue(cqlStoreManager.isCompactStorageAllowed() == cqlStoreManager.getTableMetadata(cf).getOptions().isCompactStorage());
+        assertTrue(cqlStoreManager.isCompactStorageAllowed() == cqlStoreManager.getTableMetadata(cf).isCompactStorage());
     }
 
     @Test
@@ -136,9 +150,9 @@ public class CQLStoreTest extends KeyColumnValueStoreTest {
         cqlStoreManager.openDatabase(cf);
 
         if (cqlStoreManager.isCompactStorageAllowed()) {
-            assertTrue(cqlStoreManager.getTableMetadata(cf).getOptions().isCompactStorage());
+            assertTrue(cqlStoreManager.getTableMetadata(cf).isCompactStorage());
         } else {
-            assertFalse(cqlStoreManager.getTableMetadata(cf).getOptions().isCompactStorage());
+            assertFalse(cqlStoreManager.getTableMetadata(cf).isCompactStorage());
         }
     }
 
@@ -151,7 +165,7 @@ public class CQLStoreTest extends KeyColumnValueStoreTest {
         final CQLStoreManager cqlStoreManager = openStorageManager(config);
         cqlStoreManager.openDatabase(cf);
 
-        assertFalse(cqlStoreManager.getTableMetadata(cf).getOptions().isCompactStorage());
+        assertFalse(cqlStoreManager.getTableMetadata(cf).isCompactStorage());
     }
 
     @Test
@@ -217,38 +231,28 @@ public class CQLStoreTest extends KeyColumnValueStoreTest {
         assertTrue(features.hasCellTTL());
     }
 
-    @Mock
-    private Cluster cluster;
-    @Mock
-    private Session session;
-
-    @InjectMocks
-    private CQLStoreManager mockManager = new CQLStoreManager(getBaseStorageConfiguration());
-
     @Test
     public void testExistKeyspaceSession() {
         Metadata metadata = mock(Metadata.class);
         KeyspaceMetadata keyspaceMetadata = mock(KeyspaceMetadata.class);
-        when(cluster.getMetadata()).thenReturn(metadata);
-        when(metadata.getKeyspace(TEST_KEYSPACE_NAME)).thenReturn(keyspaceMetadata);
-        when(cluster.connect()).thenReturn(session);
+        Optional<KeyspaceMetadata> keyspaceMetadataOptional = Optional.of(keyspaceMetadata);
+        when(session.getMetadata()).thenReturn(metadata);
+        when(metadata.getKeyspace(TEST_KEYSPACE_NAME)).thenReturn(keyspaceMetadataOptional);
 
-        mockManager.initializeSession(TEST_KEYSPACE_NAME);
+        mockManager.initializeKeyspace();
 
-        verify(cluster).connect();
         verify(session, never()).execute(any(Statement.class));
     }
 
     @Test
     public void testNewKeyspaceSession() {
         Metadata metadata = mock(Metadata.class);
-        when(cluster.getMetadata()).thenReturn(metadata);
-        when(metadata.getKeyspace(TEST_KEYSPACE_NAME)).thenReturn(null);
-        when(cluster.connect()).thenReturn(session);
+        Optional<KeyspaceMetadata> keyspaceMetadataOptional = Optional.empty();
+        when(session.getMetadata()).thenReturn(metadata);
+        when(metadata.getKeyspace(TEST_KEYSPACE_NAME)).thenReturn(keyspaceMetadataOptional);
 
-        mockManager.initializeSession(TEST_KEYSPACE_NAME);
+        mockManager.initializeKeyspace();
 
-        verify(cluster).connect();
         verify(session, times(1)).execute(any(Statement.class));
     }
 
@@ -258,9 +262,10 @@ public class CQLStoreTest extends KeyColumnValueStoreTest {
         String someTableName = "foo";
         Metadata metadata = mock(Metadata.class);
         KeyspaceMetadata keyspaceMetadata = mock(KeyspaceMetadata.class);
-        when(keyspaceMetadata.getTable(someTableName)).thenReturn(mock(TableMetadata.class));
-        when(cluster.getMetadata()).thenReturn(metadata);
-        when(metadata.getKeyspace(mockManager.getKeyspaceName())).thenReturn(keyspaceMetadata);
+        TableMetadata tableMetadata = mock(TableMetadata.class);
+        when(keyspaceMetadata.getTable(someTableName)).thenReturn(Optional.of(tableMetadata));
+        when(session.getMetadata()).thenReturn(metadata);
+        when(metadata.getKeyspace(mockManager.getKeyspaceName())).thenReturn(Optional.of(keyspaceMetadata));
 
         //act
         mockManager.openDatabase(someTableName, null);
@@ -275,9 +280,9 @@ public class CQLStoreTest extends KeyColumnValueStoreTest {
         String someTableName = "foo";
         Metadata metadata = mock(Metadata.class);
         KeyspaceMetadata keyspaceMetadata = mock(KeyspaceMetadata.class);
-        when(keyspaceMetadata.getTable(someTableName)).thenReturn(null);
-        when(cluster.getMetadata()).thenReturn(metadata);
-        when(metadata.getKeyspace(mockManager.getKeyspaceName())).thenReturn(keyspaceMetadata);
+        when(keyspaceMetadata.getTable(someTableName)).thenReturn(Optional.empty());
+        when(session.getMetadata()).thenReturn(metadata);
+        when(metadata.getKeyspace(mockManager.getKeyspaceName())).thenReturn(Optional.of(keyspaceMetadata));
 
         //act
         mockManager.openDatabase(someTableName, null);

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CachingCQLStoreManager.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CachingCQLStoreManager.java
@@ -14,8 +14,7 @@
 
 package org.janusgraph.diskstorage.cql;
 
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.Session;
+import com.datastax.oss.driver.api.core.CqlSession;
 import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.PermanentBackendException;
 import org.janusgraph.diskstorage.configuration.Configuration;
@@ -27,26 +26,19 @@ import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.DR
 
 public class CachingCQLStoreManager extends CQLStoreManager {
 
-    private static Cluster cluster;
 
-    private static final Map<String,Session> sessions = new HashMap<>();
+    private static final Map<String, CqlSession> sessions = new HashMap<>();
 
     public CachingCQLStoreManager(final Configuration configuration) throws BackendException {
         super(configuration);
     }
 
-    @Override
-    Cluster initializeCluster() throws PermanentBackendException {
-        if (cluster == null || cluster.isClosed()) {
-            cluster = super.initializeCluster();
-        }
-        return cluster;
-    }
 
     @Override
-    Session initializeSession(final String keyspaceName) {
+    CqlSession initializeSession() throws PermanentBackendException {
+        String keyspaceName = this.getKeyspaceName();
         if (!sessions.containsKey(keyspaceName)) {
-            sessions.put(keyspaceName, super.initializeSession(keyspaceName));
+            sessions.put(keyspaceName, super.initializeSession());
         }
         return sessions.get(keyspaceName);
     }
@@ -54,7 +46,7 @@ public class CachingCQLStoreManager extends CQLStoreManager {
     @Override
     public void close() {
         if (this.storageConfig.get(DROP_ON_CLEAR)) {
-            sessions.values().forEach(Session::close);
+            sessions.values().forEach(CqlSession::close);
             sessions.clear();
         }
         this.executorService.shutdownNow();

--- a/janusgraph-hadoop-parent/pom.xml
+++ b/janusgraph-hadoop-parent/pom.xml
@@ -205,7 +205,13 @@
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>${cassandra-driver.version}</version>
+            <version>3.7.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.jnr</groupId>
+                    <artifactId>jnr-posix</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Logging backends.
              Enforce a classpath ordering constraint to ensure slf4j-log4j12

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <zookeeper.version>3.4.6</zookeeper.version>
         <jersey.version>1.9</jersey.version>
         <!-- align with org.apache.tinkerpop:tinkerpop -->
-        <netty4.version>4.1.25.Final</netty4.version>
+        <netty4.version>4.1.35.Final</netty4.version>
         <jna.version>4.0.0</jna.version>
         <kuali.s3.wagon.version>1.1.20</kuali.s3.wagon.version>
         <jasper.version>5.5.23</jasper.version>
@@ -125,7 +125,7 @@
         <compiler.target>1.8</compiler.target>
         <test.excluded.groups>MEMORY_TESTS,PERFORMANCE_TESTS,BRITTLE_TESTS</test.excluded.groups>
         <dependency.locations.enabled>false</dependency.locations.enabled>
-        <cassandra-driver.version>3.7.2</cassandra-driver.version>
+        <cassandra-driver.version>4.2.0</cassandra-driver.version>
         <testcontainers.version>1.11.4</testcontainers.version>
     </properties>
     <modules>


### PR DESCRIPTION
The new Java driver has:

- new Maven coordinates (groupId and artifactId)
- new APIs
- does not have Cluster anymore (wrapped in Session)
- some configs are now mandatory, e.g. LocalDatacenter is now mandatory when specifying custom endpoints
- some configs have been removed

NOTES:
- initializing a table seems to be slower than before

Signed-off-by: Marco Scoppetta <marco@grakn.ai>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

