### PR TITLE
fix:  When the adjacent vertex query is not set label,all edges are r…

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -2853,6 +2853,13 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertEquals(2, v.query().labels("connect").adjacent(vs[6]).has("time", 6).edgeCount());
         assertEquals(0, v.query().labels("connect").adjacent(vs[8]).has("time", 8).edgeCount());
 
+        assertEquals(1, v.query().direction(OUT).adjacent(vs[6]).has("time", 6).edgeCount());
+        assertEquals(1, Iterables.size(v.query().direction(OUT).adjacent(vs[11]).edges()));
+        assertEquals(1, Iterables.size(v.query().direction(IN).adjacent(vs[11]).vertices()));
+        assertEquals(2, v.query().direction(BOTH).adjacent(vs[11]).edgeCount());
+        assertEquals(1, v.query().direction(OUT).adjacent(vs[11]).has("weight", 3.5).edgeCount());
+        assertEquals(2, Iterables.size(v.query().adjacent(vs[6]).has("time", 6).vertexIds()));
+
         assertEquals(edgesPerLabel, v.query().labels("connect").direction(OUT).edgeCount());
         assertEquals(edgesPerLabel, v.query().labels("connect").direction(IN).edgeCount());
         assertEquals(2 * edgesPerLabel, v.query().labels("connect").direction(BOTH).edgeCount());
@@ -2890,6 +2897,20 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         for (Iterable<JanusGraphVertexProperty> result : results2.values()) assertEquals(1, Iterables.size(result));
         results2 = tx.multiQuery(qvs).keys("name").properties();
         for (Iterable<JanusGraphVertexProperty> result : results2.values()) assertEquals(1, Iterables.size(result));
+
+        //MultiQuerys with adjacent
+        results = tx.multiQuery(qvs).direction(IN).adjacent(v).edges();
+        for (Iterable<JanusGraphEdge> result : results.values()) assertEquals(1, Iterables.size(result));
+        results = tx.multiQuery(qvs).adjacent(v).edges();
+        for (Iterable<JanusGraphEdge> result : results.values()) assertEquals(2, Iterables.size(result));
+
+        Map<JanusGraphVertex, Iterable<JanusGraphVertex>> resultVertices;
+        resultVertices = tx.multiQuery(qvs).adjacent(v).vertices();
+        for (Iterable<JanusGraphVertex> result : resultVertices.values()) assertEquals(2, Iterables.size(result));
+
+        Map<JanusGraphVertex, VertexList> resultVertexList;
+        resultVertexList = tx.multiQuery(qvs).adjacent(v).vertexIds();
+        for (VertexList result : resultVertexList.values()) assertEquals(2, Iterables.size(result));
 
         //##################################################
         //Same queries as above but without memory loading (i.e. omitting the first query)
@@ -2967,6 +2988,13 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertEquals(2, v.query().labels("connect").adjacent(vs[6]).has("time", 6).edgeCount());
         assertEquals(0, v.query().labels("connect").adjacent(vs[8]).has("time", 8).edgeCount());
 
+        assertEquals(1, v.query().direction(OUT).adjacent(vs[6]).has("time", 6).edgeCount());
+        assertEquals(1, Iterables.size(v.query().direction(OUT).adjacent(vs[11]).edges()));
+        assertEquals(1, Iterables.size(v.query().direction(IN).adjacent(vs[11]).vertices()));
+        assertEquals(2, v.query().direction(BOTH).adjacent(vs[11]).edgeCount());
+        assertEquals(1, v.query().direction(OUT).adjacent(vs[11]).has("weight", 3.5).edgeCount());
+        assertEquals(2, Iterables.size(v.query().adjacent(vs[6]).has("time", 6).vertexIds()));
+
         assertEquals(edgesPerLabel, v.query().labels("connect").direction(OUT).edgeCount());
         assertEquals(edgesPerLabel, v.query().labels("connect").direction(IN).edgeCount());
         assertEquals(2 * edgesPerLabel, v.query().labels("connect").direction(BOTH).edgeCount());
@@ -3004,6 +3032,16 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         for (final Iterable<JanusGraphVertexProperty> result : results2.values()) assertEquals(1, Iterables.size(result));
         results2 = tx.multiQuery(qvs).keys("name").properties();
         for (final Iterable<JanusGraphVertexProperty> result : results2.values()) assertEquals(1, Iterables.size(result));
+
+        //MultiQuerys with adjacent
+        results = tx.multiQuery(qvs).direction(IN).adjacent(v).edges();
+        for (Iterable<JanusGraphEdge> result : results.values()) assertEquals(1, Iterables.size(result));
+        results = tx.multiQuery(qvs).adjacent(v).edges();
+        for (Iterable<JanusGraphEdge> result : results.values()) assertEquals(2, Iterables.size(result));
+        resultVertices = tx.multiQuery(qvs).adjacent(v).vertices();
+        for (Iterable<JanusGraphVertex> result : resultVertices.values()) assertEquals(2, Iterables.size(result));
+        resultVertexList = tx.multiQuery(qvs).adjacent(v).vertexIds();
+        for (VertexList result : resultVertexList.values()) assertEquals(2, Iterables.size(result));
 
         //##################################################
         //End copied queries

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BaseVertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BaseVertexCentricQueryBuilder.java
@@ -48,7 +48,7 @@ import java.util.List;
  */
 public abstract class BaseVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q>> implements BaseVertexQuery<Q> {
 
-    private static final String[] NO_TYPES = new String[0];
+    protected static final String[] NO_TYPES = new String[0];
     private static final List<PredicateCondition<String, JanusGraphRelation>> NO_CONSTRAINTS = ImmutableList.of();
 
     /**

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
@@ -29,10 +29,12 @@ import org.janusgraph.graphdb.query.profile.QueryProfiler;
 import org.janusgraph.graphdb.relations.StandardVertexProperty;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.janusgraph.core.schema.SchemaStatus;
+import org.janusgraph.graphdb.types.system.BaseKey;
 import org.janusgraph.graphdb.types.system.ImplicitKey;
 import org.janusgraph.graphdb.types.system.SystemRelationType;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.janusgraph.util.datastructures.Interval;
+import org.janusgraph.util.datastructures.IterablesUtil;
 import org.janusgraph.util.datastructures.PointInterval;
 import org.janusgraph.util.datastructures.RangeInterval;
 import org.slf4j.Logger;
@@ -418,6 +420,20 @@ public abstract class BasicVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q
         assert returnType != null;
         Preconditions.checkArgument(adjacentVertex==null || returnType == RelationCategory.EDGE,
                 "Vertex constraints only apply to edges");
+
+        if(this.adjacentVertex != null && this.types == NO_TYPES){
+            Iterable<JanusGraphVertex> allTypes = QueryUtil.getVertices(this.tx,
+                    BaseKey.SchemaCategory, JanusGraphSchemaCategory.EDGELABEL);
+            int length = IterablesUtil.size(allTypes);
+            int index = 0;
+            String[] labels = new String[length];
+            for(JanusGraphVertex labelVertex : allTypes){
+                labels[index] = ((EdgeLabel)labelVertex).name();
+                index++;
+            }
+            labels(labels);
+        }
+
         if (limit <= 0)
             return BaseVertexCentricQuery.emptyQuery();
 


### PR DESCRIPTION
This PR is related to #1911
It currently contains the following changes:
1.add check in constructQueryWithoutProfile() method in BasicVertexCentricQueryBuilder.java.
2.The check() method will check whether the adjacent query has set the label. If not, all the labels will be obtained and set.