### PR TITLE
BasicVertexCentricQueryBuilder: Reduce duplicate getExtendedSortKey calls

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
@@ -538,6 +538,7 @@ public abstract class BasicVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q
                         InternalRelationType bestCandidate = null;
                         double bestScore = Double.NEGATIVE_INFINITY;
                         boolean bestCandidateSupportsOrder = false;
+                        PropertyKey[] bestCandidateExtendedSortKey = null;
                         for (InternalRelationType candidate : type.getRelationIndexes()) {
                             //Filter out those that don't apply
                             if (!candidate.isUnidirected(Direction.BOTH) && !candidate.isUnidirected(direction)) {
@@ -570,6 +571,7 @@ public abstract class BasicVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q
                                 bestScore=score;
                                 bestCandidate=candidate;
                                 bestCandidateSupportsOrder=supportsOrder && currentOrder==orders.size();
+                                bestCandidateExtendedSortKey = extendedSortKey;
                             }
                         }
                         Preconditions.checkArgument(bestCandidate != null,
@@ -578,10 +580,9 @@ public abstract class BasicVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q
 
                         //Construct sort key constraints for the best candidate and then serialize into a SliceQuery
                         //that is wrapped into a BackendQueryHolder
-                        PropertyKey[] extendedSortKey = getExtendedSortKey(bestCandidate,direction,tx);
                         EdgeSerializer.TypedInterval[] sortKeyConstraints
-                                = new EdgeSerializer.TypedInterval[extendedSortKey.length];
-                        constructSliceQueries(extendedSortKey, sortKeyConstraints, 0, bestCandidate, direction,
+                                = new EdgeSerializer.TypedInterval[bestCandidateExtendedSortKey.length];
+                        constructSliceQueries(bestCandidateExtendedSortKey, sortKeyConstraints, 0, bestCandidate, direction,
                                 intervalConstraints, sliceLimit, isIntervalFittedConditions, bestCandidateSupportsOrder,
                                 queries);
                     }


### PR DESCRIPTION
A small enhancement that reduces an unnecessary duplicate call.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
