### PR TITLE
Make any passed cassandra image consider as compatible

### DIFF
--- a/.github/workflows/ci-backend-cql.yml
+++ b/.github/workflows/ci-backend-cql.yml
@@ -87,6 +87,9 @@ jobs:
           - module: cql
             args: "-Pcassandra3-murmur-client-auth -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
             name: murmur-client-auth
+          - module: cql
+            args: "-Pscylladb -Dcassandra.docker.image=scylladb/scylla -Dcassandra.docker.version=4.3.0 -Dtest.cql.excludes=MEMORY_TESTS,PERFORMANCE_TESTS,BRITTLE_TESTS"
+            name: scylladb
     steps:
       - uses: actions/checkout@v2
         with:
@@ -102,9 +105,50 @@ jobs:
           java-version: 1.8
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
-      - name: cql 3.0.18
-        if: "github.event_name == 'push' && contains(github.event.head_commit.message, '[cql-tests]') || github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[cql-tests]')"
-        run: mvn verify --projects janusgraph-${{ matrix.module }} -Dcassandra.docker.version=3.0.18' ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
+      - uses: codecov/codecov-action@v1
+
+  full-tests:
+    runs-on: ubuntu-20.04
+    if: "github.event_name == 'push' && contains(github.event.head_commit.message, '[cql-tests]') || github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[cql-tests]')"
+    needs: build-all
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - module: cql
+            args: "-Pcassandra3-byteordered -Dtest=\"**/diskstorage/cql/*\""
+            name: byteordered-diskstorage
+          - module: cql
+            args: "-Pcassandra3-murmur -Dtest=\"**/diskstorage/cql/*\""
+            name: murmur-diskstorage
+          - module: cql
+            args: "-Pcassandra3-byteordered -Dtest=\"**/graphdb/cql/*\""
+            name: byteordered-graphdb
+          - module: cql
+            args: "-Pcassandra3-murmur -Dtest=\"**/graphdb/cql/*\""
+            name: murmur-graphdb
+          - module: cql
+            args: "-Pcassandra3-murmur -Dtest=\"**/hadoop/*\""
+            name: murmur-hadoop
+          - module: cql
+            args: "-Pcassandra3-murmur-ssl -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
+            name: murmur-ssl
+          - module: cql
+            args: "-Pcassandra3-murmur-client-auth -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
+            name: murmur-client-auth
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
+      - run: mvn verify --projects janusgraph-${{ matrix.module }} -Dcassandra.docker.version=3.0.18' ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
       - uses: codecov/codecov-action@v1
         with:
           name: codecov-cql-${{ matrix.name }}

--- a/.github/workflows/ci-backend-cql.yml
+++ b/.github/workflows/ci-backend-cql.yml
@@ -88,8 +88,18 @@ jobs:
             args: "-Pcassandra3-murmur-client-auth -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
             name: murmur-client-auth
           - module: cql
-            args: "-Pscylladb -Dcassandra.docker.image=scylladb/scylla -Dcassandra.docker.version=4.3.0 -Dtest.cql.excludes=MEMORY_TESTS,PERFORMANCE_TESTS,BRITTLE_TESTS"
-            name: scylladb
+            args: "-Pscylladb -Dtest=\"**/diskstorage/cql/*\""
+            name: scylladb-diskstorage
+          - module: cql
+            args: "-Pscylladb -Dtest=\"**/graphdb/cql/*\""
+            name: scylladb-graphdb
+          # FIXME: this takes forever to run
+          # - module: cql
+          #   args: "-Pscylladb -Dtest=\"**/hadoop/*\""
+          #   name: scylladb-hadoop
+          - module: cql
+            args: "-Pscylladb -Dtest=\"**/core/cql/*\""
+            name: scylladb-core
     steps:
       - uses: actions/checkout@v2
         with:
@@ -106,6 +116,8 @@ jobs:
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
       - uses: codecov/codecov-action@v1
+        with:
+          name: codecov-cql-${{ matrix.name }}
 
   full-tests:
     runs-on: ubuntu-20.04
@@ -117,25 +129,22 @@ jobs:
         include:
           - module: cql
             args: "-Pcassandra3-byteordered -Dtest=\"**/diskstorage/cql/*\""
-            name: byteordered-diskstorage
           - module: cql
             args: "-Pcassandra3-murmur -Dtest=\"**/diskstorage/cql/*\""
-            name: murmur-diskstorage
           - module: cql
             args: "-Pcassandra3-byteordered -Dtest=\"**/graphdb/cql/*\""
-            name: byteordered-graphdb
           - module: cql
             args: "-Pcassandra3-murmur -Dtest=\"**/graphdb/cql/*\""
-            name: murmur-graphdb
           - module: cql
             args: "-Pcassandra3-murmur -Dtest=\"**/hadoop/*\""
-            name: murmur-hadoop
+          - module: cql
+            args: "-Pcassandra3-byteordered -Dtest=\"**/core/cql/*\""
+          - module: cql
+            args: "-Pcassandra3-murmur -Dtest=\"**/core/cql/*\""
           - module: cql
             args: "-Pcassandra3-murmur-ssl -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
-            name: murmur-ssl
           - module: cql
             args: "-Pcassandra3-murmur-client-auth -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
-            name: murmur-client-auth
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -149,6 +158,3 @@ jobs:
           java-version: 1.8
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} -Dcassandra.docker.version=3.0.18' ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
-      - uses: codecov/codecov-action@v1
-        with:
-          name: codecov-cql-${{ matrix.name }}

--- a/janusgraph-cql/pom.xml
+++ b/janusgraph-cql/pom.xml
@@ -386,6 +386,7 @@
                 <test.skip.murmur>true</test.skip.murmur>
                 <test.skip.murmur-serial>true</test.skip.murmur-serial>
                 <test.skip.murmur-ssl>true</test.skip.murmur-ssl>
+                <test.cql.excludes>${test.excluded.groups}</test.cql.excludes>
             </properties>
         </profile>
     </profiles>

--- a/janusgraph-cql/pom.xml
+++ b/janusgraph-cql/pom.xml
@@ -379,7 +379,7 @@
         <profile>
             <id>scylladb</id>
             <properties>
-                <cassandra.docker.version>3.0.9</cassandra.docker.version>
+                <cassandra.docker.version>4.3.0</cassandra.docker.version>
                 <cassandra.docker.image>scylladb/scylla</cassandra.docker.image>
                 <cassandra.docker.useDefaultConfigFromImage>true</cassandra.docker.useDefaultConfigFromImage>
                 <test.skip.byteordered>true</test.skip.byteordered>

--- a/janusgraph-cql/src/test/java/org/janusgraph/JanusGraphCassandraContainer.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/JanusGraphCassandraContainer.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.CassandraContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -93,7 +94,7 @@ public class JanusGraphCassandraContainer extends CassandraContainer<JanusGraphC
     }
 
     public JanusGraphCassandraContainer(boolean bindDefaultPort) {
-        super(getCassandraImage() + ":" + getVersion());
+        super(DockerImageName.parse(getCassandraImage() + ":" + getVersion()).asCompatibleSubstituteFor(DEFAULT_IMAGE));
         if (bindDefaultPort) {
             addFixedExposedPort(CQL_PORT, CQL_PORT);
         }


### PR DESCRIPTION
since `scylladb/scylla` were comptible out of the box for
testcontinars, we now enable any docker image to be cosider as
cassandra comptible

Fixes: #2351

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
