### PR TITLE
Fix queries with multiple OR clauses

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphQuery.java
@@ -17,6 +17,8 @@ package org.janusgraph.core;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.janusgraph.graphdb.query.JanusGraphPredicate;
 
+import java.util.Collection;
+
 /**
  * Constructs a query against a mixed index to retrieve all elements (either vertices or edges)
  * that match all conditions.
@@ -55,7 +57,7 @@ public interface JanusGraphQuery<Q extends JanusGraphQuery<Q>> {
 
     Q hasNot(String key, Object value);
 
-    Q or(Q subQuery);
+    Q or(Collection<Q> subQueries);
 
     <T extends Comparable<?>> Q interval(String key, T startValue, T endValue);
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/step/JanusGraphPropertiesStep.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/step/JanusGraphPropertiesStep.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Iterators;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Profiling;
+import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
 import org.apache.tinkerpop.gremlin.process.traversal.util.MutableMetrics;
@@ -180,12 +181,12 @@ public class JanusGraphPropertiesStep<E> extends PropertiesStep<E> implements Ha
     }
 
     @Override
-    public List<HasContainer> addLocalHasContainersConvertingAndPContainers(List<HasContainer> localHasContainers) {
+    public List<HasContainer> addLocalHasContainersConvertingAndPContainers(TraversalParent parent, List<HasContainer> localHasContainers) {
         throw new UnsupportedOperationException("addLocalAll is not supported for properties step.");
     }
 
     @Override
-    public List<HasContainer> addLocalHasContainersSplittingAndPContainers(Iterable<HasContainer> has) {
+    public List<HasContainer> addLocalHasContainersSplittingAndPContainers(TraversalParent parent, Iterable<HasContainer> has) {
         throw new UnsupportedOperationException("addLocalAll is not supported for properties step.");
     }
 
@@ -195,7 +196,7 @@ public class JanusGraphPropertiesStep<E> extends PropertiesStep<E> implements Ha
     }
 
     @Override
-    public void localOrderBy(List<HasContainer> hasContainers, String key, Order order) {
+    public void localOrderBy(TraversalParent parent, List<HasContainer> hasContainers, String key, Order order) {
         throw new UnsupportedOperationException("LocalOrderBy is not supported for properties step.");
     }
 
@@ -206,7 +207,7 @@ public class JanusGraphPropertiesStep<E> extends PropertiesStep<E> implements Ha
     }
 
     @Override
-    public void setLocalLimit(List<HasContainer> hasContainers, int low, int high) {
+    public void setLocalLimit(TraversalParent parent, List<HasContainer> hasContainers, int low, int high) {
         throw new UnsupportedOperationException("LocalLimit is not supported for properties step.");
     }
 
@@ -216,7 +217,7 @@ public class JanusGraphPropertiesStep<E> extends PropertiesStep<E> implements Ha
     }
 
     @Override
-    public int getLocalLowLimit(List<HasContainer> hasContainers) {
+    public int getLocalLowLimit(TraversalParent parent, List<HasContainer> hasContainers) {
         throw new UnsupportedOperationException("getLocalLowLimit is not supported for properties step.");
     }
 
@@ -226,7 +227,7 @@ public class JanusGraphPropertiesStep<E> extends PropertiesStep<E> implements Ha
     }
 
     @Override
-    public int getLocalHighLimit(List<HasContainer> hasContainers) {
+    public int getLocalHighLimit(TraversalParent parent, List<HasContainer> hasContainers) {
         throw new UnsupportedOperationException("getLocalHighLimit is not supported for properties step.");
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/step/JanusGraphVertexStep.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/step/JanusGraphVertexStep.java
@@ -22,6 +22,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
 import org.apache.tinkerpop.gremlin.process.traversal.util.MutableMetrics;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalInterruptedException;
+import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
@@ -176,12 +177,12 @@ public class JanusGraphVertexStep<E extends Element> extends VertexStep<E> imple
     }
 
     @Override
-    public List<HasContainer> addLocalHasContainersConvertingAndPContainers(List<HasContainer> localHasContainers) {
+    public List<HasContainer> addLocalHasContainersConvertingAndPContainers(TraversalParent parent, List<HasContainer> localHasContainers) {
         throw new UnsupportedOperationException("addLocalAll is not supported for graph vertex step.");
     }
 
     @Override
-    public List<HasContainer> addLocalHasContainersSplittingAndPContainers(Iterable<HasContainer> has) {
+    public List<HasContainer> addLocalHasContainersSplittingAndPContainers(TraversalParent parent, Iterable<HasContainer> has) {
         throw new UnsupportedOperationException("addLocalAll is not supported for graph vertex step.");
     }
 
@@ -191,7 +192,7 @@ public class JanusGraphVertexStep<E extends Element> extends VertexStep<E> imple
     }
 
     @Override
-    public void localOrderBy(List<HasContainer> hasContainers, String key, Order order) {
+    public void localOrderBy(TraversalParent parent, List<HasContainer> hasContainers, String key, Order order) {
        throw new UnsupportedOperationException("localOrderBy is not supported for graph vertex step.");
     }
 
@@ -202,7 +203,7 @@ public class JanusGraphVertexStep<E extends Element> extends VertexStep<E> imple
     }
 
     @Override
-    public void setLocalLimit(List<HasContainer> hasContainers, int low, int high) {
+    public void setLocalLimit(TraversalParent parent, List<HasContainer> hasContainers, int low, int high) {
         throw new UnsupportedOperationException("setLocalLimit is not supported for graph vertex step.");
     }
 
@@ -212,7 +213,7 @@ public class JanusGraphVertexStep<E extends Element> extends VertexStep<E> imple
     }
 
     @Override
-    public int getLocalLowLimit(List<HasContainer> hasContainers) {
+    public int getLocalLowLimit(TraversalParent parent, List<HasContainer> hasContainers) {
         throw new UnsupportedOperationException("getLocalLowLimit is not supported for properties step.");
     }
 
@@ -222,7 +223,7 @@ public class JanusGraphVertexStep<E extends Element> extends VertexStep<E> imple
     }
 
     @Override
-    public int getLocalHighLimit(List<HasContainer> hasContainers) {
+    public int getLocalHighLimit(TraversalParent parent, List<HasContainer> hasContainers) {
         throw new UnsupportedOperationException("getLocalHighLimit is not supported for graph vertex step.");
     }
 

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphStepStrategyTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphStepStrategyTest.java
@@ -128,6 +128,7 @@ public class JanusGraphStepStrategyTest {
         final GraphTraversal.Admin<?, ?> traversal = new DefaultGraphTraversal<>();
         final JanusGraphStep<Vertex, Vertex> graphStep = new JanusGraphStep<>(new GraphStep<>(traversal, Vertex.class, true));
         List<HasContainer> localHasContainers = graphStep.addLocalHasContainersSplittingAndPContainers(
+            traversal.getParent(),
             Arrays.asList(new HasContainer("age", P.between("1", "123")), new HasContainer("age2", P.between("123", "234"))));
         assertEquals(4, localHasContainers.size());
     }
@@ -137,6 +138,7 @@ public class JanusGraphStepStrategyTest {
         final GraphTraversal.Admin<?, ?> traversal = new DefaultGraphTraversal<>();
         final JanusGraphStep<Vertex, Vertex> graphStep = new JanusGraphStep<>(new GraphStep<>(traversal, Vertex.class, true));
         List<HasContainer> localHasContainers = graphStep.addLocalHasContainersConvertingAndPContainers(
+            traversal.getParent(),
             Arrays.asList(new HasContainer("age", P.between("1", "123")), new HasContainer("age2", P.between("123", "234"))));
         assertEquals(2, localHasContainers.size());
     }
@@ -173,11 +175,12 @@ public class JanusGraphStepStrategyTest {
                 final HasStepFolder.OrderEntry orderEntry = (HasStepFolder.OrderEntry) hasKeyValues[i];
                 graphStep.orderBy(orderEntry.key, orderEntry.order);
             } else if (hasKeyValues[i] instanceof DefaultGraphTraversal && ((DefaultGraphTraversal) hasKeyValues[i]).getStartStep() instanceof OrStep){
-                for (final Traversal.Admin<?, ?> child : ((OrStep<?>) ((DefaultGraphTraversal) hasKeyValues[i]).getStartStep()).getLocalChildren()) {
+                OrStep<?> orStep = (OrStep<?>) ((DefaultGraphTraversal) hasKeyValues[i]).getStartStep();
+                for (final Traversal.Admin<?, ?> child : orStep.getLocalChildren()) {
                     final JanusGraphStep<Vertex, Vertex> localGraphStep = ((JanusGraphStep<Vertex, Vertex>) ((DefaultGraphTraversal) child).getStartStep());
-                    graphStep.addLocalHasContainersConvertingAndPContainers(localGraphStep.getHasContainers());
-                    localGraphStep.getOrders().forEach(orderEntry -> graphStep.localOrderBy(localGraphStep.getHasContainers(), orderEntry.key, orderEntry.order));
-                    graphStep.setLocalLimit(localGraphStep.getHasContainers(), localGraphStep.getLowLimit(), localGraphStep.getHighLimit());
+                    graphStep.addLocalHasContainersConvertingAndPContainers(orStep, localGraphStep.getHasContainers());
+                    localGraphStep.getOrders().forEach(orderEntry -> graphStep.localOrderBy(orStep, localGraphStep.getHasContainers(), orderEntry.key, orderEntry.order));
+                    graphStep.setLocalLimit(orStep, localGraphStep.getHasContainers(), localGraphStep.getLowLimit(), localGraphStep.getHighLimit());
                 }
             } else if (hasKeyValues[i] instanceof DefaultGraphTraversal &&  ((DefaultGraphTraversal) hasKeyValues[i]).getStartStep() instanceof RangeGlobalStep){
                 final RangeGlobalStep range = (RangeGlobalStep) ((DefaultGraphTraversal) hasKeyValues[i]).getStartStep();


### PR DESCRIPTION
This is an attempt at fixing #2231. The basic premise is that since the current code makes that assumption of the traversal having only one `.or()` statement, I wrap any related pieces of code in another layer of collections to handle multiple. I've done a lot of testing around it and it seems to work fine without breaking other queries. I'm interested in what you think about this as I'm not a 100% sure that this is a right direction.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
