### PR TITLE
fix:  When the adjacent vertex query is not set label, all edges are…

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
@@ -29,10 +29,12 @@ import org.janusgraph.graphdb.query.profile.QueryProfiler;
 import org.janusgraph.graphdb.relations.StandardVertexProperty;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.janusgraph.core.schema.SchemaStatus;
+import org.janusgraph.graphdb.types.system.BaseKey;
 import org.janusgraph.graphdb.types.system.ImplicitKey;
 import org.janusgraph.graphdb.types.system.SystemRelationType;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.janusgraph.util.datastructures.Interval;
+import org.janusgraph.util.datastructures.IterablesUtil;
 import org.janusgraph.util.datastructures.PointInterval;
 import org.janusgraph.util.datastructures.RangeInterval;
 import org.slf4j.Logger;
@@ -771,5 +773,18 @@ public abstract class BasicVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q
         return baseLimit;
     }
 
-
+    protected void check(){
+        if(adjacentVertex != null){
+            Iterable<JanusGraphVertex> allTypes = QueryUtil.getVertices(this.tx,
+                    BaseKey.SchemaCategory, JanusGraphSchemaCategory.EDGELABEL);
+            int length = IterablesUtil.size(allTypes);
+            int index = 0;
+            String[] labels = new String[length];
+            for(JanusGraphVertex labelVertex : allTypes){
+                labels[index] = ((EdgeLabel)labelVertex).name();
+                index++;
+            }
+            labels(labels);
+        }
+    }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/MultiVertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/MultiVertexCentricQueryBuilder.java
@@ -130,6 +130,7 @@ public class MultiVertexCentricQueryBuilder extends BasicVertexCentricQueryBuild
 
     @Override
     public Map<JanusGraphVertex, Iterable<JanusGraphEdge>> edges() {
+        check();
         return (Map) execute(RelationCategory.EDGE, new RelationConstructor());
     }
 
@@ -148,6 +149,7 @@ public class MultiVertexCentricQueryBuilder extends BasicVertexCentricQueryBuild
 
     @Override
     public Map<JanusGraphVertex, Iterable<JanusGraphRelation>> relations() {
+        check();
         return (Map)(isImplicitKeyQuery(RelationCategory.RELATION)?
                 executeImplicitKeyQuery():
                 execute(RelationCategory.RELATION, new RelationConstructor()));
@@ -155,11 +157,13 @@ public class MultiVertexCentricQueryBuilder extends BasicVertexCentricQueryBuild
 
     @Override
     public Map<JanusGraphVertex, Iterable<JanusGraphVertex>> vertices() {
+        check();
         return execute(RelationCategory.EDGE, new VertexConstructor());
     }
 
     @Override
     public Map<JanusGraphVertex, VertexList> vertexIds() {
+        check();
         return execute(RelationCategory.EDGE, new VertexIdConstructor());
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/VertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/VertexCentricQueryBuilder.java
@@ -90,6 +90,7 @@ public class VertexCentricQueryBuilder extends BasicVertexCentricQueryBuilder<Ve
 
     @Override
     public Iterable<JanusGraphEdge> edges() {
+        check();
         return (Iterable)execute(RelationCategory.EDGE,new RelationConstructor());
     }
 
@@ -102,6 +103,7 @@ public class VertexCentricQueryBuilder extends BasicVertexCentricQueryBuilder<Ve
 
     @Override
     public Iterable<JanusGraphRelation> relations() {
+        check();
         return (Iterable)(isImplicitKeyQuery(RelationCategory.RELATION)?
                 executeImplicitKeyQuery(vertex):
                 execute(RelationCategory.RELATION,new RelationConstructor()));
@@ -111,11 +113,13 @@ public class VertexCentricQueryBuilder extends BasicVertexCentricQueryBuilder<Ve
 
     @Override
     public Iterable<JanusGraphVertex> vertices() {
+        check();
         return execute(RelationCategory.EDGE,new VertexConstructor());
     }
 
     @Override
     public VertexList vertexIds() {
+        check();
         return execute(RelationCategory.EDGE,new VertexIdConstructor());
     }
 


### PR DESCRIPTION
This PR is related to #1911
It currently contains the following changes:
1.add check()  method to all the edge query or vertex query  method in  MultiVertexCentricQueryBuilder and VertexCentricQueryBuilder.java.
2.The check() method will check whether the adjacent query has set the label. If not, all the labels will be obtained and set.