### PR TITLE
Fix codecov configs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,18 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-coverage:
+codecov:
   notify:
-    after_n_builds: 30
+    wait_for_ci: yes
+
+coverage:
   status:
-    patch: off
+    patch:
+      default:
+        threshold: 5
     project:
       default:
         # allow test coverage to drop by 2%, assume that it's typically due to CI problems
         threshold: 2
 
-comment:
-  after_n_builds: 30
+comment: false
 
 # Ignore test files
 ignore:

--- a/.github/workflows/ci-backend-cql.yml
+++ b/.github/workflows/ci-backend-cql.yml
@@ -62,24 +62,35 @@ jobs:
         include:
           - module: cql
             args: "-Pcassandra3-byteordered -Dtest=\"**/diskstorage/cql/*\""
+            name: byteordered-diskstorage
           - module: cql
             args: "-Pcassandra3-murmur -Dtest=\"**/diskstorage/cql/*\""
+            name: murmur-diskstorage
           - module: cql
             args: "-Pcassandra3-byteordered -Dtest=\"**/graphdb/cql/*\""
+            name: byteordered-graphdb
           - module: cql
             args: "-Pcassandra3-murmur -Dtest=\"**/graphdb/cql/*\""
+            name: murmur-graphdb
           - module: cql
             args: "-Pcassandra3-murmur -Dtest=\"**/hadoop/*\""
+            name: murmur-hadoop
           - module: cql
             args: "-Pcassandra3-byteordered -Dtest=\"**/core/cql/*\""
+            name: byteordered-core
           - module: cql
             args: "-Pcassandra3-murmur -Dtest=\"**/core/cql/*\""
+            name: murmur-core
           - module: cql
             args: "-Pcassandra3-murmur-ssl -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
+            name: murmur-ssl
           - module: cql
             args: "-Pcassandra3-murmur-client-auth -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
+            name: murmur-client-auth
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -95,3 +106,5 @@ jobs:
         if: "github.event_name == 'push' && contains(github.event.head_commit.message, '[cql-tests]') || github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[cql-tests]')"
         run: mvn verify --projects janusgraph-${{ matrix.module }} -Dcassandra.docker.version=3.0.18' ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
       - uses: codecov/codecov-action@v1
+        with:
+          name: codecov-cql-${{ matrix.name }}

--- a/.github/workflows/ci-backend-hbase.yml
+++ b/.github/workflows/ci-backend-hbase.yml
@@ -62,21 +62,29 @@ jobs:
         include:
           - module: hbase-parent/janusgraph-hbase-10
             args: "-Dtest=\"**/diskstorage/hbase/*\""
+            name: hbase-10-diskstorage
           - module: hbase-parent/janusgraph-hbase-10
             args: "-Dtest=\"**/graphdb/hbase/*\""
+            name: hbase-10-graphdb
           - module: hbase-parent/janusgraph-hbase-10
             args: "-Dtest=\"**/hadoop/*\""
+            name: hbase-10-hadoop
           - module: hbase-parent/janusgraph-hbase-10
             install-args: "-Dhbase.profile -Phbase2"
             args: "-Dtest=\"**/diskstorage/hbase/*\""
+            name: hbase-2-diskstorage
           - module: hbase-parent/janusgraph-hbase-10
             install-args: "-Dhbase.profile -Phbase2"
             args: "-Dtest=\"**/graphdb/hbase/*\""
+            name: hbase-2-graphdb
           - module: hbase-parent/janusgraph-hbase-10
             install-args: "-Dhbase.profile -Phbase2"
             args: "-Dtest=\"**/hadoop/*\""
+            name: hbase-2-hadoop
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -89,3 +97,5 @@ jobs:
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
       - uses: codecov/codecov-action@v1
+        with:
+          name: codecov-hbase-${{ matrix.name }}

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -68,6 +68,8 @@ jobs:
           - module: lucene
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -80,3 +82,5 @@ jobs:
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
       - uses: codecov/codecov-action@v1
+        with:
+          name: codecov-core-${{ matrix.module }}

--- a/.github/workflows/ci-index-es.yml
+++ b/.github/workflows/ci-index-es.yml
@@ -63,12 +63,17 @@ jobs:
         include:
           - module: es
             args: "-Pelasticsearch7"
+            name: es7
           - module: es
             args: "-Pelasticsearch6"
+            name: es6
           - module: es
             args: "-Pelasticsearch60"
+            name: es60
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -81,3 +86,5 @@ jobs:
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
       - uses: codecov/codecov-action@v1
+        with:
+          name: codecov-index-${{ matrix.name }}

--- a/.github/workflows/ci-index-solr.yml
+++ b/.github/workflows/ci-index-solr.yml
@@ -63,10 +63,14 @@ jobs:
         include:
           - module: solr
             args: "-Psolr7"
+            name: solr7
           - module: solr
             args: "-Psolr8"
+            name: solr8
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -79,3 +83,5 @@ jobs:
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
       - uses: codecov/codecov-action@v1
+        with:
+          name: codecov-index-${{ matrix.name }}


### PR DESCRIPTION
1. Notify config should be under codecov group, not coverage group
2. Remove codecov.notify.after_n_builds limit so that code coverage
is always available as a GitHub check, no matter how many codecov
reports are uploaded
3. Disable pull request comment feature since it is annoying and
unstable
4. Name codecov reports

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
