### PR TITLE
Fix global config overriding

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/builder/ReadConfigurationBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/builder/ReadConfigurationBuilder.java
@@ -248,7 +248,12 @@ public class ReadConfigurationBuilder {
             Object localValue = entry.getValue();
 
             // Get the storage backend's setting and compare with localValue
-            Object storeValue = globalWrite.get(configOption, pathId.umbrellaElements);
+            Object storeValue;
+            if (globalWrite.has(configOption, pathId.umbrellaElements)) {
+                storeValue = globalWrite.get(configOption, pathId.umbrellaElements);
+            } else {
+                storeValue = configOption.getDefaultValue();
+            }
 
             // Check if the value is to be overwritten
             if (overwrite.has(configOption, pathId.umbrellaElements))

--- a/janusgraph-test/src/test/java/org/janusgraph/diskstorage/configuration/builder/ReadConfigurationBuilderTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/diskstorage/configuration/builder/ReadConfigurationBuilderTest.java
@@ -350,7 +350,7 @@ public class ReadConfigurationBuilderTest {
             if(INITIAL_JANUSGRAPH_VERSION.equals(argument)){
                 return "";
             }
-            return null;
+            return ((ConfigOption) argument).get(null);
         });
     }
 


### PR DESCRIPTION
When evaluate discrepancies options we need check for existense, otherwise we catch exception when local config try to pass new one managed option with disallow empty predicate

Signed-off-by: Pavel Ershov <owner.mad.epa@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

