### PR TITLE
Fix #2149: get a clean transaction when querying the config graph

### DIFF
--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/management/ConfigurationManagementGraphTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/management/ConfigurationManagementGraphTest.java
@@ -14,6 +14,7 @@
 
 package org.janusgraph.graphdb.management;
 
+import org.janusgraph.core.JanusGraphTransaction;
 import org.janusgraph.graphdb.configuration.builder.GraphDatabaseConfigurationBuilder;
 import org.janusgraph.core.schema.JanusGraphManagement;
 import static org.janusgraph.core.schema.SchemaStatus.ENABLED;
@@ -23,7 +24,9 @@ import org.janusgraph.core.PropertyKey;
 
 import org.janusgraph.diskstorage.configuration.backend.CommonsConfiguration;
 import org.janusgraph.graphdb.database.StandardJanusGraph;
+import org.janusgraph.graphdb.management.utils.ConfigurationManagementGraphNotEnabledException;
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.STORAGE_BACKEND;
+import static org.janusgraph.graphdb.management.ConfigurationManagementGraph.PROPERTY_GRAPH_NAME;
 
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.commons.configuration.MapConfiguration;
@@ -84,5 +87,33 @@ public class ConfigurationManagementGraphTest {
         new ConfigurationManagementGraph(graph);
 
         assertEquals(0, graph.getOpenTransactions().size());
+    }
+
+    @Test
+    public void shouldAlwaysUseACleanTx() throws ConfigurationManagementGraphNotEnabledException {
+        final StandardJanusGraph graph = (StandardJanusGraph) JanusGraphFactory.open("inmemory");
+        new ConfigurationManagementGraph(graph);
+        final ConfigurationManagementGraph configurationManagementGraph = ConfigurationManagementGraph.getInstance();
+
+        // Create a configuration
+        final Map<String, Object> map = new HashMap<>();
+        map.put(PROPERTY_GRAPH_NAME, "tx_test_graph");
+        configurationManagementGraph.createConfiguration(new MapConfiguration(map));
+
+        // Get the vertex id from the new configuration
+        long vertexId = (Long) graph.traversal().V().limit(1).next().id();
+
+        // These will use a traversal to read the configurations creating a new transaction automatically
+        assertEquals(1, configurationManagementGraph.getConfigurations().size());
+
+        // Remove the configuration from outside the ConfigurationManagementGraph, this
+        // could happen from another node in a cluster.
+        JanusGraphTransaction tx = graph.newTransaction();
+        tx.getVertex(vertexId).remove();
+        tx.commit();
+
+        // If the same transaction is being reused the traversal will be resolved without hitting
+        // the store returning the wrong value.
+        assertEquals(0, configurationManagementGraph.getConfigurations().size());
     }
 }


### PR DESCRIPTION
We found that the cause of issue #2149 was due to a dangling transaction in the graph instance used by `ConfiguredGraphManager`. These changes make sure that the traversal source used to access the configuration for a graph always starts with a clean transaction.


-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

