### PR TITLE
Use Java DateTimeFormatter instead of Jackson StdDateFormat

### DIFF
--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/database/serialize/attribute/DateSerializerTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/database/serialize/attribute/DateSerializerTest.java
@@ -42,6 +42,15 @@ public class DateSerializerTest {
             Arguments.of(new Date(1557532800000L), "2019-05-11"),
             Arguments.of(new Date(1557602288000L), "2019-05-11T19:18:08+00:00"),
             Arguments.of(new Date(1557602288000L), "2019-05-11T19:18:08Z"),
+            Arguments.of(new Date(1557602288000L), "2019-05-11T19:18:08"),
+            Arguments.of(new Date(1557598680000L), "2019-05-11T19:18+01:00"),
+            Arguments.of(new Date(1557602280000L), "2019-05-11T19:18Z"),
+            Arguments.of(new Date(1557602280000L), "2019-05-11T19:18"),
+            Arguments.of(new Date(1557602288200L), "2019-05-11T19:18:08.2"),
+            Arguments.of(new Date(1557566288400L), "2019-05-11T19:18:08.400+10"),
+            Arguments.of(new Date(1557613088010L), "2019-05-11T19:18:08.01-0300"),
+            Arguments.of(new Date(1557602280000L), "2019-05-11T19:18Z"),
+            Arguments.of(new Date(1557602280000L), "2019-05-11T19:18"),
             Arguments.of(new Date(786297600000L), "Thu, 01 Dec 1994 16:00:00 GMT"),
             Arguments.of(new Date(784111777000L), "Sun, 06 Nov 1994 08:49:37 GMT")
         );


### PR DESCRIPTION
Fixes #2429
Follow up to #2430

Usage of StdDateFormat outside of Jackson's framework is discouraged.
StdDateFormat is not thread-safe and wrapping an instance of it in a ThreadLocal could result in data leaks.

Java 8 DateTimeFormatter is thread-safe.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there an issue associated with this PR? Is it referenced in the commit message?
- [X] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
