### PR TITLE
Bump Elasticsearch version to 7.10.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -61,7 +61,7 @@ compile "org.janusgraph:janusgraph-core:0.6.0"
 * Apache HBase 1.2.6, 1.3.1, 1.4.10, 2.1.5
 * Google Bigtable 1.3.0, 1.4.0, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.9.0, 1.10.0, 1.11.0, 1.14.0
 * Oracle BerkeleyJE 7.5.11
-* Elasticsearch 6.0.1, 6.6.0, 7.6.2
+* Elasticsearch 6.0.1, 6.6.0, 7.10.1
 * Apache Lucene 8.6.0
 * Apache Solr 7.7.2, 8.5.2
 * Apache TinkerPop 3.4.9

--- a/janusgraph-es/pom.xml
+++ b/janusgraph-es/pom.xml
@@ -13,7 +13,7 @@
         <top.level.basedir>${basedir}/..</top.level.basedir>
         <elasticsearch60.docker.version>6.0.1</elasticsearch60.docker.version>
         <elasticsearch6.docker.version>6.6.0</elasticsearch6.docker.version>
-        <elasticsearch7.docker.version>7.6.2</elasticsearch7.docker.version>
+        <elasticsearch7.docker.version>7.10.1</elasticsearch7.docker.version>
         <elasticsearch.docker.version>${elasticsearch7.docker.version}</elasticsearch.docker.version>
         <skip.es.test>${skipTests}</skip.es.test>
         <elasticsearch.docker.image>docker.elastic.co/elasticsearch/elasticsearch</elasticsearch.docker.image>

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/JanusGraphElasticsearchContainer.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/JanusGraphElasticsearchContainer.java
@@ -33,7 +33,7 @@ import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.IN
 public class JanusGraphElasticsearchContainer extends ElasticsearchContainer {
 
     private static final Integer ELASTIC_PORT = 9200;
-    private static final String DEFAULT_VERSION = "7.6.0";
+    private static final String DEFAULT_VERSION = "7.10.1";
     private static final String DEFAULT_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch";
 
     public static ElasticMajorVersion getEsMajorVersion() {

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <jackson1.version>1.9.13</jackson1.version>
         <jackson2.version>2.11.2</jackson2.version>
         <lucene-solr.version>8.6.2</lucene-solr.version>
-        <elasticsearch.version>7.6.2</elasticsearch.version>
+        <elasticsearch.version>7.10.1</elasticsearch.version>
         <commons.beanutils.version>1.7.0</commons.beanutils.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <zookeeper.version>3.5.7</zookeeper.version>


### PR DESCRIPTION
I was unable to run Elasticsearch tests on my Macbook. Bumping to the latest version of ES solved the problem.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
