### PR TITLE
Increase codecov after_n_builds and fix notify config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-coverage:
+codecov:
   notify:
-    after_n_builds: 30
+    wait_for_ci: yes
+
+coverage:
   status:
     patch: off
     project:
@@ -23,7 +25,7 @@ coverage:
         threshold: 2
 
 comment:
-  after_n_builds: 30
+  after_n_builds: 26
 
 # Ignore test files
 ignore:

--- a/.github/workflows/ci-backend-cql.yml
+++ b/.github/workflows/ci-backend-cql.yml
@@ -95,3 +95,5 @@ jobs:
         if: "github.event_name == 'push' && contains(github.event.head_commit.message, '[cql-tests]') || github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[cql-tests]')"
         run: mvn verify --projects janusgraph-${{ matrix.module }} -Dcassandra.docker.version=3.0.18' ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
       - uses: codecov/codecov-action@v1
+        with:
+          name: codecov-cql

--- a/.github/workflows/ci-backend-hbase.yml
+++ b/.github/workflows/ci-backend-hbase.yml
@@ -89,3 +89,5 @@ jobs:
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
       - uses: codecov/codecov-action@v1
+        with:
+          name: codecov-hbase

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -80,3 +80,5 @@ jobs:
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
       - uses: codecov/codecov-action@v1
+        with:
+          name: codecov-core

--- a/.github/workflows/ci-index-es.yml
+++ b/.github/workflows/ci-index-es.yml
@@ -81,3 +81,5 @@ jobs:
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
       - uses: codecov/codecov-action@v1
+        with:
+          name: codecov-index-es

--- a/.github/workflows/ci-index-solr.yml
+++ b/.github/workflows/ci-index-solr.yml
@@ -79,3 +79,5 @@ jobs:
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
       - uses: codecov/codecov-action@v1
+        with:
+          name: codecov-index-solr


### PR DESCRIPTION
1. Notify config should be under codecov group, not coverage group
2. Remove codecov.notify.after_n_builds limit so that code coverage
is always available as a GitHub check, no matter how many codecov
reports are uploaded
3. Reduce comment.after_n_builds from 30 to 26 to reflect exact
number of codecov reports
4. Name codecov reports

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
