### PR TITLE
Fix #2147: graph is created again during the drop process

### DIFF
--- a/.github/workflows/ci-backend-cql.yml
+++ b/.github/workflows/ci-backend-cql.yml
@@ -71,6 +71,10 @@ jobs:
           - module: cql
             args: "-Pcassandra3-murmur -Dtest=\"**/hadoop/*\""
           - module: cql
+            args: "-Pcassandra3-byteordered -Dtest=\"**/core/cql/*\""
+          - module: cql
+            args: "-Pcassandra3-murmur -Dtest=\"**/core/cql/*\""
+          - module: cql
             args: "-Pcassandra3-murmur-ssl -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
           - module: cql
             args: "-Pcassandra3-murmur-client-auth -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""

--- a/janusgraph-backend-testutils/pom.xml
+++ b/janusgraph-backend-testutils/pom.xml
@@ -25,6 +25,10 @@
             <artifactId>gremlin-test</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.tinkerpop</groupId>
+            <artifactId>gremlin-server</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
         </dependency>

--- a/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphFactory.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphFactory.java
@@ -203,6 +203,7 @@ public class JanusGraphFactory {
         final JanusGraphManager jgm = JanusGraphManagerUtility.getInstance();
         if (jgm != null) {
             jgm.removeGraph(g.getGraphName());
+            jgm.removeTraversalSource(ConfiguredGraphFactory.toTraversalSourceName(g.getGraphName()));
         }
         if (graph.isOpen()) {
             graph.close();

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
@@ -878,8 +878,22 @@ public class ManagementSystem implements JanusGraphManagement {
      * and assuming each node is correctly configured to use the {@link org.janusgraph.graphdb.management.JanusGraphManager}.
      */
     public void evictGraphFromCache() {
+        evictGraphFromCache(null);
+    }
+
+    /**
+     * Upon the open managementsystem's commit, this graph will be asynchronously evicted from the cache on all JanusGraph nodes in your
+     * cluster, once there are no open transactions on this graph on each respective JanusGraph node
+     * and assuming each node is correctly configured to use the {@link org.janusgraph.graphdb.management.JanusGraphManager}.
+     * @param trigger A Callable that will be called once the eviction is complete in the cluster. Return
+     *                boolean value indicating trigger status.
+     */
+    public void evictGraphFromCache(Callable<Boolean> trigger) {
         this.evictGraphFromCache = true;
-        setUpdateTrigger(new GraphCacheEvictionCompleteTrigger(this.graph.getGraphName()));
+        if (trigger != null)
+            setUpdateTrigger(trigger);
+        else
+            setUpdateTrigger(new GraphCacheEvictionCompleteTrigger(this.graph.getGraphName()));
     }
 
     private static class GraphCacheEvictionCompleteTrigger implements Callable<Boolean> {

--- a/janusgraph-cql/src/test/java/org/janusgraph/JanusGraphCassandraContainer.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/JanusGraphCassandraContainer.java
@@ -42,10 +42,6 @@ public class JanusGraphCassandraContainer extends CassandraContainer<JanusGraphC
     private static final boolean DEFAULT_ENABLE_CLIENT_AUTH = false;
     private static final boolean DEFAULT_USE_DEFAULT_CONFIG_FROM_IMAGE = false;
 
-    static {
-        setWrapperStoreManager();
-    }
-
     private static String getVersion() {
         String property = System.getProperty("cassandra.docker.version");
         if (property != null && !property.isEmpty())
@@ -173,28 +169,5 @@ public class JanusGraphCassandraContainer extends CassandraContainer<JanusGraphC
 
     public int getMappedCQLPort() {
         return getMappedPort(CQL_PORT);
-    }
-
-    private static void setWrapperStoreManager() {
-        try {
-            final Field modifiersField = Field.class.getDeclaredField("modifiers");
-            modifiersField.setAccessible(true);
-
-            Field field = StandardStoreManager.class.getDeclaredField("managerClass");
-            field.setAccessible(true);
-            field.set(StandardStoreManager.CQL, CachingCQLStoreManager.class.getCanonicalName());
-
-            field = StandardStoreManager.class.getDeclaredField("ALL_SHORTHANDS");
-            field.setAccessible(true);
-            modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-            field.set(null, Collections.unmodifiableSet(StandardStoreManager.CQL.getShorthands()));
-
-            field = StandardStoreManager.class.getDeclaredField("ALL_MANAGER_CLASSES");
-            field.setAccessible(true);
-            modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-            field.set(null, Collections.singletonMap(StandardStoreManager.CQL.getFirstStoreShorthand(), StandardStoreManager.CQL.getManagerClass()));
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException("Unable to set wrapper CQL store manager", e);
-        }
     }
 }

--- a/janusgraph-cql/src/test/java/org/janusgraph/core/cql/CQLConfiguredGraphFactoryTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/core/cql/CQLConfiguredGraphFactoryTest.java
@@ -1,0 +1,84 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.cql;
+
+import com.datastax.driver.core.Session;
+import org.apache.commons.configuration.MapConfiguration;
+import org.janusgraph.JanusGraphCassandraContainer;
+import org.janusgraph.core.AbstractConfiguredGraphFactoryTest;
+import org.janusgraph.core.ConfiguredGraphFactory;
+import org.janusgraph.graphdb.database.StandardJanusGraph;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.GRAPH_NAME;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.STORAGE_BACKEND;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.STORAGE_HOSTS;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.STORAGE_PORT;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@Testcontainers
+public class CQLConfiguredGraphFactoryTest extends AbstractConfiguredGraphFactoryTest {
+
+    @Container
+    public static final JanusGraphCassandraContainer cqlContainer = new JanusGraphCassandraContainer();
+
+    protected MapConfiguration getManagementConfig() {
+        final Map<String, Object> map = new HashMap<>();
+        map.put(STORAGE_BACKEND.toStringWithoutRoot(), "cql");
+        map.put(STORAGE_HOSTS.toStringWithoutRoot(), cqlContainer.getContainerIpAddress());
+        map.put(STORAGE_PORT.toStringWithoutRoot(), cqlContainer.getMappedCQLPort());
+        return new MapConfiguration(map);
+    }
+
+    protected MapConfiguration getTemplateConfig() {
+        return getManagementConfig();
+    }
+
+    protected MapConfiguration getGraphConfig() {
+        final Map<String, Object> map = getTemplateConfig().getMap();
+        map.put(GRAPH_NAME.toStringWithoutRoot(), "cql_test_graph_name");
+        return new MapConfiguration(map);
+    }
+
+    @Test
+    public void dropGraphShouldRemoveGraphKeyspace() throws Exception {
+        final MapConfiguration graphConfig = getGraphConfig();
+        final String graphName = graphConfig.getString(GRAPH_NAME.toStringWithoutRoot());
+
+        try {
+            ConfiguredGraphFactory.createConfiguration(graphConfig);
+
+            final StandardJanusGraph graph = (StandardJanusGraph) ConfiguredGraphFactory.open(graphName);
+            assertNotNull(graph);
+
+            ConfiguredGraphFactory.drop(graphName);
+            Session cql = cqlContainer.getCluster().connect();
+            Object graph_keyspace = cql.execute("SELECT * FROM system_schema.keyspaces WHERE keyspace_name = ?", graphName).one();
+            cql.close();
+
+            assertNull(graph_keyspace);
+        } finally {
+            ConfiguredGraphFactory.removeConfiguration(graphName);
+            ConfiguredGraphFactory.close(graphName);
+        }
+    }
+}
+

--- a/janusgraph-inmemory/src/test/java/org/janusgraph/core/inmemory/InmemoryConfiguredGraphFactoryTest.java
+++ b/janusgraph-inmemory/src/test/java/org/janusgraph/core/inmemory/InmemoryConfiguredGraphFactoryTest.java
@@ -1,0 +1,44 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.inmemory;
+
+import org.apache.commons.configuration.MapConfiguration;
+import org.janusgraph.core.AbstractConfiguredGraphFactoryTest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.GRAPH_NAME;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.STORAGE_BACKEND;
+
+public class InmemoryConfiguredGraphFactoryTest extends AbstractConfiguredGraphFactoryTest {
+
+    protected MapConfiguration getManagementConfig() {
+        final Map<String, Object> map = new HashMap<>();
+        map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
+        return new MapConfiguration(map);
+    }
+
+    protected MapConfiguration getTemplateConfig() {
+        return getManagementConfig();
+    }
+
+    protected MapConfiguration getGraphConfig() {
+        final Map<String, Object> map = getTemplateConfig().getMap();
+        map.put(GRAPH_NAME.toStringWithoutRoot(), "inmemory_test_graph_name");
+        return new MapConfiguration(map);
+    }
+}
+

--- a/janusgraph-test/pom.xml
+++ b/janusgraph-test/pom.xml
@@ -30,6 +30,13 @@
     </repositories>
 
     <dependencies>
+        <!-- Enforce a classpath ordering constraint to ensure log4j is used for logging. -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <!-- End logging backends. -->
         <dependency>
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-core</artifactId>

--- a/janusgraph-test/src/test/resources/log4j.properties
+++ b/janusgraph-test/src/test/resources/log4j.properties
@@ -27,3 +27,6 @@ log4j.rootLogger=DEBUG, A1
 log4j.logger.org.apache.cassandra=INFO
 log4j.logger.org.apache.hadoop=INFO
 log4j.logger.org.apache.zookeeper=INFO
+
+log4j.logger.org.testcontainers=INFO
+log4j.logger.com.github.dockerjava=WARN


### PR DESCRIPTION
This PR address issue #2147 by refactoring the `drop()` method in the `ConfiguredGraphFactory` class.

The bug was in the call to `removeGraphFromCache(String graphName)` which internally tries to open the graph. Because of the order of the calls, the graph was already dropped by a call to `JanusGraphFactory.drop(graph)` which then result in the storage to be recreated.



-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

