### PR TITLE
Fix #2069: Replace misleading docs about default storage backend

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -119,9 +119,16 @@ $ ./bin/gremlin-server.sh /conf/gremlin-server/[...].yaml
 ```
 
 !!! info
-    By default, this will instruct JanusGraph to use it's own inmemory backend instead of a dedicated database server.
+    By default, JanusGraph will try to use a CQL-compatible storage backend.
+    To use another backend, the following line within the earlier mentioned default configuration must be altered:
+    ```yaml
+    graphs: {
+        graph: conf/gremlin-server/janusgraph-cql-es-server.properties
+    }
+    ```
+    To get started, the non-persistent `inmemory` backend provided by `conf/janusgraph-inmemory.properties` is the easiest option to use.
     For further information about storage backends, visit the [corresponding section](../storage-backend/index.md) of the documentation.
-    
+
     You are also encouraged to look into `janusgraph.sh`, which by defaults starts a more sophisticated server than `gremlin-server.sh`.
     Further documentation on server configuration can be found in the [JanusGraph Server](../basics/server.md) section.
 


### PR DESCRIPTION
Solves #2069 

The documentation for all JanusGraph versions between v0.3 and v0.5 should be updated with the corrected information.
-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
- [x] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

