### PR TITLE
Add missing `:remote console` to remote example in docs

### DIFF
--- a/docs/basics/server.md
+++ b/docs/basics/server.md
@@ -82,18 +82,18 @@ The `:remote` command tells the console to configure a remote connection
 to Gremlin Server using the `conf/remote.yaml` file to connect. That
 file points to a Gremlin Server instance running on `localhost`. The
 `:>` is the "submit" command which sends the Gremlin on that line to the
-currently active remote. By default remote conenctions are sessionless,
+currently active remote.
+Instead of prefixing every single script with `:>`, the command `:remote console` can
+be executed once to implicitly send all subsequent scripts to the current remote connection.
+By default remote conenctions are sessionless,
 meaning that each line sent in the console is interpreted as a single
 request. Multiple statements can be sent on a single line using a
-semicolon as the delimiter. Alternately, you can establish a console
-with a session by specifying
-[session](https://tinkerpop.apache.org/docs/current/reference/#sessions)
-when creating the connection. A [console
-session](https://tinkerpop.apache.org/docs/current/reference/#console-sessions)
-allows you to reuse variables across several lines of input.
+semicolon as the delimiter.
 ```groovy
 gremlin> :remote connect tinkerpop.server conf/remote.yaml
 ==>Configured localhost/127.0.0.1:8182
+gremlin> :remote console
+==>All scripts will now be sent to Gremlin Server - [localhost/127.0.0.1:8182] - type ':remote console' to return to local mode
 gremlin> graph
 ==>standardjanusgraph[cql:[127.0.0.1]]
 gremlin> g
@@ -105,8 +105,18 @@ gremlin> graph.addVertex("name", user)
 No such property: user for class: Script21
 Type ':help' or ':h' for help.
 Display stack trace? [yN]
+```
+
+Alternatively, you can establish a console with a session by specifying
+[session](https://tinkerpop.apache.org/docs/{{ tinkerpop_version }}/reference/#sessions)
+when creating the connection. A [console
+session](https://tinkerpop.apache.org/docs/{{ tinkerpop_version }}/reference/#console-sessions)
+allows you to reuse variables across several lines of input.
+```groovy
 gremlin> :remote connect tinkerpop.server conf/remote.yaml session
 ==>Configured localhost/127.0.0.1:8182-[9acf239e-a3ed-4301-b33f-55c911e04052]
+gremlin> :remote console
+==>All scripts will now be sent to Gremlin Server - [localhost/127.0.0.1:8182]-[9acf239e-a3ed-4301-b33f-55c911e04052] - type ':remote console' to return to local mode
 gremlin> g.V()
 gremlin> user = "Chris"
 ==>Chris


### PR DESCRIPTION
@FlorianHockmann discovered this in #2076 

The error dates back to the earliest version of our documentation, v0.2.
For convenience, I splitted the corresponding example into two code blocks, making it easier to follow the steps to create a sessioned connection.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
- [x] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

