### PR TITLE
Improve OLAP queries for BerkeleyDB

### DIFF
--- a/docs/basics/janusgraph-cfg.md
+++ b/docs/basics/janusgraph-cfg.md
@@ -358,6 +358,7 @@ BerkeleyDB JE configuration options
 
 | Name | Description | Datatype | Default Value | Mutability |
 | ---- | ---- | ---- | ---- | ---- |
+| storage.berkeleyje.cache-mode | Modes that can be specified for control over caching of records in the JE in-memory cache | String | DEFAULT | MASKABLE |
 | storage.berkeleyje.cache-percentage | Percentage of JVM heap reserved for BerkeleyJE's cache | Integer | 65 | MASKABLE |
 | storage.berkeleyje.isolation-level | The isolation level used by transactions | String | REPEATABLE_READ | MASKABLE |
 | storage.berkeleyje.lock-mode | The BDB record lock mode used for read operations | String | LockMode.DEFAULT | MASKABLE |

--- a/janusgraph-berkeleyje/src/main/java/org/janusgraph/diskstorage/berkeleyje/BerkeleyJETx.java
+++ b/janusgraph-berkeleyje/src/main/java/org/janusgraph/diskstorage/berkeleyje/BerkeleyJETx.java
@@ -15,6 +15,7 @@
 package org.janusgraph.diskstorage.berkeleyje;
 
 import com.google.common.base.Preconditions;
+import com.sleepycat.je.CacheMode;
 import com.sleepycat.je.Cursor;
 import com.sleepycat.je.Database;
 import com.sleepycat.je.DatabaseException;
@@ -38,15 +39,17 @@ public class BerkeleyJETx extends AbstractStoreTransaction {
     private volatile Transaction tx;
     private volatile boolean isOpen;
     private final List<Cursor> openCursors = new ArrayList<>();
-    private final LockMode lm;
+    private final LockMode lockMode;
+    private final CacheMode cacheMode;
 
-    public BerkeleyJETx(Transaction t, LockMode lockMode, BaseTransactionConfig config) {
+    public BerkeleyJETx(Transaction t, LockMode lockMode, CacheMode cacheMode, BaseTransactionConfig config) {
         super(config);
         tx = t;
-        lm = lockMode;
+        this.lockMode = lockMode;
+        this.cacheMode = cacheMode;
         isOpen = true;
         // tx may be null
-        Preconditions.checkNotNull(lm);
+        Preconditions.checkNotNull(this.lockMode);
     }
 
     public Transaction getTransaction() {
@@ -77,8 +80,12 @@ public class BerkeleyJETx extends AbstractStoreTransaction {
         }
     }
 
+    CacheMode getCacheMode() {
+        return cacheMode;
+    }
+
     LockMode getLockMode() {
-        return lm;
+        return lockMode;
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/log/kcvs/KCVSLog.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/log/kcvs/KCVSLog.java
@@ -741,6 +741,9 @@ public class KCVSLog implements Log, BackendOperation.TransactionalProvider {
                 }
                 messageTimeStart = messageTimeEnd;
             } catch (Throwable e) {
+                if (e.getCause() instanceof PermanentBackendException) {
+                    throw e;
+                }
                 log.warn("Could not read messages for timestamp ["+messageTimeStart+"] (this read will be retried)",e);
             }
         }


### PR DESCRIPTION
- Introduce CACHE_MODE parameter -- tx may be configured without storage cache -- it is usefull during single full scan queries, like reindex

- Avoid interruption if store unsupported it -- `StoreFeature.supportsInterruption` used only for BDB but not handled in any places where interruption may occur

- Do no read messages infinitely when permanent exception occurred 

Signed-off-by: Pavel Ershov <owner.mad.epa@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

