### PR TITLE
Set RelationTypeIndex status to ENABLED when the index uses a new key

### DIFF
--- a/docs/index-management/index-performance.md
+++ b/docs/index-management/index-performance.md
@@ -445,10 +445,10 @@ range/interval constraints.
     The types that are currently supported are `Boolean`, `UUID`, `Byte`, `Float`, `Long`, `String`, 
     `Integer`, `Date`, `Double`, `Character`, and `Short`
 
-If the vertex-centric index is built against an edge label that is
-defined in the same management transaction, the index will be
-immediately available for querying. If the edge label has already been
-in use, building a vertex-centric index against it requires the
+If the vertex-centric index is built against either an edge label or at least one
+property key that is defined in the same management transaction, the index will be
+immediately available for querying. If both the edge label and all of the indexed
+property keys have already been in use, building a vertex-centric index against it requires the
 execution of a [reindex procedure](./index-reindexing.md) to ensure that the index
 contains all previously added edges. Until the reindex procedure has
 completed, the index will not be available.

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -1839,6 +1839,92 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertNotEquals(SchemaStatus.ENABLED, mgmt.getGraphIndex("newIndex").getIndexStatus(existingPropertyKey));
     }
 
+    @Test
+    public void testRelationTypeIndexShouldBeEnabledForExistingPropertyKeyAndNewRelationType() {
+        mgmt.makePropertyKey("alreadyExistingProperty").dataType(String.class).cardinality(Cardinality.SINGLE).make();
+        finishSchema();
+
+        mgmt.makeEdgeLabel("newLabel").make();
+        PropertyKey existingPropertyKey  = mgmt.getPropertyKey("alreadyExistingProperty");
+        EdgeLabel newLabel = mgmt.getEdgeLabel("newLabel");
+        mgmt.buildEdgeIndex(newLabel, "newIndex", Direction.BOTH, existingPropertyKey);
+        finishSchema();
+
+        assertEquals(SchemaStatus.ENABLED, mgmt.getRelationIndex(newLabel, "newIndex").getIndexStatus());
+    }
+
+    @Test
+    public void testRelationTypeIndexShouldBeEnabledForNewPropertyKeyAndExistingRelationType() {
+        mgmt.makeEdgeLabel("alreadyExistingLabel").make();
+        finishSchema();
+
+        mgmt.makePropertyKey("newProperty").dataType(String.class).cardinality(Cardinality.SINGLE).make();
+        PropertyKey newPropertyKey  = mgmt.getPropertyKey("newProperty");
+        EdgeLabel existingLabel = mgmt.getEdgeLabel("alreadyExistingLabel");
+        mgmt.buildEdgeIndex(existingLabel, "newIndex", Direction.BOTH, newPropertyKey);
+        finishSchema();
+
+        assertEquals(SchemaStatus.ENABLED, mgmt.getRelationIndex(existingLabel, "newIndex").getIndexStatus());
+    }
+
+    @Test
+    public void testRelationTypeIndexShouldBeEnabledForSingleNewPropertyKeyAndExistingRelationType() {
+        mgmt.makeEdgeLabel("alreadyExistingLabel").make();
+        mgmt.makePropertyKey("alreadyExistingProperty").dataType(String.class).cardinality(Cardinality.SINGLE).make();
+        finishSchema();
+
+        mgmt.makePropertyKey("newProperty").dataType(String.class).cardinality(Cardinality.SINGLE).make();
+        PropertyKey existingPropertyKey  = mgmt.getPropertyKey("alreadyExistingProperty");
+        PropertyKey newPropertyKey  = mgmt.getPropertyKey("newProperty");
+        EdgeLabel existingLabel = mgmt.getEdgeLabel("alreadyExistingLabel");
+        mgmt.buildEdgeIndex(existingLabel, "newIndex", Direction.BOTH, existingPropertyKey, newPropertyKey);
+        finishSchema();
+
+        assertEquals(SchemaStatus.ENABLED, mgmt.getRelationIndex(existingLabel, "newIndex").getIndexStatus());
+    }
+
+    @Test
+    public void testRelationTypeIndexShouldBeEnabledForSingleNewPropertyKeyAndNewRelationType() {
+        mgmt.makePropertyKey("alreadyExistingProperty").dataType(String.class).cardinality(Cardinality.SINGLE).make();
+        finishSchema();
+
+        mgmt.makeEdgeLabel("newLabel").make();
+        mgmt.makePropertyKey("newProperty").dataType(String.class).cardinality(Cardinality.SINGLE).make();
+        PropertyKey existingPropertyKey  = mgmt.getPropertyKey("alreadyExistingProperty");
+        PropertyKey newPropertyKey  = mgmt.getPropertyKey("newProperty");
+        EdgeLabel newLabel = mgmt.getEdgeLabel("newLabel");
+        mgmt.buildEdgeIndex(newLabel, "newIndex", Direction.BOTH, existingPropertyKey, newPropertyKey);
+        finishSchema();
+
+        assertEquals(SchemaStatus.ENABLED, mgmt.getRelationIndex(newLabel, "newIndex").getIndexStatus());
+    }
+
+    @Test
+    public void testRelationTypeIndexShouldBeEnabledForNewPropertyKeyAndNewRelationType() {
+        mgmt.makePropertyKey("newProperty").dataType(String.class).cardinality(Cardinality.SINGLE).make();
+        mgmt.makeEdgeLabel("newLabel").make();
+        PropertyKey newPropertyKey  = mgmt.getPropertyKey("newProperty");
+        EdgeLabel newLabel = mgmt.getEdgeLabel("newLabel");
+        mgmt.buildEdgeIndex(newLabel, "newIndex", Direction.BOTH, newPropertyKey);
+        finishSchema();
+
+        assertEquals(SchemaStatus.ENABLED, mgmt.getRelationIndex(newLabel, "newIndex").getIndexStatus());
+    }
+
+    @Test
+    public void testRelationTypeIndexShouldNotBeEnabledForExistingPropertyKeyAndExistingRelationType() {
+        mgmt.makePropertyKey("alreadyExistingProperty").dataType(String.class).cardinality(Cardinality.SINGLE).make();
+        mgmt.makeEdgeLabel("alreadyExistingLabel").make();
+        finishSchema();
+
+        PropertyKey existingPropertyKey  = mgmt.getPropertyKey("alreadyExistingProperty");
+        EdgeLabel existingLabel = mgmt.getEdgeLabel("alreadyExistingLabel");
+        mgmt.buildEdgeIndex(existingLabel, "newIndex", Direction.BOTH, existingPropertyKey);
+        finishSchema();
+
+        assertNotEquals(SchemaStatus.ENABLED, mgmt.getRelationIndex(existingLabel, "newIndex").getIndexStatus());
+    }
+
    /* ==================================================================================
                             ADVANCED
      ==================================================================================*/

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
@@ -297,7 +297,10 @@ public class ManagementSystem implements JanusGraphManagement {
             lm.dataType(((PropertyKey) type).dataType());
             maker = lm;
         }
-        maker.status(type.isNew() ? SchemaStatus.ENABLED : SchemaStatus.INSTALLED);
+
+        boolean canIndexBeEnabled = type.isNew() || Arrays.stream(sortKeys).anyMatch(key -> key.isNew());
+
+        maker.status(canIndexBeEnabled ? SchemaStatus.ENABLED : SchemaStatus.INSTALLED);
         maker.invisible();
         maker.multiplicity(Multiplicity.MULTI);
         maker.sortKey(sortKeys);
@@ -315,7 +318,7 @@ public class ManagementSystem implements JanusGraphManagement {
         RelationType typeIndex = maker.make();
         addSchemaEdge(type, typeIndex, TypeDefinitionCategory.RELATIONTYPE_INDEX, null);
         RelationTypeIndexWrapper index = new RelationTypeIndexWrapper((InternalRelationType) typeIndex);
-        if (!type.isNew()) updateIndex(index, SchemaAction.REGISTER_INDEX);
+        if (!canIndexBeEnabled) updateIndex(index, SchemaAction.REGISTER_INDEX);
         return index;
     }
 
@@ -697,7 +700,7 @@ public class ManagementSystem implements JanusGraphManagement {
         }
         updateSchemaVertex(indexVertex);
         JanusGraphIndexWrapper index = new JanusGraphIndexWrapper(indexVertex.asIndexType());
-        if (!oneNewKey) updateIndex(index, SchemaAction.REGISTER_INDEX);
+        if (!canIndexBeEnabled) updateIndex(index, SchemaAction.REGISTER_INDEX);
         return index;
     }
 


### PR DESCRIPTION
This solves #1947 and also fixes one line that should have been refactored in #1190 (PR #1192)

Previously, creating a relation type index enforced a reindex operation in order to enable the index, even if one of the sort keys has been newly created within the same management transaction. Analogous to the handling of global indexes, this PR solves the issue and enables the index right away if it contains at least one new key and therefore is empty at creation time.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?

