### PR TITLE
Fixed broken dist docker-compose (updated to supported ES version)

### DIFF
--- a/janusgraph-dist/docker-compose.yml
+++ b/janusgraph-dist/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     command: ["./bin/gremlin-server.sh", "./conf/gremlin-server/gremlin-server-berkeleyje-es.yaml"]
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.3.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.4
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - "http.host=0.0.0.0"
@@ -36,7 +36,7 @@ services:
       timeout: 30s
       retries: 30
     ports:
-      - "9200"
+      - "9200:9200"
     volumes:
       - ./es/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
 


### PR DESCRIPTION
Currently it is not possible to use janusgraph-dist, beacuse of not supported ES version in docker-compose. Update of version (and mapping for port) solves the problem.

For reference - this bug resulted in "gremlin-groovy is not an available GremlinScriptEngine" in gremlin repl.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

