### PR TITLE
Make "janusgraphmr.ioformat.filter-partitioned-vertices" option work

### DIFF
--- a/janusgraph-cassandra/src/test/java/org/janusgraph/hadoop/CassandraScanJobIT.java
+++ b/janusgraph-cassandra/src/test/java/org/janusgraph/hadoop/CassandraScanJobIT.java
@@ -137,7 +137,7 @@ public class CassandraScanJobIT extends JanusGraphBaseTest {
         c.set(ConfigElement.getPath(JanusGraphHadoopConfiguration.GRAPH_CONFIG_KEYS, true) + "." + "storage.cassandra.keyspace", getClass().getSimpleName());
         c.set(ConfigElement.getPath(JanusGraphHadoopConfiguration.GRAPH_CONFIG_KEYS, true) + "." + "storage.backend", "cassandrathrift");
         c.set(ConfigElement.getPath(JanusGraphHadoopConfiguration.GRAPH_CONFIG_KEYS, true) + "." + "storage.port", String.valueOf(thriftContainer.getMappedThirftPort()));
-        c.set(ConfigElement.getPath(JanusGraphHadoopConfiguration.FILTER_PARTITIONED_VERTICES), "true");
+        c.set(ConfigElement.getPath(JanusGraphHadoopConfiguration.FILTER_PARTITIONED_VERTICES, true), "true");
         c.set("cassandra.input.partitioner.class", "org.apache.cassandra.dht.Murmur3Partitioner");
 
         Job job = getVertexJobWithDefaultMapper(c);

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/AbstractConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/AbstractConfiguration.java
@@ -46,8 +46,12 @@ public abstract class AbstractConfiguration implements Configuration {
     }
 
     protected String getPath(ConfigElement option, String... umbrellaElements) {
+        return getPath(option, false, umbrellaElements);
+    }
+
+    protected String getPath(ConfigElement option, boolean includeRoot, String... umbrellaElements) {
         verifyElement(option);
-        return ConfigElement.getPath(option,umbrellaElements);
+        return ConfigElement.getPath(option, includeRoot, umbrellaElements);
     }
 
     protected Set<String> getContainedNamespaces(ReadConfiguration config, ConfigNamespace umbrella, String... umbrellaElements) {
@@ -102,19 +106,19 @@ public abstract class AbstractConfiguration implements Configuration {
             }
 
             @Override
-            public boolean has(ConfigOption option, String... umbrellaElements) {
+            public boolean has(ConfigOption option, boolean includeRoot, String... umbrellaElements) {
                 if (option.getNamespace().hasUmbrella())
-                    return config.has(option,concat(umbrellaElements));
+                    return config.has(option, includeRoot, concat(umbrellaElements));
                 else
-                    return config.has(option);
+                    return config.has(option, includeRoot);
             }
 
             @Override
-            public <O> O get(ConfigOption<O> option, String... umbrellaElements) {
+            public <O> O get(ConfigOption<O> option, boolean includeRoot, String... umbrellaElements) {
                 if (option.getNamespace().hasUmbrella())
-                    return config.get(option,concat(umbrellaElements));
+                    return config.get(option, includeRoot, concat(umbrellaElements));
                 else
-                    return config.get(option);
+                    return config.get(option, includeRoot);
             }
 
             @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/BasicConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/BasicConfiguration.java
@@ -30,7 +30,7 @@ import java.util.Set;
 public class BasicConfiguration extends AbstractConfiguration {
 
     private static final Logger log =
-            LoggerFactory.getLogger(BasicConfiguration.class);
+        LoggerFactory.getLogger(BasicConfiguration.class);
 
     public enum Restriction { LOCAL, GLOBAL, NONE }
 
@@ -57,15 +57,15 @@ public class BasicConfiguration extends AbstractConfiguration {
 
 
     @Override
-    public boolean has(ConfigOption option, String... umbrellaElements) {
+    public boolean has(ConfigOption option, boolean includeRoot, String... umbrellaElements) {
         verifyOption(option);
-        return config.get(super.getPath(option,umbrellaElements),option.getDatatype())!=null;
+        return config.get(super.getPath(option, includeRoot, umbrellaElements),option.getDatatype())!=null;
     }
 
     @Override
-    public<O> O get(ConfigOption<O> option, String... umbrellaElements) {
+    public<O> O get(ConfigOption<O> option, boolean includeRoot, String... umbrellaElements) {
         verifyOption(option);
-        O result = config.get(super.getPath(option,umbrellaElements),option.getDatatype());
+        O result = config.get(super.getPath(option, includeRoot, umbrellaElements),option.getDatatype());
         return option.get(result);
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/Configuration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/Configuration.java
@@ -25,9 +25,17 @@ import java.util.Set;
  */
 public interface Configuration {
 
-    boolean has(ConfigOption option, String... umbrellaElements);
+    default boolean has(ConfigOption option, String... umbrellaElements) {
+        return has(option, false, umbrellaElements);
+    }
 
-    <O> O get(ConfigOption<O> option, String... umbrellaElements);
+    boolean has(ConfigOption option, boolean includeRoot, String... umbrellaElements);
+
+    default <O> O get(ConfigOption<O> option, String... umbrellaElements) {
+        return get(option, false, umbrellaElements);
+    }
+
+    <O> O get(ConfigOption<O> option, boolean includeRoot, String... umbrellaElements);
 
     Set<String> getContainedNamespaces(ConfigNamespace umbrella, String... umbrellaElements);
 
@@ -40,12 +48,12 @@ public interface Configuration {
 
     Configuration EMPTY = new Configuration() {
         @Override
-        public boolean has(ConfigOption option, String... umbrellaElements) {
+        public boolean has(ConfigOption option, boolean includeRoot, String... umbrellaElements) {
             return false;
         }
 
         @Override
-        public <O> O get(ConfigOption<O> option, String... umbrellaElements) {
+        public <O> O get(ConfigOption<O> option, boolean includeRoot, String... umbrellaElements) {
             return option.getDefaultValue();
         }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/MergedConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/MergedConfiguration.java
@@ -31,17 +31,17 @@ public class MergedConfiguration implements Configuration {
     }
 
     @Override
-    public boolean has(ConfigOption option, String... umbrellaElements) {
-        return first.has(option, umbrellaElements) || second.has(option, umbrellaElements);
+    public boolean has(ConfigOption option, boolean includeRoot, String... umbrellaElements) {
+        return first.has(option, includeRoot, umbrellaElements) || second.has(option, includeRoot, umbrellaElements);
     }
 
     @Override
-    public <O> O get(ConfigOption<O> option, String... umbrellaElements) {
-        if (first.has(option, umbrellaElements))
-            return first.get(option, umbrellaElements);
+    public <O> O get(ConfigOption<O> option, boolean includeRoot, String... umbrellaElements) {
+        if (first.has(option, includeRoot, umbrellaElements))
+            return first.get(option, includeRoot, umbrellaElements);
 
-        if (second.has(option, umbrellaElements))
-            return second.get(option, umbrellaElements);
+        if (second.has(option, includeRoot, umbrellaElements))
+            return second.get(option, includeRoot, umbrellaElements);
 
         return option.getDefaultValue();
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/MixedConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/MixedConfiguration.java
@@ -39,15 +39,15 @@ public class MixedConfiguration extends AbstractConfiguration {
     }
 
     @Override
-    public boolean has(ConfigOption option, String... umbrellaElements) {
-        final String key = super.getPath(option, umbrellaElements);
+    public boolean has(ConfigOption option, boolean includeRoot, String... umbrellaElements) {
+        final String key = super.getPath(option, includeRoot, umbrellaElements);
         return option.isLocal() && local.get(key, option.getDatatype()) != null
               || option.isGlobal() && global.get(key, option.getDatatype()) != null;
     }
 
     @Override
-    public<O> O get(ConfigOption<O> option, String... umbrellaElements) {
-        final String key = super.getPath(option,umbrellaElements);
+    public<O> O get(ConfigOption<O> option, boolean includeRoot, String... umbrellaElements) {
+        final String key = super.getPath(option, includeRoot, umbrellaElements);
         Object result = null;
         if (option.isLocal()) {
             result = local.get(key,option.getDatatype());

--- a/janusgraph-cql/src/test/java/org/janusgraph/hadoop/CQLScanJobIT.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/hadoop/CQLScanJobIT.java
@@ -143,7 +143,7 @@ public class CQLScanJobIT extends JanusGraphBaseTest {
         c.set(ConfigElement.getPath(JanusGraphHadoopConfiguration.GRAPH_CONFIG_KEYS, true) + "." + "storage.cql.keyspace", getClass().getSimpleName().toLowerCase());
         c.set(ConfigElement.getPath(JanusGraphHadoopConfiguration.GRAPH_CONFIG_KEYS, true) + "." + "storage.backend", "cql");
         c.set(ConfigElement.getPath(JanusGraphHadoopConfiguration.GRAPH_CONFIG_KEYS, true) + "." + "storage.port", String.valueOf(cql.getMappedCQLPort()));
-        c.set(ConfigElement.getPath(JanusGraphHadoopConfiguration.FILTER_PARTITIONED_VERTICES), "true");
+        c.set(ConfigElement.getPath(JanusGraphHadoopConfiguration.FILTER_PARTITIONED_VERTICES, true), "true");
         c.set("cassandra.input.partitioner.class", "org.apache.cassandra.dht.Murmur3Partitioner");
 
         Job job = getVertexJobWithDefaultMapper(c);

--- a/janusgraph-hadoop/src/main/java/org/janusgraph/hadoop/formats/util/input/current/JanusGraphHadoopSetupImpl.java
+++ b/janusgraph-hadoop/src/main/java/org/janusgraph/hadoop/formats/util/input/current/JanusGraphHadoopSetupImpl.java
@@ -126,6 +126,6 @@ public class JanusGraphHadoopSetupImpl implements JanusGraphHadoopSetup {
 
     @Override
     public boolean getFilterPartitionedVertices() {
-        return scanConf.get(JanusGraphHadoopConfiguration.FILTER_PARTITIONED_VERTICES);
+        return scanConf.get(JanusGraphHadoopConfiguration.FILTER_PARTITIONED_VERTICES, true);
     }
 }

--- a/janusgraph-hadoop/src/test/java/org/janusgraph/hadoop/ConfigurationTest.java
+++ b/janusgraph-hadoop/src/test/java/org/janusgraph/hadoop/ConfigurationTest.java
@@ -1,0 +1,44 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.hadoop;
+
+import org.apache.hadoop.conf.Configuration;
+import org.janusgraph.diskstorage.configuration.ConfigElement;
+import org.janusgraph.hadoop.config.JanusGraphHadoopConfiguration;
+import org.janusgraph.hadoop.config.ModifiableHadoopConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ConfigurationTest {
+    @Test
+    public void testIncludeRoot() {
+        Configuration config = new Configuration();
+        config.setBoolean("janusgraphmr.ioformat.filter-partitioned-vertices", true);
+
+        ModifiableHadoopConfiguration scanConf = ModifiableHadoopConfiguration.of(JanusGraphHadoopConfiguration.MAPRED_NS, config);
+
+        assertEquals(ConfigElement.getPath(JanusGraphHadoopConfiguration.FILTER_PARTITIONED_VERTICES), "ioformat.filter-partitioned-vertices");
+        assertEquals(ConfigElement.getPath(JanusGraphHadoopConfiguration.FILTER_PARTITIONED_VERTICES, true), "janusgraphmr.ioformat.filter-partitioned-vertices");
+
+        assertFalse(scanConf.has(JanusGraphHadoopConfiguration.FILTER_PARTITIONED_VERTICES));
+        assertTrue(scanConf.has(JanusGraphHadoopConfiguration.FILTER_PARTITIONED_VERTICES, true));
+
+        assertFalse(scanConf.get(JanusGraphHadoopConfiguration.FILTER_PARTITIONED_VERTICES));
+        assertTrue(scanConf.get(JanusGraphHadoopConfiguration.FILTER_PARTITIONED_VERTICES, true));
+    }
+}


### PR DESCRIPTION
- "ConfigElement.getPath" in "AbstractConfiguration.getPath" returns "ioformat.filter-partitioned-vertices", but the "config" variable only contains "janusgraphmr.ioformat.filter-partitioned-vertices". So the "includeRoot" argument has been added to be able to include root path of the "ConfigOption".

Signed-off-by: inho1213 <inho1213@naver.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

