### PR TITLE
[Doc] Remove mention of Astyanax in data consistency chapter

### DIFF
--- a/docs/advanced-topics/eventual-consistency.md
+++ b/docs/advanced-topics/eventual-consistency.md
@@ -44,19 +44,15 @@ optimizations (e.g. local conflict detection) and detection of failure
 scenarios (e.g. expired locks).
 
 The actual lock application mechanism is abstracted such that JanusGraph
-can use multiple implementations of a locking provider. Currently, two
-locking providers are supported in the JanusGraph distribution:
+can use multiple implementations of a locking provider. Currently, only one
+locking provider is included in the JanusGraph distribution:
 
-1.  A locking implementation based on key-consistent read and write
-    operations that is agnostic to the underlying storage backend as
-    long as it supports key-consistent operations (which includes
-    Cassandra and HBase). This is the default implementation and uses
-    timestamp based lock applications to determine which transaction
-    holds the lock.
-2.  A Cassandra specific locking implementation based on the Astyanax
-    locking recipe.
-
-Both locking providers require that clocks are synchronized across all
+A locking implementation based on key-consistent read and write
+operations that is agnostic to the underlying storage backend as
+long as it supports key-consistent operations (which includes
+Cassandra and HBase). This is the default implementation and uses
+timestamp based lock applications to determine which transaction
+holds the lock. It requires that clocks are synchronized across all
 machines in the cluster.
 
 !!! warning


### PR DESCRIPTION
Astyanax locking recipe is not valid anymore given Astyanax
Cassandra driver has been removed.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
