### PR TITLE
Remove v0.3 specific doc notes [doc only]

### DIFF
--- a/docs/advanced-topics/serializer.md
+++ b/docs/advanced-topics/serializer.md
@@ -1,9 +1,6 @@
 Datatype and Attribute Serializer Configuration
 ===============================================
 
-!!! Info
-    `ObjectNode` and `ArrayNode` serializers are added in JanusGraph version `0.3.2`
-
 JanusGraph supports a number of classes for attribute values on
 properties. JanusGraph efficiently serializes primitives, primitive
 arrays and `Geoshape`, `UUID`, `Date`, `ObjectNode` and `ArrayNode`.

--- a/docs/index-backend/field-mapping.md
+++ b/docs/index-backend/field-mapping.md
@@ -105,9 +105,6 @@ With these settings, JanusGraph will use a SimpleAnalyzer analyzer for property 
 
 ### Custom parameters
 
-!!! Info
-    Custom parameters are added in JanusGraph version `0.3.1`
-
 Sometimes it is required to set additional parameters on mappings (other than mapping type, mapping name and analyzer). For example, when we would like to use a different similarity algorithm (to modify the scoring algorithm of full text search) or if we want to use a custom boosting on some fields in Elasticsearch we can set custom parameters (right now only Elasticsearch supports custom parameters).
 The name of the custom parameter must be set through `ParameterType.customParameterName("yourProperty")`.
 


### PR DESCRIPTION
Additional serializers and custom ES parameters were already in `v0.4.0`. That is why we don't need to show redundant notes when the user is looking for `v0.4` docs.

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
- [x] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

