### PR TITLE
Add exec to start server

### DIFF
--- a/janusgraph-dist/src/assembly/static/bin/janusgraph-server.sh
+++ b/janusgraph-dist/src/assembly/static/bin/janusgraph-server.sh
@@ -233,7 +233,7 @@ startForeground() {
   fi
 
   if [[ -z "$RUNAS" ]]; then
-    $JAVA -Dlog4j.configuration=$LOG4J_CONF $JAVA_OPTIONS -cp $CLASSPATH $JANUSGRAPH_SERVER_CMD "$JANUSGRAPH_YAML"
+    exec $JAVA -Dlog4j.configuration=$LOG4J_CONF $JAVA_OPTIONS -cp $CLASSPATH $JANUSGRAPH_SERVER_CMD "$JANUSGRAPH_YAML"
     exit 0
   else
     echo Starting in foreground not supported with RUNAS


### PR DESCRIPTION
-----

When run in Docker (or Kubernetes) the `SIGTERM` signal is not received by the Java process.
This prevent the Shutdown Hooks to be executed properly.
Hence, the `exec` syntax could be preferred.


Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
