### PR TITLE
Enhance profiler results

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KeySliceQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KeySliceQuery.java
@@ -79,6 +79,6 @@ public class KeySliceQuery extends SliceQuery {
 
     @Override
     public String toString() {
-        return String.format("KeySliceQuery(key: %s, start: %s, end: %s, limit:%d)", key, getSliceStart(), getSliceEnd(), getLimit());
+        return "KeySliceQuery(" + key + ")[" + getSliceStart() + "," + getSliceEnd() + ")@" + getLimit();
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/SliceQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/SliceQuery.java
@@ -42,6 +42,12 @@ public class SliceQuery extends BaseQuery implements BackendQuery<SliceQuery> {
 
     private final StaticBuffer sliceStart;
     private final StaticBuffer sliceEnd;
+    private String type;
+
+    public SliceQuery(final StaticBuffer sliceStart, final StaticBuffer sliceEnd, final String type) {
+        this(sliceStart, sliceEnd);
+        this.type = type;
+    }
 
     public SliceQuery(final StaticBuffer sliceStart, final StaticBuffer sliceEnd) {
         assert sliceStart != null && sliceEnd != null;
@@ -135,6 +141,16 @@ public class SliceQuery extends BaseQuery implements BackendQuery<SliceQuery> {
     @Override
     public SliceQuery updateLimit(int newLimit) {
         return new SliceQuery(sliceStart, sliceEnd).setLimit(newLimit);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        if (type != null) {
+            sb.append(type).append(":");
+        }
+        sb.append("SliceQuery[").append(getSliceStart()).append(",").append(getSliceEnd()).append(")@").append(getLimit());
+        return sb.toString();
     }
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/EdgeSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/EdgeSerializer.java
@@ -491,7 +491,7 @@ public class EdgeSerializer implements RelationReader {
                 sliceEnd = BufferUtil.nextBiggerBuffer(sliceStart);
             }
         }
-        return new SliceQuery(sliceStart, sliceEnd);
+        return new SliceQuery(sliceStart, sliceEnd, type.name());
     }
 
     public static class TypedInterval {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/BackendQueryHolder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/BackendQueryHolder.java
@@ -73,9 +73,9 @@ public class BackendQueryHolder<E extends BackendQuery<E>> implements ProfileObs
     }
 
     @Override
-    public void observeWith(QueryProfiler parentProfiler) {
+    public void observeWith(QueryProfiler parentProfiler, boolean hasSiblings) {
         Preconditions.checkArgument(parentProfiler!=null);
-        this.profiler = parentProfiler.addNested(QueryProfiler.OR_QUERY);
+        profiler = parentProfiler.addNested(QueryProfiler.OR_QUERY, hasSiblings);
         profiler.setAnnotation(QueryProfiler.FITTED_ANNOTATION,isFitted);
         profiler.setAnnotation(QueryProfiler.ORDERED_ANNOTATION,isSorted);
         profiler.setAnnotation(QueryProfiler.QUERY_ANNOTATION,backendQuery);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/ElementQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/ElementQuery.java
@@ -15,6 +15,7 @@
 package org.janusgraph.graphdb.query;
 
 import org.janusgraph.core.JanusGraphElement;
+import org.janusgraph.graphdb.query.profile.ProfileObservable;
 
 import java.util.Comparator;
 
@@ -25,7 +26,7 @@ import java.util.Comparator;
  * @author Matthias Broecheler (me@matthiasb.com)
  */
 
-public interface ElementQuery<R extends JanusGraphElement,B extends BackendQuery<B>> extends Query {
+public interface ElementQuery<R extends JanusGraphElement,B extends BackendQuery<B>> extends Query, ProfileObservable {
 
     /**
      * Whether the combination of the individual sub-queries can result in duplicate

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/GraphCentricQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/GraphCentricQuery.java
@@ -39,7 +39,7 @@ import java.util.Objects;
  *
  * @author Matthias Broecheler (me@matthiasb.com)
  */
-public class GraphCentricQuery extends BaseQuery implements ElementQuery<JanusGraphElement, JointIndexQuery>, ProfileObservable {
+public class GraphCentricQuery extends BaseQuery implements ElementQuery<JanusGraphElement, JointIndexQuery> {
 
     /**
      * The condition of this query, the result set is the set of all elements in the graph for which this
@@ -58,6 +58,8 @@ public class GraphCentricQuery extends BaseQuery implements ElementQuery<JanusGr
      * The type of element this query is asking for: vertex, edge, or property.
      */
     private final ElementCategory resultType;
+
+    private QueryProfiler profiler;
 
     public GraphCentricQuery(ElementCategory resultType, Condition<JanusGraphElement> condition, OrderList orders,
                              BackendQueryHolder<JointIndexQuery> indexQuery, int limit) {
@@ -155,10 +157,16 @@ public class GraphCentricQuery extends BaseQuery implements ElementQuery<JanusGr
 
 
     @Override
-    public void observeWith(QueryProfiler profiler) {
+    public void observeWith(QueryProfiler profiler, boolean hasSiblings) {
+        this.profiler = profiler;
         profiler.setAnnotation(QueryProfiler.CONDITION_ANNOTATION,condition);
         profiler.setAnnotation(QueryProfiler.ORDERS_ANNOTATION,orders);
         if (hasLimit()) profiler.setAnnotation(QueryProfiler.LIMIT_ANNOTATION,getLimit());
         indexQuery.observeWith(profiler);
+    }
+
+    @Override
+    public QueryProfiler getProfiler() {
+        return profiler;
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/GraphCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/GraphCentricQueryBuilder.java
@@ -228,9 +228,6 @@ public class GraphCentricQueryBuilder implements JanusGraphQuery<GraphCentricQue
     public GraphCentricQuery constructQuery(final ElementCategory resultType) {
         final QueryProfiler optProfiler = profiler.addNested(QueryProfiler.OPTIMIZATION);
         optProfiler.startTimer();
-        if (this.globalConstraints.isEmpty()) {
-            this.globalConstraints.add(this.constraints);
-        }
         final GraphCentricQuery query = constructQueryWithoutProfile(resultType);
         optProfiler.stopTimer();
         query.observeWith(profiler);
@@ -241,6 +238,9 @@ public class GraphCentricQueryBuilder implements JanusGraphQuery<GraphCentricQue
         Preconditions.checkNotNull(resultType);
         if (limit == 0) return GraphCentricQuery.emptyQuery(resultType);
 
+        if (this.globalConstraints.isEmpty()) {
+            this.globalConstraints.add(this.constraints);
+        }
         //Prepare constraints
         final MultiCondition<JanusGraphElement> conditions;
         if (this.globalConstraints.size() == 1) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/ProfileObservable.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/ProfileObservable.java
@@ -19,6 +19,12 @@ package org.janusgraph.graphdb.query.profile;
  */
 public interface ProfileObservable {
 
-    void observeWith(QueryProfiler profiler);
+    default void observeWith(QueryProfiler profiler) {
+        observeWith(profiler, false);
+    }
+
+    void observeWith(QueryProfiler profiler, boolean hasSiblings);
+
+    QueryProfiler getProfiler();
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/SimpleQueryProfiler.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/SimpleQueryProfiler.java
@@ -44,7 +44,7 @@ public class SimpleQueryProfiler implements QueryProfiler, Iterable<SimpleQueryP
     }
 
     @Override
-    public QueryProfiler addNested(String groupName) {
+    public QueryProfiler addNested(String groupName, boolean hasSiblings) {
         SimpleQueryProfiler nested = new SimpleQueryProfiler(groupName);
         nestedProfilers.add(nested);
         return nested;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BaseVertexCentricQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BaseVertexCentricQuery.java
@@ -60,6 +60,8 @@ public class BaseVertexCentricQuery extends BaseQuery implements ProfileObservab
      */
     protected final Direction direction;
 
+    private QueryProfiler profiler = QueryProfiler.NO_OP;
+
     public BaseVertexCentricQuery(Condition<JanusGraphRelation> condition, Direction direction,
                                   List<BackendQueryHolder<SliceQuery>> queries, OrderList orders,
                                   int limit) {
@@ -136,10 +138,17 @@ public class BaseVertexCentricQuery extends BaseQuery implements ProfileObservab
     }
 
     @Override
-    public void observeWith(QueryProfiler profiler) {
+    public void observeWith(QueryProfiler profiler, boolean hasSiblings) {
+        this.profiler = profiler;
         profiler.setAnnotation(QueryProfiler.CONDITION_ANNOTATION,condition);
         profiler.setAnnotation(QueryProfiler.ORDERS_ANNOTATION,orders);
         if (hasLimit()) profiler.setAnnotation(QueryProfiler.LIMIT_ANNOTATION,getLimit());
-        queries.forEach(bqh -> bqh.observeWith(profiler));
+        boolean consistsOfMultipleQueries = queries.size() > 1;
+        queries.forEach(bqh -> bqh.observeWith(profiler, consistsOfMultipleQueries));
+    }
+
+    @Override
+    public QueryProfiler getProfiler() {
+        return profiler;
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
@@ -123,6 +123,14 @@ public abstract class BasicVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q
     }
 
     /**
+     * Returns the query profiler that observes this query
+     * @return
+     */
+    public QueryProfiler getProfiler() {
+       return profiler;
+    }
+
+    /**
      * Restricts the result set of this query to only system types.
      * @return
      */

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/VertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/VertexCentricQueryBuilder.java
@@ -83,7 +83,8 @@ public class VertexCentricQueryBuilder extends BasicVertexCentricQueryBuilder<Ve
                 }
             }
         } else profiler.setAnnotation(QueryProfiler.NUMVERTICES_ANNOTATION,1);
-        return resultConstructor.getResult(vertex,bq);
+        Q result = resultConstructor.getResult(vertex,bq);
+        return result;
     }
 
     //#### RELATIONS

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/QueryInfo.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/QueryInfo.java
@@ -28,11 +28,11 @@ public class QueryInfo {
 
     private final  List<OrderEntry> orders;
 
-    private Integer lowLimit;
+    private int lowLimit;
 
-    private Integer highLimit;
+    private int highLimit;
 
-    public QueryInfo(List<OrderEntry> orders, Integer lowLimit, Integer highLimit) {
+    public QueryInfo(List<OrderEntry> orders, int lowLimit, int highLimit) {
         this.orders = orders;
         this.lowLimit = lowLimit;
         this.highLimit = highLimit;
@@ -42,20 +42,20 @@ public class QueryInfo {
         return orders;
     }
 
-    public Integer getLowLimit() {
+    public int getLowLimit() {
         return lowLimit;
     }
 
-    public Integer getHighLimit() {
+    public int getHighLimit() {
         return highLimit;
     }
 
-    public QueryInfo setLowLimit(Integer lowLimit) {
+    public QueryInfo setLowLimit(int lowLimit) {
         this.lowLimit = lowLimit;
         return this;
     }
 
-    public QueryInfo setHighLimit(Integer highLimit) {
+    public QueryInfo setHighLimit(int highLimit) {
         this.highLimit = highLimit;
         return this;
     }
@@ -71,6 +71,6 @@ public class QueryInfo {
         else if (other==null) return false;
         else if (!getClass().isInstance(other)) return false;
         QueryInfo oth = (QueryInfo)other;
-        return Objects.equals(orders, oth.orders) && Objects.equals(lowLimit, oth.lowLimit) && highLimit.equals(oth.highLimit);
+        return Objects.equals(orders, oth.orders) && lowLimit == lowLimit && highLimit == highLimit;
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/step/JanusGraphVertexStep.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/step/JanusGraphVertexStep.java
@@ -90,7 +90,7 @@ public class JanusGraphVertexStep<E extends Element> extends VertexStep<E> imple
         }
         for (final OrderEntry order : orders) query.orderBy(order.key, order.order);
         if (limit != BaseQuery.NO_LIMIT) query.limit(limit);
-        ((BasicVertexCentricQueryBuilder) query).profiler(queryProfiler);
+        ((BasicVertexCentricQueryBuilder) query).profiler(queryProfiler.addNested(QueryProfiler.VERTEX_CENTRIC_QUERY));
         return query;
     }
 
@@ -189,7 +189,10 @@ public class JanusGraphVertexStep<E extends Element> extends VertexStep<E> imple
             result = multiQueryResults.get(traverser.get());
         } else {
             final JanusGraphVertexQuery query = makeQuery((JanusGraphTraversalUtil.getJanusGraphVertex(traverser)).query());
+            QueryProfiler profiler = ((BasicVertexCentricQueryBuilder) query).getProfiler();
+            profiler.startTimer();
             result = (Vertex.class.isAssignableFrom(getReturnClass())) ? query.vertices() : query.edges();
+            profiler.stopTimer();
         }
 
         if (batchPropertyPrefetching) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/profile/TP3ProfileWrapper.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/profile/TP3ProfileWrapper.java
@@ -26,15 +26,16 @@ public class TP3ProfileWrapper implements QueryProfiler {
 
     private final MutableMetrics metrics;
     private int subMetricCounter = 0;
+    private boolean timerRunning;
 
     public TP3ProfileWrapper(MutableMetrics metrics) {
         this.metrics = metrics;
     }
 
     @Override
-    public QueryProfiler addNested(String groupName) {
-        //Flatten out AND/OR nesting
-        if (groupName.equals(AND_QUERY) || groupName.equals(OR_QUERY)) return this;
+    public QueryProfiler addNested(String groupName, boolean hasSiblings) {
+        //Flatten out AND/OR nesting unless it has siblings
+        if (!hasSiblings && (groupName.equals(AND_QUERY) || groupName.equals(OR_QUERY))) return this;
 
         int nextId = (subMetricCounter++);
         MutableMetrics nested = new MutableMetrics(metrics.getId()+"."+groupName+"_"+nextId,groupName);

--- a/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrJanusGraphIndexTest.java
+++ b/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrJanusGraphIndexTest.java
@@ -43,6 +43,11 @@ public abstract class SolrJanusGraphIndexTest extends JanusGraphIndexTest {
         return false;
     }
 
+    @Override
+    public String getStringField(String propertyKey) {
+        return propertyKey + "_s";
+    }
+
     @Test
     public void testRawQueries() {
         clopen(option(SolrIndex.DYNAMIC_FIELDS,JanusGraphIndexTest.INDEX),false);


### PR DESCRIPTION
1. Add toString() method to SliceQuery to indicate which vertex-centric
index is used in edge queries.
2. Indicate "GraphCentricQuery" and "VertexCentricQuery" in profiler if applicable.
Previously they were incorrectly merged, causing corrupted annotations.
3. Indicate "constructGraphCentricQuery" phase in profiler rather than a vague
"optimization" annotation, if applicable.
4. Fix corrupted annotations caused by nested profile flattening issue. Now
AND/OR nesting is flattened only if it does not have siblings.
5. Remove backend-query subgroup to reduce nesting levels in profiler result.
Now whether a backend-query is fired can be inferred from "isCached" annotation.
6. Remove fullscan subgroup to reduce nesting levels in profiler result. Now
whether a full scan is done can be inferred from "fullscan" annotation.
Fixes #898, #2283, #2285

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

