### PR TITLE
Fix ElasticSearch INDEX_STORE_NAMES_CACHE should not be shared between instances

### DIFF
--- a/docs/basics/janusgraph-cfg.md
+++ b/docs/basics/janusgraph-cfg.md
@@ -114,6 +114,7 @@ Elasticsearch index configuration
 | Name | Description | Datatype | Default Value | Mutability |
 | ---- | ---- | ---- | ---- | ---- |
 | index.[X].elasticsearch.bulk-refresh | Elasticsearch bulk API refresh setting used to control when changes made by this request are made visible to search | String | false | MASKABLE |
+| index.[X].elasticsearch.enable_index_names_cache | Enables cache for generated index store names. It is recommended to always enable index store names cache unless you have more then 50000 indexes per index store. | Boolean | true | MASKABLE |
 | index.[X].elasticsearch.health-request-timeout | When JanusGraph initializes its ES backend, JanusGraph waits up to this duration for the ES cluster health to reach at least yellow status.  This string should be formatted as a natural number followed by the lowercase letter "s", e.g. 3s or 60s. | String | 30s | MASKABLE |
 | index.[X].elasticsearch.interface | Interface for connecting to Elasticsearch. TRANSPORT_CLIENT and NODE were previously supported, but now are required to migrate to REST_CLIENT. See the JanusGraph upgrade instructions for more details. | String | REST_CLIENT | MASKABLE |
 | index.[X].elasticsearch.retry_on_conflict | Specify how many times should the operation be retried when a conflict occurs. | Integer | 0 | MASKABLE |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -40,6 +40,46 @@ The versions of JanusGraph listed below are outdated and will no longer receive 
 
 ## Release Notes
 
+### Version 0.5.2 (Release Date: x, 2020)
+
+```xml tab='Maven'
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.5.2</version>
+</dependency>
+```
+
+```groovy tab='Gradle'
+compile "org.janusgraph:janusgraph-core:0.5.2"
+```
+
+**Tested Compatibility:**
+
+* Apache Cassandra 2.2.10, 3.0.14, 3.11.0
+* Apache HBase 1.2.6, 1.3.1, 1.4.10, 2.1.5
+* Google Bigtable 1.3.0, 1.4.0, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.9.0, 1.10.0, 1.11.0, 1.14.0
+* Oracle BerkeleyJE 7.5.11
+* Elasticsearch 6.0.1, 6.6.0, 7.6.1
+* Apache Lucene 7.0.0
+* Apache Solr 7.0.0
+* Apache TinkerPop 3.4.6
+* Java 1.8
+
+For more information on features and bug fixes in 0.5.2, see the GitHub milestone:
+
+-   <https://github.com/JanusGraph/janusgraph/milestone/19?closed=1>
+
+#### Upgrade Instructions
+
+##### ElasticSearch index store names cache now enabled for any amount of indexes per store
+
+In JanusGraph version `0.5.0` and `0.5.1` all ElasticSearch index store names are cached for efficient index store name 
+retrieval and the cache is disabled if there are more than `50000` indexes available per index store. 
+From JanusGraph version `0.5.2` index store names cache isn't limited to `50000` but instead can be disabled by using 
+a new added parameter `enable_index_names_cache`. It is still recommended to disable index store names cache if more 
+than `50000` indexes are used per index store.
+
 ### Version 0.5.1 (Release Date: March 25, 2020)
 
 ```xml tab='Maven'

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
@@ -72,6 +72,7 @@ import java.io.UncheckedIOException;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -243,6 +244,12 @@ public class ElasticSearchIndex implements IndexProvider {
         new ConfigOption<>(ELASTICSEARCH_NS, "retry_on_conflict",
             "Specify how many times should the operation be retried when a conflict occurs.", ConfigOption.Type.MASKABLE, 0);
 
+    public static final ConfigOption<Boolean> ENABLE_INDEX_STORE_NAMES_CACHE =
+        new ConfigOption<>(ELASTICSEARCH_NS, "enable_index_names_cache",
+            "Enables cache for generated index store names. " +
+                "It is recommended to always enable index store names cache unless you have more then 50000 indexes " +
+                "per index store.", ConfigOption.Type.MASKABLE, true);
+
     public static final int HOST_PORT_DEFAULT = 9200;
 
     /**
@@ -277,7 +284,7 @@ public class ElasticSearchIndex implements IndexProvider {
             "    }",
             "}");
 
-    private static final String INDEX_NAME_SEPARATOR = "_";
+    static final String INDEX_NAME_SEPARATOR = "_";
     private static final String SCRIPT_ID_SEPARATOR = "-";
 
     private static final String MAX_OPEN_SCROLL_CONTEXT_PARAMETER = "search.max_open_scroll_context";
@@ -289,9 +296,9 @@ public class ElasticSearchIndex implements IndexProvider {
     private static final Parameter[] TRACK_TOTAL_HITS_DISABLED_PARAMETERS = new Parameter[]{new Parameter<>(TRACK_TOTAL_HITS_PARAMETER, false)};
     private static final Map<String, Object> TRACK_TOTAL_HITS_DISABLED_REQUEST_BODY = ImmutableMap.of(TRACK_TOTAL_HITS_PARAMETER, false);
 
-    private static final Map<String, String> INDEX_STORE_NAMES_CACHE = new ConcurrentHashMap<>();
-    private static final int CACHE_LIMIT_TO_DISABLE = 50000;
-    private static volatile boolean indexStoreNameCacheEnabled = true;
+    private final Function<String, String> generateIndexStoreNameFunction = this::generateIndexStoreName;
+    private final Map<String, String> indexStoreNamesCache = new ConcurrentHashMap<>();
+    private final boolean indexStoreNameCacheEnabled;
 
     private final AbstractESCompat compat;
     private final ElasticSearchClient client;
@@ -318,6 +325,7 @@ public class ElasticSearchIndex implements IndexProvider {
         createSleep = config.get(CREATE_SLEEP);
         ingestPipelines = config.getSubset(ES_INGEST_PIPELINES);
         useMappingForES7 = config.get(USE_MAPPING_FOR_ES7);
+        indexStoreNameCacheEnabled = config.get(ENABLE_INDEX_STORE_NAMES_CACHE);
         batchSize = config.get(INDEX_MAX_RESULT_SET_SIZE);
         log.debug("Configured ES query nb result by query to {}", batchSize);
 
@@ -463,23 +471,7 @@ public class ElasticSearchIndex implements IndexProvider {
     private String getIndexStoreName(String store) {
 
         if(indexStoreNameCacheEnabled){
-
-            String cachedName = INDEX_STORE_NAMES_CACHE.get(store);
-
-            if(cachedName != null){
-                return cachedName;
-            }
-
-            cachedName = generateIndexStoreName(store);
-
-            if(INDEX_STORE_NAMES_CACHE.size() < CACHE_LIMIT_TO_DISABLE){
-                INDEX_STORE_NAMES_CACHE.put(store, cachedName);
-            } else {
-                indexStoreNameCacheEnabled = false;
-                INDEX_STORE_NAMES_CACHE.clear();
-            }
-
-            return cachedName;
+            return indexStoreNamesCache.computeIfAbsent(store, generateIndexStoreNameFunction);
         }
 
         return generateIndexStoreName(store);


### PR DESCRIPTION
- Move INDEX_STORE_NAMES_CACHE from static to instance specific scope.
- Add possibility to disable INDEX_STORE_NAMES_CACHE cache

Fixes #2102

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

