### PR TITLE
Rewrite vertex-centric reindexing test

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/job/IndexRepairJob.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/job/IndexRepairJob.java
@@ -136,21 +136,14 @@ public class IndexRepairJob extends IndexUpdateJob implements VertexScanJob {
 
                         Entry entry = edgeSerializer.writeRelation(janusgraphRelation, wrappedType, pos, writeTx);
                         
-                        //The below condition is check to avoid self-links which is getting created after re-indexing
-                        if(pos==0) {
-                            //Create OUT edge index entry. 
-                            //Here source will the current vertex and target vertex the other side of the relation 
-                            outAdditions.add(entry); 
-                        }else if(pos==1) {
-                            //Create IN edge index entry.
-                            //Here the source vertex is the other side of the current vertex and target will be the current vertex
+                        if (pos == 0) {
+                            outAdditions.add(entry);
+                        } else {
+                            assert pos == 1;
                             InternalVertex otherVertex = janusgraphRelation.getVertex(1);
                             StaticBuffer otherVertexKey = writeTx.getIdInspector().getKey(otherVertex.longId());
                             inAdditionsMap.computeIfAbsent(otherVertexKey, k -> new ArrayList<Entry>()).add(entry);
-                        }else {
-                            throw new IllegalStateException("Invalid position:" + pos);
                         }
-						 
                     }
                 }
 		


### PR DESCRIPTION
PR #2137 Fixes a bug with VCI reindexing, but the tests are
not robust and fail manual mutation testing. This commit
rewrites the test and verifies the query results before
and after reindexing.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
