### PR TITLE
EdgesRetriever introduced to fix issue with CacheVertex inconsistency

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/EqualsAwareRetriever.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/EqualsAwareRetriever.java
@@ -1,0 +1,45 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.query.vertex;
+
+import org.janusgraph.util.datastructures.Retriever;
+
+public class EqualsAwareRetriever<I, O, E> implements Retriever<I, O> {
+
+    private final E id;
+    private final Retriever<I, O> retriever;
+
+    public EqualsAwareRetriever(E id, Retriever<I, O> retriever) {
+        this.id = id;
+        this.retriever = retriever;
+    }
+
+    @Override
+    public O get(I input) {
+        return retriever.get(input);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other)
+            return true;
+
+        if (!(other instanceof EqualsAwareRetriever))
+            return false;
+
+        EqualsAwareRetriever<?, ?, ?> oth = (EqualsAwareRetriever) other;
+        return id.equals(oth.id);
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/SimpleVertexQueryProcessor.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/SimpleVertexQueryProcessor.java
@@ -17,8 +17,9 @@ package org.janusgraph.graphdb.query.vertex;
 import com.carrotsearch.hppc.LongArrayList;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.*;
-import org.janusgraph.core.*;
+import com.google.common.collect.Iterables;
+import org.janusgraph.core.JanusGraphRelation;
+import org.janusgraph.core.VertexList;
 import org.janusgraph.diskstorage.Entry;
 import org.janusgraph.diskstorage.EntryList;
 import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
@@ -30,7 +31,9 @@ import org.janusgraph.graphdb.transaction.RelationConstructor;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.Iterator;
+
+import static org.janusgraph.graphdb.transaction.StandardJanusGraphTx.edgesRetriever;
 
 /**
  * This is an optimization of specifically for {@link VertexCentricQuery} that addresses the special but
@@ -117,10 +120,10 @@ public class SimpleVertexQueryProcessor implements Iterable<Entry> {
      * @return
      */
     private Iterator<Entry> getBasicIterator() {
-        final EntryList result = vertex.loadRelations(sliceQuery, query -> QueryProfiler.profile(profiler, query, q -> tx.getGraph().edgeQuery(vertex.longId(), q, tx.getTxHandle())));
+        final EntryList result = vertex.loadRelations(sliceQuery,
+            edgesRetriever(tx.getGraph(), profiler, vertex.longId(), tx.getTxHandle()));
         return result.iterator();
     }
-
 
     private final class LimitAdjustingIterator extends org.janusgraph.graphdb.query.LimitAdjustingIterator<Entry> {
 


### PR DESCRIPTION
Fixes Inconsistency Issue in `CacheVertex`
https://github.com/JanusGraph/janusgraph/issues/1522
It's really dangerous as it was hard to find the root cause.
You can set breakpoint [in CacheVertex](https://github.com/kptfh/janusgraph/blob/feature/fix-cache-vertex/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/CacheVertex.java#L72) and run testVertexCentricQuery in debug and you fill face this issue.