### PR TITLE
Optimize performance of transaction-wise index query cache

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -4459,7 +4459,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
                 case "optimization":
                     assertNull(subMetric.getCount(TraversalMetrics.ELEMENT_COUNT_ID));
                     break;
-                case "backend-query":
+                case QueryProfiler.BACKEND_QUERY:
                     if (fromCache) fail("Should not execute backend-queries when cached");
                     assertTrue(subMetric.getCount(TraversalMetrics.ELEMENT_COUNT_ID) > 0);
                     break;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/QueryProfiler.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/QueryProfiler.java
@@ -42,6 +42,7 @@ public interface QueryProfiler {
 
     String OR_QUERY = "OR-query";
     String AND_QUERY = "AND-query";
+    String BACKEND_QUERY = "backend-query";
     String OPTIMIZATION = "optimization";
 
     QueryProfiler NO_OP = new QueryProfiler() {
@@ -88,7 +89,7 @@ public interface QueryProfiler {
     }
 
     static<Q extends Query,R extends Collection> R profile(QueryProfiler profiler, Q query, boolean multiQuery, Function<Q,R> queryExecutor) {
-        return profile("backend-query",profiler,query,multiQuery,queryExecutor);
+        return profile(BACKEND_QUERY,profiler,query,multiQuery,queryExecutor);
     }
 
     static<Q extends Query,R extends Collection> R profile(String groupName, QueryProfiler profiler, Q query, boolean multiQuery, Function<Q,R> queryExecutor) {
@@ -113,7 +114,7 @@ public interface QueryProfiler {
     }
 
     static QueryProfiler startProfile(QueryProfiler profiler, Subquery query) {
-        final QueryProfiler sub = profiler.addNested("backend-query");
+        final QueryProfiler sub = profiler.addNested(BACKEND_QUERY);
         sub.setAnnotation(QUERY_ANNOTATION, query);
         if (query.hasLimit()) sub.setAnnotation(LIMIT_ANNOTATION,query.getLimit());
         sub.startTimer();

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/subquerycache/GuavaSubqueryCache.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/subquerycache/GuavaSubqueryCache.java
@@ -1,0 +1,53 @@
+// Copyright 2020 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.transaction.subquerycache;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.Weigher;
+import org.janusgraph.graphdb.query.graph.JointIndexQuery;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+/**
+ * @author Boxuan Li (liboxuan@connect.hku.hk)
+ */
+public class GuavaSubqueryCache extends SubsetSubqueryCache {
+    private Cache<JointIndexQuery.Subquery, SubqueryResult> guavaCache;
+
+    public GuavaSubqueryCache(int concurrencyLevel, long maximumWeight) {
+        guavaCache = CacheBuilder.newBuilder()
+            .weigher((Weigher<JointIndexQuery.Subquery, SubqueryResult>) (q, r) -> 2 + r.size())
+            .concurrencyLevel(concurrencyLevel).maximumWeight(maximumWeight).build();
+    }
+
+    @Override
+    protected SubqueryResult get(JointIndexQuery.Subquery key) {
+        return guavaCache.getIfPresent(key);
+    }
+
+    @Override
+    protected void put(JointIndexQuery.Subquery key, SubqueryResult result) {
+        guavaCache.put(key, result);
+    }
+
+    @Override
+    public synchronized void close() {
+        guavaCache.invalidateAll();
+        guavaCache.cleanUp();
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/subquerycache/SubqueryCache.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/subquerycache/SubqueryCache.java
@@ -1,0 +1,64 @@
+// Copyright 2020 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.transaction.subquerycache;
+
+import org.janusgraph.graphdb.query.graph.JointIndexQuery;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * Cache for {@link JointIndexQuery.Subquery} results. Cache entries are manually added using
+ * {@link #get(JointIndexQuery.Subquery, Callable)} or {@link #put(JointIndexQuery.Subquery, List)},
+ * and stored in the cache until evicted or invalidated.
+*
+ * @author Boxuan Li (liboxuan@connect.hku.hk)
+ */
+public interface SubqueryCache {
+
+    /**
+     * Return a list of results if given query exists in cache, otherwise
+     * return null
+     *
+     * @param query a subquery of joint index query
+     * @return a list of matching results or null if is not in the cache
+     */
+    List<Object> getIfPresent(JointIndexQuery.Subquery query);
+
+    /**
+     * Add given values into cache
+     *
+     * @param query  a subquery of joint index query
+     * @param values a list of results to be cached
+     */
+    void put(JointIndexQuery.Subquery query, List<Object> values);
+
+    /**
+     * Returns a list of results. If given query not in cache, call the
+     * value loader to retrieve results and put into the cache
+     *
+     * @param query       a subquery of joint index query
+     * @param valueLoader a callable that returns a list of results
+     * @return a list of results
+     * @throws Exception if exception thrown when calling the value loader
+     */
+    List<Object> get(JointIndexQuery.Subquery query, Callable<? extends List<Object>> valueLoader) throws Exception;
+
+    /**
+     * Closes the cache which allows the cache to release allocated memory.
+     * Calling any of the other methods after closing a cache has undetermined behavior.
+     */
+    void close();
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/subquerycache/SubsetSubqueryCache.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/subquerycache/SubsetSubqueryCache.java
@@ -1,0 +1,99 @@
+// Copyright 2020 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.transaction.subquerycache;
+
+import org.janusgraph.graphdb.query.graph.JointIndexQuery;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * Different from a simple exact mapping from keys to values,
+ * it leverages the fact that the results of a Subquery A with limit X are first X entries of the results of the
+ * a Subquery B with limit Y, where A and B only differ in limit, and X is less than or equal to Y.
+ * <p>
+ * For example, suppose the cache is empty at the beginning. Firstly, prop1_idx:multiKSQ[1]@100 query leads to a cache
+ * miss, and then results are loaded into cache. Secondly, prop1_idx:multiKSQ[1]@20 query leads to a cache hit, and
+ * then first 20 results of cached responses are returned. Thirdly, prop1_idx:multiKSQ[1]@2000 leads to a cache miss,
+ * then results are loaded into cache, and initial results saved by prop1_idx:multiKSQ[1]@100 query are overriden by
+ * the new results.
+ * <p>
+ * Internally, raw query results are encapsulated in {@link SubqueryResult} object together with limit of the query.
+ * Meanwhile, keys are stored without limit (or with a dummy limit). Whenever there is a hit for key, the limit of
+ * cached results and that of the query will be compared, and whether this is a cache hit or miss will be determined.
+ * <p>
+ * Compared to a simply {@link JointIndexQuery.Subquery} to {@code List<Object>} mapping, this cache has two benefits:
+ * 1) it reduces latency, as "subset" queries can effectively leverage cached results.
+ * 2) it saves space, as queries only differing in limit will not be saved more than once in cache.
+ *
+ * @author Boxuan Li (liboxuan@connect.hku.hk)
+ */
+public abstract class SubsetSubqueryCache implements SubqueryCache {
+
+    protected abstract SubqueryResult get(JointIndexQuery.Subquery key);
+
+    protected abstract void put(JointIndexQuery.Subquery key, SubqueryResult result);
+
+    @Override
+    public List<Object> getIfPresent(JointIndexQuery.Subquery key) {
+        int limit = key.getLimit();
+        JointIndexQuery.Subquery noLimitKey = key.updateLimit(0);
+        SubqueryResult result = get(noLimitKey);
+        if (result != null && (result.getQueryLimit() >= limit || result.getQueryLimit() > result.size())) {
+            return result.getValues().subList(0, Math.min(limit, result.size()));
+        }
+        return null;
+    }
+
+    @Override
+    public void put(JointIndexQuery.Subquery key, List<Object> values) {
+        int limit = key.getLimit();
+        JointIndexQuery.Subquery noLimitKey = key.updateLimit(0);
+        put(noLimitKey, new SubqueryResult(values, limit));
+    }
+
+    @Override
+    public List<Object> get(JointIndexQuery.Subquery key, Callable<? extends List<Object>> valueLoader) throws Exception {
+        List<Object> values = getIfPresent(key);
+        if (values == null) {
+            values = valueLoader.call();
+            put(key, values);
+        }
+        return values;
+    }
+
+    class SubqueryResult {
+        private List<Object> values;
+        private int queryLimit;
+
+        protected SubqueryResult(List<Object> values, int queryLimit) {
+            this.values = values;
+            this.queryLimit = queryLimit;
+        }
+
+        public List<Object> getValues() {
+            return values;
+        }
+
+        public int getQueryLimit() {
+            return queryLimit;
+        }
+
+        public int size() {
+            return values.size();
+        }
+    }
+}
+

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/SubqueryIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/SubqueryIterator.java
@@ -30,7 +30,8 @@ import org.janusgraph.graphdb.database.IndexSerializer;
 import org.janusgraph.graphdb.query.graph.JointIndexQuery;
 import org.janusgraph.graphdb.query.profile.QueryProfiler;
 
-import com.google.common.cache.Cache;
+import org.janusgraph.graphdb.transaction.subquerycache.GuavaSubqueryCache;
+import org.janusgraph.graphdb.transaction.subquerycache.SubqueryCache;
 
 /**
  * @author davidclement90@laposte.net
@@ -39,7 +40,7 @@ public class SubqueryIterator extends CloseableAbstractIterator<JanusGraphElemen
 
     private final JointIndexQuery.Subquery subQuery;
 
-    private final Cache<JointIndexQuery.Subquery, List<Object>> indexCache;
+    private final SubqueryCache indexCache;
 
     private Iterator<? extends JanusGraphElement> elementIterator;
 
@@ -50,8 +51,8 @@ public class SubqueryIterator extends CloseableAbstractIterator<JanusGraphElemen
     private boolean isTimerRunning;
 
     public SubqueryIterator(JointIndexQuery.Subquery subQuery, IndexSerializer indexSerializer, BackendTransaction tx,
-            Cache<JointIndexQuery.Subquery, List<Object>> indexCache, int limit,
-            Function<Object, ? extends JanusGraphElement> function, List<Object> otherResults) {
+                            SubqueryCache indexCache, int limit,
+                            Function<Object, ? extends JanusGraphElement> function, List<Object> otherResults) {
         this.subQuery = subQuery;
         this.indexCache = indexCache;
         final List<Object> cacheResponse = indexCache.getIfPresent(subQuery);


### PR DESCRIPTION
This refactors indexCache used in transaction which caches index query results.
Now indexCache supports subset query, i.e., cached query responses can be
leveraged if new query and cached query only differ in limit.

Closes #2194

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

