### PR TITLE
Add optional datastax request logger

### DIFF
--- a/docs/basics/janusgraph-cfg.md
+++ b/docs/basics/janusgraph-cfg.md
@@ -424,6 +424,23 @@ Configuration options related to the Netty event loop groups used internally by 
 | storage.cql.netty.timer-tick-duration | The timer tick duration in milliseconds. This is how frequent the timer should wake up to check for timed-out tasks or speculative executions. See DataStax Java Driver option `advanced.netty.timer.tick-duration` for more information. | Long | (no default value) | LOCAL |
 | storage.cql.netty.timer-ticks-per-wheel | Number of ticks in a Timer wheel. See DataStax Java Driver option `advanced.netty.timer.ticks-per-wheel` for more information. | Integer | (no default value) | LOCAL |
 
+### storage.cql.request-tracker
+Configuration options for CQL request tracker and builtin request logger
+
+
+| Name | Description | Datatype | Default Value | Mutability |
+| ---- | ---- | ---- | ---- | ---- |
+| storage.cql.request-tracker.class | It is either a predefined DataStax driver value for a builtin request tracker or a full qualified class name which implements `com.datastax.oss.driver.internal.core.tracker.RequestTracker` interface. If no any value provided, the default DataStax request tracker is used, which is `NoopRequestTracker` which doesn't do anything. If `RequestLogger` value is provided, the DataStax [RequestLogger](https://docs.datastax.com/en/developer/java-driver/4.9/manual/core/request_tracker/#request-logger) is used. | String | (no default value) | LOCAL |
+| storage.cql.request-tracker.logs-error-enabled | Whether to log failed requests.Can be used when `root.storage.cql.request-tracker.class` is set to `RequestLogger`. | Boolean | (no default value) | LOCAL |
+| storage.cql.request-tracker.logs-max-query-length | The maximum length of the query string in the log message. Can be used when `root.storage.cql.request-tracker.class` is set to `RequestLogger`. | Integer | (no default value) | LOCAL |
+| storage.cql.request-tracker.logs-max-value-length | The maximum length for bound values in the log message. Can be used when `root.storage.cql.request-tracker.class` is set to `RequestLogger`. | Integer | (no default value) | LOCAL |
+| storage.cql.request-tracker.logs-max-values | The maximum number of bound values to log. Can be used when `root.storage.cql.request-tracker.class` is set to `RequestLogger`. | Integer | (no default value) | LOCAL |
+| storage.cql.request-tracker.logs-show-stack-traces | Whether to log stack traces for failed queries. Can be used when `root.storage.cql.request-tracker.class` is set to `RequestLogger`. | Boolean | (no default value) | LOCAL |
+| storage.cql.request-tracker.logs-show-values | Whether to log bound values in addition to the query string. Can be used when `root.storage.cql.request-tracker.class` is set to `RequestLogger`. | Boolean | (no default value) | LOCAL |
+| storage.cql.request-tracker.logs-slow-enabled | Whether to log `slow` requests.Can be used when `root.storage.cql.request-tracker.class` is set to `RequestLogger`. | Boolean | (no default value) | LOCAL |
+| storage.cql.request-tracker.logs-slow-threshold | The threshold to classify a successful request as `slow`. In milliseconds. Can be used when `root.storage.cql.request-tracker.class` is set to `RequestLogger`. | Long | (no default value) | LOCAL |
+| storage.cql.request-tracker.logs-success-enabled | Whether to log successful requests. Can be used when `root.storage.cql.request-tracker.class` is set to `RequestLogger`. | Boolean | (no default value) | LOCAL |
+
 ### storage.cql.ssl
 Configuration options for SSL
 

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
@@ -454,4 +454,96 @@ public interface CQLConfigOptions {
         "The time after which the node level metrics will be evicted in milliseconds.",
         ConfigOption.Type.LOCAL,
         Long.class);
+
+    // Request tracker (request logging)
+
+    ConfigNamespace REQUEST_TRACKER = new ConfigNamespace(
+        CQL_NS,
+        "request-tracker",
+        "Configuration options for CQL request tracker and builtin request logger");
+
+    ConfigOption<String> REQUEST_TRACKER_CLASS = new ConfigOption<>(
+        REQUEST_TRACKER,
+        "class",
+        "It is either a predefined DataStax driver value for a builtin request tracker " +
+            "or a full qualified class name which implements " +
+            "`com.datastax.oss.driver.internal.core.tracker.RequestTracker` interface. " +
+            "If no any value provided, the default DataStax request tracker is used, which is `NoopRequestTracker` " +
+            "which doesn't do anything. If `RequestLogger` value is provided, the DataStax [RequestLogger]" +
+            "(https://docs.datastax.com/en/developer/java-driver/4.9/manual/core/request_tracker/#request-logger) " +
+            "is used.",
+        ConfigOption.Type.LOCAL,
+        String.class);
+
+    ConfigOption<Boolean> REQUEST_LOGGER_SUCCESS_ENABLED = new ConfigOption<>(
+        REQUEST_TRACKER,
+        "logs-success-enabled",
+        "Whether to log successful requests. " +
+            "Can be used when `" + REQUEST_TRACKER_CLASS.toString() + "` is set to `RequestLogger`.",
+        ConfigOption.Type.LOCAL,
+        Boolean.class);
+
+    ConfigOption<Long> REQUEST_LOGGER_SLOW_THRESHOLD = new ConfigOption<>(
+        REQUEST_TRACKER,
+        "logs-slow-threshold",
+        "The threshold to classify a successful request as `slow`. In milliseconds. " +
+            "Can be used when `" + REQUEST_TRACKER_CLASS.toString() + "` is set to `RequestLogger`.",
+        ConfigOption.Type.LOCAL,
+        Long.class);
+
+    ConfigOption<Boolean> REQUEST_LOGGER_SLOW_ENABLED = new ConfigOption<>(
+        REQUEST_TRACKER,
+        "logs-slow-enabled",
+        "Whether to log `slow` requests." +
+            "Can be used when `" + REQUEST_TRACKER_CLASS.toString() + "` is set to `RequestLogger`.",
+        ConfigOption.Type.LOCAL,
+        Boolean.class);
+
+    ConfigOption<Boolean> REQUEST_LOGGER_ERROR_ENABLED = new ConfigOption<>(
+        REQUEST_TRACKER,
+        "logs-error-enabled",
+        "Whether to log failed requests." +
+            "Can be used when `" + REQUEST_TRACKER_CLASS.toString() + "` is set to `RequestLogger`.",
+        ConfigOption.Type.LOCAL,
+        Boolean.class);
+
+    ConfigOption<Integer> REQUEST_LOGGER_MAX_QUERY_LENGTH = new ConfigOption<>(
+        REQUEST_TRACKER,
+        "logs-max-query-length",
+        "The maximum length of the query string in the log message. " +
+            "Can be used when `" + REQUEST_TRACKER_CLASS.toString() + "` is set to `RequestLogger`.",
+        ConfigOption.Type.LOCAL,
+        Integer.class);
+
+    ConfigOption<Boolean> REQUEST_LOGGER_SHOW_VALUES = new ConfigOption<>(
+        REQUEST_TRACKER,
+        "logs-show-values",
+        "Whether to log bound values in addition to the query string. " +
+            "Can be used when `" + REQUEST_TRACKER_CLASS.toString() + "` is set to `RequestLogger`.",
+        ConfigOption.Type.LOCAL,
+        Boolean.class);
+
+    ConfigOption<Integer> REQUEST_LOGGER_MAX_VALUE_LENGTH = new ConfigOption<>(
+        REQUEST_TRACKER,
+        "logs-max-value-length",
+        "The maximum length for bound values in the log message. " +
+            "Can be used when `" + REQUEST_TRACKER_CLASS.toString() + "` is set to `RequestLogger`.",
+        ConfigOption.Type.LOCAL,
+        Integer.class);
+
+    ConfigOption<Integer> REQUEST_LOGGER_MAX_VALUES = new ConfigOption<>(
+        REQUEST_TRACKER,
+        "logs-max-values",
+        "The maximum number of bound values to log. " +
+            "Can be used when `" + REQUEST_TRACKER_CLASS.toString() + "` is set to `RequestLogger`.",
+        ConfigOption.Type.LOCAL,
+        Integer.class);
+
+    ConfigOption<Boolean> REQUEST_LOGGER_SHOW_STACK_TRACES = new ConfigOption<>(
+        REQUEST_TRACKER,
+        "logs-show-stack-traces",
+        "Whether to log stack traces for failed queries. " +
+            "Can be used when `" + REQUEST_TRACKER_CLASS.toString() + "` is set to `RequestLogger`.",
+        ConfigOption.Type.LOCAL,
+        Boolean.class);
 }

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
@@ -108,6 +108,16 @@ import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REMOTE_MAX_CONNECT
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REPLICATION_FACTOR;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REPLICATION_OPTIONS;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REPLICATION_STRATEGY;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REQUEST_LOGGER_ERROR_ENABLED;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REQUEST_LOGGER_MAX_QUERY_LENGTH;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REQUEST_LOGGER_MAX_VALUES;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REQUEST_LOGGER_MAX_VALUE_LENGTH;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REQUEST_LOGGER_SHOW_STACK_TRACES;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REQUEST_LOGGER_SHOW_VALUES;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REQUEST_LOGGER_SLOW_ENABLED;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REQUEST_LOGGER_SLOW_THRESHOLD;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REQUEST_LOGGER_SUCCESS_ENABLED;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.REQUEST_TRACKER_CLASS;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.SESSION_NAME;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.SSL_CLIENT_AUTHENTICATION_ENABLED;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.SSL_ENABLED;
@@ -297,6 +307,8 @@ public class CQLStoreManager extends DistributedStoreManager implements KeyColum
         if (configuration.get(BASIC_METRICS)) {
             configureMetrics(configuration, configLoaderBuilder);
         }
+
+        configureRequestTracker(configuration, configLoaderBuilder);
 
         builder.withConfigLoader(configLoaderBuilder.build());
 
@@ -587,6 +599,48 @@ public class CQLStoreManager extends DistributedStoreManager implements KeyColum
                 configLoaderBuilder.withDuration(DefaultDriverOption.METRICS_NODE_EXPIRE_AFTER,
                     Duration.ofMillis(configuration.get(METRICS_NODE_EXPIRE_AFTER)));
             }
+        }
+    }
+
+    private void configureRequestTracker(Configuration configuration, ProgrammaticDriverConfigLoaderBuilder configLoaderBuilder){
+        if (configuration.has(REQUEST_TRACKER_CLASS)) {
+            configLoaderBuilder.withString(DefaultDriverOption.REQUEST_TRACKER_CLASS, configuration.get(REQUEST_TRACKER_CLASS));
+        }
+        if (configuration.has(REQUEST_LOGGER_SUCCESS_ENABLED)) {
+            configLoaderBuilder.withBoolean(DefaultDriverOption.REQUEST_LOGGER_SUCCESS_ENABLED,
+                configuration.get(REQUEST_LOGGER_SUCCESS_ENABLED));
+        }
+        if (configuration.has(REQUEST_LOGGER_SLOW_THRESHOLD)) {
+            configLoaderBuilder.withDuration(DefaultDriverOption.REQUEST_LOGGER_SLOW_THRESHOLD,
+                Duration.ofMillis(configuration.get(REQUEST_LOGGER_SLOW_THRESHOLD)));
+        }
+        if (configuration.has(REQUEST_LOGGER_SLOW_ENABLED)) {
+            configLoaderBuilder.withBoolean(DefaultDriverOption.REQUEST_LOGGER_SLOW_ENABLED,
+                configuration.get(REQUEST_LOGGER_SLOW_ENABLED));
+        }
+        if (configuration.has(REQUEST_LOGGER_ERROR_ENABLED)) {
+            configLoaderBuilder.withBoolean(DefaultDriverOption.REQUEST_LOGGER_ERROR_ENABLED,
+                configuration.get(REQUEST_LOGGER_ERROR_ENABLED));
+        }
+        if (configuration.has(REQUEST_LOGGER_MAX_QUERY_LENGTH)) {
+            configLoaderBuilder.withInt(DefaultDriverOption.REQUEST_LOGGER_MAX_QUERY_LENGTH,
+                configuration.get(REQUEST_LOGGER_MAX_QUERY_LENGTH));
+        }
+        if (configuration.has(REQUEST_LOGGER_SHOW_VALUES)) {
+            configLoaderBuilder.withBoolean(DefaultDriverOption.REQUEST_LOGGER_VALUES,
+                configuration.get(REQUEST_LOGGER_SHOW_VALUES));
+        }
+        if (configuration.has(REQUEST_LOGGER_MAX_VALUE_LENGTH)) {
+            configLoaderBuilder.withInt(DefaultDriverOption.REQUEST_LOGGER_MAX_VALUE_LENGTH,
+                configuration.get(REQUEST_LOGGER_MAX_VALUE_LENGTH));
+        }
+        if (configuration.has(REQUEST_LOGGER_MAX_VALUES)) {
+            configLoaderBuilder.withInt(DefaultDriverOption.REQUEST_LOGGER_MAX_VALUES,
+                configuration.get(REQUEST_LOGGER_MAX_VALUES));
+        }
+        if (configuration.has(REQUEST_LOGGER_SHOW_STACK_TRACES)) {
+            configLoaderBuilder.withBoolean(DefaultDriverOption.REQUEST_LOGGER_STACK_TRACES,
+                configuration.get(REQUEST_LOGGER_SHOW_STACK_TRACES));
         }
     }
 

--- a/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLGraphTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLGraphTest.java
@@ -14,6 +14,7 @@
 
 package org.janusgraph.graphdb.cql;
 
+import com.datastax.oss.driver.internal.core.tracker.RequestLogger;
 import org.janusgraph.JanusGraphCassandraContainer;
 import org.janusgraph.core.JanusGraphFactory;
 import org.janusgraph.diskstorage.configuration.ConfigElement;
@@ -137,5 +138,38 @@ public class CQLGraphTest extends JanusGraphTest {
             tx.getTxHandle().getBaseTransactionConfig().getCustomOptions()
                 .get(WRITE_CONSISTENCY));
         tx.rollback();
+    }
+
+    @Test
+    public void testRequestLoggerConfigurationSet() {
+        close();
+        WriteConfiguration wc = getConfiguration();
+        assertNull(wc.get(ConfigElement.getPath(REQUEST_TRACKER_CLASS), REQUEST_TRACKER_CLASS.getDatatype()));
+        assertNull(wc.get(ConfigElement.getPath(REQUEST_LOGGER_SUCCESS_ENABLED), REQUEST_LOGGER_SUCCESS_ENABLED.getDatatype()));
+        assertNull(wc.get(ConfigElement.getPath(REQUEST_LOGGER_SLOW_THRESHOLD), REQUEST_LOGGER_SLOW_THRESHOLD.getDatatype()));
+        assertNull(wc.get(ConfigElement.getPath(REQUEST_LOGGER_SLOW_ENABLED), REQUEST_LOGGER_SLOW_ENABLED.getDatatype()));
+        assertNull(wc.get(ConfigElement.getPath(REQUEST_LOGGER_ERROR_ENABLED), REQUEST_LOGGER_ERROR_ENABLED.getDatatype()));
+        assertNull(wc.get(ConfigElement.getPath(REQUEST_LOGGER_MAX_QUERY_LENGTH), REQUEST_LOGGER_MAX_QUERY_LENGTH.getDatatype()));
+        assertNull(wc.get(ConfigElement.getPath(REQUEST_LOGGER_SHOW_VALUES), REQUEST_LOGGER_SHOW_VALUES.getDatatype()));
+        assertNull(wc.get(ConfigElement.getPath(REQUEST_LOGGER_MAX_VALUE_LENGTH), REQUEST_LOGGER_MAX_VALUE_LENGTH.getDatatype()));
+        assertNull(wc.get(ConfigElement.getPath(REQUEST_LOGGER_MAX_VALUES), REQUEST_LOGGER_MAX_VALUES.getDatatype()));
+        assertNull(wc.get(ConfigElement.getPath(REQUEST_LOGGER_SHOW_STACK_TRACES), REQUEST_LOGGER_SHOW_STACK_TRACES.getDatatype()));
+
+        wc.set(ConfigElement.getPath(REQUEST_TRACKER_CLASS), RequestLogger.class.getSimpleName());
+        wc.set(ConfigElement.getPath(REQUEST_LOGGER_SUCCESS_ENABLED), true);
+        wc.set(ConfigElement.getPath(REQUEST_LOGGER_SLOW_THRESHOLD), 1L);
+        wc.set(ConfigElement.getPath(REQUEST_LOGGER_SLOW_ENABLED), true);
+        wc.set(ConfigElement.getPath(REQUEST_LOGGER_ERROR_ENABLED), true);
+        wc.set(ConfigElement.getPath(REQUEST_LOGGER_MAX_QUERY_LENGTH), 100000);
+        wc.set(ConfigElement.getPath(REQUEST_LOGGER_SHOW_VALUES), true);
+        wc.set(ConfigElement.getPath(REQUEST_LOGGER_MAX_VALUE_LENGTH), 100000);
+        wc.set(ConfigElement.getPath(REQUEST_LOGGER_MAX_VALUES), 100000);
+        wc.set(ConfigElement.getPath(REQUEST_LOGGER_SHOW_STACK_TRACES), true);
+
+        graph = (StandardJanusGraph) JanusGraphFactory.open(wc);
+        assertDoesNotThrow(() -> {
+            graph.traversal().V().hasNext();
+            graph.tx().rollback();
+        });
     }
 }


### PR DESCRIPTION
Adds possibility to enable CQL request logger to debug queries. Tested manually.
Not sure how to cover this feature with tests without using reflection (which might be a bad approach).

Request tracker and a builtin request logger DataStax documentation for 4.9 driver version is here: https://docs.datastax.com/en/developer/java-driver/4.9/manual/core/request_tracker/

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

