### PR TITLE
Add mixed index support for has(key) query

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexFeatures.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexFeatures.java
@@ -37,12 +37,14 @@ public class IndexFeatures {
     private final boolean supportsNanoseconds;
     private final boolean supportsCustomAnalyzer;
     private final boolean supportsGeoContains;
+    private final boolean supportsGeoExists;
     private final boolean supportsNotQueryNormalForm;
     private final Set<Cardinality> supportedCardinalities;
 
     public IndexFeatures(boolean supportsDocumentTTL, Mapping defaultMap, Set<Mapping> supportedMap,
                          String wildcardField, Set<Cardinality> supportedCardinalities, boolean supportsNanoseconds,
-                         boolean supportCustomAnalyzer, boolean supportsGeoContains, boolean supportsNotQueryNormalForm) {
+                         boolean supportCustomAnalyzer, boolean supportsGeoContains, boolean supportGeoExists,
+                         boolean supportsNotQueryNormalForm) {
 
         Preconditions.checkArgument(defaultMap!=null && defaultMap!=Mapping.DEFAULT);
         Preconditions.checkArgument(supportedMap!=null && !supportedMap.isEmpty()
@@ -55,6 +57,7 @@ public class IndexFeatures {
         this.supportsNanoseconds = supportsNanoseconds;
         this.supportsCustomAnalyzer = supportCustomAnalyzer;
         this.supportsGeoContains = supportsGeoContains;
+        this.supportsGeoExists = supportGeoExists;
         this.supportsNotQueryNormalForm = supportsNotQueryNormalForm;
     }
 
@@ -90,6 +93,10 @@ public class IndexFeatures {
         return supportsGeoContains;
     }
 
+    public boolean supportsGeoExists() {
+        return supportsGeoExists;
+    }
+
     public boolean supportNotQueryNormalForm() {
         return supportsNotQueryNormalForm;
     }
@@ -104,6 +111,7 @@ public class IndexFeatures {
         private boolean supportsNanoseconds;
         private boolean supportsCustomAnalyzer;
         private boolean supportsGeoContains;
+        private boolean supportsGeoExists;
         private boolean supportNotQueryNormalForm;
 
         public Builder supportsDocumentTTL() {
@@ -146,6 +154,11 @@ public class IndexFeatures {
             return this;
         }
 
+        public Builder supportsGeoExists() {
+            supportsGeoExists = true;
+            return this;
+        }
+
         public Builder supportNotQueryNormalForm() {
             this.supportNotQueryNormalForm = true;
             return this;
@@ -154,7 +167,7 @@ public class IndexFeatures {
         public IndexFeatures build() {
             return new IndexFeatures(supportsDocumentTTL, defaultStringMapping, Collections.unmodifiableSet(new HashSet<>(supportedMappings)),
                 wildcardField,  Collections.unmodifiableSet(new HashSet<>(supportedCardinalities)), supportsNanoseconds, supportsCustomAnalyzer,
-                supportsGeoContains, supportNotQueryNormalForm);
+                supportsGeoContains, supportsGeoExists, supportNotQueryNormalForm);
         }
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
@@ -19,6 +19,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.*;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.janusgraph.core.*;
+import org.janusgraph.core.attribute.Geoshape;
 import org.janusgraph.core.schema.Parameter;
 import org.janusgraph.core.schema.SchemaStatus;
 import org.janusgraph.diskstorage.configuration.Configuration;
@@ -114,6 +115,13 @@ public class IndexSerializer {
 
     public boolean supports(final MixedIndexType index, final ParameterIndexField field, final JanusGraphPredicate predicate) {
         return getMixedIndex(index).supports(getKeyInformation(field),predicate);
+    }
+
+    public boolean supportsExistsQuery(final MixedIndexType index, final ParameterIndexField field) {
+        if (Geoshape.class.equals(getKeyInformation(field).getDataType())) {
+            return getMixedIndex(index).getFeatures().supportsGeoExists();
+        }
+        return true;
     }
 
     public IndexFeatures features(final MixedIndexType index) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/index/AbstractIndexSelectionStrategy.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/index/AbstractIndexSelectionStrategy.java
@@ -23,6 +23,7 @@ import org.janusgraph.core.schema.SchemaStatus;
 import org.janusgraph.diskstorage.configuration.Configuration;
 import org.janusgraph.graphdb.database.IndexSerializer;
 import org.janusgraph.graphdb.internal.OrderList;
+import org.janusgraph.graphdb.query.JanusGraphPredicate;
 import org.janusgraph.graphdb.query.QueryUtil;
 import org.janusgraph.graphdb.query.condition.*;
 import org.janusgraph.graphdb.query.graph.JointIndexQuery;
@@ -209,7 +210,7 @@ public abstract class AbstractIndexSelectionStrategy implements IndexSelectionSt
             return false;
         }
         final PredicateCondition<RelationType, JanusGraphElement> atom = (PredicateCondition) condition;
-        if (atom.getValue() == null) {
+        if (atom.getValue() == null && atom.getPredicate() != Cmp.NOT_EQUAL) {
             return false;
         }
 
@@ -220,7 +221,11 @@ public abstract class AbstractIndexSelectionStrategy implements IndexSelectionSt
             .filter(field -> field.getStatus() == SchemaStatus.ENABLED)
             .filter(field -> field.getFieldKey().equals(key))
             .findAny().orElse(null);
-        return match != null && indexInfo.supports(index, match, atom.getPredicate());
+        if (match == null) {
+            return false;
+        }
+        boolean existsQuery = atom.getValue() == null && atom.getPredicate() == Cmp.NOT_EQUAL && indexInfo.supportsExistsQuery(index, match);
+        return existsQuery || indexInfo.supports(index, match, atom.getPredicate());
     }
 
     private Map.Entry<Condition,Collection<Object>> getEqualityConditionValues(

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
@@ -930,7 +930,9 @@ public class ElasticSearchIndex implements IndexProvider {
             Object value = atom.getValue();
             final String key = atom.getKey();
             final JanusGraphPredicate predicate = atom.getPredicate();
-            if (value instanceof Number) {
+            if (value == null && predicate == Cmp.NOT_EQUAL) {
+                return compat.exists(key);
+            } else if (value instanceof Number) {
                 Preconditions.checkArgument(predicate instanceof Cmp,
                         "Relation not supported on numeric types: " + predicate);
                 return getRelationFromCmp((Cmp) predicate, key, value);

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/compat/AbstractESCompat.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/compat/AbstractESCompat.java
@@ -49,6 +49,7 @@ public abstract class AbstractESCompat {
             .supportsCardinality(Cardinality.SET)
             .supportsNanoseconds()
             .supportsCustomAnalyzer()
+            .supportsGeoExists()
             .supportNotQueryNormalForm()
         ;
     }
@@ -137,6 +138,10 @@ public abstract class AbstractESCompat {
 
     public Map<String,Object> regexp(String key, Object value) {
         return ImmutableMap.of("regexp", ImmutableMap.of(key, value));
+    }
+
+    public Map<String,Object> exists(String key) {
+        return ImmutableMap.of("exists", ImmutableMap.of("field", key));
     }
 
     public Map<String,Object> match(String key, Object value) {

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/BerkeleyElasticsearchTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/BerkeleyElasticsearchTest.java
@@ -36,33 +36,13 @@ import static org.janusgraph.BerkeleyStorageSetup.getBerkeleyJEConfiguration;
  */
 
 @Testcontainers
-public class BerkeleyElasticsearchTest extends JanusGraphIndexTest {
-
-    @Container
-    private static JanusGraphElasticsearchContainer esr = new JanusGraphElasticsearchContainer();
-
-    public BerkeleyElasticsearchTest() {
-        super(true, true, true);
-    }
+public class BerkeleyElasticsearchTest extends ElasticsearchJanusGraphIndexTest {
 
     @Override
     public WriteConfiguration getConfiguration() {
         return esr.setConfiguration(getBerkeleyJEConfiguration(), INDEX)
             .set(GraphDatabaseConfiguration.INDEX_MAX_RESULT_SET_SIZE, 3, INDEX)
             .getConfiguration();
-    }
-
-    @Override
-    public boolean supportsLuceneStyleQueries() {
-        return true;
-    }
-    @Override
-    public boolean supportsWildcardQuery() {
-        return true;
-    }
-    @Override
-    protected boolean supportsCollections() {
-        return true;
     }
 
     /**

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/CQLElasticsearchTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/CQLElasticsearchTest.java
@@ -24,17 +24,10 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
-public class CQLElasticsearchTest extends JanusGraphIndexTest {
-
-    @Container
-    private static JanusGraphElasticsearchContainer esr = new JanusGraphElasticsearchContainer();
+public class CQLElasticsearchTest extends ElasticsearchJanusGraphIndexTest {
 
     @Container
     private static JanusGraphCassandraContainer cql = new JanusGraphCassandraContainer();
-
-    public CQLElasticsearchTest() {
-        super(true, true, true);
-    }
 
     @Override
     public WriteConfiguration getConfiguration() {
@@ -42,19 +35,6 @@ public class CQLElasticsearchTest extends JanusGraphIndexTest {
         return esr.setConfiguration(config, INDEX)
             .set(GraphDatabaseConfiguration.INDEX_MAX_RESULT_SET_SIZE, 3, INDEX)
             .getConfiguration();
-    }
-
-    @Override
-    public boolean supportsLuceneStyleQueries() {
-        return true;
-    }
-    @Override
-    public boolean supportsWildcardQuery() {
-        return true;
-    }
-    @Override
-    protected boolean supportsCollections() {
-        return true;
     }
 
     @Override

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticsearchJanusGraphIndexTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticsearchJanusGraphIndexTest.java
@@ -1,0 +1,48 @@
+// Copyright 2020 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.es;
+
+import org.janusgraph.graphdb.JanusGraphIndexTest;
+import org.testcontainers.junit.jupiter.Container;
+
+public abstract class ElasticsearchJanusGraphIndexTest extends JanusGraphIndexTest {
+
+    @Container
+    protected static JanusGraphElasticsearchContainer esr = new JanusGraphElasticsearchContainer();
+
+    public ElasticsearchJanusGraphIndexTest() {
+        super(true, true, true);
+    }
+
+    @Override
+    public boolean supportsLuceneStyleQueries() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsWildcardQuery() {
+        return true;
+    }
+
+    @Override
+    protected boolean supportsCollections() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsGeoPointExistsQuery() {
+        return true;
+    }
+}

--- a/janusgraph-lucene/src/main/java/org/janusgraph/diskstorage/lucene/LuceneIndex.java
+++ b/janusgraph-lucene/src/main/java/org/janusgraph/diskstorage/lucene/LuceneIndex.java
@@ -702,7 +702,12 @@ public class LuceneIndex implements IndexProvider {
             final String key = atom.getKey();
             KeyInformation ki = information.get(key);
             final JanusGraphPredicate janusgraphPredicate = atom.getPredicate();
-            if (value instanceof Number) {
+            if (value == null && janusgraphPredicate == Cmp.NOT_EQUAL) {
+                // some fields like Integer omit norms but have docValues
+                params.addQuery(new DocValuesFieldExistsQuery(key), BooleanClause.Occur.SHOULD);
+                // some fields like Text have no docValue but have norms
+                params.addQuery(new NormsFieldExistsQuery(key), BooleanClause.Occur.SHOULD);
+            } else if (value instanceof Number) {
                 Preconditions.checkArgument(janusgraphPredicate instanceof Cmp, "Relation not supported on numeric types: " + janusgraphPredicate);
                 params.addQuery(numericQuery(key, (Cmp) janusgraphPredicate, (Number) value));
             } else if (value instanceof String) {

--- a/janusgraph-lucene/src/test/java/org/janusgraph/diskstorage/lucene/BerkeleyLuceneTest.java
+++ b/janusgraph-lucene/src/test/java/org/janusgraph/diskstorage/lucene/BerkeleyLuceneTest.java
@@ -51,6 +51,11 @@ public class BerkeleyLuceneTest extends JanusGraphIndexTest {
     }
 
     @Override
+    public boolean supportsGeoPointExistsQuery() {
+        return false;
+    }
+
+    @Override
     public boolean supportsWildcardQuery() {
         return false;
     }

--- a/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
+++ b/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
@@ -719,7 +719,9 @@ public class SolrIndex implements IndexProvider {
             final String key = atom.getKey();
             final JanusGraphPredicate predicate = atom.getPredicate();
 
-            if (value instanceof Number) {
+            if (value == null && predicate == Cmp.NOT_EQUAL) {
+                return key + ":*";
+            } else if (value instanceof Number) {
                 final String queryValue = escapeValue(value);
                 Preconditions.checkArgument(predicate instanceof Cmp,
                         "Relation not supported on numeric types: " + predicate);

--- a/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrJanusGraphIndexTest.java
+++ b/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrJanusGraphIndexTest.java
@@ -38,6 +38,11 @@ public abstract class SolrJanusGraphIndexTest extends JanusGraphIndexTest {
         return true;
     }
 
+    @Override
+    public boolean supportsGeoPointExistsQuery() {
+        return false;
+    }
+
     @Test
     public void testRawQueries() {
         clopen(option(SolrIndex.DYNAMIC_FIELDS,JanusGraphIndexTest.INDEX),false);

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphStepStrategyTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphStepStrategyTest.java
@@ -21,6 +21,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.DefaultGraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.IsStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.OrStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeGlobalStep;
@@ -67,6 +68,7 @@ import java.util.stream.Stream;
 import static org.apache.tinkerpop.gremlin.process.traversal.P.eq;
 import static org.apache.tinkerpop.gremlin.process.traversal.P.gt;
 import static org.apache.tinkerpop.gremlin.process.traversal.P.lt;
+import static org.apache.tinkerpop.gremlin.process.traversal.P.neq;
 import static org.apache.tinkerpop.gremlin.process.traversal.P.within;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.filter;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.properties;
@@ -205,19 +207,19 @@ public class JanusGraphStepStrategyTest {
             arguments(g.V().has("name", "marko").has("age", gt(31).and(lt(10).or(gt(40)))).out(),
                 g_V("name", eq("marko"), "age", new OrP<Integer>(Arrays.asList(gt(31), new AndP<Integer>(Arrays.asList(lt(10), gt(40)))))).out(), Collections.emptyList()),
             arguments(g.V().has("name", "marko").or(has("age"), has("age", gt(32))).has("lang", "java"),
-                g_V("name", eq("marko"), "lang", eq("java")).or(has("age"), has("age", gt(32))), Collections.singletonList(FilterRankingStrategy.instance())),
+                g_V("name", eq("marko"), "lang", eq("java"), __.or(g_V("age", neq(null)), g_V("age", gt(32)))), Collections.singletonList(FilterRankingStrategy.instance())),
             arguments(g.V().has("name", "marko").as("a").or(has("age"), has("age", gt(32))).has("lang", "java"),
-                g_V("name", eq("marko")).as("a").or(has("age"), has("age", gt(32))).has("lang", "java"), Collections.emptyList()),
+                g_V("name", eq("marko"), __.or(g_V("age", neq(null)), g_V("age", gt(32))), "lang", eq("java")).as("a"), Collections.emptyList()),
             arguments(g.V().has("name", "marko").as("a").or(has("age"), has("age", gt(32))).has("lang", "java"),
-                g_V("name", eq("marko"), "lang", eq("java")).or(has("age"), has("age", gt(32))).as("a"), Collections.singletonList(FilterRankingStrategy.instance())),
+                g_V("name", eq("marko"), "lang", eq("java"), __.or(g_V("age", neq(null)), g_V("age", gt(32)))).as("a"), Collections.singletonList(FilterRankingStrategy.instance())),
             arguments(g.V().dedup().has("name", "marko").or(has("age"), has("age", gt(32))).has("lang", "java"),
-                g_V("name", eq("marko"), "lang", eq("java")).or(has("age"), has("age", gt(32))).dedup(), Collections.singletonList(FilterRankingStrategy.instance())),
+                g_V("name", eq("marko"), "lang", eq("java"), __.or(g_V("age", neq(null)), g_V("age", gt(32)))).dedup(), Collections.singletonList(FilterRankingStrategy.instance())),
             arguments(g.V().as("a").dedup().has("name", "marko").or(has("age"), has("age", gt(32))).has("lang", "java"),
-                g_V("name", eq("marko"), "lang", eq("java")).or(has("age"), has("age", gt(32))).dedup().as("a"), Collections.singletonList(FilterRankingStrategy.instance())),
+                g_V("name", eq("marko"), "lang", eq("java"), __.or(g_V("age", neq(null)), g_V("age", gt(32)))).dedup().as("a"), Collections.singletonList(FilterRankingStrategy.instance())),
             arguments(g.V().as("a").has("name", "marko").as("b").or(has("age"), has("age", gt(32))).has("lang", "java"),
-                g_V("name", eq("marko"), "lang", eq("java")).or(has("age"), has("age", gt(32))).as("b", "a"), Collections.singletonList(FilterRankingStrategy.instance())),
+                g_V("name", eq("marko"), "lang", eq("java"), __.or(g_V("age", neq(null)), g_V("age", gt(32)))).as("b", "a"), Collections.singletonList(FilterRankingStrategy.instance())),
             arguments(g.V().as("a").dedup().has("name", "marko").or(has("age"), has("age", gt(32))).filter(has("name", "bob")).has("lang", "java"),
-                g_V("name", eq("marko"), "lang", eq("java"), "name", eq("bob")).or(has("age"), has("age", gt(32))).dedup().as("a"), Arrays.asList(InlineFilterStrategy.instance(), FilterRankingStrategy.instance())),
+                g_V("name", eq("marko"), "lang", eq("java"), "name", eq("bob"), __.or(g_V("age", neq(null)), g_V("age", gt(32)))).dedup().as("a"), Arrays.asList(InlineFilterStrategy.instance(), FilterRankingStrategy.instance())),
             arguments(g.V().has("name", "marko").or(not(has("age")), has("age", gt(32))).has("name", "bob").has("lang", "java"),
                 g_V("name", eq("marko"), "name", eq("bob"), "lang", eq("java")).or(not(filter(properties("age"))), has("age", gt(32))), TraversalStrategies.GlobalCache.getStrategies(JanusGraph.class).toList()),
             arguments(g.V().has("name", eq("marko").and(eq("bob").and(eq("stephen")))).out("knows"),


### PR DESCRIPTION
Currently, has(key) query does not use index at all. This commit
tries to use mixed index if possible. Geoshape type exists query
is not supported by Lucene and Solr index backends.

Related to #284

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

