### PR TITLE
Increase default cql max connection configuration options

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -221,6 +221,11 @@ New cql configuration options should be used for upgrade:
 
 See more new cql configuration options in configuration references under `storage.cql` section.
 
+##### Increase default cql max connection configuration options
+
+The default option `storage.cql.local-max-connections-per-host` is increased from `1` to `20`.
+The default option `storage.cql.remote-max-connections-per-host` is increased from `1` to `5`.
+
 ### Version 0.5.3 (Release Date: December 24, 2020)
 
 === "Maven"

--- a/docs/configs/janusgraph-cfg.md
+++ b/docs/configs/janusgraph-cfg.md
@@ -384,12 +384,12 @@ CQL storage backend options
 | storage.cql.heartbeat-timeout | How long the driver waits for the response (in milliseconds) to a heartbeat. | Long | (no default value) | MASKABLE |
 | storage.cql.keyspace | The name of JanusGraph's keyspace.  It will be created if it does not exist. | String | janusgraph | LOCAL |
 | storage.cql.local-datacenter | The name of the local or closest Cassandra datacenter. This value will be passed into CqlSessionBuilder.withLocalDatacenter. | String | datacenter1 | MASKABLE |
-| storage.cql.local-max-connections-per-host | The maximum number of connections that can be created per host for local datacenter | Integer | 1 | FIXED |
+| storage.cql.local-max-connections-per-host | The maximum number of connections that can be created per host for local datacenter | Integer | 20 | FIXED |
 | storage.cql.max-requests-per-connection | The maximum number of requests that can be executed concurrently on a connection. | Integer | 1024 | FIXED |
 | storage.cql.only-use-local-consistency-for-system-operations | True to prevent any system queries from using QUORUM consistency and always use LOCAL_QUORUM instead | Boolean | false | MASKABLE |
 | storage.cql.protocol-version | The protocol version used to connect to the Cassandra database.  If no value is supplied then the driver will negotiate with the server. | Integer | 0 | LOCAL |
 | storage.cql.read-consistency-level | The consistency level of read operations against Cassandra | String | QUORUM | MASKABLE |
-| storage.cql.remote-max-connections-per-host | The maximum number of connections that can be created per host for remote datacenter | Integer | 1 | FIXED |
+| storage.cql.remote-max-connections-per-host | The maximum number of connections that can be created per host for remote datacenter | Integer | 5 | FIXED |
 | storage.cql.replication-factor | The number of data replicas (including the original copy) that should be kept | Integer | 1 | GLOBAL_OFFLINE |
 | storage.cql.replication-strategy-class | The replication strategy to use for JanusGraph keyspace | String | SimpleStrategy | FIXED |
 | storage.cql.replication-strategy-options | Replication strategy options, e.g. factor or replicas per datacenter.  This list is interpreted as a map.  It must have an even number of elements in [key,val,key,val,...] form.  A replication_factor set here takes precedence over one set with storage.cql.replication-factor | String[] | (no default value) | FIXED |

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
@@ -163,14 +163,14 @@ public interface CQLConfigOptions {
             "local-max-connections-per-host",
             "The maximum number of connections that can be created per host for local datacenter",
             ConfigOption.Type.FIXED,
-            1);
+            20);
 
     ConfigOption<Integer> REMOTE_MAX_CONNECTIONS_PER_HOST = new ConfigOption<>(
             CQL_NS,
             "remote-max-connections-per-host",
             "The maximum number of connections that can be created per host for remote datacenter",
             ConfigOption.Type.FIXED,
-            1);
+            5);
 
     ConfigOption<Integer> MAX_REQUESTS_PER_CONNECTION = new ConfigOption<>(
             CQL_NS,
@@ -200,8 +200,8 @@ public interface CQLConfigOptions {
             "Configuration options for SSL");
 
     ConfigNamespace SSL_KEYSTORE_NS = new ConfigNamespace(
-            SSL_NS, 
-            "keystore", 
+            SSL_NS,
+            "keystore",
             "Configuration options for SSL Keystore.");
 
     ConfigNamespace SSL_TRUSTSTORE_NS = new ConfigNamespace(
@@ -236,21 +236,21 @@ public interface CQLConfigOptions {
             "Marks the location of the SSL Keystore.",
             ConfigOption.Type.LOCAL,
             "");
-    
+
     ConfigOption<String> SSL_KEYSTORE_KEY_PASSWORD = new ConfigOption<>(
             SSL_KEYSTORE_NS,
             "keypassword",
             "The password to access the key in SSL Keystore.",
             ConfigOption.Type.LOCAL,
             "");
-    
+
     ConfigOption<String> SSL_KEYSTORE_STORE_PASSWORD = new ConfigOption<>(
             SSL_KEYSTORE_NS,
             "storepassword",
             "The password to access the SSL Keystore.",
             ConfigOption.Type.LOCAL,
             "");
-    
+
     ConfigOption<String> SSL_TRUSTSTORE_LOCATION = new ConfigOption<>(
             SSL_TRUSTSTORE_NS,
             "location",


### PR DESCRIPTION
I don't have strong opinion about this PR. I'm good merging it or closing it.
I just noticed that some novice users which start using JanusGraph with default configurations might bump to an issue with cql connections where they use only one connection and try to execute some basic benchmarks. In some situations a CQL connection might not be immediately available and thus we might see hangs between cql writes. With this simple change, users who don't configure JanusGraph at all will bump to this issue much rarely (hopefully).
That said, this is a breaking change which might be not welcoming, thus I don't have strong opinion about this PR.

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
