### PR TITLE
Enhance GraphCentricQuery profiling

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -72,7 +72,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.util.Metrics;
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalMetrics;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Property;
@@ -4455,29 +4454,6 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertTrue(queryProfilerAnnotationIsPresent(t, QueryProfiler.MULTIQUERY_ANNOTATION));
     }
 
-    private static void verifyMetrics(Metrics metric, boolean fromCache, boolean multiQuery) {
-        assertTrue(metric.getDuration(TimeUnit.MICROSECONDS) > 0);
-        assertTrue(metric.getCount(TraversalMetrics.ELEMENT_COUNT_ID) > 0);
-        String hasMultiQuery = (String) metric.getAnnotation(QueryProfiler.MULTIQUERY_ANNOTATION);
-        assertTrue(multiQuery ? hasMultiQuery.equalsIgnoreCase("true") : hasMultiQuery == null);
-        for (Metrics subMetric : metric.getNested()) {
-            assertTrue(subMetric.getDuration(TimeUnit.MICROSECONDS) > 0);
-            switch (subMetric.getName()) {
-                case "optimization":
-                    assertNull(subMetric.getCount(TraversalMetrics.ELEMENT_COUNT_ID));
-                    break;
-                case QueryProfiler.BACKEND_QUERY:
-                    if (fromCache) fail("Should not execute backend-queries when cached");
-                    assertTrue(subMetric.getCount(TraversalMetrics.ELEMENT_COUNT_ID) > 0);
-                    break;
-                default:
-                    fail("Unrecognized nested query: " + subMetric.getName());
-            }
-
-        }
-
-    }
-
     @Test
     public void testSimpleTinkerPopTraversal() {
         Vertex v1 = graph.addVertex("name", "josh");
@@ -5692,6 +5668,135 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertTrue(tx.traversal().V().not(__.has("p2")).hasNext());
         // property registered in schema and has composite index
         assertTrue(tx.traversal().V().not(__.has("p3")).hasNext());
+    }
+
+    @Test
+    public void testGraphCentricQueryProfiling() {
+        final PropertyKey name = makeKey("name", String.class);
+        final PropertyKey weight = makeKey("weight", Integer.class);
+        final JanusGraphIndex compositeNameIndex = mgmt.buildIndex("nameIdx", Vertex.class).addKey(name).buildCompositeIndex();
+        final JanusGraphIndex compositeWeightIndex = mgmt.buildIndex("weightIdx", Vertex.class).addKey(weight).buildCompositeIndex();
+        final PropertyKey prop = makeKey("prop", Integer.class);
+        finishSchema();
+
+        JanusGraphVertex v = tx.addVertex("name", "bob", "prop", 100, "weight", 100);
+        tx.commit();
+
+        // satisfied by a single composite index query
+        newTx();
+        Metrics mCompSingle = tx.traversal().V().has("name", "bob").profile().next().getMetrics(0);
+        assertEquals("JanusGraphStep([],[name.eq(bob)])", mCompSingle.getName());
+        assertTrue(mCompSingle.getDuration(TimeUnit.MICROSECONDS) > 0);
+        assertEquals(3, mCompSingle.getNested().size());
+        Metrics nested = (Metrics) mCompSingle.getNested().toArray()[0];
+        assertEquals(QueryProfiler.CONSTRUCT_GRAPH_CENTRIC_QUERY, nested.getName());
+        assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
+        nested = (Metrics) mCompSingle.getNested().toArray()[1];
+        assertEquals(QueryProfiler.CONSTRUCT_GRAPH_CENTRIC_QUERY, nested.getName());
+        assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
+        nested = (Metrics) mCompSingle.getNested().toArray()[2];
+        assertEquals(QueryProfiler.GRAPH_CENTRIC_QUERY, nested.getName());
+        assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
+        Map<String, String> nameIdxAnnotations = new HashMap() {{
+            put("condition", "(name = bob)");
+            put("orders", "[]");
+            put("isFitted", "true");
+            put("isOrdered", "true");
+            put("query", "multiKSQ[1]@1000");
+            put("index", "nameIdx");
+        }};
+        assertEquals(nameIdxAnnotations, nested.getAnnotations());
+
+        // satisfied by unions of two separate graph-centric queries, each satisfied by a single composite index query
+        newTx();
+        Metrics mCompMultiOr = tx.traversal().V().or(__.has("name", "bob"), __.has("weight", 100))
+            .profile().next().getMetrics(0);
+        assertEquals("Or(JanusGraphStep([],[name.eq(bob)]),JanusGraphStep([],[weight.eq(100)]))", mCompMultiOr.getName());
+        assertTrue(mCompMultiOr.getDuration(TimeUnit.MICROSECONDS) > 0);
+        assertEquals(5, mCompMultiOr.getNested().size());
+        nested = (Metrics) mCompMultiOr.getNested().toArray()[0];
+        assertEquals(QueryProfiler.CONSTRUCT_GRAPH_CENTRIC_QUERY, nested.getName());
+        assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
+        nested = (Metrics) mCompMultiOr.getNested().toArray()[1];
+        assertEquals(QueryProfiler.CONSTRUCT_GRAPH_CENTRIC_QUERY, nested.getName());
+        assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
+        nested = (Metrics) mCompMultiOr.getNested().toArray()[2];
+        assertEquals(QueryProfiler.GRAPH_CENTRIC_QUERY, nested.getName());
+        assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
+        assertEquals(nameIdxAnnotations, nested.getAnnotations());
+        nested = (Metrics) mCompMultiOr.getNested().toArray()[3];
+        assertEquals(QueryProfiler.CONSTRUCT_GRAPH_CENTRIC_QUERY, nested.getName());
+        assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
+        nested = (Metrics) mCompMultiOr.getNested().toArray()[4];
+        assertEquals(QueryProfiler.GRAPH_CENTRIC_QUERY, nested.getName());
+        assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
+        Map<String, String> weightIdxAnnotations = new HashMap() {{
+            put("condition", "(weight = 100)");
+            put("orders", "[]");
+            put("isFitted", "true");
+            put("isOrdered", "true");
+            put("query", "multiKSQ[1]@1000");
+            put("index", "weightIdx");
+        }};
+        assertEquals(weightIdxAnnotations, nested.getAnnotations());
+
+        // satisfied by one graph-centric query, which satisfied by in-memory filtering after one composite index query
+        newTx();
+        Metrics mUnfittedMultiAnd = tx.traversal().V().and(__.has("name", "bob"), __.has("prop", 100))
+            .profile().next().getMetrics(0);
+        assertEquals("JanusGraphStep([],[name.eq(bob), prop.eq(100)])", mUnfittedMultiAnd.getName());
+        assertTrue(mUnfittedMultiAnd.getDuration(TimeUnit.MICROSECONDS) > 0);
+        assertEquals(3, mUnfittedMultiAnd.getNested().size());
+        nested = (Metrics) mUnfittedMultiAnd.getNested().toArray()[0];
+        assertEquals(QueryProfiler.CONSTRUCT_GRAPH_CENTRIC_QUERY, nested.getName());
+        assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
+        nested = (Metrics) mUnfittedMultiAnd.getNested().toArray()[1];
+        assertEquals(QueryProfiler.CONSTRUCT_GRAPH_CENTRIC_QUERY, nested.getName());
+        assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
+        nested = (Metrics) mUnfittedMultiAnd.getNested().toArray()[2];
+        assertEquals(QueryProfiler.GRAPH_CENTRIC_QUERY, nested.getName());
+        assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
+        Map<String, String> annotations = new HashMap() {{
+            put("condition", "(name = bob AND prop = 100)");
+            put("orders", "[]");
+            put("isFitted", "false"); // not fitted because prop = 100 requires in-memory filtering
+            put("isOrdered", "true");
+            put("query", "multiKSQ[1]@2000");
+            put("index", "nameIdx");
+        }};
+        assertEquals(annotations, nested.getAnnotations());
+
+        // satisfied by union of two separate graph-centric queries, one satisfied by a composite index query and the other requires full scan
+        newTx();
+        Metrics mUnfittedMultiOr = tx.traversal().V().or(__.has("name", "bob"), __.has("prop", 100))
+            .profile().next().getMetrics(0);
+        assertEquals("Or(JanusGraphStep([],[name.eq(bob)]),JanusGraphStep([],[prop.eq(100)]))", mUnfittedMultiOr.getName());
+        assertTrue(mUnfittedMultiOr.getDuration(TimeUnit.MICROSECONDS) > 0);
+        assertEquals(5, mUnfittedMultiOr.getNested().size());
+        nested = (Metrics) mUnfittedMultiOr.getNested().toArray()[0];
+        assertEquals(QueryProfiler.CONSTRUCT_GRAPH_CENTRIC_QUERY, nested.getName());
+        assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
+        nested = (Metrics) mUnfittedMultiOr.getNested().toArray()[1];
+        assertEquals(QueryProfiler.CONSTRUCT_GRAPH_CENTRIC_QUERY, nested.getName());
+        assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
+        nested = (Metrics) mUnfittedMultiOr.getNested().toArray()[2];
+        assertEquals(QueryProfiler.GRAPH_CENTRIC_QUERY, nested.getName());
+        assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
+        assertEquals(nameIdxAnnotations, nested.getAnnotations());
+        nested = (Metrics) mUnfittedMultiOr.getNested().toArray()[3];
+        assertEquals(QueryProfiler.CONSTRUCT_GRAPH_CENTRIC_QUERY, nested.getName());
+        assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
+        nested = (Metrics) mUnfittedMultiOr.getNested().toArray()[4];
+        assertEquals(QueryProfiler.GRAPH_CENTRIC_QUERY, nested.getName());
+        assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
+        Map<String, String> fullScanAnnotations = new HashMap() {{
+            put("condition", "(prop = 100)");
+            put("orders", "[]");
+            put("isFitted", "false");
+            put("isOrdered", "true");
+            put("query", "[]");
+        }};
+        assertEquals(fullScanAnnotations, nested.getAnnotations());
     }
 
     @Test

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/testutil/JanusGraphAssert.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/testutil/JanusGraphAssert.java
@@ -31,6 +31,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.StartStep;
 import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies;
+import org.apache.tinkerpop.gremlin.process.traversal.util.Metrics;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalMetrics;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.janusgraph.graphdb.query.profile.QueryProfiler;
@@ -93,15 +94,23 @@ public class JanusGraphAssert {
         assertArrayEquals(intArray, traversal.toList().stream().mapToInt(i -> i).toArray());
     }
 
+    private static boolean hasBackendHit(Metrics metrics) {
+        if (QueryProfiler.BACKEND_QUERY.equals(metrics.getName())) return true;
+        for (Metrics subMetrics : metrics.getNested()) {
+            if (hasBackendHit(subMetrics)) return true;
+        }
+        return false;
+    }
+
     public static void assertBackendHit(TraversalMetrics profile) {
         assertTrue(profile.getMetrics().stream().anyMatch(metrics -> {
-            return metrics.getNested().stream().anyMatch(m -> m.getName().equals(QueryProfiler.BACKEND_QUERY));
+            return hasBackendHit(metrics);
         }));
     }
 
     public static void assertNoBackendHit(TraversalMetrics profile) {
         assertFalse(profile.getMetrics().stream().anyMatch(metrics -> {
-            return metrics.getNested().stream().anyMatch(m -> m.getName().equals(QueryProfiler.BACKEND_QUERY));
+            return hasBackendHit(metrics);
         }));
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/GraphCentricQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/GraphCentricQuery.java
@@ -59,6 +59,8 @@ public class GraphCentricQuery extends BaseQuery implements ElementQuery<JanusGr
      */
     private final ElementCategory resultType;
 
+    private QueryProfiler profiler;
+
     public GraphCentricQuery(ElementCategory resultType, Condition<JanusGraphElement> condition, OrderList orders,
                              BackendQueryHolder<JointIndexQuery> indexQuery, int limit) {
         super(limit);
@@ -156,9 +158,14 @@ public class GraphCentricQuery extends BaseQuery implements ElementQuery<JanusGr
 
     @Override
     public void observeWith(QueryProfiler profiler) {
+        this.profiler = profiler;
         profiler.setAnnotation(QueryProfiler.CONDITION_ANNOTATION,condition);
         profiler.setAnnotation(QueryProfiler.ORDERS_ANNOTATION,orders);
         if (hasLimit()) profiler.setAnnotation(QueryProfiler.LIMIT_ANNOTATION,getLimit());
         indexQuery.observeWith(profiler);
+    }
+
+    public QueryProfiler getProfiler() {
+        return profiler;
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/GraphCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/GraphCentricQueryBuilder.java
@@ -228,9 +228,6 @@ public class GraphCentricQueryBuilder implements JanusGraphQuery<GraphCentricQue
     public GraphCentricQuery constructQuery(final ElementCategory resultType) {
         final QueryProfiler optProfiler = profiler.addNested(QueryProfiler.OPTIMIZATION);
         optProfiler.startTimer();
-        if (this.globalConstraints.isEmpty()) {
-            this.globalConstraints.add(this.constraints);
-        }
         final GraphCentricQuery query = constructQueryWithoutProfile(resultType);
         optProfiler.stopTimer();
         query.observeWith(profiler);
@@ -241,6 +238,9 @@ public class GraphCentricQueryBuilder implements JanusGraphQuery<GraphCentricQue
         Preconditions.checkNotNull(resultType);
         if (limit == 0) return GraphCentricQuery.emptyQuery(resultType);
 
+        if (globalConstraints.isEmpty()) {
+            globalConstraints.add(constraints);
+        }
         //Prepare constraints
         final MultiCondition<JanusGraphElement> conditions;
         if (this.globalConstraints.size() == 1) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/QueryProfiler.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/QueryProfiler.java
@@ -47,6 +47,10 @@ public interface QueryProfiler {
     String AND_QUERY = "AND-query";
     String BACKEND_QUERY = "backend-query";
     String OPTIMIZATION = "optimization";
+    // graph centric query construction phase
+    String CONSTRUCT_GRAPH_CENTRIC_QUERY = "constructGraphCentricQuery";
+    // graph centric query execution phase
+    String GRAPH_CENTRIC_QUERY = "GraphCentricQuery";
 
     QueryProfiler NO_OP = new QueryProfiler() {
         @Override
@@ -85,10 +89,6 @@ public interface QueryProfiler {
 
     static<Q extends Query,R extends Collection> R profile(QueryProfiler profiler, Q query, Function<Q,R> queryExecutor) {
         return profile(profiler,query,false,queryExecutor);
-    }
-
-    static<Q extends Query,R extends Collection> R profile(String groupName, QueryProfiler profiler, Q query, Function<Q,R> queryExecutor) {
-        return profile(groupName,profiler,query,false,queryExecutor);
     }
 
     static<Q extends Query,R extends Collection> R profile(QueryProfiler profiler, Q query, boolean multiQuery, Function<Q,R> queryExecutor) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -1346,7 +1346,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
                             return indexCache.get(adjustedQuery,
                                 () -> QueryProfiler.profile(subquery.getProfiler(), adjustedQuery, q -> indexSerializer.query(q, txHandle).collect(Collectors.toList())));
                         } catch (Exception e) {
-                            throw new JanusGraphException("Could not call index", e.getCause());
+                            throw new JanusGraphException("Could not call index", e);
                         }
                     });
                 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/ProfiledIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/ProfiledIterator.java
@@ -1,0 +1,56 @@
+// Copyright 2021 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.util;
+
+import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
+import org.janusgraph.core.JanusGraphElement;
+import org.janusgraph.graphdb.query.profile.QueryProfiler;
+
+import java.util.Iterator;
+import java.util.function.Supplier;
+
+/**
+ * @author Boxuan Li (liboxuan@connect.hku.hk)
+ */
+public class ProfiledIterator<E extends JanusGraphElement> extends CloseableAbstractIterator<E> {
+    private final QueryProfiler profiler;
+    private final Iterator<E> iterator;
+    private boolean timerRunning;
+
+    public ProfiledIterator(QueryProfiler profiler, Supplier<Iterator<E>> iteratorSupplier) {
+        this.profiler = profiler;
+        profiler.startTimer();
+        timerRunning = true;
+        iterator = iteratorSupplier.get();
+    }
+
+    @Override
+    protected E computeNext() {
+        if (iterator.hasNext()) {
+            return iterator.next();
+        }
+        close();
+        return endOfData();
+    }
+
+    @Override
+    public void close() {
+        if (timerRunning) {
+            profiler.stopTimer();
+            timerRunning = false;
+        }
+        CloseableIterator.closeIterator(iterator);
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/SubqueryIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/SubqueryIterator.java
@@ -66,7 +66,7 @@ public class SubqueryIterator extends CloseableAbstractIterator<JanusGraphElemen
                 isTimerRunning = true;
                 stream = indexSerializer.query(subQuery, tx).peek(r -> currentIds.add(r));
             } catch (final Exception e) {
-                throw new JanusGraphException("Could not call index", e.getCause());
+                throw new JanusGraphException("Could not call index", e);
             }
         }
         elementIterator = stream.filter(e -> otherResults == null || otherResults.contains(e)).limit(limit).map(function).map(r -> (JanusGraphElement) r).iterator();

--- a/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrJanusGraphIndexTest.java
+++ b/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrJanusGraphIndexTest.java
@@ -56,6 +56,11 @@ public abstract class SolrJanusGraphIndexTest extends JanusGraphIndexTest {
         return false;
     }
 
+    @Override
+    public String getStringField(String propertyKey) {
+        return propertyKey + "_s";
+    }
+
     @Test
     public void testRawQueries() {
         clopen(option(SolrIndex.DYNAMIC_FIELDS,JanusGraphIndexTest.INDEX),false);


### PR DESCRIPTION
1. Indicate "constructGraphCentricQuery" phase in profiler rather than a vague
"optimization" annotation, if applicable.
2. Indicate "GraphCentricQuery" in profiler if applicable. Previously profiling result
is corrupted when a gremlin query is satisfied by multiple graph centric queries.


Note that this PR does not fix https://github.com/JanusGraph/janusgraph/issues/2285 (corruption due to flattening multiple AND/OR groups). That issue is trickier and will be addressed in the next PR.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
