### PR TITLE
Test Improvement: grouping individual assertions

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/diskstorage/configuration/WritableConfigurationTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/diskstorage/configuration/WritableConfigurationTest.java
@@ -53,17 +53,19 @@ public abstract class WritableConfigurationTest {
         config.set("storage.duba", new String[]{"x", "y"});
         config.set("times.60m", Duration.ofMinutes(60));
         config.set("obj", new Object()); // necessary for AbstractConfiguration.getSubset
-        assertEquals("world", config.get("test.key", String.class));
-        assertEquals(ImmutableSet.of("test.key", "test.bar"), Sets.newHashSet(config.getKeys("test")));
-        // assertEquals(ImmutableSet.of("test.key", "test.bar", "test.baz"), Sets.newHashSet(config.getKeys("test")));
-        assertEquals(ImmutableSet.of("storage.xyz", "storage.duba", "storage.abc"),
-            Sets.newHashSet(config.getKeys("storage")));
-        assertEquals(100,config.get("test.bar",Integer.class).intValue());
-        // assertEquals(1,config.get("test.baz",Integer.class).intValue());
-        assertEquals(true, config.get("storage.xyz", Boolean.class));
-        assertEquals(false, config.get("storage.abc", Boolean.class));
-        assertArrayEquals(new String[]{"x", "y"}, config.get("storage.duba", String[].class));
-        assertEquals(Duration.ofMinutes(60), config.get("times.60m", Duration.class));
-        assertTrue(Object.class.isAssignableFrom(config.get("obj", Object.class).getClass()));
+        assertAll(
+            () -> assertEquals("world", config.get("test.key", String.class)),
+            () -> assertEquals(ImmutableSet.of("test.key", "test.bar"), Sets.newHashSet(config.getKeys("test"))),
+            // () -> assertEquals(ImmutableSet.of("test.key", "test.bar", "test.baz"), Sets.newHashSet(config.getKeys("test"))),
+            () -> assertEquals(ImmutableSet.of("storage.xyz", "storage.duba", "storage.abc"),
+                Sets.newHashSet(config.getKeys("storage"))),
+            () -> assertEquals(100,config.get("test.bar",Integer.class).intValue()),
+            // () -> assertEquals(1,config.get("test.baz",Integer.class).intValue()),
+            () -> assertEquals(true, config.get("storage.xyz", Boolean.class)),
+            () -> assertEquals(false, config.get("storage.abc", Boolean.class)),
+            () -> assertArrayEquals(new String[]{"x", "y"}, config.get("storage.duba", String[].class)),
+            () -> assertEquals(Duration.ofMinutes(60), config.get("times.60m", Duration.class)),
+            () -> assertTrue(Object.class.isAssignableFrom(config.get("obj", Object.class).getClass()))
+        );
     }
 }


### PR DESCRIPTION
**Problem:**
A test method with many individual assertions stops being executed on the first failed assertion, which prevents the execution of the remaining ones.

**Solution:**
By using the JUnit5 grouped assertions feature, all assertions are executed and all failures will be reported together. In this refactoring, no original assertion was changed.

**Result:**
_Before:_
```
        ...
        assertEquals("world", config.get("test.key", String.class));
        assertEquals(ImmutableSet.of("test.key", "test.bar"), Sets.newHashSet(config.getKeys("test")));
        assertEquals(ImmutableSet.of("storage.xyz", "storage.duba", "storage.abc"),
            Sets.newHashSet(config.getKeys("storage")));
        assertEquals(100,config.get("test.bar",Integer.class).intValue());
        assertEquals(true, config.get("storage.xyz", Boolean.class));
        assertEquals(false, config.get("storage.abc", Boolean.class));
        assertArrayEquals(new String[]{"x", "y"}, config.get("storage.duba", String[].class));
        assertEquals(Duration.ofMinutes(60), config.get("times.60m", Duration.class));
        assertTrue(Object.class.isAssignableFrom(config.get("obj", Object.class).getClass()));
```
_After:_
```
       assertAll(
            () -> assertEquals("world", config.get("test.key", String.class)),
            () -> assertEquals(ImmutableSet.of("test.key", "test.bar"), Sets.newHashSet(config.getKeys("test"))),
            () -> assertEquals(ImmutableSet.of("storage.xyz", "storage.duba", "storage.abc"),
                Sets.newHashSet(config.getKeys("storage"))),
            () -> assertEquals(100,config.get("test.bar",Integer.class).intValue()),
            () -> assertEquals(true, config.get("storage.xyz", Boolean.class)),
            () -> assertEquals(false, config.get("storage.abc", Boolean.class)),
            () -> assertArrayEquals(new String[]{"x", "y"}, config.get("storage.duba", String[].class)),
            () -> assertEquals(Duration.ofMinutes(60), config.get("times.60m", Duration.class)),
            () -> assertTrue(Object.class.isAssignableFrom(config.get("obj", Object.class).getClass()))
        );
```