### PR TITLE
KeySlicesIterator introduced

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KCVSProxy.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KCVSProxy.java
@@ -62,6 +62,11 @@ public class KCVSProxy implements KeyColumnValueStore {
     }
 
     @Override
+    public KeySlicesIterator getKeys(MultiSlicesQuery queries, StoreTransaction txh) throws BackendException {
+        return store.getKeys(queries, txh);
+    }
+
+    @Override
     public String getName() {
         return store.getName();
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KeyColumnValueStore.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KeyColumnValueStore.java
@@ -174,6 +174,19 @@ public interface KeyColumnValueStore {
     // like current getKeys if column-slice is such that it queries for vertex state property
 
     /**
+     * Returns a {@link KeySlicesIterator} over all keys in the store that have one or more columns matching the column-range. Calling {@link KeySlicesIterator#getEntries()}
+     * returns the map of all entries that match the column-range specified by the given queries.
+     * <p>
+     * This method is mandatory for stores which do not guaranty key orders while running parallel scans.
+     *
+     * @param queries
+     * @param txh
+     * @return
+     * @throws org.janusgraph.diskstorage.BackendException
+     */
+    KeySlicesIterator getKeys(MultiSlicesQuery queries, StoreTransaction txh) throws BackendException;
+
+    /**
      * Returns the name of this store. Each store has a unique name which is used to open it.
      *
      * @return store name

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KeySlicesIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KeySlicesIterator.java
@@ -19,27 +19,29 @@ import org.janusgraph.diskstorage.StaticBuffer;
 import org.janusgraph.diskstorage.util.RecordIterator;
 import org.janusgraph.graphdb.olap.VertexJobConverter;
 
+import java.util.Map;
+
 /**
- * @author Matthias Broecheler (me@matthiasb.com)
+ * @author Sergii Karpenko (sergiy.karpenko@gmail.com)
  */
 
-public interface KeyIterator extends RecordIterator<StaticBuffer> {
+public interface KeySlicesIterator extends RecordIterator<StaticBuffer> {
 
     /**
-     * Returns an iterator over all entries associated with the current
-     * key that match the column range specified in the query.
+     * Returns map of iterators over all entries associated with the current
+     * key that match the column range specified in the queries.
      * <p>
-     * Closing the returned sub-iterator has no effect on this iterator.
+     * Closing any of the returned sub-iterators has no effect on this iterator.
      *
      * Calling {@link #next()} might close previously returned RecordIterators
      * depending on the implementation, hence it is important to iterate over
      * (and close) the RecordIterator before calling {@link #next()} or {@link #hasNext()}.
      *
-     * Important! Entries should be sorted inside iterator.
+     * Important! Entries should be sorted inside iterators.
      * Otherwise {@link VertexJobConverter} will not work correctly
      *
      * @return
      */
-    RecordIterator<Entry> getEntries();
+    Map<SliceQuery, RecordIterator<Entry>> getEntries();
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/MultiSlicesQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/MultiSlicesQuery.java
@@ -1,0 +1,51 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.keycolumnvalue;
+
+import org.janusgraph.diskstorage.StaticBuffer;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Queries for a list of slices of data, each identified by a start points (inclusive) and end points (exclusive).
+ * Returns all {@link StaticBuffer}s that lie in this ranges up to the given limit.
+ * <p>
+ * If a MultiSlicesQuery is marked <i>static</i> it is expected that the result set does not change.
+ *
+ * @author Sergii Karpenko (sergiy.karpenko@gmail.com)
+ */
+
+public class MultiSlicesQuery {
+
+    private final List<SliceQuery> queries;
+
+    public MultiSlicesQuery(List<SliceQuery> queries) {
+        this.queries = queries;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MultiSlicesQuery that = (MultiSlicesQuery) o;
+        return Objects.equals(queries, that.queries);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(queries);
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/StandardStoreFeatures.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/StandardStoreFeatures.java
@@ -22,6 +22,7 @@ import org.janusgraph.diskstorage.util.time.TimestampProviders;
  */
 public class StandardStoreFeatures implements StoreFeatures {
 
+    private final boolean consistentScan;
     private final boolean unorderedScan;
     private final boolean orderedScan;
     private final boolean multiQuery;
@@ -52,6 +53,11 @@ public class StandardStoreFeatures implements StoreFeatures {
     @Override
     public boolean hasUnorderedScan() {
         return unorderedScan;
+    }
+
+    @Override
+    public boolean hasConsistentScan() {
+        return consistentScan;
     }
 
     @Override
@@ -158,6 +164,7 @@ public class StandardStoreFeatures implements StoreFeatures {
      */
     public static class Builder {
 
+        private boolean consistentScan = true;
         private boolean unorderedScan;
         private boolean orderedScan;
         private boolean multiQuery;
@@ -190,6 +197,7 @@ public class StandardStoreFeatures implements StoreFeatures {
          * the supplied {@code template}.
          */
         public Builder(StoreFeatures template) {
+            consistentScan(template.hasConsistentScan());
             unorderedScan(template.hasUnorderedScan());
             orderedScan(template.hasOrderedScan());
             multiQuery(template.hasMultiQuery());
@@ -215,6 +223,11 @@ public class StandardStoreFeatures implements StoreFeatures {
 
         public Builder optimisticLocking(boolean b) {
             optimisticLocking = b;
+            return this;
+        }
+
+        public Builder consistentScan(boolean consistentScan) {
+            this.consistentScan = consistentScan;
             return this;
         }
 
@@ -324,7 +337,7 @@ public class StandardStoreFeatures implements StoreFeatures {
         }
 
         public StandardStoreFeatures build() {
-            return new StandardStoreFeatures(unorderedScan, orderedScan,
+            return new StandardStoreFeatures(consistentScan, unorderedScan, orderedScan,
                     multiQuery, locking, batchMutation, localKeyPartition,
                     keyOrdered, distributed, transactional, keyConsistent,
                     timestamps, preferredTimestamps, cellLevelTTL,
@@ -334,16 +347,17 @@ public class StandardStoreFeatures implements StoreFeatures {
         }
     }
 
-    private StandardStoreFeatures(boolean unorderedScan, boolean orderedScan,
-            boolean multiQuery, boolean locking, boolean batchMutation,
-            boolean localKeyPartition, boolean keyOrdered, boolean distributed,
-            boolean transactional, boolean keyConsistent,
-            boolean timestamps, TimestampProviders preferredTimestamps,
-            boolean cellLevelTTL, boolean storeLevelTTL,
-            boolean visibility, boolean supportsPersist,
-            Configuration keyConsistentTxConfig,
-            Configuration localKeyConsistentTxConfig,
-            Configuration scanTxConfig, boolean supportsInterruption, boolean optimisticLocking) {
+    private StandardStoreFeatures(boolean consistentScan, boolean unorderedScan, boolean orderedScan,
+                                  boolean multiQuery, boolean locking, boolean batchMutation,
+                                  boolean localKeyPartition, boolean keyOrdered, boolean distributed,
+                                  boolean transactional, boolean keyConsistent,
+                                  boolean timestamps, TimestampProviders preferredTimestamps,
+                                  boolean cellLevelTTL, boolean storeLevelTTL,
+                                  boolean visibility, boolean supportsPersist,
+                                  Configuration keyConsistentTxConfig,
+                                  Configuration localKeyConsistentTxConfig,
+                                  Configuration scanTxConfig, boolean supportsInterruption, boolean optimisticLocking) {
+        this.consistentScan = consistentScan;
         this.unorderedScan = unorderedScan;
         this.orderedScan = orderedScan;
         this.multiQuery = multiQuery;

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/StoreFeatures.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/StoreFeatures.java
@@ -40,6 +40,14 @@ public interface StoreFeatures {
     boolean hasUnorderedScan();
 
     /**
+     * Whether this storage backend supports a consistent key order among different scans.
+     * If it supports ordered scan, it must support consistent key scan.
+     * If it doesn't support ordered scan, it may or may not support consistent key scan.
+     * If the consistent scan is not supported, the backend should support {@link KeyColumnValueStore#getKeys(MultiSlicesQuery, StoreTransaction)}
+     */
+    boolean hasConsistentScan();
+
+    /**
      * Whether this storage backend supports global key scans via
      * {@link KeyColumnValueStore#getKeys(KeyRangeQuery, StoreTransaction)}.
      */

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/keyvalue/OrderedKeyValueStoreAdapter.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/keyvalue/OrderedKeyValueStoreAdapter.java
@@ -135,6 +135,11 @@ public class OrderedKeyValueStoreAdapter extends BaseKeyColumnValueAdapter {
     }
 
     @Override
+    public KeySlicesIterator getKeys(MultiSlicesQuery queries, StoreTransaction txh) throws BackendException {
+        throw new UnsupportedOperationException("This store has ordered keys, use getKeys(KeyRangeQuery, StoreTransaction) instead");
+    }
+
+    @Override
     public void acquireLock(StaticBuffer key, StaticBuffer column, StaticBuffer expectedValue,
                             StoreTransaction txh) throws BackendException {
         store.acquireLock(concatenate(key, column), expectedValue, txh);

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/MultiThreadsRowsCollector.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/MultiThreadsRowsCollector.java
@@ -1,0 +1,260 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.keycolumnvalue.scan;
+
+import org.janusgraph.diskstorage.BackendException;
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.EntryList;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.TemporaryBackendException;
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.diskstorage.keycolumnvalue.KCVSUtil;
+import org.janusgraph.diskstorage.keycolumnvalue.KeyColumnValueStore;
+import org.janusgraph.diskstorage.keycolumnvalue.KeyIterator;
+import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
+import org.janusgraph.diskstorage.keycolumnvalue.StoreFeatures;
+import org.janusgraph.diskstorage.keycolumnvalue.StoreTransaction;
+import org.janusgraph.diskstorage.util.EntryArrayList;
+import org.janusgraph.diskstorage.util.RecordIterator;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import static org.janusgraph.diskstorage.keycolumnvalue.scan.StandardScannerExecutor.Row;
+import static org.janusgraph.diskstorage.keycolumnvalue.scan.StandardScannerExecutor.TIME_PER_TRY;
+
+/**
+ * Uses separate thread per query. May be used for {@link KeyColumnValueStore}
+ * that preserves keys order while running parallel scans (f.e. Cassandra)
+ *
+ * @author Sergii Karpenko (sergiy.karpenko@gmail.com)
+ */
+
+class MultiThreadsRowsCollector extends RowsCollector {
+
+    private static final int MAX_KEY_LENGTH = 128; //in bytes
+
+    private static final Logger log = LoggerFactory.getLogger(MultiThreadsRowsCollector.class);
+
+    private final StoreFeatures storeFeatures;
+    private final StoreTransaction storeTx;
+    private final List<SliceQuery> queries;
+    private final Predicate<StaticBuffer> keyFilter;
+    private final Configuration graphConfiguration;
+    private final DataPuller[] pullThreads;
+    private final BlockingQueue<SliceResult>[] dataQueues;
+    private boolean interrupted = false;
+
+    MultiThreadsRowsCollector(
+        KeyColumnValueStore store,
+        StoreFeatures storeFeatures,
+        StoreTransaction storeTx,
+        List<SliceQuery> queries,
+        Predicate<StaticBuffer> keyFilter,
+        BlockingQueue<Row> rowQueue,
+        Configuration graphConfiguration) throws BackendException {
+
+        super(store, rowQueue);
+        this.storeFeatures = storeFeatures;
+        this.storeTx = storeTx;
+        this.queries = queries;
+        this.keyFilter = keyFilter;
+        this.graphConfiguration = graphConfiguration;
+
+        this.dataQueues = new BlockingQueue[queries.size()];
+        this.pullThreads = new DataPuller[queries.size()];
+
+        setUp(queries);
+    }
+
+    private void setUp(List<SliceQuery> queries) throws BackendException {
+
+        int pos = 0;
+        for(SliceQuery sliceQuery : queries){
+            addDataPuller(sliceQuery, storeTx, pos);
+            pos++;
+        }
+    }
+
+    void run() throws InterruptedException, TemporaryBackendException {
+        int numQueries = queries.size();
+        SliceResult[] currentResults = new SliceResult[numQueries];
+        while (!interrupted) {
+            collectDataFromPullers(currentResults, numQueries);
+
+            SliceResult conditionQuery = currentResults[0];
+            if (conditionQuery==null) break; //Termination condition - primary query has no more data
+            final StaticBuffer key = conditionQuery.key;
+
+            Row e = buildRow(numQueries, currentResults, key);
+
+            rowQueue.put(e);
+        }
+    }
+
+    private void collectDataFromPullers(SliceResult[] currentResults, int numQueries) throws InterruptedException, TemporaryBackendException {
+        for (int i = 0; i < numQueries; i++) {
+            if (currentResults[i]!=null) continue;
+            BlockingQueue<SliceResult> queue = dataQueues[i];
+
+            SliceResult qr = queue.poll(TIME_PER_TRY, TimeUnit.MILLISECONDS); //Try very short time to see if we are done
+            if (qr==null) {
+                DataPuller dataPuller = pullThreads[i];
+                if (dataPuller.isFinished()) continue; //No more data to be expected
+                while (!dataPuller.isFinished() && qr == null) {
+                    qr = queue.poll(TIME_PER_TRY, TimeUnit.MILLISECONDS);
+                }
+                if (qr==null && !dataPuller.isFinished())
+                    throw new TemporaryBackendException("Timed out waiting for next row data - storage error likely");
+            }
+            currentResults[i]=qr;
+        }
+    }
+
+    private Row buildRow(int numQueries, SliceResult[] currentResults, StaticBuffer key) {
+        Map<SliceQuery,EntryList> queryResults = new HashMap<>(numQueries);
+        for (int i = 0; i< currentResults.length; i++) {
+            SliceQuery query = queries.get(i);
+            EntryList entries = EntryList.EMPTY_LIST;
+            if (currentResults[i]!=null && currentResults[i].key.equals(key)) {
+                assert query.equals(currentResults[i].query);
+                entries = currentResults[i].entries;
+                currentResults[i]=null;
+            }
+            queryResults.put(query,entries);
+        }
+        return new Row(key, queryResults);
+    }
+
+    @Override
+    void join() throws InterruptedException {
+        int i = 0;
+        for (DataPuller dataPuller : pullThreads) {
+            dataPuller.join(10);
+            if (dataPuller.isAlive()) {
+                log.warn("Data pulling thread [{}] did not terminate. Forcing termination",i);
+                if (storeFeatures.supportsInterruption()) {
+                    dataPuller.interrupt();
+                } else {
+                    log.warn("Store does not support interruption, so data pulling thread [{}] cannot be interrupted", i);
+                    dataPuller.finished = true;
+                }
+            }
+            i++;
+        }
+    }
+
+    @Override
+    void interrupt() {
+        interrupted = true;
+    }
+
+    @Override
+    void cleanup() {
+        if (pullThreads!=null) {
+            for (DataPuller pullThread : pullThreads) {
+                if (pullThread.isAlive()) {
+                    if (storeFeatures.supportsInterruption()) {
+                        pullThread.interrupt();
+                    } else {
+                        log.warn("Store does not support interruption, so data pulling thread cannot be interrupted");
+                        pullThread.finished = true;
+                    }
+                }
+            }
+        }
+    }
+
+    private void addDataPuller(SliceQuery sq, StoreTransaction stx, int pos) throws BackendException {
+        final BlockingQueue<SliceResult> queue = new LinkedBlockingQueue<>(
+            this.graphConfiguration.get(GraphDatabaseConfiguration.PAGE_SIZE));
+        dataQueues[pos] = queue;
+
+        DataPuller dp = new DataPuller(sq, queue,
+            KCVSUtil.getKeys(store,sq,storeFeatures, MAX_KEY_LENGTH,stx), keyFilter);
+        pullThreads[pos] = dp;
+        dp.setName("data-puller-" + pos); // setting the name for thread dumps!
+        dp.start();
+    }
+
+    private static class DataPuller extends Thread {
+
+        private final BlockingQueue<SliceResult> queue;
+        private final KeyIterator keyIterator;
+        private final SliceQuery query;
+        private final Predicate<StaticBuffer> keyFilter;
+        private volatile boolean finished;
+
+        private DataPuller(SliceQuery query, BlockingQueue<SliceResult> queue,
+                           KeyIterator keyIterator, Predicate<StaticBuffer> keyFilter) {
+            this.query = query;
+            this.queue = queue;
+            this.keyIterator = keyIterator;
+            this.keyFilter = keyFilter;
+            this.finished = false;
+        }
+
+        @Override
+        public void run() {
+            try {
+                while (keyIterator.hasNext()) {
+                    StaticBuffer key = keyIterator.next();
+                    RecordIterator<Entry> entries = keyIterator.getEntries();
+                    if (!keyFilter.test(key)) continue;
+                    EntryList entryList = EntryArrayList.of(entries);
+                    queue.put(new SliceResult(query, key, entryList));
+                }
+            } catch (InterruptedException e) {
+                log.error("Data-pulling thread interrupted while waiting on queue or data", e);
+            } catch (Throwable e) {
+                log.error("Could not load data from storage", e);
+            } finally {
+                try {
+                    keyIterator.close();
+                } catch (IOException e) {
+                    log.warn("Could not close storage iterator ", e);
+                }
+                finished=true;
+            }
+        }
+
+        public boolean isFinished() {
+            return finished;
+        }
+    }
+
+    private static class SliceResult {
+
+        final SliceQuery query;
+        final StaticBuffer key;
+        final EntryList entries;
+
+        private SliceResult(SliceQuery query, StaticBuffer key, EntryList entries) {
+            this.query = query;
+            this.key = key;
+            this.entries = entries;
+        }
+    }
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/RowsCollector.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/RowsCollector.java
@@ -1,0 +1,49 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.keycolumnvalue.scan;
+
+import org.janusgraph.diskstorage.PermanentBackendException;
+import org.janusgraph.diskstorage.TemporaryBackendException;
+import org.janusgraph.diskstorage.keycolumnvalue.KeyColumnValueStore;
+
+import java.util.concurrent.BlockingQueue;
+
+import static org.janusgraph.diskstorage.keycolumnvalue.scan.StandardScannerExecutor.Row;
+
+/**
+ * Produces data to {@link BlockingQueue<Row>}
+ * for each key in {@link KeyColumnValueStore}
+ *
+ * @author Sergii Karpenko (sergiy.karpenko@gmail.com)
+ */
+abstract class RowsCollector {
+
+    protected final KeyColumnValueStore store;
+    protected final BlockingQueue<Row> rowQueue;
+
+    RowsCollector(KeyColumnValueStore store, BlockingQueue<Row> rowQueue) {
+        this.store = store;
+        this.rowQueue = rowQueue;
+    }
+
+    abstract void run() throws InterruptedException, TemporaryBackendException;
+
+    abstract void join() throws InterruptedException;
+
+    abstract void interrupt();
+
+    abstract void cleanup() throws PermanentBackendException;
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/SingleThreadRowsCollector.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/SingleThreadRowsCollector.java
@@ -1,0 +1,119 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.keycolumnvalue.scan;
+
+import org.janusgraph.diskstorage.BackendException;
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.EntryList;
+import org.janusgraph.diskstorage.PermanentBackendException;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.keycolumnvalue.KeyColumnValueStore;
+import org.janusgraph.diskstorage.keycolumnvalue.KeySlicesIterator;
+import org.janusgraph.diskstorage.keycolumnvalue.MultiSlicesQuery;
+import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
+import org.janusgraph.diskstorage.keycolumnvalue.StoreTransaction;
+import org.janusgraph.diskstorage.util.EntryArrayList;
+import org.janusgraph.diskstorage.util.RecordIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.function.Predicate;
+
+import static org.janusgraph.diskstorage.keycolumnvalue.scan.StandardScannerExecutor.Row;
+
+/**
+ *  Uses one thread for all queries. May be used for {@link KeyColumnValueStore}
+ *  that do not guarantee keys order between different scans (f.e. Aerospike)
+ * @author Sergii Karpenko (sergiy.karpenko@gmail.com)
+ */
+
+class SingleThreadRowsCollector extends RowsCollector {
+
+    private static final Logger log = LoggerFactory.getLogger(SingleThreadRowsCollector.class);
+
+    private final StoreTransaction storeTx;
+    private final Predicate<StaticBuffer> keyFilter;
+    private KeySlicesIterator keyIterator;
+
+    private boolean interrupted = false;
+
+    SingleThreadRowsCollector(
+        KeyColumnValueStore store,
+        StoreTransaction storeTx,
+        List<SliceQuery> queries,
+        Predicate<StaticBuffer> keyFilter,
+        BlockingQueue<Row> rowQueue) throws BackendException {
+
+        super(store, rowQueue);
+        this.storeTx = storeTx;
+        this.keyFilter = keyFilter;
+
+        setUp(queries);
+    }
+
+    private void setUp(List<SliceQuery> queries) throws BackendException {
+        keyIterator = store.getKeys(new MultiSlicesQuery(queries), storeTx);
+    }
+
+    void run()  {
+        try {
+            while (!interrupted && keyIterator.hasNext()) {
+                StaticBuffer key = keyIterator.next();
+                Map<SliceQuery, RecordIterator<Entry>> sliceToEntriesMap = keyIterator.getEntries();
+                if (!keyFilter.test(key)) continue;
+                Map<SliceQuery, EntryList> rowEntries = new HashMap<>(sliceToEntriesMap.size());
+                sliceToEntriesMap.entrySet().forEach(mapEntry -> {
+                    rowEntries.put(mapEntry.getKey(), EntryArrayList.of(mapEntry.getValue()));
+                });
+                rowQueue.put(new Row(key, rowEntries));
+            }
+        } catch (InterruptedException e) {
+            log.error("Data-pulling thread interrupted while waiting on queue or data", e);
+        } catch (Throwable e) {
+            log.error("Could not load data from storage", e);
+        } finally {
+            try {
+                keyIterator.close();
+            } catch (IOException e) {
+                log.warn("Could not close storage iterator ", e);
+            }
+        }
+    }
+
+    @Override
+    void join() {
+        //no need to wait
+    }
+
+    @Override
+    void interrupt() {
+        interrupted = true;
+    }
+
+    @Override
+    void cleanup() throws PermanentBackendException {
+        try {
+            keyIterator.close();
+        } catch (IOException e) {
+            throw new PermanentBackendException(e);
+        }
+    }
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/MetricInstrumentedSlicesIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/MetricInstrumentedSlicesIterator.java
@@ -1,0 +1,103 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.util;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.lang.StringUtils;
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.keycolumnvalue.KeySlicesIterator;
+import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * This class is used by {@code MetricInstrumentedStore} to measure wall clock
+ * time, method invocation counts, and exceptions thrown by the methods on
+ * {@link RecordIterator} instances returned from
+ * {@link MetricInstrumentedStore#getSlice(org.janusgraph.diskstorage.keycolumnvalue.KeySliceQuery, org.janusgraph.diskstorage.keycolumnvalue.StoreTransaction)}.
+ * 
+ * @author Dan LaRocque (dalaro@hopcount.org)
+ */
+public class MetricInstrumentedSlicesIterator implements KeySlicesIterator {
+
+    private final KeySlicesIterator iterator;
+    private final String p;
+
+    private static final String M_HAS_NEXT = "hasNext";
+    private static final String M_NEXT = "next";
+    static final String M_CLOSE = "close";
+
+    /**
+     * If the iterator argument is non-null, then return a new
+     * {@code MetricInstrumentedIterator} wrapping it. Metrics for method calls
+     * on the wrapped instance will be prefixed with the string {@code prefix}
+     * which must be non-null. If the iterator argument is null, then return
+     * null.
+     *
+     * @param keyIterator
+     *            the iterator to wrap with Metrics measurements
+     * @param prefix
+     *            the Metrics name prefix string
+     *
+     * @return a wrapper around {@code keyIterator} or null if
+     *         {@code keyIterator} is null
+     */
+    public static MetricInstrumentedSlicesIterator of(KeySlicesIterator keyIterator, String... prefix) {
+        if (keyIterator == null) {
+            return null;
+        }
+
+        Preconditions.checkNotNull(prefix);
+        return new MetricInstrumentedSlicesIterator(keyIterator, StringUtils.join(prefix,"."));
+    }
+
+    private MetricInstrumentedSlicesIterator(KeySlicesIterator i, String p) {
+        this.iterator = i;
+        this.p = p;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return MetricInstrumentedStore.runWithMetrics(p, M_HAS_NEXT,
+                (UncheckedCallable<Boolean>) iterator::hasNext);
+    }
+
+    @Override
+    public StaticBuffer next() {
+        return MetricInstrumentedStore.runWithMetrics(p, M_NEXT,
+                (UncheckedCallable<StaticBuffer>) iterator::next);
+    }
+    
+    @Override
+    public void close() throws IOException {
+        MetricInstrumentedStore.runWithMetrics(p, MetricInstrumentedSlicesIterator.M_CLOSE, (IOCallable<Void>) () -> {
+            iterator.close();
+            return null;
+        });
+    }
+
+    @Override
+    public Map<SliceQuery, RecordIterator<Entry>> getEntries() {
+        // TODO: add metrics to entries if ever needed
+        return iterator.getEntries();
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/MetricInstrumentedStore.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/MetricInstrumentedStore.java
@@ -169,6 +169,18 @@ public class MetricInstrumentedStore implements KeyColumnValueStore {
     }
 
     @Override
+    public KeySlicesIterator getKeys(MultiSlicesQuery queries, StoreTransaction txh) throws BackendException {
+        return runWithMetrics(txh, metricsStoreName, M_GET_KEYS, () -> {
+            final KeySlicesIterator ki = backend.getKeys(queries, txh);
+            if (txh.getConfiguration().hasGroupName()) {
+                return MetricInstrumentedSlicesIterator.of(ki, txh.getConfiguration().getGroupName(), metricsStoreName, M_GET_KEYS, M_ITERATOR);
+            } else {
+                return ki;
+            }
+        });
+    }
+
+    @Override
     public String getName() {
         return backend.getName();
     }

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStore.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStore.java
@@ -49,6 +49,8 @@ import org.janusgraph.diskstorage.keycolumnvalue.KeyColumnValueStore;
 import org.janusgraph.diskstorage.keycolumnvalue.KeyIterator;
 import org.janusgraph.diskstorage.keycolumnvalue.KeyRangeQuery;
 import org.janusgraph.diskstorage.keycolumnvalue.KeySliceQuery;
+import org.janusgraph.diskstorage.keycolumnvalue.KeySlicesIterator;
+import org.janusgraph.diskstorage.keycolumnvalue.MultiSlicesQuery;
 import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
 import org.janusgraph.diskstorage.keycolumnvalue.StoreTransaction;
 import org.janusgraph.diskstorage.util.RecordIterator;
@@ -430,6 +432,11 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
                         .setPageSize(this.storeManager.getPageSize())
                         .setConsistencyLevel(getTransaction(txh).getReadConsistencyLevel()).build())))
                 .getOrElseThrow(EXCEPTION_MAPPER);
+    }
+
+    @Override
+    public KeySlicesIterator getKeys(MultiSlicesQuery queries, StoreTransaction txh) throws BackendException {
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/janusgraph-hbase-parent/janusgraph-hbase-core/src/main/java/org/janusgraph/diskstorage/hbase/HBaseKeyColumnValueStore.java
+++ b/janusgraph-hbase-parent/janusgraph-hbase-core/src/main/java/org/janusgraph/diskstorage/hbase/HBaseKeyColumnValueStore.java
@@ -130,6 +130,11 @@ public class HBaseKeyColumnValueStore implements KeyColumnValueStore {
         return executeKeySliceQuery(new FilterList(FilterList.Operator.MUST_PASS_ALL), query);
     }
 
+    @Override
+    public KeySlicesIterator getKeys(MultiSlicesQuery queries, StoreTransaction txh) throws BackendException {
+        throw new UnsupportedOperationException();
+    }
+
     public static Filter getFilter(SliceQuery query) {
         byte[] colStartBytes = query.getSliceStart().length() > 0 ? query.getSliceStart().as(StaticBuffer.ARRAY_FACTORY) : null;
         byte[] colEndBytes = query.getSliceEnd().length() > 0 ? query.getSliceEnd().as(StaticBuffer.ARRAY_FACTORY) : null;

--- a/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/InMemoryKeyColumnValueStore.java
+++ b/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/InMemoryKeyColumnValueStore.java
@@ -122,6 +122,11 @@ public class InMemoryKeyColumnValueStore implements KeyColumnValueStore {
     }
 
     @Override
+    public KeySlicesIterator getKeys(MultiSlicesQuery queries, StoreTransaction txh) throws BackendException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public String getName() {
         return name;
     }

--- a/janusgraph-test/src/main/java/org/janusgraph/diskstorage/cache/KCVSCacheTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/diskstorage/cache/KCVSCacheTest.java
@@ -223,6 +223,11 @@ public abstract class KCVSCacheTest {
         }
 
         @Override
+        public KeySlicesIterator getKeys(MultiSlicesQuery queries, StoreTransaction txh) throws BackendException {
+            return store.getKeys(queries, txh);
+        }
+
+        @Override
         public String getName() {
             return store.getName();
         }


### PR DESCRIPTION
`KeySlicesIterator` introduced to fix issue with key inconsistency while running parallel scans in `StandartScannerExcecutor`

fixes https://github.com/JanusGraph/janusgraph/issues/1527

Without this fix Aerospike (that doesn't guaranty order of keys while running scan operation) can't utilize Janusgraph jobs 
(Reindex, GhostVertexRemover)