### PR TITLE
Utilize data model layout when getting edge by id

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphPerformanceMemoryTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphPerformanceMemoryTest.java
@@ -18,11 +18,15 @@ import static org.janusgraph.testutil.JanusGraphAssert.assertCount;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.commons.math.stat.descriptive.SummaryStatistics;
+
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
@@ -44,6 +48,33 @@ public abstract class JanusGraphPerformanceMemoryTest extends JanusGraphBaseTest
 
     @Rule
     public TestRule benchmark = JUnitBenchmarkProvider.get();
+
+    @Test
+    void edgeById() {
+        Vertex v1 = graph.traversal()
+                         .addV("V1")
+                         .property("p1", "1").next();
+
+        Vertex v2 = graph.traversal()
+                         .addV("V1")
+                         .property("p1", "1").next();
+        for (int i = 0; i < 10000; i++) {
+            graph.traversal()
+                 .V(v1)
+                 .addE("E")
+                 .to(v2)
+                 .property("time", i)
+                 .iterate();
+        }
+        graph.traversal().tx().commit();
+
+        List<Edge> edges = graph.traversal().E().toList();
+
+        for (Edge edge : edges) {
+            graph.traversal().E(edge).count().next();
+        }
+        assertEquals(10000, graph.traversal().E(edges).count().next());
+    }
 
     @Test
     public void testMemoryLeakage() {

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -397,6 +397,17 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertFalse(graph.traversal().E().has("_e", -3).hasNext());
     }
 
+    @Test
+    public void testUpdateForkEdgePropertyThenFindEdgeById() {
+        initializeGraphWithVerticesAndEdges();
+        AbstractEdge edge = (AbstractEdge) graph.traversal().E().has("_e", 2).next();
+        Object id = edge.id();
+
+        edge.property("_e", -2);
+
+        assertTrue(graph.traversal().E(id).hasNext());
+    }
+
   /* ==================================================================================
                             INDEXING
      ==================================================================================*/

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/EdgeSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/EdgeSerializer.java
@@ -421,8 +421,7 @@ public class EdgeSerializer implements RelationReader {
                     assert propertyKey==ImplicitKey.JANUSGRAPHID || propertyKey==ImplicitKey.ADJACENT_ID;
                     assert propertyKey!=ImplicitKey.ADJACENT_ID || (i==sortKeyIDs.length);
                     assert propertyKey!=ImplicitKey.JANUSGRAPHID || (!type.multiplicity().isConstrained() &&
-                                                  (i==sortKeyIDs.length && propertyKey.isPropertyKey()
-                                                      || i==sortKeyIDs.length+1 && propertyKey.isEdgeLabel() ));
+                                                  (i==sortKeyIDs.length || i==sortKeyIDs.length+1));
                     assert colStart.getPosition()==colEnd.getPosition();
                     assert interval==null || interval.isPoints();
                     keyEndPos = colStart.getPosition();


### PR DESCRIPTION
It benefit when two vertices contains many edges of same type, but we can get only one by id. Instead of filter out in memory we can construct direct query (more info about data model layout https://docs.janusgraph.org/advanced-topics/data-model/)

Signed-off-by: Pavel Ershov <owner.mad.epa@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
