### PR TITLE
Add grpc server to janusgraph-server

### DIFF
--- a/janusgraph-all/pom.xml
+++ b/janusgraph-all/pom.xml
@@ -70,6 +70,12 @@
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-hadoop</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.janusgraph</groupId>

--- a/janusgraph-dist/pom.xml
+++ b/janusgraph-dist/pom.xml
@@ -65,6 +65,10 @@
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-compress</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/janusgraph-server/pom.xml
+++ b/janusgraph-server/pom.xml
@@ -55,7 +55,7 @@
             <artifactId>annotations-api</artifactId>
             <version>6.0.53</version>
             <scope>provided</scope>
-          </dependency>
+        </dependency>
 
         <!-- TESTING -->
         <dependency>
@@ -109,8 +109,8 @@
                 <executions>
                     <execution>
                         <goals>
-                        <goal>compile</goal>
-                        <goal>compile-custom</goal>
+                            <goal>compile</goal>
+                            <goal>compile-custom</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/janusgraph-server/pom.xml
+++ b/janusgraph-server/pom.xml
@@ -11,6 +11,8 @@
     <url>https://janusgraph.org</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <grpc.version>1.35.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
+        <protoc.version>3.14.0</protoc.version>
     </properties>
     <dependencies>
         <dependency>
@@ -22,6 +24,39 @@
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-server</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <scope>runtime</scope>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency> <!-- necessary for Java 9+ -->
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>annotations-api</artifactId>
+            <version>6.0.53</version>
+            <scope>provided</scope>
+          </dependency>
+
         <!-- TESTING -->
         <dependency>
             <groupId>org.easymock</groupId>
@@ -40,5 +75,46 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-testing</artifactId>
+            <version>${grpc.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.6.2</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+                    <pluginId>grpc-java</pluginId>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                        <goal>compile</goal>
+                        <goal>compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/janusgraph-server/src/main/java/org/janusgraph/graphdb/server/JanusGraphManagerImpl.java
+++ b/janusgraph-server/src/main/java/org/janusgraph/graphdb/server/JanusGraphManagerImpl.java
@@ -1,0 +1,69 @@
+// Copyright 2020 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.server;
+
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import org.apache.commons.lang.NullArgumentException;
+import org.apache.tinkerpop.gremlin.server.GraphManager;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.janusgraph.core.JanusGraph;
+
+public class JanusGraphManagerImpl extends JanusGraphManagerGrpc.JanusGraphManagerImplBase {
+    private final GraphManager graphManager;
+
+    public JanusGraphManagerImpl(GraphManager graphManager) {
+        this.graphManager = graphManager;
+    }
+
+    @Override
+    public void getJanusGraphContexts(GetJanusGraphContextsRequest request, StreamObserver<JanusGraphContext> responseObserver) {
+        if (request == null) {
+            responseObserver.onError(Status.INTERNAL.withCause(new NullArgumentException("request should be set")).asRuntimeException());
+            return;
+        }
+        for (String graphName : graphManager.getGraphNames()) {
+            Graph graph = graphManager.getGraph(graphName);
+            if (!(graph instanceof JanusGraph)) {
+                continue;
+            }
+            responseObserver.onNext(JanusGraphContext.newBuilder().setGraphName(graphName).build());
+        }
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void getJanusGraphContextByGraphName(GetJanusGraphContextByGraphNameRequest request,
+                                                StreamObserver<JanusGraphContext> responseObserver) {
+        if (request == null) {
+            responseObserver.onError(Status.INVALID_ARGUMENT
+                .withCause(new NullArgumentException("request should be set")).asRuntimeException());
+            return;
+        }
+        final String graphName = request.getGraphName();
+        if (graphName.isEmpty()) {
+            responseObserver.onError(Status.INVALID_ARGUMENT
+                .withCause(new NullArgumentException("graphName should be set")).asRuntimeException());
+            return;
+        }
+        Graph graph = graphManager.getGraph(graphName);
+        if (!(graph instanceof JanusGraph)) {
+            responseObserver.onError(Status.INTERNAL
+                .withCause(new IllegalStateException("graphName should access a JanusGraph instance")).asException());
+        }
+        responseObserver.onNext(JanusGraphContext.newBuilder().setGraphName(graphName).build());
+        responseObserver.onCompleted();
+    }
+}

--- a/janusgraph-server/src/main/java/org/janusgraph/graphdb/server/JanusGraphServer.java
+++ b/janusgraph-server/src/main/java/org/janusgraph/graphdb/server/JanusGraphServer.java
@@ -66,7 +66,7 @@ public class JanusGraphServer {
 
     private Server createGrpcServer(JanusGraphSettings janusGraphSettings, GraphManager graphManager) {
         return ServerBuilder
-            .forPort(janusGraphSettings.grpcServer.port)
+            .forPort(janusGraphSettings.getGrpcServer().getPort())
             .addService(new JanusGraphManagerImpl(graphManager))
             .build();
     }
@@ -82,7 +82,7 @@ public class JanusGraphServer {
             gremlinSettings = GremlinSettingsUtils.configureDefaultSerializersIfNotSet(janusGraphSettings.getGremlinSettings());
             gremlinServer = new GremlinServer(gremlinSettings);
             CompletableFuture<Void> grpcServerFuture = CompletableFuture.completedFuture(null);
-            if (janusGraphSettings.grpcServer.enable) {
+            if (janusGraphSettings.getGrpcServer().isEnabled()) {
                 grpcServerFuture = CompletableFuture.runAsync(() -> {
                     GraphManager graphManager = gremlinServer.getServerGremlinExecutor().getGraphManager();
                     grpcServer = createGrpcServer(janusGraphSettings, graphManager);

--- a/janusgraph-server/src/main/java/org/janusgraph/graphdb/server/JanusGraphSettings.java
+++ b/janusgraph-server/src/main/java/org/janusgraph/graphdb/server/JanusGraphSettings.java
@@ -1,0 +1,76 @@
+// Copyright 2020 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.server;
+
+import org.apache.tinkerpop.gremlin.server.Settings;
+import org.yaml.snakeyaml.TypeDescription;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.representer.Representer;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Objects;
+
+public class JanusGraphSettings {
+    public JanusGraphSettings.GrpcServerSettings grpcServer = new JanusGraphSettings.GrpcServerSettings();
+
+    private Settings gremlinSettings;
+
+    public static class GrpcServerSettings {
+        public boolean enable = false;
+        public int port = 10182;
+    }
+
+    public Settings getGremlinSettings() {
+        return gremlinSettings;
+    }
+
+    public static JanusGraphSettings read(final String file) throws Exception {
+        InputStream input = new FileInputStream(file);
+        return read(input);
+    }
+
+    public static JanusGraphSettings read(final InputStream stream) throws IOException {
+        Objects.requireNonNull(stream);
+        Constructor constructor = new Constructor(JanusGraphSettings.class);
+        TypeDescription grpcServerSettings = new TypeDescription(JanusGraphSettings.GrpcServerSettings.class);
+        constructor.addTypeDescription(grpcServerSettings);
+        Representer representer = new Representer();
+        representer.getPropertyUtils().setSkipMissingProperties(true);
+
+        String yamlInput = getStringFromInputStream(stream);
+
+        Yaml yaml = new Yaml(constructor, representer);
+        JanusGraphSettings settings = yaml.loadAs(yamlInput, JanusGraphSettings.class);
+        Yaml yamlMap = new Yaml();
+        Map<String, Object> obj = yamlMap.load(yamlInput);
+        obj.remove("grpcServer");
+        String dump = yamlMap.dump(obj);
+        settings.gremlinSettings = Settings.read(new ByteArrayInputStream(dump.getBytes()));
+        return settings;
+    }
+
+    private static String getStringFromInputStream(InputStream stream) throws IOException {
+        int ch;
+        StringBuilder sb = new StringBuilder();
+        while ((ch = stream.read()) != -1)
+            sb.append((char) ch);
+        return sb.toString();
+    }
+}

--- a/janusgraph-server/src/main/java/org/janusgraph/graphdb/server/JanusGraphSettings.java
+++ b/janusgraph-server/src/main/java/org/janusgraph/graphdb/server/JanusGraphSettings.java
@@ -28,24 +28,15 @@ import java.util.Map;
 import java.util.Objects;
 
 public class JanusGraphSettings {
-    public JanusGraphSettings.GrpcServerSettings grpcServer = new JanusGraphSettings.GrpcServerSettings();
-
+    private JanusGraphSettings.GrpcServerSettings grpcServer = new JanusGraphSettings.GrpcServerSettings();
     private Settings gremlinSettings;
-
-    public static class GrpcServerSettings {
-        public boolean enable = false;
-        public int port = 10182;
-    }
-
-    public Settings getGremlinSettings() {
-        return gremlinSettings;
-    }
 
     public static JanusGraphSettings read(final String file) throws Exception {
         InputStream input = new FileInputStream(file);
         return read(input);
     }
 
+    // TODO: Merge JanusGraphSettings with GremlinSettings which will be released in TinkerPop 3.4.11 and ongoing
     public static JanusGraphSettings read(final InputStream stream) throws IOException {
         Objects.requireNonNull(stream);
         Constructor constructor = new Constructor(JanusGraphSettings.class);
@@ -72,5 +63,38 @@ public class JanusGraphSettings {
         while ((ch = stream.read()) != -1)
             sb.append((char) ch);
         return sb.toString();
+    }
+
+    public GrpcServerSettings getGrpcServer() {
+        return grpcServer;
+    }
+
+    public void setGrpcServer(GrpcServerSettings grpcServer) {
+        this.grpcServer = grpcServer;
+    }
+
+    public Settings getGremlinSettings() {
+        return gremlinSettings;
+    }
+
+    public static class GrpcServerSettings {
+        private boolean enabled = false;
+        private int port = 10182;
+
+        public int getPort() {
+            return port;
+        }
+
+        public void setPort(int port) {
+            this.port = port;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
     }
 }

--- a/janusgraph-server/src/main/proto/graph-manager.proto
+++ b/janusgraph-server/src/main/proto/graph-manager.proto
@@ -25,7 +25,7 @@ message JanusGraphContext {
 }
 
 message GetJanusGraphContextByGraphNameRequest {
-    string graphName = 2;
+    string graphName = 1;
 }
 
 message GetJanusGraphContextsRequest {

--- a/janusgraph-server/src/main/proto/graph-manager.proto
+++ b/janusgraph-server/src/main/proto/graph-manager.proto
@@ -1,0 +1,38 @@
+// Copyright 2020 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package grpc;
+
+option java_multiple_files = true;
+option java_package = "org.janusgraph.graphdb.server";
+option java_outer_classname = "GraphManagerProto";
+
+message JanusGraphContext {
+    string graphName = 1;
+}
+
+message GetJanusGraphContextByGraphNameRequest {
+    string graphName = 2;
+}
+
+message GetJanusGraphContextsRequest {
+
+}
+
+service JanusGraphManager {
+    rpc GetJanusGraphContexts (GetJanusGraphContextsRequest) returns (stream JanusGraphContext);
+    rpc GetJanusGraphContextByGraphName (GetJanusGraphContextByGraphNameRequest) returns (JanusGraphContext);
+}

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/server/JanusGraphManagerImplTest.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/server/JanusGraphManagerImplTest.java
@@ -1,0 +1,133 @@
+// Copyright 2020 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.server;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import org.apache.tinkerpop.gremlin.server.GraphManager;
+import org.apache.tinkerpop.gremlin.server.Settings;
+import org.apache.tinkerpop.gremlin.server.util.DefaultGraphManager;
+import org.javatuples.Pair;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class JanusGraphManagerImplTest {
+
+    private GraphManager getGraphManager() {
+        Settings settings = new Settings();
+        HashMap<String, String> map = new HashMap<>();
+        map.put("graph", "src/test/resources/janusgraph-inmemory.properties");
+        map.put("graph2", "src/test/resources/janusgraph-inmemory.properties");
+        map.put("tinkergraph", "src/test/resources/tinkergraph.properties");
+        settings.graphs = map;
+        return new DefaultGraphManager(settings);
+    }
+
+    private Pair<Server, String> createServer(GraphManager graphManager) throws IOException {
+        String serverName = InProcessServerBuilder.generateName();
+        Server server = InProcessServerBuilder
+            .forName(serverName).directExecutor().addService(new JanusGraphManagerImpl(graphManager)).build().start();
+        return new Pair<>(server, serverName);
+    }
+
+    private Pair<TestingServerClosable, JanusGraphManagerGrpc.JanusGraphManagerBlockingStub> createServerStub(GraphManager graphManager) throws IOException {
+        Pair<Server, String> server = createServer(graphManager);
+        ManagedChannel channel = InProcessChannelBuilder.forName(server.getValue1()).directExecutor().build();
+        JanusGraphManagerGrpc.JanusGraphManagerBlockingStub stub = JanusGraphManagerGrpc.newBlockingStub(channel);
+        TestingServerClosable testingServerClosable = new TestingServerClosable(server.getValue0(), channel);
+        return new Pair<>(testingServerClosable, stub);
+    }
+
+    @Test
+    public void testContextIsReturnedForGivenGraphName() throws IOException {
+        GraphManager graphManager = getGraphManager();
+        Pair<TestingServerClosable, JanusGraphManagerGrpc.JanusGraphManagerBlockingStub> serverStub = createServerStub(graphManager);
+
+        JanusGraphContext test = serverStub.getValue1().getJanusGraphContextByGraphName(
+            GetJanusGraphContextByGraphNameRequest.newBuilder().setGraphName("graph").build());
+
+        assertEquals("graph", test.getGraphName());
+        serverStub.getValue0().close();
+    }
+
+    @Test
+    public void testErrorIsReturnedForGivenGraphNameWhichIsNotAJanusGraph() throws IOException {
+        GraphManager graphManager = getGraphManager();
+        Pair<TestingServerClosable, JanusGraphManagerGrpc.JanusGraphManagerBlockingStub> serverStub = createServerStub(graphManager);
+
+        assertThrows(StatusRuntimeException.class, () ->
+            serverStub.getValue1().getJanusGraphContextByGraphName(
+                GetJanusGraphContextByGraphNameRequest.newBuilder().setGraphName("tinkergraph").build()));
+        serverStub.getValue0().close();
+    }
+
+    @Test
+    public void testErrorIsReturnedForEmptyGivenGraphName() throws IOException {
+        GraphManager graphManager = getGraphManager();
+        Pair<TestingServerClosable, JanusGraphManagerGrpc.JanusGraphManagerBlockingStub> serverStub = createServerStub(graphManager);
+
+        assertThrows(StatusRuntimeException.class, () ->
+            serverStub.getValue1().getJanusGraphContextByGraphName(
+                GetJanusGraphContextByGraphNameRequest.newBuilder().setGraphName("").build()));
+        serverStub.getValue0().close();
+    }
+
+    @Test
+    public void testErrorIsReturnedForUnknownGivenGraphName() throws IOException {
+        GraphManager graphManager = getGraphManager();
+        Pair<TestingServerClosable, JanusGraphManagerGrpc.JanusGraphManagerBlockingStub> serverStub = createServerStub(graphManager);
+
+        assertThrows(StatusRuntimeException.class, () ->
+            serverStub.getValue1().getJanusGraphContextByGraphName(
+                GetJanusGraphContextByGraphNameRequest.newBuilder().setGraphName("test").build()));
+        serverStub.getValue0().close();
+    }
+
+    @Test
+    public void testErrorIsReturnedForNotSetGraphName() throws IOException {
+        GraphManager graphManager = getGraphManager();
+        Pair<TestingServerClosable, JanusGraphManagerGrpc.JanusGraphManagerBlockingStub> serverStub = createServerStub(graphManager);
+
+        assertThrows(StatusRuntimeException.class, () ->
+            serverStub.getValue1().getJanusGraphContextByGraphName(
+                GetJanusGraphContextByGraphNameRequest.newBuilder().build()));
+        serverStub.getValue0().close();
+    }
+
+    @Test
+    public void testAllContextAreReturned() throws IOException {
+        GraphManager graphManager = getGraphManager();
+        Pair<TestingServerClosable, JanusGraphManagerGrpc.JanusGraphManagerBlockingStub> serverStub = createServerStub(graphManager);
+
+        Iterator<JanusGraphContext> iterator = serverStub.getValue1().getJanusGraphContexts(
+            GetJanusGraphContextsRequest.newBuilder().build());
+
+        List<JanusGraphContext> actualList = new ArrayList<>();
+        iterator.forEachRemaining(actualList::add);
+        assertEquals(2, actualList.size());
+        assertTrue(actualList.stream().anyMatch(it -> it.getGraphName().equals("graph")));
+        assertTrue(actualList.stream().anyMatch(it -> it.getGraphName().equals("graph2")));
+        serverStub.getValue0().close();
+    }
+}

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/server/JanusGraphServerTest.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/server/JanusGraphServerTest.java
@@ -59,6 +59,21 @@ public class JanusGraphServerTest {
     }
 
     @Test
+    public void testGrpcServerIsEnabled() {
+        final JanusGraphServer server = new JanusGraphServer("src/test/resources/janusgraph-server-with-server-configs.yaml");
+
+        CompletableFuture<Void> start = server.start();
+
+        assertFalse(start.isCompletedExceptionally());
+
+        JanusGraphSettings settings = server.getJanusGraphSettings();
+        assertTrue(settings.grpcServer.enable);
+
+        CompletableFuture<Void> stop = server.stop();
+        CompletableFuture.allOf(start, stop).join();
+    }
+
+    @Test
     public void testInvalidConfigurationInitializeFails() {
         final JanusGraphServer server = new JanusGraphServer("src/test/resources/invalid-config.yaml");
 

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/server/JanusGraphServerTest.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/server/JanusGraphServerTest.java
@@ -60,14 +60,14 @@ public class JanusGraphServerTest {
 
     @Test
     public void testGrpcServerIsEnabled() {
-        final JanusGraphServer server = new JanusGraphServer("src/test/resources/janusgraph-server-with-server-configs.yaml");
+        final JanusGraphServer server = new JanusGraphServer("src/test/resources/janusgraph-server-with-grpc.yaml");
 
         CompletableFuture<Void> start = server.start();
 
         assertFalse(start.isCompletedExceptionally());
 
         JanusGraphSettings settings = server.getJanusGraphSettings();
-        assertTrue(settings.grpcServer.enable);
+        assertTrue(settings.getGrpcServer().isEnabled());
 
         CompletableFuture<Void> stop = server.stop();
         CompletableFuture.allOf(start, stop).join();

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/server/JanusGraphSettingsTest.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/server/JanusGraphSettingsTest.java
@@ -1,0 +1,52 @@
+// Copyright 2020 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.server;
+
+import org.apache.tinkerpop.gremlin.server.Settings;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JanusGraphSettingsTest {
+
+    @Test
+    public void testGrpcServerDefaultValues() throws Exception {
+        JanusGraphSettings settings = JanusGraphSettings.read("src/test/resources/janusgraph-server-without-serializers.yaml");
+
+        assertFalse(settings.grpcServer.enable);
+        assertEquals(10182, settings.grpcServer.port);
+    }
+
+    @Test
+    public void testGrpcServerOverwriteDefaultValues() throws Exception {
+        JanusGraphSettings settings = JanusGraphSettings.read("src/test/resources/janusgraph-server-with-server-configs.yaml");
+
+        assertTrue(settings.grpcServer.enable);
+        assertEquals(8042, settings.grpcServer.port);
+    }
+
+    @Test
+    public void testLoadGremlinServerCorrectly() throws Exception {
+        JanusGraphSettings janusGraphSettings = JanusGraphSettings.read("src/test/resources/janusgraph-server-with-server-configs.yaml");
+
+        Settings settings = janusGraphSettings.getGremlinSettings();
+
+        assertEquals("0.0.0.0", settings.host);
+        assertEquals(1, settings.graphs.size());
+        assertEquals(11, settings.serializers.size());
+    }
+}

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/server/JanusGraphSettingsTest.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/server/JanusGraphSettingsTest.java
@@ -27,21 +27,21 @@ public class JanusGraphSettingsTest {
     public void testGrpcServerDefaultValues() throws Exception {
         JanusGraphSettings settings = JanusGraphSettings.read("src/test/resources/janusgraph-server-without-serializers.yaml");
 
-        assertFalse(settings.grpcServer.enable);
-        assertEquals(10182, settings.grpcServer.port);
+        assertFalse(settings.getGrpcServer().isEnabled());
+        assertEquals(10182, settings.getGrpcServer().getPort());
     }
 
     @Test
     public void testGrpcServerOverwriteDefaultValues() throws Exception {
-        JanusGraphSettings settings = JanusGraphSettings.read("src/test/resources/janusgraph-server-with-server-configs.yaml");
+        JanusGraphSettings settings = JanusGraphSettings.read("src/test/resources/janusgraph-server-with-grpc.yaml");
 
-        assertTrue(settings.grpcServer.enable);
-        assertEquals(8042, settings.grpcServer.port);
+        assertTrue(settings.getGrpcServer().isEnabled());
+        assertEquals(8042, settings.getGrpcServer().getPort());
     }
 
     @Test
     public void testLoadGremlinServerCorrectly() throws Exception {
-        JanusGraphSettings janusGraphSettings = JanusGraphSettings.read("src/test/resources/janusgraph-server-with-server-configs.yaml");
+        JanusGraphSettings janusGraphSettings = JanusGraphSettings.read("src/test/resources/janusgraph-server-with-grpc.yaml");
 
         Settings settings = janusGraphSettings.getGremlinSettings();
 

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/server/TestingServerClosable.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/server/TestingServerClosable.java
@@ -1,0 +1,44 @@
+// Copyright 2020 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.server;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+public class TestingServerClosable implements Closeable {
+    private final Server server;
+    private final ManagedChannel channel;
+
+    public TestingServerClosable(Server server, ManagedChannel channel){
+        this.server = server;
+        this.channel = channel;
+    }
+
+    @Override
+    public void close() throws IOException {
+        channel.shutdown();
+        server.shutdown();
+        try{
+            channel.awaitTermination(1, TimeUnit.SECONDS);
+            server.awaitTermination();
+        }catch (InterruptedException e){
+            throw new IOException(e);
+        }
+    }
+}

--- a/janusgraph-server/src/test/resources/janusgraph-inmemory.properties
+++ b/janusgraph-server/src/test/resources/janusgraph-inmemory.properties
@@ -1,0 +1,17 @@
+# Copyright 2020 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+gremlin.graph=org.janusgraph.core.JanusGraphFactory
+
+storage.backend=inmemory

--- a/janusgraph-server/src/test/resources/janusgraph-server-with-grpc.yaml
+++ b/janusgraph-server/src/test/resources/janusgraph-server-with-grpc.yaml
@@ -16,7 +16,7 @@ host: 0.0.0.0
 port: 8182
 scriptEvaluationTimeout: 30000
 grpcServer: {
-    enable: true,
+    enabled: true,
     port: 8042
 }
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer

--- a/janusgraph-server/src/test/resources/janusgraph-server-with-server-configs.yaml
+++ b/janusgraph-server/src/test/resources/janusgraph-server-with-server-configs.yaml
@@ -1,0 +1,63 @@
+# Copyright 2020 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+host: 0.0.0.0
+port: 8182
+scriptEvaluationTimeout: 30000
+grpcServer: {
+    enable: true,
+    port: 8042
+}
+channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
+graphs: {
+    graph: "src/test/resources/janusgraph-inmemory.properties"
+}
+scriptEngines: {
+    gremlin-groovy: {
+        plugins: { org.janusgraph.graphdb.tinkerpop.plugin.JanusGraphGremlinPlugin: {},
+                   org.apache.tinkerpop.gremlin.server.jsr223.GremlinServerGremlinPlugin: {},
+                   org.apache.tinkerpop.gremlin.tinkergraph.jsr223.TinkerGraphGremlinPlugin: {},
+                   org.apache.tinkerpop.gremlin.jsr223.ImportGremlinPlugin: {classImports: [java.lang.Math], methodImports: [java.lang.Math#*]}}}}
+serializers:
+    - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphBinaryMessageSerializerV1, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
+    - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphBinaryMessageSerializerV1, config: { serializeResultToString: true }}
+    - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
+    - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0, config: { serializeResultToString: true }}
+    - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV3d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
+    # Older serialization versions for backwards compatibility:
+    - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
+    - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoLiteMessageSerializerV1d0, config: {ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
+    - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}
+    - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV2d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
+    - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }}
+    - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }}
+processors:
+    - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
+    - { className: org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor, config: { cacheExpirationTime: 600000, cacheMaxSize: 1000 }}
+metrics: {
+    consoleReporter: {enabled: false, interval: 180000},
+    csvReporter: {enabled: false, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},
+    jmxReporter: {enabled: false},
+    slf4jReporter: {enabled: false, interval: 180000},
+    gangliaReporter: {enabled: false, interval: 180000, addressingMode: MULTICAST},
+    graphiteReporter: {enabled: false, interval: 180000}}
+maxInitialLineLength: 4096
+maxHeaderSize: 8192
+maxChunkSize: 8192
+maxContentLength: 65536
+maxAccumulationBufferComponents: 1024
+resultIterationBatchSize: 64
+writeBufferLowWaterMark: 32768
+writeBufferHighWaterMark: 65536
+

--- a/janusgraph-server/src/test/resources/tinkergraph.properties
+++ b/janusgraph-server/src/test/resources/tinkergraph.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+gremlin.graph=org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph
+gremlin.tinkergraph.vertexIdManager=LONG

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@
         <cassandra-driver.version>4.10.0</cassandra-driver.version>
         <testcontainers.version>1.15.1</testcontainers.version>
         <easymock.version>4.2</easymock.version>
+        <protobuf.version>3.14.0</protobuf.version>
     </properties>
     <modules>
         <module>janusgraph-driver</module>
@@ -781,6 +782,11 @@
                 <version>29.0-jre</version>
             </dependency>
             <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>2.4.0</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-lang</groupId>
                 <artifactId>commons-lang</artifactId>
                 <version>2.6</version>
@@ -934,7 +940,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>3.14.0</version>
+                <version>${protobuf.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.velocity</groupId>


### PR DESCRIPTION
Part of #1853 

* Add basic config parameters to the gremlin-server.yaml
* Add first server component to get a janusgraph which is managed by a graphmanager by name
* Setup protobuf building process
* Allow testing of new grpc components

Signed-off-by: Jan Jansen <jan.jansen@gdata.de

-----

Follow up PRs
* add basic schema interaction using grpc
* add basic driver part
* setup integration test
* add auth and security

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?