### PR TITLE
Add docker based build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Copyright 2020 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+**/target/**

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -37,6 +37,22 @@ mvn clean install -Pjanusgraph-release -Dgpg.skip=true -DskipTests=true
 This command generates the distribution archive in `janusgraph-dist/target/janusgraph-$VERSION.zip`.
 For more details information, please see [here](janusgraph-dist/README.md#building-zip-archives)
 
+## Docker Based Build
+
+It is also possible to build and test JanusGraph using Docker.
+This has the advantage that no dependencies need to be installed.
+
+The Bash script `docker-build/docker-build.sh` can be used to execute the
+build.
+It has the following options:
+
+* `-t` / `--tests`: Run standard test suite.
+* `-p` / `--tinkerpop-tests`: Run TinkerPop tests.
+* `-m` / `--in-memory`: Use tmpfs to build in-memory.
+
+**NOTE:** The tests can currently not be executed on Docker for Windows due to
+limitations in the networking implementation.
+
 ## Building Docker Image for JanusGraph Server
 
 In order to build Docker image for JanusGraph Server, a

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -1,0 +1,36 @@
+#
+# Copyright 2019 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM openjdk:8
+
+RUN apt update && \
+    apt install -y \
+        maven \
+        rsync \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg2 \
+        software-properties-common && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
+    apt update && \
+    apt install -y docker-ce && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY . /usr/src/janusgraph
+WORKDIR /usr/src/janusgraph
+
+ENTRYPOINT [ "docker-build/docker-entrypoint.sh" ]

--- a/docker-build/docker-build.sh
+++ b/docker-build/docker-build.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Copyright 2019 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+RUN_TESTS=
+RUN_TINKERPOP_TESTS=
+BUILD_IN_MEMORY=
+
+function usage {
+  echo -e "\nUsage: `basename $0` [OPTIONS]" \
+          "\nBuild the current local JanusGraph project in a Docker container." \
+          "\n\nOptions are:\n" \
+          "\n\t-t, --tests              run standard test suite" \
+          "\n\t-p, --tinkerpop-tests    run TinkerPop tests" \
+          "\n\t-m, --in-memory          use tmpfs to build in-memory" \
+          "\n\t-h, --help               show this message" \
+          "\n"
+}
+
+while [ ! -z "$1" ]; do
+  case "$1" in
+    -t | --tests ) RUN_TESTS=true; shift ;;
+    -p | --tinkerpop-tests ) RUN_TINKERPOP_TESTS=true; shift ;;
+    -m | --in-memory ) BUILD_IN_MEMORY=true; shift ;;
+    -h | --help ) usage; exit 0 ;;
+    *) usage 1>&2; exit 1 ;;
+  esac
+done
+
+JANUSGRAPH_BUILD_OPTIONS=""
+
+[ -z "${RUN_TESTS}" ] && JANUSGRAPH_BUILD_OPTIONS="${JANUSGRAPH_BUILD_OPTIONS} -DskipTests"
+[ -z "${RUN_TINKERPOP_TESTS}" ] || JANUSGRAPH_BUILD_OPTIONS="${JANUSGRAPH_BUILD_OPTIONS} -Dtest.skip.tp=false"
+
+JANUSGRAPH_DOCKER_OPTIONS=""
+
+[ -z "${BUILD_IN_MEMORY}" ] || JANUSGRAPH_DOCKER_OPTIONS="${JANUSGRAPH_DOCKER_OPTIONS} --tmpfs /usr/src/janusgraph_inmemory"
+
+if [ "${RUN_TESTS}" ] || [ "${RUN_TINKERPOP_TESTS}" ]; then
+    JANUSGRAPH_DOCKER_OPTIONS="-v /var/run/docker.sock:/var/run/docker.sock"
+fi
+
+docker build -t janusgraph-builder -f build.Dockerfile .
+echo Starting container with: docker run ${JANUSGRAPH_DOCKER_OPTIONS} --rm -it janusgraph-builder ${JANUSGRAPH_BUILD_OPTIONS}
+docker run ${JANUSGRAPH_DOCKER_OPTIONS} --rm -it janusgraph-builder ${JANUSGRAPH_BUILD_OPTIONS}

--- a/docker-build/docker-build.sh
+++ b/docker-build/docker-build.sh
@@ -39,7 +39,7 @@ while [ ! -z "$1" ]; do
   esac
 done
 
-JANUSGRAPH_BUILD_OPTIONS=""
+JANUSGRAPH_BUILD_OPTIONS="-pl janusgraph-cql -am"
 
 [ -z "${RUN_TESTS}" ] && JANUSGRAPH_BUILD_OPTIONS="${JANUSGRAPH_BUILD_OPTIONS} -DskipTests"
 [ -z "${RUN_TINKERPOP_TESTS}" ] || JANUSGRAPH_BUILD_OPTIONS="${JANUSGRAPH_BUILD_OPTIONS} -Dtest.skip.tp=false"

--- a/docker-build/docker-entrypoint.sh
+++ b/docker-build/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright 2019 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+JANUSGRAPH_INMEM_DIR=/usr/src/janusgraph_inmemory
+if [ -d "${JANUSGRAPH_INMEM_DIR}" ]; then
+    rsync --remove-source-files -a . ${JANUSGRAPH_INMEM_DIR}
+    cd ${JANUSGRAPH_INMEM_DIR}
+fi
+
+echo Running: mvn clean install --batch-mode "$@"
+mvn clean install --batch-mode "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
             <plugin>        
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M2</version>
+                <version>3.0.0-M3</version>
                 <executions>
                     <execution>
                         <id>enforce-dependency-convergence</id>


### PR DESCRIPTION
The idea is to use Docker to build JanusGraph in a deterministic environment. This enables contributors to build JanusGraph and test their changes without having to install dependencies (despite Docker obviously).

Fixes #1856

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [x] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

