### PR TITLE
Issue 2236: Remove graph and traversal source from script engine bind…

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/core/ConfiguredGraphFactory.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/ConfiguredGraphFactory.java
@@ -139,6 +139,7 @@ public class ConfiguredGraphFactory {
         final JanusGraphManager jgm = JanusGraphManagerUtility.getInstance();
         Preconditions.checkNotNull(jgm, JANUS_GRAPH_MANAGER_EXPECTED_STATE_MSG);
         final Graph graph = jgm.removeGraph(graphName);
+        jgm.removeTraversalSource(toTraversalSourceName(graphName));
         if (null != graph) graph.close();
         return (JanusGraph) graph;
     }
@@ -243,7 +244,9 @@ public class ConfiguredGraphFactory {
     private static void removeGraphFromCache(final JanusGraph graph) {
         final JanusGraphManager jgm = JanusGraphManagerUtility.getInstance();
         Preconditions.checkNotNull(jgm, JANUS_GRAPH_MANAGER_EXPECTED_STATE_MSG);
-        jgm.removeGraph(((StandardJanusGraph) graph).getGraphName());
+        final String graphName = ((StandardJanusGraph) graph).getGraphName();
+        jgm.removeGraph(graphName);
+        jgm.removeTraversalSource(toTraversalSourceName(graphName));
         final ManagementSystem mgmt = (ManagementSystem) graph.openManagement();
         mgmt.evictGraphFromCache();
         mgmt.commit();
@@ -287,6 +290,15 @@ public class ConfiguredGraphFactory {
     public static Map<String, Object> getTemplateConfiguration() {
         final ConfigurationManagementGraph configManagementGraph = getConfigGraphManagementInstance();
         return configManagementGraph.getTemplateConfiguration();
+    }
+
+    /**
+     * Get traversal source name given a graph name.
+     * @param graphName
+     * @return A traversal source name for the provided graph name
+     */
+    public static String toTraversalSourceName(String graphName){
+        return graphName + "_traversal";
     }
 }
 


### PR DESCRIPTION
This fixes #2236 by removing graph traversal sources and graphs when they are dropped/removed by the `ConfiguredGraphFactory`.

### For all changes:
- [X] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

