### PR TITLE
Add CacheVertex::refresh method to allow clearing vertex cache

### DIFF
--- a/docs/operations/cache.md
+++ b/docs/operations/cache.md
@@ -47,6 +47,29 @@ which means they cannot be evicted since that would entail loosing their
 changes. Therefore, transaction which contain a lot of modifications may
 end up with a larger than configured vertex cache.
 
+Assuming your vertex is not evicted from cache, or it is evicted from
+cache but your program context still holds the reference to the vertex,
+then its properties are cached together with the vertex. This means once
+a property is queried, any subsequent reads will hit the cache. In case
+you want to force JanusGraph to read from the data storage again, or you
+simply want to save memory, you could clear the cache of that vertex manually.
+Note this is not gremlin compliant, so you need to cast your vertex into
+CacheVertex type to do the refresh:
+
+```groovy
+// first read automatically caches the property together with v
+v.property("prop").value();
+// force refresh to clear the cache
+((CacheVertex) v).refresh();
+// now a subsequent read will lead to a data storage read
+v.property("prop").value();
+```
+
+Note that refresh operation cannot guarantee your current transaction reads
+the latest data from an eventual consistent backend. You should not attempt
+to achieve Compare-And-Set (CAS) via refresh operation, even though it might
+be helpful to detect conflicts among transactions in some cases.
+
 ### Index Cache
 
 The index cache contains the results of index queries executed in the

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/CacheVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/CacheVertex.java
@@ -38,6 +38,12 @@ public class CacheVertex extends StandardVertex {
         queryCache = new HashMap<>(4);
     }
 
+    public void refresh() {
+        synchronized (queryCache) {
+            queryCache.clear();
+        }
+    }
+
     protected void addToQueryCache(final SliceQuery query, final EntryList entries) {
         synchronized (queryCache) {
             //TODO: become smarter about what to cache and when (e.g. memory pressure)


### PR DESCRIPTION
In some use cases, users might want to read from the underlying storage
backend again in the mid of a transaction, bypassing the vertex cache.
This commit adds a refresh method to CacheVertex which user could call
to clear the cache.

Related to https://lists.lfaidata.foundation/g/janusgraph-users/topic/81050716

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
