### PR TITLE
[Doc] Remove mention of Faunus

### DIFF
--- a/docs/advanced-topics/eventual-consistency.md
+++ b/docs/advanced-topics/eventual-consistency.md
@@ -185,8 +185,7 @@ from the user.
 Run regular batch-jobs to repair inconsistencies in the graph using
 [JanusGraph with TinkerPop’s Hadoop-Gremlin](hadoop.md). 
 This is the only strategy that can address all
-inconsistencies and effectively repair them. We will provide increasing
-support for such repairs in future versions of Faunus.
+inconsistencies and effectively repair them.
 
 **Soft Deletes**  
 Instead of deleting vertices, they are marked as deleted which keeps


### PR DESCRIPTION
Faunus was a standalone product (https://github.com/thinkaurelius/faunus)
which later merged into Titan codebase, and now is a part of JanusGraph-hadoop
module. This commit removes mention of Faunus in the documentation.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
