### PR TITLE
Fix cached relation update hashcode change bug

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/CacheEdge.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/CacheEdge.java
@@ -87,9 +87,9 @@ public class CacheEdge extends AbstractEdge {
         copyProperties(copy);
         copy.remove();
 
-        StandardEdge u = (StandardEdge) tx().addEdge(getVertex(0), getVertex(1), edgeLabel());
-        if (type.getConsistencyModifier()!=ConsistencyModifier.FORK) u.setId(super.longId());
-        u.setPreviousID(super.longId());
+        Long id = type.getConsistencyModifier() != ConsistencyModifier.FORK ? longId() : null;
+        StandardEdge u = (StandardEdge) tx().addEdge(id, getVertex(0), getVertex(1), edgeLabel());
+        u.setPreviousID(longId());
         copyProperties(u);
         setId(u.longId());
         return u;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/CacheVertexProperty.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/CacheVertexProperty.java
@@ -71,8 +71,8 @@ public class CacheVertexProperty extends AbstractVertexProperty {
         copyProperties(copy);
         copy.remove();
 
-        StandardVertexProperty u = (StandardVertexProperty) tx().addProperty(getVertex(0), propertyKey(), value());
-        if (type.getConsistencyModifier()!= ConsistencyModifier.FORK) u.setId(longId());
+        Long id = type.getConsistencyModifier() != ConsistencyModifier.FORK ? longId() : null;
+        StandardVertexProperty u = (StandardVertexProperty) tx().addProperty(getVertex(0), propertyKey(), value(), id);
         u.setPreviousID(longId());
         copyProperties(u);
         return u;


### PR DESCRIPTION
When a CacheEdge or a CacheVertexProperty is updated, JanusGraph
creates a new edge/property with auto-generated longId, and then overrides
it with the old id. Since AddedRelationsContainer implementation
relies on the longId as part of hash key, creating a new edge/property
with new longId can lead to a commit exception. This bug appears
when a vertex property or an edge is updated and then deleted in the
same transaction.

Fixes #2138

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

