### PR TITLE
Fix adjacent query bug when label is null and direction is both

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -2822,7 +2822,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         JanusGraphVertex u = tx.addVertex("name", "u");
         assertEquals(0, (noVertices - 1) % 3);
         JanusGraphVertex[] vs = new JanusGraphVertex[noVertices];
-        for (int i = 1; i < noVertices; i++) {
+        for (int i = 0; i < noVertices; i++) {
             vs[i] = tx.addVertex("name", "v" + i);
         }
         EdgeLabel[] labelsV = {tx.getEdgeLabel("connect"), tx.getEdgeLabel("friend"), tx.getEdgeLabel("knows")};
@@ -2939,6 +2939,15 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertEquals(1, v.query().labels("knows").direction(OUT).adjacent(vs[11]).has("weight", 3.5).edgeCount());
         assertEquals(2, v.query().labels("connect").adjacent(vs[6]).has("time", 6).edgeCount());
         assertEquals(0, v.query().labels("connect").adjacent(vs[8]).has("time", 8).edgeCount());
+        assertEquals(2, v.query().labels().direction(BOTH).adjacent(vs[11]).edgeCount());
+        assertEquals(2, v.query().direction(BOTH).adjacent(vs[11]).edgeCount());
+        assertEquals(2, v.query().adjacent(vs[11]).edgeCount());
+
+        // v and vs[0] are not adjacent
+        assertEquals(0, v.query().adjacent(vs[0]).edgeCount());
+        assertEquals(0, v.query().labels().adjacent(vs[0]).edgeCount());
+        assertEquals(0, v.query().direction(BOTH).adjacent(vs[0]).edgeCount());
+        assertEquals(0, v.query().labels().direction(BOTH).adjacent(vs[0]).edgeCount());
 
         assertEquals(edgesPerLabel, v.query().labels("connect").direction(OUT).edgeCount());
         assertEquals(edgesPerLabel, v.query().labels("connect").direction(IN).edgeCount());
@@ -3053,6 +3062,15 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertEquals(1, v.query().labels("knows").direction(OUT).adjacent(vs[11]).has("weight", 3.5).edgeCount());
         assertEquals(2, v.query().labels("connect").adjacent(vs[6]).has("time", 6).edgeCount());
         assertEquals(0, v.query().labels("connect").adjacent(vs[8]).has("time", 8).edgeCount());
+        assertEquals(2, v.query().labels().direction(BOTH).adjacent(vs[11]).edgeCount());
+        assertEquals(2, v.query().direction(BOTH).adjacent(vs[11]).edgeCount());
+        assertEquals(2, v.query().adjacent(vs[11]).edgeCount());
+
+        // v and vs[0] are not adjacent
+        assertEquals(0, v.query().adjacent(vs[0]).edgeCount());
+        assertEquals(0, v.query().labels().adjacent(vs[0]).edgeCount());
+        assertEquals(0, v.query().direction(BOTH).adjacent(vs[0]).edgeCount());
+        assertEquals(0, v.query().labels().direction(BOTH).adjacent(vs[0]).edgeCount());
 
         assertEquals(edgesPerLabel, v.query().labels("connect").direction(OUT).edgeCount());
         assertEquals(edgesPerLabel, v.query().labels("connect").direction(IN).edgeCount());

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
@@ -446,8 +446,8 @@ public abstract class BasicVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q
         if (!hasTypes()) {
             final BackendQueryHolder<SliceQuery> query= new BackendQueryHolder<>(
                 serializer.getQuery(returnType, querySystem),
-                ((dir == Direction.BOTH || (returnType == RelationCategory.PROPERTY && dir == Direction.OUT))
-                        && !conditions.hasChildren()),
+                (adjacentVertex == null && dir == Direction.BOTH || returnType == RelationCategory.PROPERTY && dir == Direction.OUT)
+                        && !conditions.hasChildren(),
                 orders.isEmpty());
             if (sliceLimit!=Query.NO_LIMIT && sliceLimit<Integer.MAX_VALUE/3) {
                 //If only one direction is queried, ask for twice the limit from backend since approximately


### PR DESCRIPTION
When label is null and direction is both, adjacent constraint is overlooked.
This commit fixes this by setting isFitted to be false when adjacentVertex
is present.

Closes #1911

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

