### PR TITLE
Allow nesting CONTAIN predicates with and/or

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -4029,6 +4029,72 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertFalse(graph.traversal().V(vertexIdToBeDeleted).hasNext());
     }
 
+    @Test
+    public void testNestedContainPredicates() {
+        int graphSize = 10;
+        for (int i = 0; i < graphSize; ++i) {
+            graph.addVertex("id", i);
+        }
+        GraphTraversalSource g = graph.traversal();
+
+        /*
+         P.within
+         */
+
+        // unnested
+        assertEquals(3, g.V().has("id", P.within(4, 5, 6)).count().next());
+        assertEquals(0, g.V().has("id", P.within()).count().next());
+
+        // or
+        assertEquals(3, g.V().or(__.has("id", P.within(2, 3, 4))).count().next());
+        assertEquals(6, g.V().or(__.has("id", P.within(2, 3, 4)), __.has("id", P.within(6, 7, 8))).count().next());
+        assertEquals(5, g.V().or(__.has("id", P.within(2, 3, 4)), __.has("id", P.within(4, 5, 6))).count().next());
+        assertEquals(3, g.V().or(__.has("id", P.within(2, 3, 4)), __.has("id", P.within())).count().next());
+
+        // and
+        assertEquals(3, g.V().and(__.has("id", P.within(2, 3, 4))).count().next());
+        assertEquals(0, g.V().and(__.has("id", P.within(2, 3, 4)), __.has("id", P.within(6, 7, 8))).count().next());
+        assertEquals(1, g.V().and(__.has("id", P.within(2, 3, 4)), __.has("id", P.within(4, 5, 6))).count().next());
+        assertEquals(0, g.V().and(__.has("id", P.within(2, 3, 4)), __.has("id", P.within())).count().next());
+
+        /*
+         P.without
+         */
+
+        // unnested
+        assertEquals(graphSize - 3, g.V().has("id", P.without(4, 5, 6)).count().next());
+        assertEquals(graphSize, g.V().has("id", P.without()).count().next());
+
+        // or
+        assertEquals(graphSize - 3, g.V().or(__.has("id", P.without(2, 3, 4))).count().next());
+        assertEquals(graphSize, g.V().or(__.has("id", P.without(2, 3, 4)), __.has("id", P.without(6, 7, 8))).count().next());
+        assertEquals(graphSize - 1, g.V().or(__.has("id", P.without(2, 3, 4)), __.has("id", P.without(4, 5, 6))).count().next());
+        assertEquals(graphSize, g.V().or(__.has("id", P.without(2, 3, 4)), __.has("id", P.without())).count().next());
+
+        // and
+        assertEquals(graphSize - 3, g.V().and(__.has("id", P.without(2, 3, 4))).count().next());
+        assertEquals(graphSize - 6, g.V().and(__.has("id", P.without(2, 3, 4)), __.has("id", P.without(6, 7, 8))).count().next());
+        assertEquals(graphSize - 5, g.V().and(__.has("id", P.without(2, 3, 4)), __.has("id", P.without(4, 5, 6))).count().next());
+        assertEquals(graphSize - 3, g.V().and(__.has("id", P.without(2, 3, 4)), __.has("id", P.without())).count().next());
+
+        /*
+         both P.within and P.without
+         */
+
+        // or
+        assertEquals(graphSize - 3, g.V().or(__.has("id", P.within(2, 3, 4)), __.has("id", P.without(6, 7, 8))).count().next());
+        assertEquals(graphSize - 2, g.V().or(__.has("id", P.within(2, 3, 4)), __.has("id", P.without(4, 5, 6))).count().next());
+        assertEquals(graphSize, g.V().or(__.has("id", P.within(2, 3, 4)), __.has("id", P.without(2, 3, 4))).count().next());
+        assertEquals(graphSize, g.V().or(__.has("id", P.within(2, 3, 4)), __.has("id", P.without())).count().next());
+        assertEquals(graphSize - 3, g.V().or(__.has("id", P.within()), __.has("id", P.without(2, 3, 4))).count().next());
+
+        // and
+        assertEquals(3, g.V().and(__.has("id", P.within(2, 3, 4)), __.has("id", P.without(6, 7, 8))).count().next());
+        assertEquals(2, g.V().and(__.has("id", P.within(2, 3, 4)), __.has("id", P.without(4, 5, 6))).count().next());
+        assertEquals(0, g.V().and(__.has("id", P.within(2, 3, 4)), __.has("id", P.without(2, 3, 4))).count().next());
+        assertEquals(3, g.V().and(__.has("id", P.within(2, 3, 4)), __.has("id", P.without())).count().next());
+        assertEquals(0, g.V().and(__.has("id", P.within()), __.has("id", P.without(2, 3, 4))).count().next());
+    }
 
     @Test
     public void testTinkerPopCardinality() {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/QueryUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/QueryUtil.java
@@ -220,7 +220,28 @@ public class QueryUtil {
     private static <E extends JanusGraphElement> And<E> addConstraint(final RelationType type, AndJanusPredicate predicate, List<Object> values, And<E> and, StandardJanusGraphTx tx) {
         for (int i = 0 ; i < values.size(); i++) {
             final JanusGraphPredicate janusGraphPredicate = predicate.get(i);
-            if (janusGraphPredicate instanceof AndJanusPredicate) {
+            if (janusGraphPredicate instanceof Contain) {
+                //Rewrite contains conditions
+                final Collection childValues = (Collection) values.get(i);
+                if (janusGraphPredicate == Contain.NOT_IN) {
+                    if (childValues.isEmpty()) continue; //Simply ignore since trivially satisfied
+                    for (final Object inValue : childValues)
+                        addConstraint(type, Cmp.NOT_EQUAL, inValue, and, tx);
+                } else {
+                    Preconditions.checkArgument(janusGraphPredicate == Contain.IN);
+                    if (childValues.isEmpty()) {
+                        return null; //Cannot be satisfied
+                    }
+                    if (childValues.size() == 1) {
+                        addConstraint(type, Cmp.EQUAL, childValues.iterator().next(), and, tx);
+                    } else {
+                        final Or<E> nested = new Or<>(childValues.size());
+                        for (final Object inValue : childValues)
+                            addConstraint(type, Cmp.EQUAL, inValue, nested, tx);
+                        and.add(nested);
+                    }
+                }
+            } else if (janusGraphPredicate instanceof AndJanusPredicate) {
                 if (addConstraint(type, (AndJanusPredicate) (janusGraphPredicate), (List<Object>) (values.get(i)), and, tx) == null) {
                     return null;
                 }
@@ -241,7 +262,30 @@ public class QueryUtil {
     private static <E extends JanusGraphElement> Or<E> addConstraint(final RelationType type, OrJanusPredicate predicate, List<Object> values, Or<E> or, StandardJanusGraphTx tx) {
         for (int i = 0 ; i < values.size(); i++) {
             final JanusGraphPredicate janusGraphPredicate = predicate.get(i);
-            if (janusGraphPredicate instanceof AndJanusPredicate) {
+            if (janusGraphPredicate instanceof Contain) {
+                //Rewrite contains conditions
+                final Collection childValues = (Collection) values.get(i);
+                if (janusGraphPredicate == Contain.NOT_IN) {
+                    if (childValues.size() == 1) {
+                        addConstraint(type, Cmp.NOT_EQUAL, childValues.iterator().next(), or, tx);
+                    }
+                    // Don't need to handle the case where childValues is empty, because it defaults to
+                    // an or(and()) is added, which is a tautology
+                    final And<E> nested = new And<>(childValues.size());
+                    for (final Object inValue : childValues) {
+                        addConstraint(type, Cmp.NOT_EQUAL, inValue, nested, tx);
+                    }
+                    or.add(nested);
+                } else {
+                    Preconditions.checkArgument(janusGraphPredicate == Contain.IN);
+                    if (childValues.isEmpty()) {
+                        continue; // Handle any unsatisfiable condition that occurs within an OR statement like it does not exist
+                    }
+                    for (final Object inValue : childValues) {
+                        addConstraint(type, Cmp.EQUAL, inValue, or, tx);
+                    }
+                }
+            } else if (janusGraphPredicate instanceof AndJanusPredicate) {
                 final List<Object> childValues = (List<Object>) (values.get(i));
                 final And<E> nested = addConstraint(type, (AndJanusPredicate) janusGraphPredicate, childValues, new And<>(childValues.size()), tx);
                 if (nested == null) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/condition/PredicateCondition.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/condition/PredicateCondition.java
@@ -106,7 +106,7 @@ public class PredicateCondition<K, E extends JanusGraphElement> extends Literal<
             return false;
 
         PredicateCondition oth = (PredicateCondition) other;
-        return key.equals(oth.key) && predicate.equals(oth.predicate) && value.equals(oth.value);
+        return key.equals(oth.key) && predicate.equals(oth.predicate) && Objects.equals(value, oth.value);
     }
 
     @Override


### PR DESCRIPTION
Fixes #2188

The needed changes are already described in #2188. To solve this issue, it was also necessary to alter the definition of two `PredicateCondition`s being equal to each other. Nesting `P.without()` predicates on a property value within an `and()` step automatically adds a `PredicateCondition` that this property value must not equal `null`. Therefore, `PredicateCondition` should handle `null` values on equality checks.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

