### PR TITLE
Ignore tests in codecov report and upload jacoco artefacts

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -30,6 +30,6 @@ comment: false
 
 # Ignore test files
 ignore:
-  - "**/test/.*"
+  - "**/test/**"
   - "janusgraph-backend-testutils/**"
   - "janusgraph-test/**"

--- a/.github/workflows/ci-backend-cql.yml
+++ b/.github/workflows/ci-backend-cql.yml
@@ -115,6 +115,10 @@ jobs:
           java-version: 1.8
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: jacoco-reports
+          path: target/jacoco-combined.exec
       - uses: codecov/codecov-action@v1
         with:
           name: codecov-cql-${{ matrix.name }}

--- a/.github/workflows/ci-backend-hbase.yml
+++ b/.github/workflows/ci-backend-hbase.yml
@@ -96,6 +96,10 @@ jobs:
           java-version: 1.8
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: jacoco-reports
+          path: target/jacoco-combined.exec
       - uses: codecov/codecov-action@v1
         with:
           name: codecov-hbase-${{ matrix.name }}

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -81,6 +81,10 @@ jobs:
           java-version: 1.8
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: jacoco-reports
+          path: target/jacoco-combined.exec
       - uses: codecov/codecov-action@v1
         with:
           name: codecov-core-${{ matrix.module }}

--- a/.github/workflows/ci-index-es.yml
+++ b/.github/workflows/ci-index-es.yml
@@ -85,6 +85,10 @@ jobs:
           java-version: 1.8
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: jacoco-reports
+          path: target/jacoco-combined.exec
       - uses: codecov/codecov-action@v1
         with:
           name: codecov-index-${{ matrix.name }}

--- a/.github/workflows/ci-index-solr.yml
+++ b/.github/workflows/ci-index-solr.yml
@@ -82,6 +82,10 @@ jobs:
           java-version: 1.8
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.args }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: jacoco-reports
+          path: target/jacoco-combined.exec
       - uses: codecov/codecov-action@v1
         with:
           name: codecov-index-${{ matrix.name }}


### PR DESCRIPTION
1. In codecov reports, ignore all test files. Currently tests under janusgraph-cql module
are picked up by codecov. After this change, overall test coverage will be increased.
2. Upload jacoco artefacts in GitHub actions, so that developers can
download the generated jacoco test coverage reports and view locally
(e.g. in IDE).

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
