### PR TITLE
Fix for reindexing OOM issue with CQL backend

### DIFF
--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStore.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStore.java
@@ -54,6 +54,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import com.datastax.driver.core.PagingState;
 import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.Entry;
 import org.janusgraph.diskstorage.EntryList;
@@ -378,7 +379,8 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
         return Try.of(() -> new CQLResultSetKeyIterator(
                 query,
                 this.getter,
-                this.session.execute(this.getKeysRanged.bind()
+                new CQLPagingIterator(this.storeManager.getPageSize(), () ->
+                    getKeysRanged.bind()
                         .setToken(KEY_START_BINDING, metadata.newToken(query.getKeyStart().asByteBuffer()))
                         .setToken(KEY_END_BINDING, metadata.newToken(query.getKeyEnd().asByteBuffer()))
                         .setBytes(SLICE_START_BINDING, query.getSliceStart().asByteBuffer())
@@ -397,11 +399,63 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
         return Try.of(() -> new CQLResultSetKeyIterator(
                 query,
                 this.getter,
-                this.session.execute(this.getKeysAll.bind()
+                new CQLPagingIterator(this.storeManager.getPageSize(), () ->
+                    getKeysAll.bind()
                         .setBytes(SLICE_START_BINDING, query.getSliceStart().asByteBuffer())
                         .setBytes(SLICE_END_BINDING, query.getSliceEnd().asByteBuffer())
                         .setFetchSize(this.storeManager.getPageSize())
                         .setConsistencyLevel(getTransaction(txh).getReadConsistencyLevel()))))
                 .getOrElseThrow(EXCEPTION_MAPPER);
+    }
+
+    /**
+     * This class provides a paging implementation that sits on top of the DSE Cassandra driver. The driver already
+     * has its own built in paging support but this has limitations when doing a full scan of the key ring due
+     * to how driver paging metadata is stored. The driver stores a full history of a given query's paging metadata
+     * which can lead to OOM issues on non-trivially sized data sets. This class overcomes this by doing another level
+     * of paging that re-executes the query after a configurable number of rows. When the original query is re-executed
+     * it is initialized to the correct offset using the last page's metadata.
+     */
+    private class CQLPagingIterator implements Iterator<Row> {
+
+        private ResultSet currentResultSet;
+
+        private int index;
+        private int paginatedResultSize;
+        private final Supplier<Statement> statementSupplier;
+
+        private PagingState lastPagingState = null;
+
+        public CQLPagingIterator(final int pageSize, Supplier<Statement> statementSupplier) {
+            this.index = 0;
+            this.paginatedResultSize = pageSize;
+            this.statementSupplier = statementSupplier;
+            this.currentResultSet = getResultSet();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return !currentResultSet.isExhausted();
+        }
+
+        @Override
+        public Row next() {
+            if(index == paginatedResultSize) {
+                currentResultSet = getResultSet();
+                this.index = 0;
+            }
+            this.index++;
+            lastPagingState = currentResultSet.getExecutionInfo().getPagingState();
+            return currentResultSet.one();
+
+        }
+
+        private ResultSet getResultSet() {
+            final Statement boundStmnt = statementSupplier.get();
+            if (lastPagingState != null) {
+                boundStmnt.setPagingState(lastPagingState);
+            }
+            return session.execute(boundStmnt);
+        }
     }
 }

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLResultSetKeyIterator.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLResultSetKeyIterator.java
@@ -48,10 +48,10 @@ class CQLResultSetKeyIterator extends AbstractIterator<StaticBuffer> implements 
     private StaticBuffer currentKey = null;
     private StaticBuffer lastKey = null;
 
-    CQLResultSetKeyIterator(final SliceQuery sliceQuery, final CQLColValGetter getter, final ResultSet resultSet) {
+    CQLResultSetKeyIterator(final SliceQuery sliceQuery, final CQLColValGetter getter, final Iterable<Row> resultSet) {
         this.sliceQuery = sliceQuery;
         this.getter = getter;
-        this.iterator = Iterator.ofAll(resultSet.iterator())
+        this.iterator = Iterator.ofAll(resultSet)
                 .peek(row -> {
                     this.currentRow = row;
                     this.currentKey = StaticArrayBuffer.of(row.getBytes(CQLKeyColumnValueStore.KEY_COLUMN_NAME));


### PR DESCRIPTION
Fixes: #1813 

Fix to add a level of paging above the CQL driver to prevent OOM issus when performing reindexing operations.

Signed-off-by: Ted Wilmes <ted.wilmes@experoinc.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

