### PR TITLE
Add job to run all TinkerPop tests on schedule

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -31,6 +31,8 @@ on:
     - 'requirements.txt'
     - 'docs.Dockerfile'
     - '*.md'
+  schedule:
+    - cron:  '0 0 * * 3'
 
 env:
   ES_JAVA_OPTS: "-Xms256m -Xmx512m"
@@ -78,7 +80,7 @@ jobs:
 
   tp-tests:
     runs-on: ubuntu-20.04
-    if: "github.event_name == 'push' && contains(github.event.head_commit.message, '[tp-tests]') || github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[tp-tests]')"
+    if: "github.event_name == 'push' && contains(github.event.head_commit.message, '[tp-tests]') || github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[tp-tests]') || github.event_name == 'schedule'"
     needs: build-all
     strategy:
       fail-fast: false


### PR DESCRIPTION
Run TinkerPop tests 4 times a week.

Based on the next documentation: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule

Fixes #1620

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
