### PR TITLE
Disable smart limit adjustment for count query

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/GraphCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/GraphCentricQueryBuilder.java
@@ -79,12 +79,21 @@ public class GraphCentricQueryBuilder implements JanusGraphQuery<GraphCentricQue
      * The profiler observing this query
      */
     private QueryProfiler profiler = QueryProfiler.NO_OP;
+    /**
+     * Whether smart limit adjustment is enabled
+     */
+    private boolean useSmartLimit;
 
     public GraphCentricQueryBuilder(StandardJanusGraphTx tx, IndexSerializer serializer) {
         Preconditions.checkNotNull(tx);
         Preconditions.checkNotNull(serializer);
+        useSmartLimit = tx.getGraph().getConfiguration().adjustQueryLimit();
         this.tx = tx;
         this.serializer = serializer;
+    }
+
+    public void disableSmartLimit() {
+        useSmartLimit = false;
     }
 
     /* ---------------------------------------------------------------
@@ -353,7 +362,7 @@ public class GraphCentricQueryBuilder implements JanusGraphQuery<GraphCentricQue
         BackendQueryHolder<JointIndexQuery> query;
         if (!coveredClauses.isEmpty()) {
             int indexLimit = limit == Query.NO_LIMIT ? HARD_MAX_LIMIT : limit;
-            if (tx.getGraph().getConfiguration().adjustQueryLimit()) {
+            if (useSmartLimit) {
                 indexLimit = limit == Query.NO_LIMIT ? DEFAULT_NO_LIMIT : Math.min(MAX_BASE_LIMIT, limit);
             }
             indexLimit = Math.min(HARD_MAX_LIMIT,


### PR DESCRIPTION
Closes #2042

-----

I ran the following sample program to test the optimization on my laptop using Cassandra + ES:

```java
public void testMultipleIndexQueryWithHeavyLoad() {
    final PropertyKey name = makeKey("name", String.class);
    final PropertyKey text = makeKey("text", String.class);

    final JanusGraphIndex composite = mgmt.buildIndex("composite", Vertex.class).addKey(name).buildCompositeIndex();
    final JanusGraphIndex mixed = mgmt.buildIndex("mixed", Vertex.class).addKey(text, getTextMapping()).buildMixedIndex(INDEX);
    mixed.name();
    composite.name();
    finishSchema();

    final int numV = 100000;
    final String[] strings = {"houseboat", "humanoid", "differential", "extraordinary"};
    final int modulo = 5;

    for (int i = 0; i < numV; i++) {
        final JanusGraphVertex v = tx.addVertex();
        v.property("name", strings[i % 4]);
        v.property("text", strings[i % 3]);
    }
    tx.commit();

    long startTimeMs;
    long measuredTimeMs;

    for (int noOfSubqueries : Arrays.asList(1, 2)) {
        System.out.println("############################");
        System.out.println("Number of index subqueries is: " + noOfSubqueries);
        long totalTimeMs = 0;
        for (int i = 0; i < 5; i++) {
            GraphTraversalSource g = graph.traversal();
            startTimeMs = System.currentTimeMillis();
            GraphTraversal<Vertex, Vertex> query = g.V().has("name", "houseboat");
            if (noOfSubqueries > 1) query = query.has("text", Text.textContains("houseboat"));
            Long count = query.count().next();
            measuredTimeMs = System.currentTimeMillis() - startTimeMs;
            totalTimeMs += measuredTimeMs;
            System.out.println("search time: " + measuredTimeMs + ", count = " + count);
            g.tx().rollback();
        }
        System.out.println("average time (ms): " + totalTimeMs / 5.0);
    }
}
```

Optimized:

############################
Number of index subqueries is: 1
search time: 476, count = 25000
search time: 257, count = 25000
search time: 213, count = 25000
search time: 236, count = 25000
search time: 138, count = 25000
**average time (ms): 264.0**
############################
Number of index subqueries is: 2
search time: 28961, count = 8334
search time: 23486, count = 8334
search time: 22249, count = 8334
search time: 22687, count = 8334
search time: 22802, count = 8334
**average time (ms): 24037.0**


Original:

############################
Number of index subqueries is: 1
search time: 773, count = 25000
search time: 438, count = 25000
search time: 330, count = 25000
search time: 230, count = 25000
search time: 200, count = 25000
**average time (ms): 394.2**
############################
Number of index subqueries is: 2
search time: 74833, count = 8334
search time: 68750, count = 8334
search time: 68378, count = 8334
search time: 67366, count = 8334
search time: 67688, count = 8334
**average time (ms): 69403.0**

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

