### PR TITLE
Move reflections to reflections8

### DIFF
--- a/janusgraph-core/pom.xml
+++ b/janusgraph-core/pom.xml
@@ -60,8 +60,8 @@
             <artifactId>metrics-graphite</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
+            <groupId>net.oneandone.reflections8</groupId>
+            <artifactId>reflections8</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>

--- a/janusgraph-core/src/main/java/org/janusgraph/core/util/ReflectiveConfigOptionLoader.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/util/ReflectiveConfigOptionLoader.java
@@ -25,10 +25,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import org.janusgraph.diskstorage.util.time.Timer;
 import org.janusgraph.diskstorage.util.time.TimestampProviders;
-import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
-import org.reflections.scanners.TypeAnnotationsScanner;
-import org.reflections.vfs.Vfs;
+import org.reflections8.Reflections;
+import org.reflections8.scanners.SubTypesScanner;
+import org.reflections8.scanners.TypeAnnotationsScanner;
+import org.reflections8.vfs.Vfs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -227,7 +227,7 @@ public enum ReflectiveConfigOptionLoader {
             URL u = i.next();
             File f;
             try {
-                f = Vfs.getFile(u);
+                f = Vfs.getFile(u).orElse(null);
             } catch (Throwable t) {
                 log.debug("Error invoking Vfs.getFile on URL {}", u, t);
                 f = new File(u.getPath());
@@ -239,7 +239,7 @@ public enum ReflectiveConfigOptionLoader {
             log.trace("Retaining classpath element {}", f);
         }
 
-        org.reflections.Configuration rc = new org.reflections.util.ConfigurationBuilder()
+        org.reflections8.Configuration rc = new org.reflections8.util.ConfigurationBuilder()
             .setUrls(scanUrls)
             .setScanners(new TypeAnnotationsScanner(), new SubTypesScanner());
         Reflections reflections = new Reflections(rc);

--- a/janusgraph-test/src/test/java/org/janusgraph/core/util/ReflectiveConfigOptionLoaderTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/core/util/ReflectiveConfigOptionLoaderTest.java
@@ -1,0 +1,51 @@
+// Copyright 2020 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.util;
+
+import org.janusgraph.graphdb.configuration.PreInitializeConfigOptions;
+import org.junit.jupiter.api.Test;
+import org.reflections8.Reflections;
+import org.reflections8.scanners.SubTypesScanner;
+import org.reflections8.scanners.TypeAnnotationsScanner;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class ReflectiveConfigOptionLoaderTest {
+
+    /**
+     * The test checks if the included `reflections` dependency with the bug
+     * https://github.com/ronmamo/reflections/issues/273 or not.
+     * The bug in `reflections` was introduced in the version `0.9.12`.
+     */
+    @Test
+    public void shouldLoadAllClasses(){
+        org.reflections8.Configuration rc = new org.reflections8.util.ConfigurationBuilder()
+            .setUrls(Collections.emptyList())
+            .setScanners(new TypeAnnotationsScanner(), new SubTypesScanner());
+        Reflections reflections = new Reflections(rc);
+        assertDoesNotThrow(() -> reflections.getTypesAnnotatedWith(PreInitializeConfigOptions.class));
+        /*
+        To reproduce the problem in the code, we can use the next example but notice that the assertion will never fail
+        because we swallow any errors reproduced in `loadAll`. That is why, the above code mimics the below configuration.
+
+        ReflectiveConfigOptionLoader.INSTANCE.setUseThreadContextLoader(false);
+        ReflectiveConfigOptionLoader.INSTANCE.setUseCallerLoader(false);
+        ReflectiveConfigOptionLoader.INSTANCE.setPreferredClassLoaders(Collections.emptyList());
+        Assertions.assertDoesNotThrow(() -> ReflectiveConfigOptionLoader.INSTANCE.loadAll(this.getClass()));
+         */
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -714,9 +714,9 @@
                 <version>1.11</version>
             </dependency>
             <dependency>
-                <groupId>org.reflections</groupId>
-                <artifactId>reflections</artifactId>
-                <version>0.9.9-RC1</version>
+                <groupId>net.oneandone.reflections8</groupId>
+                <artifactId>reflections8</artifactId>
+                <version>0.11.7</version>
             </dependency>
             <dependency>
                 <groupId>xml-apis</groupId>


### PR DESCRIPTION
Updates reflections to `reflections8` which doesn't depend on guava.

Notice `reflections` version `0.9.12` is the newest version which doesn't depend on guava but it currently has a bug https://github.com/ronmamo/reflections/issues/273 which might be fixed by https://github.com/ronmamo/reflections/pull/278 in the future versions.

`reflections8` become obsolete after `reflections` version `0.9.12` but `reflections8` version `0.11.7` is a newer version than `reflections` version `0.9.11` and it doesn't depend on guava.

That is why, this PR updates `reflections` to `reflections8` which uses Java 8 Stream API instead of guava. In the future if the bug is fixed in `reflections` and a newer version of `reflections` is released with the bugfix we may go back to `reflections`. In the meantime I am proposing to move to `reflections8` which is a cleaner version of `reflections` and doesn't depend on guava anymore.

The added unit test shows the bug which is introduced in reflections `0.9.12`. The unit test passes for current master branch and current PR (i.e. for all versions of `reflections` but fails for `reflections` `0.9.12`).

Suppresses #2023 
Related to #2033 

P.S. Before I found `reflections8` fork, I was trying to update `reflections` to version `0.9.11` which didn't go smooth because that version depends on `guava >= 20` and some of our dependencies depend on `guava 18`. Guava is often binary  incompatible with previous versions that is why it produces some troubles when some dependencies depend on one guava version and some dependencies on another guava version. In the long term I would like to remove usage of guava completely from the project. 

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

