### PR TITLE
Optimize KVCMutation construct for deletions in CacheTransaction

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/Mutation.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/Mutation.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 
 import java.util.*;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Container for collection mutations against a data store.
@@ -33,12 +34,23 @@ public abstract class Mutation<E,K> {
     private List<K> deletions;
 
     public Mutation(List<E> additions, List<K> deletions) {
-        Preconditions.checkNotNull(additions);
-        Preconditions.checkNotNull(deletions);
-        if (additions.isEmpty()) this.additions=null;
-        else this.additions = new ArrayList<>(additions);
-        if (deletions.isEmpty()) this.deletions=null;
-        else this.deletions = new ArrayList<>(deletions);
+        assert additions!=null;
+        assert deletions!=null;
+        this.additions = additions.isEmpty()? null : new ArrayList<>(additions);
+        this.deletions = deletions.isEmpty()? null : new ArrayList<>(deletions);
+    }
+
+    public Mutation(Supplier<List<E>> additionsCopySupplier, Supplier<List<K>> deletionsCopySupplier) {
+        additions = additionsCopySupplier.get();
+        deletions = deletionsCopySupplier.get();
+        assert additions!=null;
+        assert deletions!=null;
+        if (additions.isEmpty()){
+            additions=null;
+        }
+        if (deletions.isEmpty()){
+            deletions=null;
+        }
     }
 
     public Mutation() {

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KCVMutation.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KCVMutation.java
@@ -21,6 +21,7 @@ import org.janusgraph.diskstorage.keycolumnvalue.cache.KCVEntryMutation;
 
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * {@link Mutation} type for {@link KeyColumnValueStore}.
@@ -32,6 +33,10 @@ public class KCVMutation extends Mutation<Entry,StaticBuffer> {
 
     public KCVMutation(List<Entry> additions, List<StaticBuffer> deletions) {
         super(additions, deletions);
+    }
+
+    public KCVMutation(Supplier<List<Entry>> additionsCopySupplier, Supplier<List<StaticBuffer>> deletionsCopySupplier) {
+        super(additionsCopySupplier, deletionsCopySupplier);
     }
 
     @Override


### PR DESCRIPTION
Instead of copying elements to a list and then again to a new list, this PR provides a function to copy all deletions in a single pass.

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

