### PR TITLE
Fix JanusGraphManagement::printIndexes output

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/JanusGraphManagement.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/JanusGraphManagement.java
@@ -436,7 +436,7 @@ public interface JanusGraphManagement extends JanusGraphConfiguration, SchemaMan
     /**
      * Prints out schema information related to indexes
      *
-     * @return String with graph index information
+     * @return String with graph index and relation index information
      */
     String printIndexes();
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
@@ -497,17 +497,17 @@ public class ManagementSystem implements JanusGraphManagement {
         } else {
             sb.append(DASHBREAK);
         }
-        sb.append(String.format(pattern, "Vertex Index Name", "Type", "Unique", "Backing", "Key:", "Status"));
+        sb.append(String.format(pattern, "Graph Index (Vertex)", "Type", "Unique", "Backing", "Key:", "Status"));
         sb.append(DASHBREAK);
         sb.append(iterateIndexes(pattern, vertexIndexes));
         
         sb.append(DASHBREAK);
-        sb.append(String.format(pattern, "Edge Index (VCI) Name", "Type", "Unique", "Backing", "Key:", "Status"));
+        sb.append(String.format(pattern, "Graph Index (Edge)", "Type", "Unique", "Backing", "Key:", "Status"));
         sb.append(DASHBREAK);
         sb.append(iterateIndexes(pattern, edgeIndexes));
 
         sb.append(DASHBREAK);
-        sb.append(String.format(relationPattern,"Relation Index", "Type", "Direction", "Sort Key", "Order", "Status"));
+        sb.append(String.format(relationPattern,"Relation Index (VCI)", "Type", "Direction", "Sort Key", "Order", "Status"));
         sb.append(DASHBREAK);
         for (RelationTypeIndex ri: relationIndexes) {
             sb.append(String.format(relationPattern, ri.name(), ri.getType(), ri.getDirection(), ri.getSortKey()[0], ri.getSortOrder(), ri.getIndexStatus().name()));

--- a/janusgraph-lucene/src/test/java/org/janusgraph/diskstorage/lucene/BerkeleyLuceneTest.java
+++ b/janusgraph-lucene/src/test/java/org/janusgraph/diskstorage/lucene/BerkeleyLuceneTest.java
@@ -76,30 +76,66 @@ public class BerkeleyLuceneTest extends JanusGraphIndexTest {
         GraphOfTheGodsFactory.load(graph);
         mgmt = graph.openManagement();
 
-        String expected = "A18422278042949EE2B162837EC27A63";
+        String expected = "026DCB18B35C198CC54FA66B3D86C3FB";
         String output = mgmt.printSchema();
         String outputHash = DigestUtils.md5Hex(output).toUpperCase();
         assertEquals(expected, outputHash);
 
-        expected = "2114C009DC359B1C9AD7D0655AC6C9BF";
-        output = mgmt.printVertexLabels();
-        outputHash = DigestUtils.md5Hex(output).toUpperCase();
-        assertEquals(expected, outputHash);
+        String expectedVertexLabels =
+            "------------------------------------------------------------------------------------------------\n" +
+             "Vertex Label Name              | Partitioned | Static                                             |\n" +
+             "---------------------------------------------------------------------------------------------------\n" +
+             "titan                          | false       | false                                              |\n" +
+             "location                       | false       | false                                              |\n" +
+             "god                            | false       | false                                              |\n" +
+             "demigod                        | false       | false                                              |\n" +
+             "human                          | false       | false                                              |\n" +
+             "monster                        | false       | false                                              |\n" +
+             "---------------------------------------------------------------------------------------------------\n";
+        assertEquals(expectedVertexLabels, mgmt.printVertexLabels());
 
-        expected = "1E8AAE2C887544E490948F2ACBBFE312";
-        output = mgmt.printEdgeLabels();
-        outputHash = DigestUtils.md5Hex(output).toUpperCase();
-        assertEquals(expected, outputHash);
+        String expectedEdgeLabels =
+            "------------------------------------------------------------------------------------------------\n" +
+            "Edge Label Name                | Directed    | Unidirected | Multiplicity                         |\n" +
+            "---------------------------------------------------------------------------------------------------\n" +
+            "brother                        | true        | false       | MULTI                                |\n" +
+            "father                         | true        | false       | MANY2ONE                             |\n" +
+            "mother                         | true        | false       | MANY2ONE                             |\n" +
+            "battled                        | true        | false       | MULTI                                |\n" +
+            "lives                          | true        | false       | MULTI                                |\n" +
+            "pet                            | true        | false       | MULTI                                |\n" +
+            "---------------------------------------------------------------------------------------------------\n";
+        assertEquals(expectedEdgeLabels, mgmt.printEdgeLabels());
 
-        expected = "35851C8867321C8CB3E275886F40E8B9";
-        output = mgmt.printPropertyKeys();
-        outputHash = DigestUtils.md5Hex(output).toUpperCase();
-        assertEquals(expected, outputHash);
+        String expectedPropertyKeys =
+            "------------------------------------------------------------------------------------------------\n" +
+            "Property Key Name              | Cardinality | Data Type                                          |\n" +
+            "---------------------------------------------------------------------------------------------------\n" +
+            "name                           | SINGLE      | class java.lang.String                             |\n" +
+            "age                            | SINGLE      | class java.lang.Integer                            |\n" +
+            "time                           | SINGLE      | class java.lang.Integer                            |\n" +
+            "reason                         | SINGLE      | class java.lang.String                             |\n" +
+            "place                          | SINGLE      | class org.janusgraph.core.attribute.Geoshape       |\n" +
+            "---------------------------------------------------------------------------------------------------\n";
+        assertEquals(expectedPropertyKeys, mgmt.printPropertyKeys());
 
-        expected = "3951BBB935D39EE0FF74CE2D5F7CA997";
-        output = mgmt.printIndexes();
-        outputHash = DigestUtils.md5Hex(output).toUpperCase();
-        assertEquals(expected, outputHash);
+        String expectedIndexes =
+            "------------------------------------------------------------------------------------------------\n" +
+            "Graph Index (Vertex)           | Type        | Unique    | Backing        | Key:           Status |\n" +
+            "---------------------------------------------------------------------------------------------------\n" +
+            "name                           | Composite   | true      | internalindex  | name:         ENABLED |\n" +
+            "vertices                       | Mixed       | false     | search         | age:          ENABLED |\n" +
+            "---------------------------------------------------------------------------------------------------\n" +
+            "Graph Index (Edge)             | Type        | Unique    | Backing        | Key:           Status |\n" +
+            "---------------------------------------------------------------------------------------------------\n" +
+            "edges                          | Mixed       | false     | search         | reason:       ENABLED |\n" +
+            "                               |             |           |                | place:        ENABLED |\n" +
+            "---------------------------------------------------------------------------------------------------\n" +
+            "Relation Index (VCI)           | Type        | Direction | Sort Key       | Order    |     Status |\n" +
+            "---------------------------------------------------------------------------------------------------\n" +
+            "battlesByTime                  | battled     | BOTH      | time           | desc     |    ENABLED |\n" +
+            "---------------------------------------------------------------------------------------------------\n";
+        assertEquals(expectedIndexes, mgmt.printIndexes());
     }
 
 }


### PR DESCRIPTION
The old output confuses 'graph edge index' with 'vertex centric index (VCI)'

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
