### PR TITLE
Optimize ES queries to not count total hits for all requests

### DIFF
--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchClient.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchClient.java
@@ -54,6 +54,8 @@ public interface ElasticSearchClient extends Closeable {
 
     void bulkRequest(List<ElasticSearchMutation> requests, String ingestPipeline) throws IOException;
 
+    long countTotal(String indexName, Map<String,Object> requestData) throws IOException;
+
     ElasticSearchResponse search(String indexName, Map<String,Object> request, boolean useScroll) throws IOException;
 
     ElasticSearchResponse search(String scrollId) throws IOException;

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchResponse.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchResponse.java
@@ -23,8 +23,6 @@ public class ElasticSearchResponse {
 
     private long took;
 
-    private long total;
-
     private String scrollId;
 
     private List<RawQuery.Result<String>> results;
@@ -35,14 +33,6 @@ public class ElasticSearchResponse {
 
     public void setTook(long took) {
         this.took = took;
-    }
-
-    public long getTotal() {
-        return total;
-    }
-
-    public void setTotal(long total) {
-        this.total = total;
     }
 
     public Stream<RawQuery.Result<String>> getResults() {

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/compat/AbstractESCompat.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/compat/AbstractESCompat.java
@@ -181,7 +181,7 @@ public abstract class AbstractESCompat {
     }
 
     public Map<String,Object> createRequestBody(ElasticSearchRequest request, Parameter[] parameters) {
-        final Map<String,Object> requestBody = new HashMap<>();
+        final Map<String,Object> requestBody = createRequestBody(request.getQuery(), parameters);
 
         if(request.getSize() != null){
             requestBody.put("size", request.getSize());
@@ -195,18 +195,24 @@ public abstract class AbstractESCompat {
             requestBody.put("sort", request.getSorts());
         }
 
-        if(request.getQuery() != null){
-            requestBody.put("query", request.getQuery());
+        if(request.isDisableSourceRetrieval()){
+            requestBody.put("_source", false);
+        }
+
+        return requestBody;
+    }
+
+    public Map<String,Object> createRequestBody(Map<String,Object> query, Parameter[] parameters) {
+        final Map<String,Object> requestBody = new HashMap<>();
+
+        if(query != null){
+            requestBody.put("query", query);
         }
 
         if(parameters != null){
             for(Parameter parameter : parameters){
                 requestBody.put(parameter.key(), parameter.value());
             }
-        }
-
-        if(request.isDisableSourceRetrieval()){
-            requestBody.put("_source", false);
         }
 
         return requestBody;

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestCountResponse.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestCountResponse.java
@@ -1,4 +1,4 @@
-// Copyright 2017 JanusGraph Authors
+// Copyright 2019 JanusGraph Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,32 +15,17 @@
 package org.janusgraph.diskstorage.es.rest;
 
 import org.apache.tinkerpop.shaded.jackson.annotation.JsonIgnoreProperties;
-import org.apache.tinkerpop.shaded.jackson.annotation.JsonProperty;
-
-import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class RestSearchResults {
+public class RestCountResponse {
 
-    @JsonProperty("max_score")
-    private Float maxScore;
+    private long count;
 
-    private List<RestSearchHit> hits;
-
-    public Float getMaxScore() {
-        return maxScore;
+    public long getCount() {
+        return count;
     }
 
-    public void setMaxScore(Float maxScore) {
-        this.maxScore = maxScore;
+    public void setCount(long count) {
+        this.count = count;
     }
-
-    public List<RestSearchHit> getHits() {
-        return hits;
-    }
-
-    public void setHits(List<RestSearchHit> hits) {
-        this.hits = hits;
-    }
-
 }

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestSearchResponse.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestSearchResponse.java
@@ -54,11 +54,6 @@ public class RestSearchResponse extends ElasticSearchResponse {
         return hits.getHits().size();
     }
 
-    @Override
-    public long getTotal() {
-        return hits.getTotal();
-    }
-
     public Float getMaxScore() {
         return hits.getMaxScore();
     }

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticsearchConfigTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticsearchConfigTest.java
@@ -64,6 +64,7 @@ import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -389,7 +390,7 @@ public class ElasticsearchConfigTest {
         }
 
         final HttpPut newMapping = new HttpPut(uriBuilder.build());
-        newMapping.setEntity(new StringEntity(objectMapper.writeValueAsString(content), Charset.forName("UTF-8")));
+        newMapping.setEntity(new StringEntity(objectMapper.writeValueAsString(content), StandardCharsets.UTF_8));
         executeRequest(newMapping);
     }
 


### PR DESCRIPTION
We only need total hits for `vertexTotals`, `edgeTotals`, `propertyTotals` index requests.

- Optimizes totals to run not a `search` query but `count` query
- Optimizes search queries which don't need Search API to not count total hits at all

Fixes #1679

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[skip ci]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

