### PR TITLE
Add exists clause to negated Text predicates

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/core/attribute/TextArgument.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/core/attribute/TextArgument.java
@@ -45,7 +45,11 @@ public class TextArgument {
     private static Stream<Arguments> negate(Stream<Arguments> argStream) {
         return argStream.map(argList -> {
             Object[] rawArgs = argList.get();
-            return arguments(!((boolean) rawArgs[0]), rawArgs[1], rawArgs[2]);
+            if (rawArgs[1] == null)
+                // null values have the same result in both negated and non negated tests
+                return argList;
+            else
+                return arguments(!((boolean) rawArgs[0]), rawArgs[1], rawArgs[2]);
         });
     }
 
@@ -71,7 +75,10 @@ public class TextArgument {
             arguments(true, text, "full,surprises,world"),
             arguments(true, text, "a world"),
 
-            arguments(false, text, "full bunny")
+            arguments(false, text, "full bunny"),
+
+            // null value
+            arguments(false, null, "anything")
         });
     }
 
@@ -85,7 +92,10 @@ public class TextArgument {
             arguments(true, name, "fully"),
             arguments(true, name, "ful"),
             arguments(true, name, "fully fu"),
-            arguments(false, name, "fun")
+            arguments(false, name, "fun"),
+
+            // null value
+            arguments(false, null, "anything")
         });
     }
 
@@ -109,6 +119,9 @@ public class TextArgument {
             arguments(false, text, "ses"),
 
             arguments(true, name, "fun"),
+
+            // null value
+            arguments(false, null, "anything")
         });
     }
 
@@ -139,7 +152,10 @@ public class TextArgument {
 
             arguments(true, name, "(fu[ln]*y) (fu[ln]*y)"),
             arguments(false, name, "(fu[l]*y) (fu[l]*y)"),
-            arguments(true, name, "(fu[l]*y) .*")
+            arguments(true, name, "(fu[l]*y) .*"),
+
+            // null value
+            arguments(false, null, "anything")
         });
     }
 
@@ -173,7 +189,10 @@ public class TextArgument {
 
             arguments(false, text, "fo"),
             arguments(false, text, "wor[l]+"),
-            arguments(false, text, "wor[ld]{3,5}")
+            arguments(false, text, "wor[ld]{3,5}"),
+
+            // null value
+            arguments(false, null, "anything")
         });
     }
 
@@ -201,6 +220,9 @@ public class TextArgument {
             arguments(true, text, "is full of 1funny"),
             arguments(true, text, "This world is"),
             arguments(false, text, "A Full Yes Or No"),
+
+            // null value
+            arguments(false, null, "anything")
         });
     }
 
@@ -227,7 +249,10 @@ public class TextArgument {
             arguments(true, longValue, "surpprises"),
             arguments(true, longValue, "sutprises"),
             arguments(true, longValue, "surprise"),
-            arguments(false, longValue, "surppirsses")
+            arguments(false, longValue, "surppirsses"),
+
+            // null value
+            arguments(false, null, "anything")
         });
     }
 
@@ -274,6 +299,9 @@ public class TextArgument {
             arguments(true, text, "Sutrises"),
             arguments(true, text, "surprise"),
             arguments(false, text, "surppirsses"),
+
+            // null value
+            arguments(false, null, "anything")
         });
     }
 

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/diskstorage/indexing/IndexProviderTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/diskstorage/indexing/IndexProviderTest.java
@@ -1205,7 +1205,11 @@ public abstract class IndexProviderTest {
     @MethodSource("org.janusgraph.core.attribute.TextArgument#text")
     public void testTextPredicate(JanusGraphPredicate predicate, boolean expected, String value, String condition) throws BackendException {
         assumeIndexSupportFor(Mapping.TEXT, predicate);
-        initializeWithDoc("vertex", "test1", TEXT, value, true);
+        if (value != null)
+            initializeWithDoc("vertex", "test1", TEXT, value, true);
+        else
+            // if the value is null, replicate a missing field by indexing a different one
+            initializeWithDoc("vertex", "test1", BOOLEAN, true, true);
         testPredicateByCount((expected) ? 1 : 0, predicate, TEXT, condition);
     }
 
@@ -1213,7 +1217,11 @@ public abstract class IndexProviderTest {
     @MethodSource("org.janusgraph.core.attribute.TextArgument#string")
     public void testStringPredicate(JanusGraphPredicate predicate, boolean expected, String value, String condition) throws BackendException {
         assumeIndexSupportFor(Mapping.STRING, predicate);
-        initializeWithDoc("vertex", "test1", NAME, value, true);
+        if (value != null)
+            initializeWithDoc("vertex", "test1", NAME, value, true);
+        else
+            // if the value is null, replicate a missing field by indexing a different one
+            initializeWithDoc("vertex", "test1", BOOLEAN, true, true);
         testPredicateByCount((expected) ? 1 : 0, predicate, NAME, condition);
     }
 
@@ -1232,7 +1240,7 @@ public abstract class IndexProviderTest {
      * @param isNew
      * @throws BackendException
      */
-    private void initializeWithDoc(String store, String docId, String field, String value, boolean isNew) throws BackendException {
+    private void initializeWithDoc(String store, String docId, String field, Object value, boolean isNew) throws BackendException {
         initialize(store);
 
         Multimap<String, Object> doc = HashMultimap.create();

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
@@ -965,41 +965,48 @@ public class ElasticSearchIndex implements IndexProvider {
                 if (predicate == Text.CONTAINS || predicate == Cmp.EQUAL) {
                     return compat.match(fieldName, value);
                 } else if (predicate == Text.NOT_CONTAINS) {
-                    return compat.boolMustNot(compat.match(fieldName, value));
+                    return compat.boolMust(ImmutableList.of(compat.exists(fieldName),
+                        compat.boolMustNot(compat.match(fieldName, value))));
                 } else if (predicate == Text.CONTAINS_PHRASE) {
                     return compat.matchPhrase(fieldName, value);
                 } else if (predicate == Text.NOT_CONTAINS_PHRASE) {
-                    return compat.boolMustNot(compat.matchPhrase(fieldName, value));
+                    return compat.boolMust(ImmutableList.of(compat.exists(fieldName),
+                        compat.boolMustNot(compat.matchPhrase(fieldName, value))));
                 } else if (predicate == Text.CONTAINS_PREFIX) {
                     if (!ParameterType.TEXT_ANALYZER.hasParameter(information.get(key).getParameters()))
                         value = ((String) value).toLowerCase();
                     return compat.prefix(fieldName, value);
                 } else if (predicate == Text.NOT_CONTAINS_PREFIX) {
                     if (!ParameterType.TEXT_ANALYZER.hasParameter(information.get(key).getParameters()))
-                            value = ((String) value).toLowerCase();
-                    return compat.boolMustNot(compat.prefix(fieldName, value));
+                        value = ((String) value).toLowerCase();
+                    return compat.boolMust(ImmutableList.of(compat.exists(fieldName),
+                        compat.boolMustNot(compat.prefix(fieldName, value))));
                 } else if (predicate == Text.CONTAINS_REGEX) {
                     if (!ParameterType.TEXT_ANALYZER.hasParameter(information.get(key).getParameters()))
                         value = ((String) value).toLowerCase();
                     return compat.regexp(fieldName, value);
                 } else if (predicate == Text.NOT_CONTAINS_REGEX) {
                     if (!ParameterType.TEXT_ANALYZER.hasParameter(information.get(key).getParameters()))
-                            value = ((String) value).toLowerCase();
-                    return compat.boolMustNot(compat.regexp(fieldName, value));
+                        value = ((String) value).toLowerCase();
+                    return compat.boolMust(ImmutableList.of(compat.exists(fieldName),
+                        compat.boolMustNot(compat.regexp(fieldName, value))));
                 } else if (predicate == Text.PREFIX) {
                     return compat.prefix(fieldName, value);
                 } else if (predicate == Text.NOT_PREFIX) {
-                    return compat.boolMustNot(compat.prefix(fieldName, value));
+                    return compat.boolMust(ImmutableList.of(compat.exists(fieldName),
+                        compat.boolMustNot(compat.prefix(fieldName, value))));
                 } else if (predicate == Text.REGEX) {
                     return compat.regexp(fieldName, value);
                 } else if (predicate == Text.NOT_REGEX) {
-                    return compat.boolMustNot(compat.regexp(fieldName, value));
+                    return compat.boolMust(ImmutableList.of(compat.exists(fieldName),
+                        compat.boolMustNot(compat.regexp(fieldName, value))));
                 } else if (predicate == Cmp.NOT_EQUAL) {
                     return compat.boolMustNot(compat.match(fieldName, value));
                 } else if (predicate == Text.FUZZY || predicate == Text.CONTAINS_FUZZY) {
                     return compat.fuzzyMatch(fieldName, value);
                 } else if (predicate == Text.NOT_FUZZY || predicate == Text.NOT_CONTAINS_FUZZY) {
-                    return compat.boolMustNot(compat.fuzzyMatch(fieldName, value));
+                    return compat.boolMust(ImmutableList.of(compat.exists(fieldName),
+                        compat.boolMustNot(compat.fuzzyMatch(fieldName, value))));
                 } else if (predicate == Cmp.LESS_THAN) {
                     return compat.lt(fieldName, value);
                 } else if (predicate == Cmp.LESS_THAN_EQUAL) {


### PR DESCRIPTION
Refines negated Text predicates so missing, i.e. null, values evaluate to false in the ElasticSearch backend:

```
gremlin> g.V().has('missingField', textNotRegex('.*'))
gremlin>
gremlin> g.V(86040L).propertyMap()
==>[]
gremlin> g.V(86040L).has('missingField', textNotRegex('.*'))
gremlin>
```

This adds an exists clause to the evaluation of each negated text predicate, aligning it to the JanusGraph implementation which assumes `.has(X, Y)` is equivalent to `.has(X).has(X, Y)`.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
