### PR TITLE
avoid expensive regular regexp operations while getting name of Janus…

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/vertices/JanusGraphSchemaVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/vertices/JanusGraphSchemaVertex.java
@@ -55,10 +55,10 @@ public class JanusGraphSchemaVertex extends CacheVertex implements SchemaSource 
                 p = Iterables.getOnlyElement(query().type(BaseKey.SchemaName).properties(), null);
             }
             Preconditions.checkNotNull(p,"Could not find type for id: %s", longId());
-            name = p.value();
+            name = JanusGraphSchemaCategory.getName(p.value());
         }
         assert name != null;
-        return JanusGraphSchemaCategory.getName(name);
+        return name;
     }
 
     @Override


### PR DESCRIPTION
this pr allow to avoid expensive regular regexp operations while getting name of `JanusGraphSchemaVertex`

Regular calls to `JanusGraphSchemaCategory.getName(name)` is relatively expensive 
