### PR TITLE
Always use the most recent _scroll_id

### DIFF
--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchScroll.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchScroll.java
@@ -30,21 +30,22 @@ import java.util.concurrent.LinkedBlockingQueue;
 public class ElasticSearchScroll implements Iterator<RawQuery.Result<String>> {
 
     private final BlockingQueue<RawQuery.Result<String>> queue;
-    private boolean isFinished;
     private final ElasticSearchClient client;
-    private final String scrollId;
     private final int batchSize;
+
+    private boolean isFinished;
+    private String scrollId;
 
     public ElasticSearchScroll(ElasticSearchClient client, ElasticSearchResponse initialResponse, int nbDocByQuery) {
         queue = new LinkedBlockingQueue<>();
         this.client = client;
-        this.scrollId = initialResponse.getScrollId();
         this.batchSize = nbDocByQuery;
         update(initialResponse);
     }
 
     private void update(ElasticSearchResponse response) {
         response.getResults().forEach(queue::add);
+        this.scrollId = response.getScrollId();
         this.isFinished = response.numResults() < this.batchSize;
         try {
             if (isFinished) client.deleteScroll(scrollId);


### PR DESCRIPTION
The _scroll_id may change between requests and only the
most recently received one should be used.

Fixes #2582

Signed-off-by: Clement de Groc <clement.degroc@datadoghq.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there an issue associated with this PR? Is it referenced in the commit message?
- [X] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
