### PR TITLE
Fixes #2255: leaked transactions in ConsistentKeyLocker

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/locking/consistentkey/ConsistentKeyLocker.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/locking/consistentkey/ConsistentKeyLocker.java
@@ -382,13 +382,20 @@ public class ConsistentKeyLocker extends AbstractLocker<ConsistentKeyLockStatus>
         final Timer writeTimer = times.getTimer().start();
         StaticBuffer newLockCol = serializer.toLockCol(writeTimer.getStartTime(), rid, times);
         Entry newLockEntry = StaticArrayEntry.of(newLockCol, zeroBuf);
+        StoreTransaction newTx = null;
         try {
-            final StoreTransaction newTx = overrideTimestamp(txh, writeTimer.getStartTime());
+            newTx = overrideTimestamp(txh, writeTimer.getStartTime());
+
             store.mutate(key, Collections.singletonList(newLockEntry),
                 null == del ? KeyColumnValueStore.NO_DELETIONS : Collections.singletonList(del), newTx);
+
+            newTx.commit();
+            newTx = null;
         } catch (BackendException e) {
             log.debug("Lock write attempt failed with exception", e);
             t = e;
+        } finally {
+            rollbackIfNotNull(newTx);
         }
         writeTimer.stop();
 
@@ -398,11 +405,18 @@ public class ConsistentKeyLocker extends AbstractLocker<ConsistentKeyLockStatus>
     private WriteResult tryDeleteLockOnce(StaticBuffer key, StaticBuffer col, StoreTransaction txh) {
         Throwable t = null;
         final Timer delTimer = times.getTimer().start();
+        StoreTransaction newTx = null;
         try {
-            final StoreTransaction newTx = overrideTimestamp(txh, delTimer.getStartTime());
+            newTx = overrideTimestamp(txh, delTimer.getStartTime());
+
             store.mutate(key, ImmutableList.of(), Collections.singletonList(col), newTx);
+
+            newTx.commit();
+            newTx = null;
         } catch (BackendException e) {
             t = e;
+        } finally {
+            rollbackIfNotNull(newTx);
         }
         delTimer.stop();
 
@@ -533,9 +547,13 @@ public class ConsistentKeyLocker extends AbstractLocker<ConsistentKeyLockStatus>
     protected void deleteSingleLock(KeyColumn kc, ConsistentKeyLockStatus ls, StoreTransaction tx) {
         List<StaticBuffer> deletions = ImmutableList.of(serializer.toLockCol(ls.getWriteTimestamp(), rid, times));
         for (int i = 0; i < lockRetryCount; i++) {
+            StoreTransaction newTx = null;
             try {
-                StoreTransaction newTx = overrideTimestamp(tx, times.getTime());
+                newTx = overrideTimestamp(tx, times.getTime());
                 store.mutate(serializer.toLockKey(kc.getKey(), kc.getColumn()), ImmutableList.of(), deletions, newTx);
+
+                newTx.commit();
+                newTx = null;
                 return;
             } catch (TemporaryBackendException e) {
                 log.warn("Temporary storage exception while deleting lock", e);
@@ -543,6 +561,8 @@ public class ConsistentKeyLocker extends AbstractLocker<ConsistentKeyLockStatus>
             } catch (BackendException e) {
                 log.error("Storage exception while deleting lock", e);
                 return; // give up on this lock
+            } finally {
+                rollbackIfNotNull(newTx);
             }
         }
     }
@@ -552,6 +572,21 @@ public class ConsistentKeyLocker extends AbstractLocker<ConsistentKeyLockStatus>
         StandardBaseTransactionConfig newCfg = new StandardBaseTransactionConfig.Builder(tx.getConfiguration())
                .commitTime(commitTime).build();
         return manager.beginTransaction(newCfg);
+    }
+
+    private void rollbackIfNotNull(StoreTransaction tx) {
+        if (tx != null) {
+            try {
+                if (log.isDebugEnabled()) {
+                    log.debug("Transaction is still open! Rolling back: " + tx.toString(), new Throwable());
+                }
+
+                tx.rollback();
+            } catch (Throwable excp) {
+                log.error("Failed to rollback transaction " + tx.toString() + ". The transaction may be leaked.", excp);
+            }
+        }
+
     }
 
     private static class WriteResult {


### PR DESCRIPTION
#2225: Fixed transaction leaks in ConsistentKeyLocker. Updated unit tests to detect leaked transaction.

(cherry picked from commit 12718473fae6e9172e292cfcd61de175d22b2577)
(cherry picked from commit 3e16a8fdd8dc81a47529cf0950d60c7ed3debdd3)
