### PR TITLE
[doc only] #2044 Some properties like index.*.elastic…

### DIFF
--- a/docs/basics/common-questions.md
+++ b/docs/basics/common-questions.md
@@ -48,13 +48,13 @@ modified in another, both transactions will successfully commit on
 eventually consistent storage backends and the vertex will still exist
 with only the modified properties or edges. This is referred to as a
 ghost vertex. It is possible to guard against ghost vertices on
-eventually consistent backends using key [uniqueness](#index-unique) but
+eventually consistent backends using key [uniqueness](../index-management/index-performance.md#index-uniqueness) but
 this is prohibitively expensive in most cases. A more scalable approach
 is to allow ghost vertices temporarily and clearing them out in regular
 time intervals.
 
 Another option is to detect them at read-time using the option
-`checkInternalVertexExistence()` documented in [Transaction Configuration](#tx-config).
+`checkInternalVertexExistence()` documented in [Transaction Configuration](transactions.md#transaction-configuration).
 
 ## Debug-level Logging Slows Execution
 

--- a/docs/basics/janusgraph-cfg.md
+++ b/docs/basics/janusgraph-cfg.md
@@ -103,7 +103,7 @@ Configuration options for the individual indexing backends
 | index.[X].directory | Directory to store index data locally | String | (no default value) | MASKABLE |
 | index.[X].hostname | The hostname or comma-separated list of hostnames of index backend servers.  This is only applicable to some index backends, such as elasticsearch and solr. | String[] | 127.0.0.1 | MASKABLE |
 | index.[X].index-name | Name of the index if required by the indexing backend | String | janusgraph | GLOBAL_OFFLINE |
-| index.[X].map-name | Whether to use the name of the property key as the field name in the index. It must be ensured, that theindexed property key names are valid field names. Renaming the property key will NOT rename the field and its the developers responsibility to avoid field collisions. | Boolean | true | GLOBAL |
+| index.[X].map-name | Whether to use the name of the property key as the field name in the index. It must be ensured, that the indexed property key names are valid field names. Renaming the property key will NOT rename the field and its the developers responsibility to avoid field collisions. | Boolean | true | GLOBAL |
 | index.[X].max-result-set-size | Maximum number of results to return if no limit is specified. For index backends that support scrolling, it represents the number of results in each batch | Integer | 50 | MASKABLE |
 | index.[X].port | The port on which to connect to index backend servers | Integer | (no default value) | MASKABLE |
 
@@ -131,6 +131,16 @@ Settings related to index creation
 | index.[X].elasticsearch.create.allow-mapping-update | Whether JanusGraph should allow a mapping update when registering an index. Only applicable when use-external-mappings is true. | Boolean | false | MASKABLE |
 | index.[X].elasticsearch.create.sleep | How long to sleep, in milliseconds, between the successful completion of a (blocking) index creation request and the first use of that index.  This only applies when creating an index in ES, which typically only happens the first time JanusGraph is started on top of ES. If the index JanusGraph is configured to use already exists, then this setting has no effect. | Long | 200 | MASKABLE |
 | index.[X].elasticsearch.create.use-external-mappings | Whether JanusGraph should make use of an external mapping when registering an index. | Boolean | false | MASKABLE |
+
+### index.[X].elasticsearch.create.ext
+Overrides for arbitrary settings applied at index creation.
+See [Elasticsearch](../index-backend/elasticsearch.md#index-creation-options), The full list of possible setting is available at [Elasticsearch index settings](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-modules-settings).
+
+
+| Name | Description | Datatype | Default Value | Mutability |
+| ---- | ---- | ---- | ---- | ---- |
+| index.[X].elasticsearch.create.ext.number_of_replicas | The number of replicas each primary shard has | Integer | 1 | MASKABLE |
+| index.[X].elasticsearch.create.ext.number_of_shards | The number of primary shards that an index should have.Default value is 5 on ES 6 and 1 on ES 7 | Integer | (no default value) | MASKABLE |
 
 ### index.[X].elasticsearch.http.auth
 Configuration options for HTTP(S) authentication.

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -864,7 +864,7 @@ public class GraphDatabaseConfiguration {
             ConfigOption.Type.MASKABLE, 50);
 
     public static final ConfigOption<Boolean> INDEX_NAME_MAPPING = new ConfigOption<>(INDEX_NS,"map-name",
-            "Whether to use the name of the property key as the field name in the index. It must be ensured, that the" +
+            "Whether to use the name of the property key as the field name in the index. It must be ensured, that the " +
                     "indexed property key names are valid field names. Renaming the property key will NOT rename the field " +
                     "and its the developers responsibility to avoid field collisions.",
             ConfigOption.Type.GLOBAL, true);

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
@@ -122,12 +122,24 @@ public class ElasticSearchIndex implements IndexProvider {
             "configured to use already exists, then this setting has no effect.", ConfigOption.Type.MASKABLE, 200L);
 
     public static final ConfigNamespace ES_CREATE_EXTRAS_NS =
-            new ConfigNamespace(ES_CREATE_NS, "ext", "Overrides for arbitrary settings applied at index creation", true);
+            new ConfigNamespace(ES_CREATE_NS, "ext", "Overrides for arbitrary settings applied at index creation.\n" +
+            		"See [Elasticsearch](../index-backend/elasticsearch.md#index-creation-options), The full list of possible setting is available at " + 
+            		"[Elasticsearch index settings](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-modules-settings).");
 
     public static final ConfigOption<Boolean> USE_EXTERNAL_MAPPINGS =
             new ConfigOption<>(ES_CREATE_NS, "use-external-mappings",
             "Whether JanusGraph should make use of an external mapping when registering an index.", ConfigOption.Type.MASKABLE, false);
 
+    public static final ConfigOption<Integer> NUMBER_OF_REPLICAS =
+            new ConfigOption<>(ES_CREATE_EXTRAS_NS, "number_of_replicas",
+            "The number of replicas each primary shard has", ConfigOption.Type.MASKABLE, 1);
+
+    public static final ConfigOption<Integer> NUMBER_OF_SHARDS =
+            new ConfigOption<>(ES_CREATE_EXTRAS_NS, "number_of_shards",
+            "The number of primary shards that an index should have." +
+            "Default value is 5 on ES 6 and 1 on ES 7", ConfigOption.Type.MASKABLE, Integer.class);
+
+    
     public static final ConfigOption<Boolean> ALLOW_MAPPING_UPDATE =
             new ConfigOption<>(ES_CREATE_NS, "allow-mapping-update",
             "Whether JanusGraph should allow a mapping update when registering an index. " +


### PR DESCRIPTION
Closes #2044 Some properties like index.*.elasticsearch.create.ext.number_of_shards are not present in configuration reference

Signed-off-by: Nicolas Trangosi <nicolas.trangosi@dcbrain.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?


### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
- [x] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

