### PR TITLE
Upgrade DataStax cassandra driver to 4.9.0 [full build]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ cov-int.tar.gz
 cov-int/
 
 /site/
+
+*.hprof

--- a/docs/basics/janusgraph-cfg.md
+++ b/docs/basics/janusgraph-cfg.md
@@ -371,28 +371,57 @@ CQL storage backend options
 | ---- | ---- | ---- | ---- | ---- |
 | storage.cql.atomic-batch-mutate | True to use Cassandra atomic batch mutation, false to use non-atomic batches | Boolean | false | MASKABLE |
 | storage.cql.batch-statement-size | The number of statements in each batch | Integer | 20 | MASKABLE |
-| storage.cql.cluster-name | Default name for the Cassandra cluster | String | JanusGraph Cluster | MASKABLE |
 | storage.cql.compaction-strategy-class | The compaction strategy to use for JanusGraph tables | String | (no default value) | FIXED |
 | storage.cql.compaction-strategy-options | Compaction strategy options.  This list is interpreted as a map.  It must have an even number of elements in [key,val,key,val,...] form. | String[] | (no default value) | FIXED |
 | storage.cql.compression | Whether the storage backend should use compression when storing the data | Boolean | true | FIXED |
 | storage.cql.compression-block-size | The size of the compression blocks in kilobytes | Integer | 64 | FIXED |
 | storage.cql.compression-type | The sstable_compression value JanusGraph uses when creating column families. This accepts any value allowed by Cassandra's sstable_compression option. Leave this unset to disable sstable_compression on JanusGraph-created CFs. | String | LZ4Compressor | MASKABLE |
+| storage.cql.heartbeat-interval | The connection heartbeat interval in milliseconds. | Long | (no default value) | MASKABLE |
+| storage.cql.heartbeat-timeout | How long the driver waits for the response (in milliseconds) to a heartbeat. | Long | (no default value) | MASKABLE |
 | storage.cql.keyspace | The name of JanusGraph's keyspace.  It will be created if it does not exist. | String | janusgraph | LOCAL |
-| storage.cql.local-core-connections-per-host | The number of connections initially created and kept open to each host for local datacenter | Integer | 1 | FIXED |
-| storage.cql.local-datacenter | The name of the local or closest Cassandra datacenter.  When set and not whitespace, this value will be passed into ConnectionPoolConfigurationImpl.setLocalDatacenter. When unset or set to whitespace, setLocalDatacenter will not be invoked. | String | (no default value) | MASKABLE |
+| storage.cql.local-datacenter | The name of the local or closest Cassandra datacenter. This value will be passed into CqlSessionBuilder.withLocalDatacenter. | String | datacenter1 | MASKABLE |
 | storage.cql.local-max-connections-per-host | The maximum number of connections that can be created per host for local datacenter | Integer | 1 | FIXED |
-| storage.cql.local-max-requests-per-connection | The maximum number of requests per connection for local datacenter | Integer | 1024 | FIXED |
+| storage.cql.max-requests-per-connection | The maximum number of requests that can be executed concurrently on a connection. | Integer | 1024 | FIXED |
 | storage.cql.only-use-local-consistency-for-system-operations | True to prevent any system queries from using QUORUM consistency and always use LOCAL_QUORUM instead | Boolean | false | MASKABLE |
 | storage.cql.protocol-version | The protocol version used to connect to the Cassandra database.  If no value is supplied then the driver will negotiate with the server. | Integer | 0 | LOCAL |
 | storage.cql.read-consistency-level | The consistency level of read operations against Cassandra | String | QUORUM | MASKABLE |
-| storage.cql.remote-core-connections-per-host | The number of connections initially created and kept open to each host for remote datacenter | Integer | 1 | FIXED |
 | storage.cql.remote-max-connections-per-host | The maximum number of connections that can be created per host for remote datacenter | Integer | 1 | FIXED |
-| storage.cql.remote-max-requests-per-connection | The maximum number of requests per connection for remote datacenter | Integer | 256 | FIXED |
 | storage.cql.replication-factor | The number of data replicas (including the original copy) that should be kept | Integer | 1 | GLOBAL_OFFLINE |
 | storage.cql.replication-strategy-class | The replication strategy to use for JanusGraph keyspace | String | SimpleStrategy | FIXED |
 | storage.cql.replication-strategy-options | Replication strategy options, e.g. factor or replicas per datacenter.  This list is interpreted as a map.  It must have an even number of elements in [key,val,key,val,...] form.  A replication_factor set here takes precedence over one set with storage.cql.replication-factor | String[] | (no default value) | FIXED |
+| storage.cql.session-name | Default name for the Cassandra session | String | JanusGraph Session | MASKABLE |
 | storage.cql.use-external-locking | True to prevent JanusGraph from using its own locking mechanism. Setting this to true eliminates redundant checks when using an external locking mechanism outside of JanusGraph. Be aware that when use-external-locking is set to true, that failure to employ a locking algorithm which locks all columns that participate in a transaction upfront and unlocks them when the transaction ends, will result in a 'read uncommitted' transaction isolation level guarantee. If set to true without an appropriate external locking mechanism in place side effects such as dirty/non-repeatable/phantom reads should be expected. | Boolean | false | MASKABLE |
 | storage.cql.write-consistency-level | The consistency level of write operations against Cassandra | String | QUORUM | MASKABLE |
+
+### storage.cql.metrics
+Configuration options for CQL metrics
+
+
+| Name | Description | Datatype | Default Value | Mutability |
+| ---- | ---- | ---- | ---- | ---- |
+| storage.cql.metrics.cql-messages-delay-refresh-interval | The interval at which percentile data is refreshed in milliseconds for requests. Used if 'cql-messages' node metric is enabled. See DataStax driver configuration option `advanced.metrics.node.cql-messages.refresh-interval` | Long | (no default value) | LOCAL |
+| storage.cql.metrics.cql-messages-highest-latency | The largest latency that we expect to record for requests in milliseconds. Used if 'cql-messages' node metric is enabled. See DataStax driver configuration option `advanced.metrics.node.cql-messages.highest-latency` | Long | (no default value) | LOCAL |
+| storage.cql.metrics.cql-messages-significant-digits | The number of significant decimal digits to which internal structures will maintain value resolution and separation for requests. This must be between 0 and 5. Used if 'cql-messages' node metric is enabled. See DataStax driver configuration option `advanced.metrics.node.cql-messages.significant-digits` | Integer | (no default value) | LOCAL |
+| storage.cql.metrics.cql-requests-highest-latency | The largest latency that we expect to record for requests in milliseconds. Used if 'cql-requests' session metric is enabled. See DataStax driver configuration option `advanced.metrics.session.cql-requests.highest-latency` | Long | (no default value) | LOCAL |
+| storage.cql.metrics.cql-requests-refresh-interval | The interval at which percentile data is refreshed in milliseconds for requests. Used if 'cql-requests' session metric is enabled. See DataStax driver configuration option `advanced.metrics.session.cql-requests.refresh-interval` | Long | (no default value) | LOCAL |
+| storage.cql.metrics.cql-requests-significant-digits | The number of significant decimal digits to which internal structures will maintain value resolution and separation for requests. This must be between 0 and 5. Used if 'cql-requests' session metric is enabled. See DataStax driver configuration option `advanced.metrics.session.cql-requests.significant-digits` | Integer | (no default value) | LOCAL |
+| storage.cql.metrics.node-enabled | Comma separated list of enabled node metrics. Used only when basic metrics are enabled. Check DataStax Cassandra Driver 4 documentation for available metrics (example: pool.open-connections, pool.available-streams, bytes-sent). | String[] | (no default value) | LOCAL |
+| storage.cql.metrics.node-expire-after | The time after which the node level metrics will be evicted in milliseconds. | Long | (no default value) | LOCAL |
+| storage.cql.metrics.session-enabled | Comma separated list of enabled session metrics. Used only when basic metrics are enabled. Check DataStax Cassandra Driver 4 documentation for available metrics (example: bytes-sent, bytes-received, connected-nodes). | String[] | (no default value) | LOCAL |
+| storage.cql.metrics.throttling-delay-highest-latency | The largest latency that we expect to record for throttling in milliseconds. Used if 'throttling.delay' session metric is enabled. See DataStax driver configuration option `advanced.metrics.session.throttling.delay.highest-latency` | Long | (no default value) | LOCAL |
+| storage.cql.metrics.throttling-delay-refresh-interval | The interval at which percentile data is refreshed in milliseconds for throttling. Used if 'throttling.delay' session metric is enabled. See DataStax driver configuration option `advanced.metrics.session.throttling.delay.refresh-interval` | Long | (no default value) | LOCAL |
+| storage.cql.metrics.throttling-delay-significant-digits | The number of significant decimal digits to which internal structures will maintain value resolution and separation for throttling. This must be between 0 and 5. Used if 'throttling.delay' session metric is enabled. See DataStax driver configuration option `advanced.metrics.session.throttling.delay.significant-digits` | Integer | (no default value) | LOCAL |
+
+### storage.cql.netty
+Configuration options related to the Netty event loop groups used internally by the CQL driver.
+
+
+| Name | Description | Datatype | Default Value | Mutability |
+| ---- | ---- | ---- | ---- | ---- |
+| storage.cql.netty.admin-size | The number of threads for the event loop group used for admin tasks not related to request I/O (handle cluster events, refresh metadata, schedule reconnections, etc.). If this is set to 0, the driver will use `Runtime.getRuntime().availableProcessors() * 2`. | Integer | 0 | LOCAL |
+| storage.cql.netty.io-size | The number of threads for the event loop group used for I/O operations (reading and writing to Cassandra nodes). If this is set to 0, the driver will use `Runtime.getRuntime().availableProcessors() * 2`. | Integer | 0 | LOCAL |
+| storage.cql.netty.timer-tick-duration | The timer tick duration in milliseconds. This is how frequent the timer should wake up to check for timed-out tasks or speculative executions. See DataStax Java Driver option `advanced.netty.timer.tick-duration` for more information. | Long | (no default value) | LOCAL |
+| storage.cql.netty.timer-ticks-per-wheel | Number of ticks in a Timer wheel. See DataStax Java Driver option `advanced.netty.timer.ticks-per-wheel` for more information. | Integer | (no default value) | LOCAL |
 
 ### storage.cql.ssl
 Configuration options for SSL
@@ -402,6 +431,7 @@ Configuration options for SSL
 | ---- | ---- | ---- | ---- | ---- |
 | storage.cql.ssl.client-authentication-enabled | Enables use of a client key to authenticate with Cassandra | Boolean | false | LOCAL |
 | storage.cql.ssl.enabled | Controls use of the SSL connection to Cassandra | Boolean | false | LOCAL |
+| storage.cql.ssl.hostname_validation | Enable / disable SSL hostname validation. | Boolean | false | LOCAL |
 
 ### storage.cql.ssl.keystore
 Configuration options for SSL Keystore.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -165,6 +165,43 @@ after a shiny new JanusGraph header.
 
 We are dropping Ganglia as we are using dropwizard for metrics. Dropwizard did drop Ganglia in the newest major version.
 
+##### DataStax cassandra driver upgrade from 3.9.0 to 4.9.0
+
+All DataStax cassandra driver metrics are now disabled by default. To enable DataStax driver metrics you need to provide 
+a list of Session level metrics and / or Node level metrics you want to enable. To provide a list of enabled metrics, 
+you can use the next configuration options: `storage.cql.metrics.session-enabled` and `storage.cql.metrics.node-enabled`. 
+Notice, DataStax metrics are enabled only when basic metrics are enabled (i.e. `metrics.enabled = true`).
+See configuration references `storage.cql.metrics` for additional DataStax metrics configuration.
+
+An example configuration which enables some CQL Session level and Node level metrics reporting by JMX:
+```properties
+metrics.enabled=true
+metrics.jmx.enabled=true
+metrics.jmx.domain=com.datastax.oss.driver
+metrics.jmx.agentid=agent
+storage.cql.metrics.session-enabled=bytes-sent,bytes-received,connected-nodes,cql-requests,throttling.delay
+storage.cql.metrics.node-enabled=pool.open-connections,pool.available-streams,bytes-sent,cql-messages
+```
+
+See `advanced.metrics.session.enabled` and `advanced.metrics.node.enabled` sections in 
+[DataStax Metrics Configuration](https://docs.datastax.com/en/developer/java-driver/4.9/manual/core/configuration/reference/) 
+for a complete list of available Session level and Node level metrics.
+
+Due to driver upgrade the next cql configuration options have been removed:
+- `local-core-connections-per-host`
+- `remote-core-connections-per-host`
+- `local-max-requests-per-connection`
+- `remote-max-requests-per-connection`
+- `cluster-name`
+
+New cql configuration options should be used for upgrade:
+- `max-requests-per-connection`
+- `session-name`
+
+`storage.cql.local-datacenter` is mandatory now and defaults to `datacenter1`.
+
+See more new cql configuration options in configuration references under `storage.cql` section.
+
 ### Version 0.5.2 (Release Date: May 3, 2020)
 
 === "Maven"

--- a/janusgraph-cql/pom.xml
+++ b/janusgraph-cql/pom.xml
@@ -114,9 +114,74 @@
         </dependency>
 
         <dependency>
+            <groupId>com.datastax.oss</groupId>
+            <artifactId>java-driver-core</artifactId>
+            <version>${cassandra-driver.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.json</groupId>
+                    <artifactId>json</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tinkerpop</groupId>
+                    <artifactId>gremlin-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tinkerpop</groupId>
+                    <artifactId>tinkergraph-gremlin</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.datastax.oss</groupId>
+            <artifactId>java-driver-query-builder</artifactId>
+            <version>${cassandra-driver.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.json</groupId>
+                    <artifactId>json</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tinkerpop</groupId>
+                    <artifactId>gremlin-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tinkerpop</groupId>
+                    <artifactId>tinkergraph-gremlin</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Required for Cassandra-3 connectivity, see issue 172 -->
+        <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>${cassandra-driver.version}</version>
+            <version>3.10.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.jnr</groupId>
+                    <artifactId>jnr-ffi</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.jnr</groupId>
+                    <artifactId>jnr-posix</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.dropwizard.metrics</groupId>
+                    <artifactId>metrics-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.vavr</groupId>

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLColValGetter.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLColValGetter.java
@@ -18,7 +18,7 @@ import org.janusgraph.diskstorage.EntryMetaData;
 import org.janusgraph.diskstorage.StaticBuffer;
 import org.janusgraph.diskstorage.util.StaticArrayEntry.GetColVal;
 
-import com.datastax.driver.core.Row;
+import com.datastax.oss.driver.api.core.cql.Row;
 
 import io.vavr.Tuple3;
 

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLResultSetKeyIterator.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLResultSetKeyIterator.java
@@ -24,7 +24,7 @@ import org.janusgraph.diskstorage.util.RecordIterator;
 import org.janusgraph.diskstorage.util.StaticArrayBuffer;
 import org.janusgraph.diskstorage.util.StaticArrayEntry;
 
-import com.datastax.driver.core.Row;
+import com.datastax.oss.driver.api.core.cql.Row;
 import com.google.common.collect.AbstractIterator;
 
 import io.vavr.Tuple;
@@ -53,7 +53,7 @@ class CQLResultSetKeyIterator extends AbstractIterator<StaticBuffer> implements 
         this.iterator = Iterator.ofAll(resultSet)
                 .peek(row -> {
                     this.currentRow = row;
-                    this.currentKey = StaticArrayBuffer.of(row.getBytes(CQLKeyColumnValueStore.KEY_COLUMN_NAME));
+                    this.currentKey = StaticArrayBuffer.of(row.getByteBuffer(CQLKeyColumnValueStore.KEY_COLUMN_NAME));
                 });
     }
 
@@ -94,10 +94,10 @@ class CQLResultSetKeyIterator extends AbstractIterator<StaticBuffer> implements 
             final StaticBuffer sliceEnd = sliceQuery.getSliceEnd();
             this.iterator = iterator
                     .<Tuple3<StaticBuffer, StaticBuffer, Row>> map(row -> Tuple.of(
-                            StaticArrayBuffer.of(row.getBytes(CQLKeyColumnValueStore.COLUMN_COLUMN_NAME)),
-                            StaticArrayBuffer.of(row.getBytes(CQLKeyColumnValueStore.VALUE_COLUMN_NAME)),
+                            StaticArrayBuffer.of(row.getByteBuffer(CQLKeyColumnValueStore.COLUMN_COLUMN_NAME)),
+                            StaticArrayBuffer.of(row.getByteBuffer(CQLKeyColumnValueStore.VALUE_COLUMN_NAME)),
                             row))
-                    .takeWhile(tuple -> key.equals(StaticArrayBuffer.of(tuple._3.getBytes(CQLKeyColumnValueStore.KEY_COLUMN_NAME))) && !sliceEnd.equals(tuple._1))
+                    .takeWhile(tuple -> key.equals(StaticArrayBuffer.of(tuple._3.getByteBuffer(CQLKeyColumnValueStore.KEY_COLUMN_NAME))) && !sliceEnd.equals(tuple._1))
                     .take(sliceQuery.getLimit());
         }
 

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLTransaction.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLTransaction.java
@@ -14,14 +14,16 @@
 
 package org.janusgraph.diskstorage.cql;
 
-import static org.janusgraph.diskstorage.cql.CQLConfigOptions.*;
-
 import org.janusgraph.diskstorage.BaseTransactionConfig;
 import org.janusgraph.diskstorage.common.AbstractStoreTransaction;
 import org.janusgraph.diskstorage.keycolumnvalue.StoreTransaction;
 
-import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
 import com.google.common.base.Preconditions;
+
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.READ_CONSISTENCY;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.WRITE_CONSISTENCY;
 
 /**
  * This class manages the translation of read and write consistency configuration values to CQL API {@link ConsistencyLevel} types.
@@ -33,8 +35,8 @@ public class CQLTransaction extends AbstractStoreTransaction {
 
     public CQLTransaction(final BaseTransactionConfig config) {
         super(config);
-        this.readConsistencyLevel = ConsistencyLevel.valueOf(getConfiguration().getCustomOption(READ_CONSISTENCY));
-        this.writeConsistencyLevel = ConsistencyLevel.valueOf(getConfiguration().getCustomOption(WRITE_CONSISTENCY));
+        this.readConsistencyLevel = DefaultConsistencyLevel.valueOf(getConfiguration().getCustomOption(READ_CONSISTENCY));
+        this.writeConsistencyLevel = DefaultConsistencyLevel.valueOf(getConfiguration().getCustomOption(WRITE_CONSISTENCY));
     }
 
     ConsistencyLevel getReadConsistencyLevel() {

--- a/janusgraph-cql/src/main/java/org/janusgraph/hadoop/CqlHadoopStoreManager.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/hadoop/CqlHadoopStoreManager.java
@@ -14,21 +14,21 @@
 
 package org.janusgraph.hadoop;
 
-import com.datastax.driver.core.Cluster;
+import com.datastax.oss.driver.api.core.CqlSession;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.janusgraph.hadoop.formats.cql.CqlBinaryInputFormat;
 
 public class CqlHadoopStoreManager implements HadoopStoreManager {
 
-    private Cluster cluster;
+    private CqlSession session;
 
-    public CqlHadoopStoreManager(Cluster cluster){
-        this.cluster = cluster;
+    public CqlHadoopStoreManager(CqlSession session){
+        this.session = session;
     }
 
     public String getPartitioner(){
-        return this.cluster.getMetadata().getPartitioner();
+        return this.session.getMetadata().getTokenMap().get().getPartitionerName();
     }
 
     @Override

--- a/janusgraph-cql/src/test/java/org/janusgraph/JanusGraphCassandraContainer.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/JanusGraphCassandraContainer.java
@@ -152,7 +152,7 @@ public class JanusGraphCassandraContainer extends CassandraContainer<JanusGraphC
         config.set(STORAGE_PORT, getMappedPort(CQL_PORT));
         config.set(STORAGE_HOSTS, new String[]{getContainerIpAddress()});
         config.set(DROP_ON_CLEAR, false);
-        config.set(REMOTE_MAX_REQUESTS_PER_CONNECTION, 1024);
+        config.set(MAX_REQUESTS_PER_CONNECTION, 1024);
         if (useDynamicConfig()) {
             if(useSSL()) {
                 config.set(SSL_ENABLED, true);

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLResultSetKeyIteratorTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLResultSetKeyIteratorTest.java
@@ -31,8 +31,8 @@ import org.janusgraph.diskstorage.util.BufferUtil;
 import org.janusgraph.diskstorage.util.RecordIterator;
 import org.junit.jupiter.api.Test;
 
-import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.Row;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
 
 import io.vavr.Function1;
 import io.vavr.Tuple;
@@ -49,9 +49,9 @@ public class CQLResultSetKeyIteratorTest {
     public void testIterator() throws IOException {
         final Array<Row> rows = Array.rangeClosed(1, 100).map(idx -> {
             final Row row = mock(Row.class);
-            when(row.getBytes("key")).thenReturn(ByteBuffer.wrap(Integer.toString(idx / 5).getBytes()));
-            when(row.getBytes("column1")).thenReturn(ByteBuffer.wrap(Integer.toString(idx % 5).getBytes()));
-            when(row.getBytes("value")).thenReturn(ByteBuffer.wrap(Integer.toString(idx).getBytes()));
+            when(row.getByteBuffer("key")).thenReturn(ByteBuffer.wrap(Integer.toString(idx / 5).getBytes()));
+            when(row.getByteBuffer("column1")).thenReturn(ByteBuffer.wrap(Integer.toString(idx % 5).getBytes()));
+            when(row.getByteBuffer("value")).thenReturn(ByteBuffer.wrap(Integer.toString(idx).getBytes()));
             return row;
         });
 
@@ -69,9 +69,9 @@ public class CQLResultSetKeyIteratorTest {
                     final Row row = rows.get(i++);
                     final Entry entry = entries.next();
 
-                    assertEquals(row.getBytes("key"), next.asByteBuffer());
-                    assertEquals(row.getBytes("column1"), entry.getColumn().asByteBuffer());
-                    assertEquals(row.getBytes("value"), entry.getValue().asByteBuffer());
+                    assertEquals(row.getByteBuffer("key"), next.asByteBuffer());
+                    assertEquals(row.getByteBuffer("column1"), entry.getColumn().asByteBuffer());
+                    assertEquals(row.getByteBuffer("value"), entry.getValue().asByteBuffer());
                 }
             }
         }
@@ -189,9 +189,9 @@ public class CQLResultSetKeyIteratorTest {
     private ResultSet generateMockedResultSet(Array<Tuple2<ByteBuffer, Array<Tuple2<ByteBuffer, ByteBuffer>>>> keysMap){
         final Seq<Row> rows = keysMap.flatMap(tuple -> tuple._2.map(columnAndValue -> {
             final Row row = mock(Row.class);
-            when(row.getBytes("key")).thenReturn(tuple._1);
-            when(row.getBytes("column1")).thenReturn(columnAndValue._1);
-            when(row.getBytes("value")).thenReturn(columnAndValue._2);
+            when(row.getByteBuffer("key")).thenReturn(tuple._1);
+            when(row.getByteBuffer("column1")).thenReturn(columnAndValue._1);
+            when(row.getByteBuffer("value")).thenReturn(columnAndValue._2);
             return row;
         }));
 

--- a/janusgraph-dist/pom.xml
+++ b/janusgraph-dist/pom.xml
@@ -75,6 +75,10 @@
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-compress</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-annotations</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/janusgraph-hadoop/pom.xml
+++ b/janusgraph-hadoop/pom.xml
@@ -66,6 +66,10 @@
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-compress</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-annotations</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <test.excluded.groups>MEMORY_TESTS,PERFORMANCE_TESTS,BRITTLE_TESTS</test.excluded.groups>
         <dependency.locations.enabled>false</dependency.locations.enabled>
         <cassandra.version>3.11.6</cassandra.version>
-        <cassandra-driver.version>3.9.0</cassandra-driver.version>
+        <cassandra-driver.version>4.9.0</cassandra-driver.version>
         <testcontainers.version>1.14.3</testcontainers.version>
         <easymock.version>3.4</easymock.version>
     </properties>


### PR DESCRIPTION
Mostly based on #1733 .

This PR adds 2 DataStax drivers into `janusgraph-cql`:
- DataStax 4.9.0 is the main driver which is now used.
- DataStax 3.10.2 is the driver which is now used for Hadoop. `CqlBinaryRecordReader` which is used for Hadoop jobs is still using DataStax Cassandra Driver 3.x.y.

Notice, even so this PR adds 2 different versions of DataStax Cassandra Driver in the same module, those drivers are binary incompatible and share different classpath, thus they don't conflict with each other and can be used simultaneously. 
Later we can move CQL Hadoop formats from `janusgraph-cql` to a new module like `janusgraph-hadoop-cql` or something like that. It will allow to include only 4.x version of the driver into classpath for users who use `janusgraph-cql` but don't use `janusgraph-hadoop-cql`.

Tests passed:
- Custom integration tests. Storage backend: ScyllaDB 4.2.0 (cql driver). Index backend: ElasticSearch 7.6.0 (es driver).
- Distribution build. `janusgraph.sh` starts Cassandra and ElasticSearch. `janusgraph-server` successfully connects to storage backends via cql driver.
- janusgraph-full distribution successfully logs different metrics via JMX (https://github.com/JanusGraph/janusgraph/issues/1087#issuecomment-534513530), console, slf4j.
- Embedded janusgraph successfully logs different metrics via JMX, console, slf4j. Also, tried to log new CQL Session Level and Node Level metrics via [JMX exporter](https://github.com/prometheus/jmx_exporter). New CQL Session Level and Node Level metrics to enable are provided via `storage.cql.metrics.session-enabled` and `storage.cql.metrics.node-enabled` respectively. 
- All TinkerPop tests passed. Executed with `mvn clean install -Dtest.skip.tp=false -DskipTests=true`.
- TravisCI `[full build]` passed.

Compared performance of `master` branch (f5001e6210baa15bc136f3224ba1e83521782cba) and this PR (65cad01828f1a455cc51435f8efaf309111c0768). The performance is fairly the same. I tried several times to execute custom integration tests which showed that the PR branch in most cases runs about 1%-1.5% faster than `master` branch. I tried to execute CQL TP tests 2 times for each branch which showed again that this PR runs 1%-1.5% faster (in average 4:20 h for this PR and 4:25 h for master branch). The performance improvement most likely achieved because of a slightly more optimal `CQLPagingIterator` implementation and most likely not directly related to driver upgrade. Overall I would say that the performance is the same but I didn't get enough statistics for real comparison. The custom integration tests were executed on  ScyllaDB 4.2.0 on the same machine with JanusGraph in embedded mode with no replication.   

Changelog: https://docs.datastax.com/en/developer/java-driver/4.9/changelog/

Fixes #1510
Potentially solves #2254 for `master` branch (`0.6.0` release)

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

