### PR TITLE
Fix nested AND/OR profiler group issue

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/BackendQueryHolder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/BackendQueryHolder.java
@@ -73,9 +73,9 @@ public class BackendQueryHolder<E extends BackendQuery<E>> implements ProfileObs
     }
 
     @Override
-    public void observeWith(QueryProfiler parentProfiler) {
+    public void observeWith(QueryProfiler parentProfiler, boolean hasSiblings) {
         Preconditions.checkArgument(parentProfiler!=null);
-        this.profiler = parentProfiler.addNested(QueryProfiler.OR_QUERY);
+        profiler = parentProfiler.addNested(QueryProfiler.OR_QUERY, hasSiblings);
         profiler.setAnnotation(QueryProfiler.FITTED_ANNOTATION,isFitted);
         profiler.setAnnotation(QueryProfiler.ORDERED_ANNOTATION,isSorted);
         profiler.setAnnotation(QueryProfiler.QUERY_ANNOTATION,backendQuery);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/GraphCentricQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/GraphCentricQuery.java
@@ -157,7 +157,7 @@ public class GraphCentricQuery extends BaseQuery implements ElementQuery<JanusGr
 
 
     @Override
-    public void observeWith(QueryProfiler profiler) {
+    public void observeWith(QueryProfiler profiler, boolean hasSiblings) {
         this.profiler = profiler;
         profiler.setAnnotation(QueryProfiler.CONDITION_ANNOTATION,condition);
         profiler.setAnnotation(QueryProfiler.ORDERS_ANNOTATION,orders);
@@ -165,6 +165,7 @@ public class GraphCentricQuery extends BaseQuery implements ElementQuery<JanusGr
         indexQuery.observeWith(profiler);
     }
 
+    @Override
     public QueryProfiler getProfiler() {
         return profiler;
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/ProfileObservable.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/ProfileObservable.java
@@ -19,6 +19,12 @@ package org.janusgraph.graphdb.query.profile;
  */
 public interface ProfileObservable {
 
-    void observeWith(QueryProfiler profiler);
+    default void observeWith(QueryProfiler profiler) {
+        observeWith(profiler, false);
+    }
+
+    void observeWith(QueryProfiler profiler, boolean hasSiblings);
+
+    QueryProfiler getProfiler();
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/QueryProfiler.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/QueryProfiler.java
@@ -54,7 +54,7 @@ public interface QueryProfiler {
 
     QueryProfiler NO_OP = new QueryProfiler() {
         @Override
-        public QueryProfiler addNested(String groupName) {
+        public QueryProfiler addNested(String groupName, boolean hasSiblings) {
             return this;
         }
 
@@ -76,8 +76,11 @@ public interface QueryProfiler {
         }
     };
 
+    default QueryProfiler addNested(String groupName) {
+        return addNested(groupName, false);
+    }
 
-    QueryProfiler addNested(String groupName);
+    QueryProfiler addNested(String groupName, boolean hasSiblings);
 
     QueryProfiler setAnnotation(String key, Object value);
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/SimpleQueryProfiler.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/SimpleQueryProfiler.java
@@ -44,7 +44,7 @@ public class SimpleQueryProfiler implements QueryProfiler, Iterable<SimpleQueryP
     }
 
     @Override
-    public QueryProfiler addNested(String groupName) {
+    public QueryProfiler addNested(String groupName, boolean hasSiblings) {
         SimpleQueryProfiler nested = new SimpleQueryProfiler(groupName);
         nestedProfilers.add(nested);
         return nested;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BaseVertexCentricQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BaseVertexCentricQuery.java
@@ -60,6 +60,8 @@ public class BaseVertexCentricQuery extends BaseQuery implements ProfileObservab
      */
     protected final Direction direction;
 
+    private QueryProfiler profiler = QueryProfiler.NO_OP;
+
     public BaseVertexCentricQuery(Condition<JanusGraphRelation> condition, Direction direction,
                                   List<BackendQueryHolder<SliceQuery>> queries, OrderList orders,
                                   int limit) {
@@ -136,10 +138,17 @@ public class BaseVertexCentricQuery extends BaseQuery implements ProfileObservab
     }
 
     @Override
-    public void observeWith(QueryProfiler profiler) {
+    public void observeWith(QueryProfiler profiler, boolean hasSiblings) {
+        this.profiler = profiler;
         profiler.setAnnotation(QueryProfiler.CONDITION_ANNOTATION,condition);
         profiler.setAnnotation(QueryProfiler.ORDERS_ANNOTATION,orders);
         if (hasLimit()) profiler.setAnnotation(QueryProfiler.LIMIT_ANNOTATION,getLimit());
-        queries.forEach(bqh -> bqh.observeWith(profiler));
+        boolean consistsOfMultipleQueries = queries.size() > 1;
+        queries.forEach(bqh -> bqh.observeWith(profiler, consistsOfMultipleQueries));
+    }
+
+    @Override
+    public QueryProfiler getProfiler() {
+        return profiler;
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/profile/TP3ProfileWrapper.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/profile/TP3ProfileWrapper.java
@@ -32,9 +32,9 @@ public class TP3ProfileWrapper implements QueryProfiler {
     }
 
     @Override
-    public QueryProfiler addNested(String groupName) {
-        //Flatten out AND/OR nesting
-        if (groupName.equals(AND_QUERY) || groupName.equals(OR_QUERY)) return this;
+    public QueryProfiler addNested(String groupName, boolean hasSiblings) {
+        //Flatten out AND/OR nesting unless it has siblings
+        if (!hasSiblings && (groupName.equals(AND_QUERY) || groupName.equals(OR_QUERY))) return this;
 
         int nextId = (subMetricCounter++);
         MutableMetrics nested = new MutableMetrics(metrics.getId()+"."+groupName+"_"+nextId,groupName);

--- a/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrJanusGraphIndexTest.java
+++ b/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrJanusGraphIndexTest.java
@@ -61,6 +61,11 @@ public abstract class SolrJanusGraphIndexTest extends JanusGraphIndexTest {
         return propertyKey + "_s";
     }
 
+    @Override
+    public String getTextField(String propertyKey) {
+        return propertyKey + "_t";
+    }
+
     @Test
     public void testRawQueries() {
         clopen(option(SolrIndex.DYNAMIC_FIELDS,JanusGraphIndexTest.INDEX),false);


### PR DESCRIPTION
Currently, when there is more than one backend query, annotations
(condition, orders, isFitted, isOrdered, query, index) of the last
one overwrites previous annotations in the profiling result.

This commit fixes this problem by avoiding flattening AND/OR query
groups. The drawback of this commit is those groups (AND-query, OR-query)
are not timed due to technical difficulty, which is left as future
work.

Fixes #2285

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
