### PR TITLE
CQLKeyColumnValueStore: Avoid fetching WRITETIME and/or TTL if no need

### DIFF
--- a/docs/configs/janusgraph-cfg.md
+++ b/docs/configs/janusgraph-cfg.md
@@ -512,9 +512,9 @@ Meta data to include in storage backend retrievals
 
 | Name | Description | Datatype | Default Value | Mutability |
 | ---- | ---- | ---- | ---- | ---- |
-| storage.meta.[X].timestamps | Whether to include timestamps in retrieved entries for storage backends that automatically annotated entries with timestamps | Boolean | false | GLOBAL |
-| storage.meta.[X].ttl | Whether to include ttl in retrieved entries for storage backends that support storage and retrieval of cell level TTL | Boolean | false | GLOBAL |
-| storage.meta.[X].visibility | Whether to include visibility in retrieved entries for storage backends that support cell level visibility | Boolean | true | GLOBAL |
+| storage.meta.[X].timestamps | Whether to include timestamps in retrieved entries for storage backends that automatically annotated entries with timestamps. If enabled, timestamp can be retrieved by `element.value(ImplicitKey.TIMESTAMP.name())` or equivalently, `element.value("~timestamp")`. | Boolean | false | GLOBAL |
+| storage.meta.[X].ttl | Whether to include ttl in retrieved entries for storage backends that support storage and retrieval of cell level TTL. If enabled, ttl can be retrieved by `element.value(ImplicitKey.TTL.name())` or equivalently, `element.value("~ttl")`. | Boolean | false | GLOBAL |
+| storage.meta.[X].visibility | Whether to include visibility in retrieved entries for storage backends that support cell level visibility. If enabled, visibility can be retrieved by `element.value(ImplicitKey.VISIBILITY.name())` or equivalently, `element.value("~visibility")`. | Boolean | true | GLOBAL |
 
 ### tx
 Configuration options for transaction handling

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -29,6 +29,7 @@ import org.janusgraph.core.schema.JanusGraphDefaultSchemaMaker;
 import org.janusgraph.core.schema.Tp3DefaultSchemaMaker;
 import org.janusgraph.core.schema.DisableDefaultSchemaMaker;
 import org.janusgraph.core.schema.IgnorePropertySchemaMaker;
+import org.janusgraph.graphdb.types.system.ImplicitKey;
 import org.janusgraph.util.StringUtils;
 import org.janusgraph.util.stats.NumberUtil;
 import org.janusgraph.diskstorage.util.time.*;
@@ -676,15 +677,21 @@ public class GraphDatabaseConfiguration {
     public static final ConfigNamespace STORE_META_NS = new ConfigNamespace(STORAGE_NS,"meta","Meta data to include in storage backend retrievals",true);
 
     public static final ConfigOption<Boolean> STORE_META_TIMESTAMPS = new ConfigOption<>(STORE_META_NS,"timestamps",
-            "Whether to include timestamps in retrieved entries for storage backends that automatically annotated entries with timestamps",
+            "Whether to include timestamps in retrieved entries for storage backends that automatically annotated entries with timestamps. " +
+            "If enabled, timestamp can be retrieved by `element.value(ImplicitKey.TIMESTAMP.name())` or equivalently, " +
+            "`element.value(\"" + ImplicitKey.TIMESTAMP.name() + "\")`.",
             ConfigOption.Type.GLOBAL, false);
 
     public static final ConfigOption<Boolean> STORE_META_TTL = new ConfigOption<>(STORE_META_NS,"ttl",
-            "Whether to include ttl in retrieved entries for storage backends that support storage and retrieval of cell level TTL",
+            "Whether to include ttl in retrieved entries for storage backends that support storage and retrieval of cell level TTL. " +
+            "If enabled, ttl can be retrieved by `element.value(ImplicitKey.TTL.name())` or equivalently, " +
+            "`element.value(\"" + ImplicitKey.TTL.name() + "\")`.",
             ConfigOption.Type.GLOBAL, false);
 
     public static final ConfigOption<Boolean> STORE_META_VISIBILITY = new ConfigOption<>(STORE_META_NS,"visibility",
-            "Whether to include visibility in retrieved entries for storage backends that support cell level visibility",
+            "Whether to include visibility in retrieved entries for storage backends that support cell level visibility. " +
+            "If enabled, visibility can be retrieved by `element.value(ImplicitKey.VISIBILITY.name())` or equivalently, " +
+            "`element.value(\"" + ImplicitKey.VISIBILITY.name() + "\")`.",
             ConfigOption.Type.GLOBAL, true);
 
 


### PR DESCRIPTION
When meta.*.timestamps and/or meta.*.ttl are disabled (which are by default),
write timestamps and TTL info will not be retrieved. CQLKeyColumnValueStore,
however, retrieves them anyways, and simply discard them. This commit makes
CQL driver fetches them only when needed.

It also enhances relevant documentation so that users know how to make use of
these metadata if needed.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
