### PR TITLE
Adding codacy opt-out instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,3 +213,9 @@ for all of the commits in your PR.
 
 If you are not sure what's wrong, reach out to
 janusgraph-cla@googlegroups.com with further questions.
+
+### Code Review
+
+JanusGraph uses [Codacy](https://www.codacy.com) for static analysis pull requests to ensure code
+quality. Codacy creates in-line comments for items which require attention, and can generate a large
+number of potentially unwanted emails. Adding codacy-bot to your [blocked users](https://github.com/settings/blocked_users) will stop the notifications.


### PR DESCRIPTION
[doc-only] Fixes JanusGraph#1513.

The codacy-bot repository, as described in the issue, is no longer available, so the blocked user approach was highlighted as the appropriate solution.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
- [] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

