### PR TITLE
Fix memory utilization for long query

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/MultiDistinctOrderedIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/MultiDistinctOrderedIterator.java
@@ -25,17 +25,18 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.ElementValueComparator;
+import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 import org.apache.tinkerpop.gremlin.util.function.MultiComparator;
 import org.janusgraph.graphdb.tinkerpop.optimize.step.HasStepFolder.OrderEntry;
 
 
-public class MultiDistinctOrderedIterator<E> implements CloseableIterator<E> {
+public class MultiDistinctOrderedIterator<E extends Element> implements CloseableIterator<E> {
 
     private final Map<Integer, Iterator<E>> iterators = new LinkedHashMap<>();
     private final Map<Integer, E> values = new LinkedHashMap<>();
     private final TreeMap<E, Integer> currentElements;
-    private final Set<E> allElements = new HashSet<>();
+    private final Set<Object> allElements = new HashSet<>();
     private final Integer limit;
     private long count = 0;
 
@@ -65,14 +66,14 @@ public class MultiDistinctOrderedIterator<E> implements CloseableIterator<E> {
                 E element = null;
                 do {
                     element = iterators.get(i).next();
-                    if (allElements.contains(element)) {
+                    if (allElements.contains(element.id())) {
                         element = null;
                     }
                 } while (element == null && iterators.get(i).hasNext());
                 if (element != null) {
                     values.put(i, element);
                     currentElements.put(element, i);
-                    allElements.add(element);
+                    allElements.add(element.id());
                 }
             }
         }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/MultiDistinctUnorderedIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/MultiDistinctUnorderedIterator.java
@@ -14,6 +14,7 @@
 
 package org.janusgraph.graphdb.util;
 
+import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 
 import java.util.HashSet;
@@ -22,9 +23,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-public class MultiDistinctUnorderedIterator<E> extends CloseableAbstractIterator<E> {
+public class MultiDistinctUnorderedIterator<E extends Element> extends CloseableAbstractIterator<E> {
 
-    private final Set<E> allElements = new HashSet<E>();
+    private final Set<Object> allElements = new HashSet<>();
     private final CloseableIterator<E> iterator;
     private final int limit;
     private long count;
@@ -46,7 +47,7 @@ public class MultiDistinctUnorderedIterator<E> extends CloseableAbstractIterator
         if (count < limit) {
             while (iterator.hasNext()) {
                 E elem = iterator.next();
-                if (allElements.add(elem)) {
+                if (allElements.add(elem.id())) {
                     count++;
                     return elem;
                 }

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/util/MultiDistinctUnorderedIteratorTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/util/MultiDistinctUnorderedIteratorTest.java
@@ -14,8 +14,12 @@
 
 package org.janusgraph.graphdb.util;
 
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.janusgraph.graphdb.query.Query;
+
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -41,16 +45,18 @@ public class MultiDistinctUnorderedIteratorTest {
 
     @Test
     public void shouldConcatIteratorsAndDedup() {
-        List<Iterator<Integer>> iterators = new ArrayList<>();
+        List<Iterator<Vertex>> iterators = new ArrayList<>();
         final int num = 5;
         for (int i = 0; i < num; i++) {
             iterators.add(CloseableIteratorUtils.emptyIterator());
-            iterators.add(Arrays.asList(i, i + 1).iterator());
+            List<Vertex> vertices = Arrays.asList(DetachedVertex.build().setId(i).create(),
+                DetachedVertex.build().setId(i + 1).create());
+            iterators.add(vertices.iterator());
         }
 
-        MultiDistinctUnorderedIterator<Integer> multiIterator = new MultiDistinctUnorderedIterator<>(0, Query.NO_LIMIT, iterators);
+        MultiDistinctUnorderedIterator<Vertex> multiIterator = new MultiDistinctUnorderedIterator<>(0, Query.NO_LIMIT, iterators);
         for (int i = 0; i <= num; i++) {
-            assertEquals(i, multiIterator.next());
+            assertEquals(DetachedVertex.build().setId(i).create(), multiIterator.next());
         }
         assertFalse(multiIterator.hasNext());
         multiIterator.close();
@@ -58,16 +64,18 @@ public class MultiDistinctUnorderedIteratorTest {
 
     @Test
     public void shouldSkipLowLimit() {
-        List<Iterator<Integer>> iterators = new ArrayList<>();
+        List<Iterator<Vertex>> iterators = new ArrayList<>();
         final int num = 5;
         for (int i = 0; i < num; i++) {
             iterators.add(CloseableIteratorUtils.emptyIterator());
-            iterators.add(Arrays.asList(i, i + 1).iterator());
+            List<Vertex> vertices = Arrays.asList(DetachedVertex.build().setId(i).create(),
+                DetachedVertex.build().setId(i + 1).create());
+            iterators.add(vertices.iterator());
         }
 
-        MultiDistinctUnorderedIterator<Integer> multiIterator = new MultiDistinctUnorderedIterator<>(2, Query.NO_LIMIT, iterators);
+        MultiDistinctUnorderedIterator<Vertex> multiIterator = new MultiDistinctUnorderedIterator<>(2, Query.NO_LIMIT, iterators);
         for (int i = 2; i <= num; i++) {
-            assertEquals(i, multiIterator.next());
+            assertEquals(DetachedVertex.build().setId(i).create(), multiIterator.next());
         }
         assertFalse(multiIterator.hasNext());
         multiIterator.close();
@@ -75,19 +83,20 @@ public class MultiDistinctUnorderedIteratorTest {
 
     @Test
     public void shouldStopAtHighLimit() {
-        List<Iterator<Integer>> iterators = new ArrayList<>();
+        List<Iterator<Vertex>> iterators = new ArrayList<>();
         final int num = 5;
         for (int i = 0; i < num; i++) {
             iterators.add(CloseableIteratorUtils.emptyIterator());
-            iterators.add(Arrays.asList(i, i + 1).iterator());
+            List<Vertex> vertices = Arrays.asList(DetachedVertex.build().setId(i).create(),
+                DetachedVertex.build().setId(i + 1).create());
+            iterators.add(vertices.iterator());
         }
 
-        MultiDistinctUnorderedIterator<Integer> multiIterator = new MultiDistinctUnorderedIterator<>(2, num, iterators);
+        MultiDistinctUnorderedIterator<Vertex> multiIterator = new MultiDistinctUnorderedIterator<>(2, num, iterators);
         for (int i = 2; i < num; i++) {
-            assertEquals(i, multiIterator.next());
+            assertEquals(DetachedVertex.build().setId(i).create(), multiIterator.next());
         }
         assertFalse(multiIterator.hasNext());
         multiIterator.close();
     }
-
 }


### PR DESCRIPTION
By default tx vertex cache contains only 20k vertices, but references to these vertices collected in MultiDistinct*Iterator.allElements so these vertices still consume memory. For eliminate this, just store only Element.id() and now GC may clean up memory during long queries

Signed-off-by: Pavel Ershov <owner.mad.epa@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
