### PR TITLE
Enable serial tests for cassandra

### DIFF
--- a/janusgraph-cql/pom.xml
+++ b/janusgraph-cql/pom.xml
@@ -20,7 +20,7 @@
         <test.jvm.opts>-Xms256m -Xmx1280m -ea -XX:+HeapDumpOnOutOfMemoryError ${test.extra.jvm.opts}</test.jvm.opts>
         <test.excluded.groups>MEMORY_TESTS,PERFORMANCE_TESTS,BRITTLE_TESTS</test.excluded.groups>
         <top.level.basedir>${basedir}/..</top.level.basedir>
-        <test.docker.version.cassandra3>3.11.10</test.docker.version.cassandra3>
+        <test.docker.version.cassandra3>${cassandra.version}</test.docker.version.cassandra3>
     </properties>
 
     <dependencies>
@@ -291,19 +291,19 @@
                         <phase>test</phase>
                     </execution>
                     <execution>
-                        <id>${test.murmur}-serial-test</id>
+                        <id>cql-serial-test</id>
                         <goals>
                             <goal>test</goal>
                         </goals>
                         <phase>test</phase>
                         <configuration>
-                            <excludedGroups />
+                            <excludedGroups>none</excludedGroups>
                             <groups>SERIAL_TESTS</groups>
                             <parallel>none</parallel>
                             <perCoreThreadCount>false</perCoreThreadCount>
                             <threadCount>1</threadCount>
                             <runOrder>alphabetical</runOrder>
-                            <skip>${test.skip.murmur-serial}</skip>
+                            <skip>${test.skip.serial}</skip>
                         </configuration>
                     </execution>
                 </executions>
@@ -342,7 +342,7 @@
             <properties>
                 <cassandra.docker.version>${test.docker.version.cassandra3}</cassandra.docker.version>
                 <cassandra.docker.partitioner>${test.byteordered}</cassandra.docker.partitioner>
-                <test.skip.murmur-serial>true</test.skip.murmur-serial>
+                <test.skip.serial>true</test.skip.serial>
                 <test.cql.excludes>${test.excluded.groups},SERIAL_TESTS</test.cql.excludes>
             </properties>
         </profile>
@@ -354,7 +354,7 @@
             <properties>
                 <cassandra.docker.version>${test.docker.version.cassandra3}</cassandra.docker.version>
                 <cassandra.docker.partitioner>${test.murmur}</cassandra.docker.partitioner>
-                <test.skip.murmur-serial>false</test.skip.murmur-serial>
+                <test.skip.serial>false</test.skip.serial>
                 <test.cql.excludes>${test.excluded.groups},SERIAL_TESTS</test.cql.excludes>
             </properties>
         </profile>
@@ -367,7 +367,7 @@
                 <cassandra.docker.version>${test.docker.version.cassandra3}</cassandra.docker.version>
                 <cassandra.docker.partitioner>${test.murmur}</cassandra.docker.partitioner>
                 <cassandra.docker.useSSL>true</cassandra.docker.useSSL>
-                <test.skip.murmur-serial>false</test.skip.murmur-serial>
+                <test.skip.serial>false</test.skip.serial>
                 <test.cql.excludes>${test.excluded.groups},SERIAL_TESTS</test.cql.excludes>
             </properties>
         </profile>
@@ -381,7 +381,7 @@
                 <cassandra.docker.partitioner>${test.murmur}</cassandra.docker.partitioner>
                 <cassandra.docker.useSSL>true</cassandra.docker.useSSL>
                 <cassandra.docker.enableClientAuth>true</cassandra.docker.enableClientAuth>
-                <test.skip.murmur-serial>false</test.skip.murmur-serial>
+                <test.skip.serial>false</test.skip.serial>
                 <test.cql.excludes>${test.excluded.groups},SERIAL_TESTS</test.cql.excludes>
             </properties>
         </profile>
@@ -389,14 +389,14 @@
         <profile>
             <id>scylladb</id>
             <properties>
-                <cassandra.docker.version>4.3.0</cassandra.docker.version>
+                <cassandra.docker.version>${scylladb.version}</cassandra.docker.version>
                 <cassandra.docker.image>scylladb/scylla</cassandra.docker.image>
                 <cassandra.docker.useDefaultConfigFromImage>true</cassandra.docker.useDefaultConfigFromImage>
                 <test.skip.byteordered>true</test.skip.byteordered>
                 <test.skip.murmur>true</test.skip.murmur>
-                <test.skip.murmur-serial>true</test.skip.murmur-serial>
+                <test.skip.serial>false</test.skip.serial>
                 <test.skip.murmur-ssl>true</test.skip.murmur-ssl>
-                <test.cql.excludes>${test.excluded.groups}</test.cql.excludes>
+                <test.cql.excludes>${test.excluded.groups},SERIAL_TESTS</test.cql.excludes>
             </properties>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
         <dependency.locations.enabled>false</dependency.locations.enabled>
         <cassandra.version>3.11.10</cassandra.version>
         <cassandra-driver.version>4.11.0</cassandra-driver.version>
+        <scylladb.version>4.4.0</scylladb.version>
         <testcontainers.version>1.15.2</testcontainers.version>
         <easymock.version>4.2</easymock.version>
         <protobuf.version>3.15.6</protobuf.version>


### PR DESCRIPTION
Previously, due to a misconfiguration, serial tests are skipped
for Cassandra. This commit fixes the config and does some cleanup.

This commit also bumps the Scylladb version from 4.3.0 to 4.4.0.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
