### PR TITLE
Fix range interval intersection

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -2918,6 +2918,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertEquals(1, u.query().labels("friendDesc").direction(OUT).has("weight", 0.5).interval("time", 4, 10).edgeCount());
         assertEquals(3, v.query().labels("friend").direction(OUT).interval("time", 3, 33).has("weight", 0.5).edgeCount());
         assertEquals(4, v.query().labels("friend").direction(OUT).has("time", Cmp.LESS_THAN_EQUAL, 10).edgeCount());
+        assertEquals(2, v.query().labels("friend").direction(OUT).has("time", Cmp.LESS_THAN_EQUAL, 10).has("time", Cmp.LESS_THAN_EQUAL, 5).edgeCount());
         assertEquals(edgesPerLabel - 4, v.query().labels("friend").direction(OUT).has("time", Cmp.GREATER_THAN, 10).edgeCount());
         assertEquals(20, v.query().labels("friend", "connect").direction(OUT).interval("time", 3, 33).edgeCount());
 

--- a/janusgraph-core/src/main/java/org/janusgraph/util/datastructures/RangeInterval.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/util/datastructures/RangeInterval.java
@@ -115,9 +115,13 @@ public class RangeInterval<T> implements Interval<T> {
             final RangeInterval<T> rint = (RangeInterval)other;
             final Map.Entry<T,Boolean> newStart = comparePoints(start,startInclusive,rint.start,rint.startInclusive,true);
             final Map.Entry<T,Boolean> newEnd = comparePoints(end,endInclusive,rint.end,rint.endInclusive,false);
-            final RangeInterval<T> result = new RangeInterval<>(newStart.getKey(), newEnd.getKey());
-            result.setStartInclusive(newStart.getValue());
-            result.setEndInclusive(newEnd.getValue());
+            final RangeInterval<T> result = new RangeInterval<>();
+            if (newStart.getKey() != null) {
+                result.setStart(newStart.getKey(), newStart.getValue());
+            }
+            if (newEnd.getKey() != null) {
+                result.setEnd(newEnd.getKey(), newEnd.getValue());
+            }
             return result;
         } else throw new AssertionError("Unexpected interval: " + other);
     }


### PR DESCRIPTION
```
java.lang.IllegalArgumentException
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:108)
	at org.janusgraph.util.datastructures.RangeInterval.setStart(RangeInterval.java:42)
	at org.janusgraph.util.datastructures.RangeInterval.<init>(RangeInterval.java:37)
	at org.janusgraph.util.datastructures.RangeInterval.intersect(RangeInterval.java:118)
...
```
Signed-off-by: Pavel Ershov <owner.mad.epa@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

