### PR TITLE
Fix integer overflow bug in StaticArrayEntryList

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/ArrayUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/ArrayUtil.java
@@ -1,0 +1,51 @@
+// Copyright 2021 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.util;
+
+public class ArrayUtil {
+    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
+    /**
+     * Given an old capacity of an array, generate the new capacity that is larger than or equal to minimum required capacity.
+     * Under most circumstances, it doubles the old capacity. If the old capacity is already larger than half of @{link #MAX_ARRAY_SIZE},
+     * then new capacity will be {@link #MAX_ARRAY_SIZE}, which is slightly smaller than Integer.MAX_VALUE to avoid
+     * Out of Memory error. If the min capacity is smaller than old capacity, then old capacity will be simply returned.
+     * @param oldCapacity old capacity
+     * @param minCapacity minimum desired capacity
+     * @return a new capacity that is larger than or equal to minCapacity
+     * @throws IllegalArgumentException if minimum required capacity is larger than {@link #MAX_ARRAY_SIZE}, or minimum
+     * required capacity is negative (likely caused by integer overflow)
+     */
+    public static int growSpace(int oldCapacity, int minCapacity) {
+        if (minCapacity < 0) {
+            throw new IllegalArgumentException(String.format("required capacity %d is negative, likely caused by integer overflow", minCapacity));
+        }
+        if (minCapacity <= oldCapacity) {
+            return oldCapacity;
+        }
+        if (minCapacity > MAX_ARRAY_SIZE) {
+            throw new IllegalArgumentException(String.format("required capacity %d is larger than MAX_ARRAY_SIZE [%d]",
+                minCapacity, MAX_ARRAY_SIZE));
+        }
+        int newCapacity = oldCapacity << 1;
+        if (newCapacity - minCapacity < 0) {
+            newCapacity = minCapacity;
+        } else if (newCapacity - MAX_ARRAY_SIZE > 0) {
+            newCapacity = MAX_ARRAY_SIZE;
+        }
+        return newCapacity;
+    }
+
+}

--- a/janusgraph-test/src/test/java/org/janusgraph/diskstorage/util/ArrayUtilTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/diskstorage/util/ArrayUtilTest.java
@@ -1,0 +1,53 @@
+// Copyright 2021 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ArrayUtilTest {
+
+    @Test
+    void testGrowSpace() {
+        // small capacity
+        assertEquals(6, ArrayUtil.growSpace(3, 5));
+        assertEquals(10, ArrayUtil.growSpace(3, 10));
+        assertEquals(10, ArrayUtil.growSpace(10, 8));
+        assertEquals(10, ArrayUtil.growSpace(10, 10));
+
+        // minCapacity is negative (usually caused by overflow then calculating minCapacity)
+        assertThrows(IllegalArgumentException.class, () -> ArrayUtil.growSpace(100, Integer.MAX_VALUE + 1));
+        assertThrows(IllegalArgumentException.class, () -> ArrayUtil.growSpace(100, -1));
+        assertThrows(IllegalArgumentException.class, () -> ArrayUtil.growSpace(Integer.MAX_VALUE - 100, Integer.MAX_VALUE + 100));
+
+        // minCapacity larger than MAX_ARRAY_SIZE
+        assertThrows(IllegalArgumentException.class, () -> ArrayUtil.growSpace(100, Integer.MAX_VALUE - 7));
+        assertThrows(IllegalArgumentException.class, () -> ArrayUtil.growSpace(100, Integer.MAX_VALUE));
+
+        // allocate MAX_ARRAY_SIZE when old capacity is larger than MAX_ARRAY_SIZE / 2
+        assertEquals(Integer.MAX_VALUE - 8, ArrayUtil.growSpace(Integer.MAX_VALUE - 100, Integer.MAX_VALUE - 50));
+        assertEquals(Integer.MAX_VALUE - 8, ArrayUtil.growSpace(Integer.MAX_VALUE / 2, Integer.MAX_VALUE / 2 + 100));
+        assertEquals(Integer.MAX_VALUE - 8, ArrayUtil.growSpace(Integer.MAX_VALUE / 2 - 3, Integer.MAX_VALUE - 8));
+        assertEquals(Integer.MAX_VALUE - 8, ArrayUtil.growSpace(Integer.MAX_VALUE / 2 - 3, Integer.MAX_VALUE / 2 + 100));
+        assertEquals(Integer.MAX_VALUE - 8, ArrayUtil.growSpace((int) (Integer.MAX_VALUE * 0.7), (int) (Integer.MAX_VALUE * 0.7) + 1));
+        assertEquals((Integer.MAX_VALUE / 2 - 4) * 2, ArrayUtil.growSpace(Integer.MAX_VALUE / 2 - 4, Integer.MAX_VALUE / 2 + 100));
+
+        // old capacity already reaches MAX_ARRAY_SIZE
+        assertEquals(Integer.MAX_VALUE - 8, ArrayUtil.growSpace(Integer.MAX_VALUE - 8, Integer.MAX_VALUE - 100));
+        assertEquals(Integer.MAX_VALUE - 8, ArrayUtil.growSpace(Integer.MAX_VALUE - 8, Integer.MAX_VALUE - 8));
+    }
+}


### PR DESCRIPTION
StaticArrayEntryList::ensureSpace method expands an immutable
array by allocating a larger array and copies data from the old array
to the new one. It tries to avoid expensive copy operations by
doubling the estimated size each time, however, when the array
size is very large (larger than Integer.MAX_VALUE / 2), the new estimated
size will overflow and thus the array won't be effectively expanded.
As a consequence, it will be expanded into the minimum required
size, which is very ineffective and incurs great overhead.

This commit takes java.io.ByteArrayOutputStream implementation as a reference
and adds an ArrayUtil::growSpace method which can properly handle large
size and avoids integer overflow problems.

Related to #2524

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
