### PR TITLE
Iterator changes for atomic batch mutate to fix #2607

### DIFF
--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
@@ -487,7 +487,7 @@ public class CQLStoreManager extends DistributedStoreManager implements KeyColum
         BatchStatementBuilder builder = BatchStatement.builder(DefaultBatchType.LOGGED);
         builder.setConsistencyLevel(getTransaction(txh).getWriteConsistencyLevel());
 
-        builder.addStatements(Iterator.ofAll(mutations.entrySet()).flatMap(tableNameAndMutations -> {
+        Iterator.ofAll(mutations.entrySet()).flatMap(tableNameAndMutations -> {
             final String tableName = tableNameAndMutations.getKey();
             final Map<StaticBuffer, KCVMutation> tableMutations = tableNameAndMutations.getValue();
 
@@ -504,7 +504,8 @@ public class CQLStoreManager extends DistributedStoreManager implements KeyColum
 
                 return Iterator.concat(deletions, additions);
             });
-        }));
+        }).forEach(builder::addStatement);
+
         final Future<AsyncResultSet> result = Future.fromJavaFuture(this.executorService, this.session.executeAsync(builder.build()).toCompletableFuture());
 
         result.await();

--- a/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLGraphTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLGraphTest.java
@@ -47,6 +47,13 @@ public class CQLGraphTest extends JanusGraphTest {
         assertTrue(features.hasCellTTL());
     }
 
+    @Test
+    public void testAddNodes() {
+        clopen(option(ATOMIC_BATCH_MUTATE), true);
+        graph.addVertex();
+        graph.tx().commit();
+    }
+
     @RepeatedIfExceptionsTest(repeats = 3)
     @Override
     public void simpleLogTest() throws InterruptedException{


### PR DESCRIPTION
Changes to for #2607 which reported errors when testing with `storage.cql.atomic-batch-mutate=true` following the upgrade to the DataStax Cassandra driver to 4.9.0 made under #2169. I've also included the test from the issue which reproduced the problem and which prior to these changes failed.

Tracked the problem down using a debugger, to what was being passed to [BatchStatementBuilder::addStatements](https://docs.datastax.com/en/drivers/java/4.9/com/datastax/oss/driver/api/core/cql/BatchStatementBuilder.html#addStatements-java.lang.Iterable-) which was an `Iterator` when the method was expecting an `Iterable`. The debugger showed that no statements were getting added to the builder. Converting the `Iterator` to an `List` fixed the failing test and using the debugger I could see the contents of the list being iterated over and added to the list of statements by the builder.


Signed-off-by: Scott McQuillan <scott.mcquillan@uk.ibm.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
