### PR TITLE
Refactor GhostVertexRemover and VertexJobConverter

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/core/TransactionBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/TransactionBuilder.java
@@ -34,6 +34,13 @@ public interface TransactionBuilder {
     TransactionBuilder readOnly();
 
     /**
+     * A shortcut for a number of configs that are commonly used by read-only OLAP jobs.
+     *
+     * @return Object containing a number of properties optimized for read-only OLAP jobs
+     */
+    TransactionBuilder readOnlyOLAP();
+
+    /**
      * Enabling batch loading disables a number of consistency checks inside JanusGraph to speed up the ingestion of
      * data under the assumptions that inconsistencies are resolved prior to loading.
      *

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/AbstractScanJob.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/AbstractScanJob.java
@@ -1,0 +1,72 @@
+// Copyright 2021 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.olap;
+
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.diskstorage.EntryList;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.diskstorage.keycolumnvalue.scan.ScanJob;
+import org.janusgraph.graphdb.database.StandardJanusGraph;
+import org.janusgraph.graphdb.idmanagement.IDManager;
+import org.janusgraph.graphdb.relations.RelationCache;
+import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
+import org.janusgraph.graphdb.types.system.BaseKey;
+
+public abstract class AbstractScanJob implements ScanJob {
+    protected final GraphProvider graph;
+    protected StandardJanusGraphTx tx;
+    private IDManager idManager;
+
+    public AbstractScanJob(JanusGraph graph) {
+        this.graph = new GraphProvider();
+        if (graph != null) this.graph.setGraph(graph);
+    }
+
+    public AbstractScanJob(AbstractScanJob copy) {
+        this.graph = copy.graph;
+        this.tx = copy.tx;
+        this.idManager = copy.idManager;
+    }
+
+    protected abstract StandardJanusGraphTx startTransaction(StandardJanusGraph graph);
+
+    protected void open(Configuration graphConfig) {
+        graph.initializeGraph(graphConfig);
+        idManager = graph.get().getIDManager();
+        tx = startTransaction(graph.get());
+    }
+
+    protected void close() {
+        if (null != tx && tx.isOpen())
+            tx.rollback();
+        graph.close();
+    }
+
+    protected boolean isGhostVertex(long vertexId, EntryList firstEntries) {
+        if (idManager.isPartitionedVertex(vertexId) && !idManager.isCanonicalVertexId(vertexId)) return false;
+
+        RelationCache relCache = tx.getEdgeSerializer().parseRelation(
+            firstEntries.get(0), true, tx);
+        return relCache.typeId != BaseKey.VertexExists.longId();
+    }
+
+    protected long getVertexId(StaticBuffer key) {
+        return idManager.getKeyID(key);
+    }
+
+    @Override
+    public abstract AbstractScanJob clone();
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/GraphProvider.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/GraphProvider.java
@@ -1,0 +1,56 @@
+// Copyright 2021 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.olap;
+
+import com.google.common.base.Preconditions;
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.JanusGraphFactory;
+import org.janusgraph.diskstorage.configuration.BasicConfiguration;
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.graphdb.database.StandardJanusGraph;
+
+public class GraphProvider {
+
+    private StandardJanusGraph graph = null;
+    private boolean provided = false;
+
+    public void setGraph(JanusGraph graph) {
+        Preconditions.checkArgument(graph != null && graph.isOpen(), "Need to provide open graph");
+        this.graph = (StandardJanusGraph) graph;
+        provided = true;
+    }
+
+    public void initializeGraph(Configuration config) {
+        if (!provided) {
+            this.graph = (StandardJanusGraph) JanusGraphFactory.open((BasicConfiguration) config);
+        }
+    }
+
+    public void close() {
+        if (!provided && null != graph && graph.isOpen()) {
+            graph.close();
+            graph = null;
+        }
+    }
+
+    public boolean isProvided() {
+        return provided;
+    }
+
+    public final StandardJanusGraph get() {
+        Preconditions.checkNotNull(graph);
+        return graph;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/job/IndexRemoveJob.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/job/IndexRemoveJob.java
@@ -34,6 +34,7 @@ import org.janusgraph.graphdb.database.IndexSerializer;
 import org.janusgraph.graphdb.database.management.RelationTypeIndexWrapper;
 import org.janusgraph.graphdb.idmanagement.IDManager;
 import org.janusgraph.graphdb.internal.InternalRelationType;
+import org.janusgraph.graphdb.olap.GraphProvider;
 import org.janusgraph.graphdb.olap.QueryContainer;
 import org.janusgraph.graphdb.olap.VertexJobConverter;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
@@ -53,7 +54,7 @@ import java.util.function.Predicate;
  */
 public class IndexRemoveJob extends IndexUpdateJob implements ScanJob {
 
-    private final VertexJobConverter.GraphProvider graph = new VertexJobConverter.GraphProvider();
+    private final GraphProvider graph = new GraphProvider();
 
     public static final String DELETED_RECORDS_COUNT = "deletes";
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardTransactionBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardTransactionBuilder.java
@@ -139,6 +139,16 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
     }
 
     @Override
+    public StandardTransactionBuilder readOnlyOLAP() {
+        isReadOnly = true;
+        preloadedData = true;
+        verifyInternalVertexExistence = false;
+        dirtyVertexSize = 0;
+        vertexCacheSize = 0;
+        return this;
+    }
+
+    @Override
     public StandardTransactionBuilder enableBatchLoading() {
         hasEnabledBatchLoading = true;
         checkExternalVertexExistence(false);


### PR DESCRIPTION
This commit extracts common code from VertexJobConverter into the new class AbstractScanJob,
and makes both GhostVertexRemover and VertexJobConverter inherit it. Previously,
GhostVertexRemover inherits VertexJobConverter which does not make sense.

Part of #2555 

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
