### PR TITLE
Fix profiling when limit adjusting is enabled

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KeySliceQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KeySliceQuery.java
@@ -79,6 +79,9 @@ public class KeySliceQuery extends SliceQuery {
 
     @Override
     public String toString() {
-        return "KeySliceQuery(" + key + ")[" + getSliceStart() + "," + getSliceEnd() + ")@" + getLimit();
+        StringBuilder builder = new StringBuilder("KeySliceQuery(");
+        builder.append(key).append(")[").append(getSliceStart()).append(",").append(getSliceEnd()).append(")");
+        if (hasLimit()) builder.append("@").append(getLimit());
+        return builder.toString();
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/SliceQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/SliceQuery.java
@@ -149,7 +149,8 @@ public class SliceQuery extends BaseQuery implements BackendQuery<SliceQuery> {
         if (type != null) {
             sb.append(type).append(":");
         }
-        sb.append("SliceQuery[").append(getSliceStart()).append(",").append(getSliceEnd()).append(")@").append(getLimit());
+        sb.append("SliceQuery[").append(getSliceStart()).append(",").append(getSliceEnd()).append(")");
+        if (hasLimit()) sb.append("@").append(getLimit());
         return sb.toString();
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/LimitAdjustingIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/LimitAdjustingIterator.java
@@ -71,6 +71,8 @@ public abstract class LimitAdjustingIterator<R> implements CloseableIterator<R> 
             return iterator.hasNext();
         if (currentLimit>=maxLimit) return false;
 
+        //Close old iterator. This is needed otherwise it would not be timed properly by profiler.
+        CloseableIterator.closeIterator(iterator);
         //Get an iterator with an updated limit
         currentLimit = (int) Math.min(maxLimit, Math.round(currentLimit * 2.0));
         iterator = getNewIterator(currentLimit);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/QueryProcessor.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/QueryProcessor.java
@@ -196,7 +196,7 @@ public class QueryProcessor<Q extends ElementQuery<R, B>, R extends JanusGraphEl
 
         @Override
         public Iterator<R> getNewIterator(int newLimit) {
-            if (!backendQuery.hasLimit() || newLimit>backendQuery.getLimit())
+            if (newLimit>backendQuery.getLimit())
                 backendQuery = backendQuery.updateLimit(newLimit);
             return executor.execute(query, backendQuery, executionInfo, profiler);
         }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/JointIndexQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/JointIndexQuery.java
@@ -116,6 +116,7 @@ public class JointIndexQuery extends BaseQuery implements BackendQuery<JointInde
             subqueries = new ArrayList<>(queries);
         }
         JointIndexQuery jointIndexQuery = new JointIndexQuery(subqueries);
+        jointIndexQuery.observeWith(this.profiler, false);
         jointIndexQuery.setLimit(newLimit);
         return jointIndexQuery;
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/MultiKeySliceQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/MultiKeySliceQuery.java
@@ -73,7 +73,10 @@ public class MultiKeySliceQuery extends BaseQuery implements BackendQuery<MultiK
 
     @Override
     public String toString() {
-        return "multiKSQ["+queries.size()+"]@"+getLimit();
+        StringBuilder builder = new StringBuilder("multiKSQ[");
+        builder.append(queries.size()).append("]");
+        if (hasLimit()) builder.append("@").append(getLimit());
+        return builder.toString();
     }
 
 }

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/query/QueryTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/query/QueryTest.java
@@ -86,7 +86,7 @@ public class QueryTest {
 
         for (int i = 0; i < 20; i++) {
             tx.addVertex().property("prop1", "prop1val").element().property("prop2", "prop2val")
-                .element().property("prop3", "prop3val" + i % 2).element().property("prop4", "prop4val" + i % 2);
+                .element().property("prop3", "prop3val").element().property("prop4", "prop4val");
         }
         tx.commit();
 
@@ -101,13 +101,13 @@ public class QueryTest {
             .profile().next()));
 
         // Two conditions, one of which met by index prop1_idx. Multiply original limit by two for sake of in-memory filtering.
-        assertCount(5, graph.traversal().V().has("prop1", "prop1val").has("prop3", "prop3val0").limit(5));
-        assertEquals("multiKSQ[1]@10", getQueryAnnotation(graph.traversal().V().has("prop1", "prop1val").has("prop3", "prop3val0").limit(5)
+        assertCount(5, graph.traversal().V().has("prop1", "prop1val").has("prop3", "prop3val").limit(5));
+        assertEquals("multiKSQ[1]@10", getQueryAnnotation(graph.traversal().V().has("prop1", "prop1val").has("prop3", "prop3val").limit(5)
             .profile().next()));
 
         // Three conditions, one of which met by index prop1_idx. Multiply original limit by four for sake of in-memory filtering.
-        assertCount(5, graph.traversal().V().has("prop1", "prop1val").has("prop3", "prop3val0").has("prop4", "prop4val0").limit(5));
-        assertEquals("multiKSQ[1]@20", getQueryAnnotation(graph.traversal().V().has("prop1", "prop1val").has("prop3", "prop3val0").has("prop4", "prop4val0").limit(5)
+        assertCount(5, graph.traversal().V().has("prop1", "prop1val").has("prop3", "prop3val").has("prop4", "prop4val").limit(5));
+        assertEquals("multiKSQ[1]@20", getQueryAnnotation(graph.traversal().V().has("prop1", "prop1val").has("prop3", "prop3val").has("prop4", "prop4val").limit(5)
             .profile().next()));
     }
 


### PR DESCRIPTION
When LimitAdjustingIterator is in effect, multiple backend queries with
different limits (e.g. 1000, 2000, 4000, ...) are fired progressively.
They are, however, not all profiled. Currently, only the last backend
query is profiled because of a bug. This commit fixes it and now users
can see timing of each backend query to better understand whether they
need smart-limit or not.

This commit also fixes a minor thing with profiler output, such that when
QUERY.NO_LIMIT is used or no limit is given, we don't display Integer.MAX_VALUE
in the profile output.


-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
