### PR TITLE
Add strategy that optimize mixed index lookup followed by count step

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/IndexMetricTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/IndexMetricTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.janusgraph.diskstorage.Backend.METRICS_INDEX_PROVIDER_NAME;
+import static org.janusgraph.diskstorage.util.MetricInstrumentedIndexProvider.M_MIXED_COUNT_QUERY;
 import static org.janusgraph.diskstorage.util.MetricInstrumentedIndexProvider.M_MUTATE;
 import static org.janusgraph.diskstorage.util.MetricInstrumentedIndexProvider.M_QUERY;
 import static org.janusgraph.diskstorage.util.MetricInstrumentedIndexProvider.M_RAW_QUERY;
@@ -60,13 +61,14 @@ public abstract class IndexMetricTest extends JanusGraphBaseTest {
         graph.tx().commit();
         graph.traversal().V().has("p1", "value").iterate();
         graph.traversal().V().has("p2", "value").iterate();
+        graph.traversal().V().has("p1", "value").count().next();
         graph.indexQuery("idx", "p1:*").vertexTotals();
         graph.indexQuery("idx", "p1:*").vertexStream();
 
         Assertions.assertThrows(JanusGraphException.class,  () ->
             graph.indexQuery("idx", "!@#$%^").vertexTotals());
 
-        verifyIndexMetrics("search", METRICS_INDEX_PREFIX, ImmutableMap.of(M_MUTATE, 1L, M_QUERY, 1L, M_TOTALS, 2L, M_RAW_QUERY, 1L));
+        verifyIndexMetrics("search", METRICS_INDEX_PREFIX, ImmutableMap.of(M_MUTATE, 1L, M_QUERY, 1L, M_MIXED_COUNT_QUERY, 1L, M_TOTALS, 2L, M_RAW_QUERY, 1L));
         assertEquals(1, metric.getCounter(METRICS_INDEX_PREFIX, "search", M_TOTALS, MetricInstrumentedStore.M_EXCEPTIONS).getCount());
     }
 

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/TestMockIndexProvider.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/TestMockIndexProvider.java
@@ -84,6 +84,11 @@ public class TestMockIndexProvider implements IndexProvider {
     }
 
     @Override
+    public Long queryCount(IndexQuery query, KeyInformation.IndexRetriever information, BaseTransaction tx) throws BackendException {
+        return index.queryCount(query, information, tx);
+    }
+
+    @Override
     public Stream<RawQuery.Result<String>> query(RawQuery query, KeyInformation.IndexRetriever information, BaseTransaction tx) throws BackendException {
         return index.query(query, information,tx);
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/core/MixedIndexCountQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/MixedIndexCountQuery.java
@@ -1,0 +1,30 @@
+// Copyright 2020 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core;
+
+import org.janusgraph.graphdb.query.profile.ProfileObservable;
+
+/**
+ * @author Boxuan Li (liboxuan@connect.hku.hk)
+ */
+public interface MixedIndexCountQuery extends ProfileObservable {
+
+    /**
+     * Fire a count query against index backend to retrieve total number of satisfying elements
+     *
+     * @return total elements that match the query
+     */
+    Long executeTotals();
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/Transaction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/Transaction.java
@@ -16,6 +16,7 @@ package org.janusgraph.core;
 
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.janusgraph.core.schema.SchemaManager;
+import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 
 import java.util.Collection;
 
@@ -63,6 +64,12 @@ public interface Transaction extends Graph, SchemaManager {
      * @see JanusGraph#query()
      */
     JanusGraphQuery<? extends JanusGraphQuery> query();
+
+    /**
+     * @return a mixed index count query which leverages mixed index for counts
+     * @see StandardJanusGraphTx#mixedIndexCountQuery()
+     */
+    MixedIndexCountQuery mixedIndexCountQuery();
 
     /**
      * Returns a {@link org.janusgraph.core.JanusGraphIndexQuery} to query for vertices or edges against the specified indexing backend using

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/BackendTransaction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/BackendTransaction.java
@@ -421,6 +421,22 @@ public class BackendTransaction implements LoggableTransaction {
         });
     }
 
+    public Long indexQueryCount(final String index, final IndexQuery query) {
+        final IndexTransaction indexTx = getIndexTransaction(index);
+        return executeRead(new Callable<Long>() {
+            @Override
+            public Long call() throws Exception {
+                return indexTx.queryCount(query);
+            }
+
+            @Override
+            public String toString() {
+                return "indexQueryCount";
+            }
+        });
+
+    }
+
     public Stream<RawQuery.Result<String>> rawQuery(final String index, final RawQuery query) {
         final IndexTransaction indexTx = getIndexTransaction(index);
         return executeRead(new Callable<Stream<RawQuery.Result<String>>>() {

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexProvider.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexProvider.java
@@ -84,6 +84,8 @@ public interface IndexProvider extends IndexInformation {
      */
     void restore(Map<String,Map<String, List<IndexEntry>>> documents, KeyInformation.IndexRetriever information, BaseTransaction tx) throws BackendException;
 
+    Long queryCount(IndexQuery query, KeyInformation.IndexRetriever information, BaseTransaction tx) throws BackendException;
+
     /**
      * Executes the given query against the index.
      *

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexTransaction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexTransaction.java
@@ -110,6 +110,10 @@ public class IndexTransaction implements BaseTransaction, LoggableTransaction {
         return index.query(query, keyInformation, indexTx);
     }
 
+    public Long queryCount(IndexQuery query) throws BackendException {
+        return index.queryCount(query, keyInformation, indexTx);
+    }
+
     /**
      * @deprecated use {@link #queryStream(RawQuery query)} instead.
      */

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/MetricInstrumentedIndexProvider.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/MetricInstrumentedIndexProvider.java
@@ -42,13 +42,14 @@ public class MetricInstrumentedIndexProvider implements IndexProvider {
     public static final String M_MUTATE = "mutate";
     public static final String M_RESTORE = "restore";
     public static final String M_QUERY = "query";
+    public static final String M_MIXED_COUNT_QUERY = "mixedIndexCountQuery";
     public static final String M_RAW_QUERY = "rawQuery";
     public static final String M_TOTALS = "totals";
     public static final String M_CALLS = "calls";
     public static final String M_TIME = "time";
     public static final String M_EXCEPTIONS = "exceptions";
     public static final List<String> OPERATION_NAMES = Collections.unmodifiableList(
-        Arrays.asList(M_MUTATE, M_RESTORE, M_QUERY, M_RAW_QUERY, M_TOTALS));
+        Arrays.asList(M_MUTATE, M_RESTORE, M_QUERY, M_MIXED_COUNT_QUERY, M_RAW_QUERY, M_TOTALS));
 
     public MetricInstrumentedIndexProvider(final IndexProvider indexProvider, String prefix) {
         this.indexProvider = indexProvider;
@@ -71,6 +72,11 @@ public class MetricInstrumentedIndexProvider implements IndexProvider {
         final Map<String, Map<String, List<IndexEntry>>> documents, final KeyInformation.IndexRetriever information,
         final BaseTransaction tx) throws BackendException {
         runWithMetrics((BaseTransactionConfigurable) tx, M_RESTORE, () -> indexProvider.restore(documents, information, tx));
+    }
+
+    @Override
+    public Long queryCount(IndexQuery query, KeyInformation.IndexRetriever information, BaseTransaction tx) throws BackendException {
+        return runWithMetrics((BaseTransactionConfigurable) tx, M_MIXED_COUNT_QUERY, () -> indexProvider.queryCount(query, information, tx));
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
@@ -588,6 +588,12 @@ public class IndexSerializer {
         }
     }
 
+    public Long queryCount(final JointIndexQuery.Subquery query, final BackendTransaction tx) {
+        final IndexType index = query.getIndex();
+        assert index.isMixedIndex();
+        return tx.indexQueryCount(index.getBackingIndexName(), query.getMixedQuery());
+    }
+
     public MultiKeySliceQuery getQuery(final CompositeIndexType index, List<Object[]> values) {
         final List<KeySliceQuery> ksqs = new ArrayList<>(values.size());
         for (final Object[] value : values) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/StandardJanusGraph.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/StandardJanusGraph.java
@@ -83,6 +83,7 @@ import org.janusgraph.graphdb.tinkerpop.JanusGraphBlueprintsGraph;
 import org.janusgraph.graphdb.tinkerpop.JanusGraphFeatures;
 import org.janusgraph.graphdb.tinkerpop.optimize.strategy.AdjacentVertexFilterOptimizerStrategy;
 import org.janusgraph.graphdb.tinkerpop.optimize.strategy.AdjacentVertexHasIdOptimizerStrategy;
+import org.janusgraph.graphdb.tinkerpop.optimize.strategy.JanusGraphMixedIndexCountStrategy;
 import org.janusgraph.graphdb.tinkerpop.optimize.strategy.AdjacentVertexHasUniquePropertyOptimizerStrategy;
 import org.janusgraph.graphdb.tinkerpop.optimize.strategy.AdjacentVertexIsOptimizerStrategy;
 import org.janusgraph.graphdb.tinkerpop.optimize.strategy.JanusGraphIoRegistrationStrategy;
@@ -136,6 +137,7 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
                                AdjacentVertexHasUniquePropertyOptimizerStrategy.instance(),
                                JanusGraphLocalQueryOptimizerStrategy.instance(),
                                JanusGraphMultiQueryStrategy.instance(),
+                               JanusGraphMixedIndexCountStrategy.instance(),
                                JanusGraphStepStrategy.instance(),
                                JanusGraphIoRegistrationStrategy.instance());
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/GraphCentricQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/GraphCentricQuery.java
@@ -126,6 +126,10 @@ public class GraphCentricQuery extends BaseQuery implements ElementQuery<JanusGr
         return 1;
     }
 
+    public BackendQueryHolder<JointIndexQuery> getIndexQuery() {
+        return indexQuery;
+    }
+
     @Override
     public BackendQueryHolder<JointIndexQuery> getSubQuery(int position) {
         if (position == 0) return indexQuery;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/GraphCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/GraphCentricQueryBuilder.java
@@ -41,11 +41,8 @@ import org.janusgraph.graphdb.query.condition.MultiCondition;
 import org.janusgraph.graphdb.query.condition.Or;
 import org.janusgraph.graphdb.query.condition.PredicateCondition;
 import org.janusgraph.graphdb.query.index.IndexSelectionStrategy;
-import org.janusgraph.graphdb.query.index.IndexSelectionUtil;
 import org.janusgraph.graphdb.query.profile.QueryProfiler;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
-import org.janusgraph.graphdb.types.IndexType;
-import org.janusgraph.graphdb.types.MixedIndexType;
 import org.janusgraph.graphdb.util.CloseableIteratorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -281,14 +278,9 @@ public class GraphCentricQueryBuilder implements JanusGraphQuery<GraphCentricQue
         orders.makeImmutable();
         if (orders.isEmpty()) orders = OrderList.NO_ORDER;
 
-        //Compile all indexes that cover at least one of the query conditions
-        final Set<IndexType> indexCandidates = IndexSelectionUtil.getMatchingIndexes(conditions,
-            indexType -> indexType.getElement() == resultType
-                    && !(conditions instanceof Or && (indexType.isCompositeIndex() || !serializer.features((MixedIndexType) indexType).supportNotQueryNormalForm()))
-        );
-
         final Set<Condition> coveredClauses = new HashSet<>();
-        final IndexSelectionStrategy.SelectedIndexQuery selectedIndex = indexSelector.selectIndices(indexCandidates, conditions, coveredClauses, orders, serializer);
+        final IndexSelectionStrategy.SelectedIndexQuery selectedIndex = indexSelector.selectIndices(
+            resultType, conditions, coveredClauses, orders, serializer);
 
         BackendQueryHolder<JointIndexQuery> query;
         if (!coveredClauses.isEmpty()) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/MixedIndexCountQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/MixedIndexCountQueryBuilder.java
@@ -1,0 +1,75 @@
+// Copyright 2020 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.query.graph;
+
+import com.google.common.base.Preconditions;
+import org.janusgraph.core.MixedIndexCountQuery;
+import org.janusgraph.diskstorage.BackendTransaction;
+import org.janusgraph.graphdb.database.IndexSerializer;
+import org.janusgraph.graphdb.internal.ElementCategory;
+import org.janusgraph.graphdb.query.profile.QueryProfiler;
+
+/**
+ * Builds a {@link MixedIndexCountQuery}, which contains a single query against a mixed index. It is used to retrieve
+ * total number of elements satisfying given conditions.
+ *
+ * @author Boxuan Li (liboxuan@connect.hku.hk)
+ */
+public class MixedIndexCountQueryBuilder implements MixedIndexCountQuery {
+    private final BackendTransaction txHandle;
+    private final IndexSerializer serializer;
+    /**
+     * Search query against index backend
+     */
+    private JointIndexQuery.Subquery query;
+    /**
+     * The profiler observing this query
+     */
+    private QueryProfiler profiler = QueryProfiler.NO_OP;
+
+    public MixedIndexCountQueryBuilder(IndexSerializer serializer, BackendTransaction txHandle) {
+        Preconditions.checkNotNull(serializer);
+        this.serializer = serializer;
+        this.txHandle = txHandle;
+    }
+
+    public MixedIndexCountQueryBuilder constructIndex(JointIndexQuery indexQuery, ElementCategory resultType) {
+        if (indexQuery.size() != 1 || !indexQuery.getQuery(0).getIndex().isMixedIndex()) {
+            return null;
+        }
+        JointIndexQuery.Subquery subquery = indexQuery.getQuery(0);
+        this.query = subquery;
+        return this;
+    }
+
+    @Override
+    public Long executeTotals() {
+        profiler.startTimer();
+        profiler.setAnnotation(QueryProfiler.QUERY_ANNOTATION, query.getMixedQuery());
+        Long result = serializer.queryCount(query, txHandle);
+        profiler.stopTimer();
+        return result;
+    }
+
+    @Override
+    public void observeWith(QueryProfiler parentProfiler, boolean hasSiblings) {
+        profiler = parentProfiler.addNested(QueryProfiler.MIXED_INEX_COUNT_QUERY);
+    }
+
+    @Override
+    public QueryProfiler getProfiler() {
+        return profiler;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/index/IndexSelectionStrategy.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/index/IndexSelectionStrategy.java
@@ -16,6 +16,7 @@ package org.janusgraph.graphdb.query.index;
 
 import org.janusgraph.core.JanusGraphElement;
 import org.janusgraph.graphdb.database.IndexSerializer;
+import org.janusgraph.graphdb.internal.ElementCategory;
 import org.janusgraph.graphdb.internal.OrderList;
 import org.janusgraph.graphdb.query.condition.Condition;
 import org.janusgraph.graphdb.query.condition.MultiCondition;
@@ -33,6 +34,10 @@ public interface IndexSelectionStrategy {
                                      final Set<Condition> coveredClauses, OrderList orders,
                                      IndexSerializer serializer);
 
+    SelectedIndexQuery selectIndices(final ElementCategory resultType,
+                                     final MultiCondition<JanusGraphElement> conditions,
+                                     final Set<Condition> coveredClauses, OrderList orders,
+                                     IndexSerializer serializer);
     class SelectedIndexQuery {
         private JointIndexQuery query;
         private boolean isSorted;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/QueryProfiler.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/QueryProfiler.java
@@ -51,6 +51,7 @@ public interface QueryProfiler {
     String CONSTRUCT_GRAPH_CENTRIC_QUERY = "constructGraphCentricQuery";
     // graph centric query execution phase
     String GRAPH_CENTRIC_QUERY = "GraphCentricQuery";
+    String MIXED_INEX_COUNT_QUERY = "MixedIndexCountQuery";
 
     QueryProfiler NO_OP = new QueryProfiler() {
         @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphBlueprintsGraph.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphBlueprintsGraph.java
@@ -33,6 +33,7 @@ import org.janusgraph.core.JanusGraphMultiVertexQuery;
 import org.janusgraph.core.JanusGraphQuery;
 import org.janusgraph.core.JanusGraphTransaction;
 import org.janusgraph.core.JanusGraphVertex;
+import org.janusgraph.core.MixedIndexCountQuery;
 import org.janusgraph.core.PropertyKey;
 import org.janusgraph.core.RelationType;
 import org.janusgraph.core.VertexLabel;
@@ -175,6 +176,11 @@ public abstract class JanusGraphBlueprintsGraph implements JanusGraph {
     @Override
     public JanusGraphQuery<? extends JanusGraphQuery> query() {
         return getAutoStartTx().query();
+    }
+
+    @Override
+    public MixedIndexCountQuery mixedIndexCountQuery() {
+        return getAutoStartTx().mixedIndexCountQuery();
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/step/JanusGraphMixedIndexCountStep.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/step/JanusGraphMixedIndexCountStep.java
@@ -1,0 +1,98 @@
+// Copyright 2020 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.optimize.step;
+
+import org.apache.commons.collections.iterators.EmptyIterator;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.Profiling;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.ReducingBarrierStep;
+import org.apache.tinkerpop.gremlin.process.traversal.util.MutableMetrics;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
+import org.janusgraph.core.JanusGraphTransaction;
+import org.janusgraph.core.MixedIndexCountQuery;
+import org.janusgraph.graphdb.internal.ElementCategory;
+import org.janusgraph.graphdb.query.graph.GraphCentricQuery;
+import org.janusgraph.graphdb.query.graph.JointIndexQuery;
+import org.janusgraph.graphdb.query.graph.MixedIndexCountQueryBuilder;
+import org.janusgraph.graphdb.query.profile.QueryProfiler;
+import org.janusgraph.graphdb.tinkerpop.optimize.JanusGraphTraversalUtil;
+import org.janusgraph.graphdb.tinkerpop.profile.TP3ProfileWrapper;
+
+import java.util.ArrayList;
+
+/**
+ * A custom count step similar to {@link org.apache.tinkerpop.gremlin.process.traversal.step.map.CountGlobalStep} but
+ * uses mixed index query to directly fetch number of satisfying elements without actually fetching the elements.
+ *
+ * @author Boxuan Li (liboxuan@connect.hku.hk)
+ */
+public class JanusGraphMixedIndexCountStep<S> extends ReducingBarrierStep<S, Long> implements Profiling {
+
+    private final ArrayList<HasContainer> hasContainers = new ArrayList<>();
+    private MixedIndexCountQuery mixedIndexCountQuery = null;
+    private boolean done;
+
+    public JanusGraphMixedIndexCountStep(JanusGraphStep janusGraphStep, Traversal.Admin<?, ?> traversal) {
+        super(traversal);
+        JanusGraphTransaction tx = JanusGraphTraversalUtil.getTx(traversal);
+
+        final MixedIndexCountQueryBuilder countQueryBuilder = (MixedIndexCountQueryBuilder) tx.mixedIndexCountQuery();
+
+        final GraphCentricQuery query = janusGraphStep.buildGlobalGraphCentricQuery();
+
+        if (query != null && query.getIndexQuery().isFitted()) {
+            final JointIndexQuery indexQuery = query.getIndexQuery().getBackendQuery();
+            mixedIndexCountQuery = countQueryBuilder.constructIndex(indexQuery,
+                Vertex.class.isAssignableFrom(janusGraphStep.getReturnClass()) ? ElementCategory.VERTEX : ElementCategory.EDGE);
+        }
+    }
+
+    @Override
+    public Long projectTraverser(Traverser.Admin<S> traverser) {
+        return traverser.bulk();
+    }
+
+    @Override
+    public Traverser.Admin<Long> processNextStart() {
+        if (!this.done) {
+            this.done = true;
+            return getTraversal().getTraverserGenerator().generate(this.mixedIndexCountQuery.executeTotals(), (Step) this, 1L);
+        } else {
+            return getTraversal().getTraverserGenerator().generate(EmptyIterator.INSTANCE.next(), (Step) this, 1L);
+        }
+    }
+
+    @Override
+    public String toString() {
+        if (this.hasContainers.isEmpty()) {
+            return super.toString();
+        }
+        return StringFactory.stepString(this, this.hasContainers);
+    }
+
+    @Override
+    public void setMetrics(final MutableMetrics metrics) {
+        QueryProfiler queryProfiler = new TP3ProfileWrapper(metrics);
+        mixedIndexCountQuery.observeWith(queryProfiler);
+    }
+
+    public MixedIndexCountQuery getMixedIndexCountQuery() {
+        return mixedIndexCountQuery;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/strategy/JanusGraphMixedIndexCountStrategy.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/strategy/JanusGraphMixedIndexCountStrategy.java
@@ -1,0 +1,112 @@
+// Copyright 2020 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.tinkerpop.optimize.strategy;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.CountGlobalStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.NoOpBarrierStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.IdentityStep;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.janusgraph.graphdb.tinkerpop.optimize.step.JanusGraphMixedIndexCountStep;
+import org.janusgraph.graphdb.tinkerpop.optimize.step.JanusGraphStep;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * If the query can be satisfied by a single mixed index query, and the query is followed by a count step, then
+ * this strategy replaces original step with {@link JanusGraphMixedIndexCountStep}, which fires a count query against
+ * mixed index backend without retrieving all elements
+ *
+ * @author Boxuan Li (liboxuan@connect.hku.hk)
+ */
+public class JanusGraphMixedIndexCountStrategy extends AbstractTraversalStrategy<TraversalStrategy.ProviderOptimizationStrategy>
+    implements TraversalStrategy.ProviderOptimizationStrategy {
+    private static final JanusGraphMixedIndexCountStrategy INSTANCE = new JanusGraphMixedIndexCountStrategy();
+    private static final Set<Class<? extends ProviderOptimizationStrategy>> PRIORS = Collections.singleton(JanusGraphStepStrategy.class);
+
+    private JanusGraphMixedIndexCountStrategy() {
+    }
+
+    @Override
+    public void apply(final Traversal.Admin<?, ?> traversal) {
+        if (TraversalHelper.onGraphComputer(traversal))
+            return;
+
+        TraversalHelper.getStepsOfClass(JanusGraphStep.class, traversal).forEach(originalGraphStep -> {
+            buildMixedIndexCountStep(originalGraphStep, traversal);
+        });
+    }
+
+    /**
+     * Check if a mixed index count step can be built, and if so, apply it.
+     *
+     * @param originalGraphStep
+     * @param traversal
+     */
+    private void buildMixedIndexCountStep(final JanusGraphStep originalGraphStep, final Traversal.Admin<?, ?> traversal) {
+        if (!originalGraphStep.isStartStep() || !hasCountGlobalStep(originalGraphStep)) {
+            return;
+        }
+        // try to find a suitable mixed index and build a mixed index count query
+        final JanusGraphMixedIndexCountStep<?> directQueryCountStep = new JanusGraphMixedIndexCountStep<>(originalGraphStep, traversal);
+        if (directQueryCountStep.getMixedIndexCountQuery() != null) {
+            applyMixedIndexCountStep(originalGraphStep, directQueryCountStep, traversal);
+        }
+    }
+
+    private boolean isEligibleToSkip(final Step currentStep) {
+        return currentStep instanceof IdentityStep || currentStep instanceof NoOpBarrierStep;
+    }
+
+    private boolean hasCountGlobalStep(final GraphStep originalGraphStep) {
+        Step<?, ?> currentStep = originalGraphStep.getNextStep();
+        while (isEligibleToSkip(currentStep)) {
+            currentStep = currentStep.getNextStep();
+        }
+        return currentStep instanceof CountGlobalStep;
+    }
+
+    /**
+     * Apply mixed index count step in the traversal and remove "has" steps that already folded in the mixedIndexCountStep
+     *
+     * @param originalGraphStep
+     * @param mixedIndexCountStep
+     * @param traversal
+     */
+    private void applyMixedIndexCountStep(final GraphStep originalGraphStep, final JanusGraphMixedIndexCountStep mixedIndexCountStep,
+                                          final Traversal.Admin<?, ?> traversal) {
+        Step<?, ?> currentStep = originalGraphStep.getNextStep();
+        while (isEligibleToSkip(currentStep)) {
+            currentStep = currentStep.getNextStep();
+        }
+        assert currentStep instanceof CountGlobalStep;
+        traversal.removeStep(currentStep);
+        TraversalHelper.replaceStep(originalGraphStep, mixedIndexCountStep, traversal);
+    }
+
+    public static JanusGraphMixedIndexCountStrategy instance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public Set<Class<? extends ProviderOptimizationStrategy>> applyPrior() {
+        return PRIORS;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/profile/TP3ProfileWrapper.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/profile/TP3ProfileWrapper.java
@@ -42,6 +42,10 @@ public class TP3ProfileWrapper implements QueryProfiler {
         return new TP3ProfileWrapper(nested);
     }
 
+    public MutableMetrics getMetrics() {
+        return metrics;
+    }
+
     @Override
     public QueryProfiler setAnnotation(String key, Object value) {
         Preconditions.checkNotNull(key, "Key must be not null");

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -35,6 +35,7 @@ import org.janusgraph.core.JanusGraphMultiVertexQuery;
 import org.janusgraph.core.JanusGraphRelation;
 import org.janusgraph.core.JanusGraphVertex;
 import org.janusgraph.core.JanusGraphVertexProperty;
+import org.janusgraph.core.MixedIndexCountQuery;
 import org.janusgraph.core.Multiplicity;
 import org.janusgraph.core.PropertyKey;
 import org.janusgraph.core.ReadOnlyTransactionException;
@@ -52,6 +53,7 @@ import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.BackendTransaction;
 import org.janusgraph.diskstorage.EntryList;
 import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
+import org.janusgraph.graphdb.query.graph.MixedIndexCountQueryBuilder;
 import org.janusgraph.diskstorage.util.time.TimestampProvider;
 import org.janusgraph.graphdb.database.EdgeSerializer;
 import org.janusgraph.graphdb.database.IndexSerializer;
@@ -1489,6 +1491,11 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
     @Override
     public GraphCentricQueryBuilder query() {
         return new GraphCentricQueryBuilder(this, graph.getIndexSerializer(), indexSelector);
+    }
+
+    @Override
+    public MixedIndexCountQuery mixedIndexCountQuery() {
+       return new MixedIndexCountQueryBuilder(indexSerializer, txHandle);
     }
 
     @Override

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
@@ -1291,6 +1291,20 @@ public class ElasticSearchIndex implements IndexProvider {
     }
 
     @Override
+    public Long queryCount(IndexQuery query, KeyInformation.IndexRetriever information, BaseTransaction tx) throws BackendException {
+        final ElasticSearchRequest sr = new ElasticSearchRequest();
+        final Map<String,Object> esQuery = getFilter(query.getCondition(), information.get(query.getStore()));
+        sr.setQuery(compat.prepareQuery(esQuery));
+        try {
+            return client.countTotal(
+                getIndexStoreName(query.getStore()),
+                compat.createRequestBody(sr, null));
+        } catch (final IOException | UncheckedIOException e) {
+            throw new PermanentBackendException(e);
+        }
+    }
+
+    @Override
     public Long totals(RawQuery query, KeyInformation.IndexRetriever information,
                        BaseTransaction tx) throws BackendException {
         long startTime = System.currentTimeMillis();


### PR DESCRIPTION
This adds JanusGraphMixedIndexCountStrategy which leverages mixed index
to return the total count if applicable. The implementation idea is to
leverage the partial result of JanusGraphStepStrategy and JanusGraphStep
which handle folding and building a global graph centric query.

Closes #874

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

