### PR TITLE
Upgrade TinkerPop to 3.5.0 [tp-tests]

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -64,7 +64,7 @@ compile "org.janusgraph:janusgraph-core:0.6.0"
 * Elasticsearch 6.0.1, 6.6.0, 7.12.0
 * Apache Lucene 8.6.0
 * Apache Solr 7.7.2, 8.5.2
-* Apache TinkerPop 3.4.10
+* Apache TinkerPop 3.5.0
 * Java 1.8
 
 #### Changes
@@ -81,6 +81,23 @@ For more information on features and bug fixes in 0.6.0, see the GitHub mileston
 * [JanusGraph zip with embedded Cassandra and ElasticSearch](https://github.com/JanusGraph/janusgraph/releases/download/v0.6.0/janusgraph-full-0.6.0.zip)
 
 #### Upgrade Instructions
+
+##### Breaking change for Configuration objects
+
+Prior to JanusGraph 0.6.0, `Configuration` objects were from the Apache `commons-configuration` library.
+To comply with the [TinkerPop change](http://tinkerpop.apache.org/docs/3.5.0-SNAPSHOT/upgrade/#_versions_and_dependencies),
+JanusGraph now uses the `commons-configuration2` library. A typical usage of configuration object is to
+create configuration using `ConfigurationGraphFactory`. Now you would need to use the new configuration2 library.
+Please refer to the
+[commons-configuration 2.0 migration guide](https://commons.apache.org/proper/commons-configuration/userguide/upgradeto2_0.html)
+for details. Note that this very likely does not affect gremlin console usage, since the new library
+is auto-imported, and the basic APIs remain the same. For java code usage, you need to import
+configuration2 library rather than the old configuration library.
+
+##### Breaking change for gremlin server configs
+
+`scriptEvaluationTimeout` is renamed to `evaluationTimeout`. You can refer to `conf/gremlin-server/gremlin-server.yaml`
+for example.
 
 ##### Breaking change for gremlin EventStrategy usage
 

--- a/janusgraph-all/src/test/java/org/janusgraph/core/EnsureCacheTest.java
+++ b/janusgraph-all/src/test/java/org/janusgraph/core/EnsureCacheTest.java
@@ -14,10 +14,11 @@
 
 package org.janusgraph.core;
 
-import org.apache.commons.configuration.MapConfiguration;
+import org.apache.commons.configuration2.MapConfiguration;
 import org.janusgraph.diskstorage.configuration.backend.CommonsConfiguration;
 import org.janusgraph.graphdb.configuration.builder.GraphDatabaseConfigurationBuilder;
 import org.janusgraph.graphdb.database.StandardJanusGraph;
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -35,7 +36,7 @@ public class EnsureCacheTest {
     public void NopTest() {
         final Map<String, Object> map = new HashMap<>();
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
-        final MapConfiguration config = new MapConfiguration(map);
+        final MapConfiguration config = ConfigurationUtil.loadMapConfiguration(map);
         final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
 
         graph.traversal().addV().iterate();

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/StorageSetup.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/StorageSetup.java
@@ -24,7 +24,7 @@ import org.janusgraph.diskstorage.configuration.WriteConfiguration;
 
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.*;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.time.Duration;

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/blueprints/AbstractJanusGraphProvider.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/blueprints/AbstractJanusGraphProvider.java
@@ -48,7 +48,7 @@ import org.janusgraph.graphdb.types.vertices.JanusGraphSchemaVertex;
 import org.janusgraph.graphdb.vertices.CacheVertex;
 import org.janusgraph.graphdb.vertices.PreloadedVertex;
 import org.janusgraph.graphdb.vertices.StandardVertex;
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 import org.apache.tinkerpop.gremlin.AbstractGraphProvider;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/core/AbstractConfiguredGraphFactoryTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/core/AbstractConfiguredGraphFactoryTest.java
@@ -14,7 +14,7 @@
 
 package org.janusgraph.core;
 
-import org.apache.commons.configuration.MapConfiguration;
+import org.apache.commons.configuration2.MapConfiguration;
 import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
 import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngineManager;
 import org.apache.tinkerpop.gremlin.server.Settings;
@@ -24,6 +24,7 @@ import org.janusgraph.graphdb.database.StandardJanusGraph;
 import org.janusgraph.graphdb.management.ConfigurationManagementGraph;
 import org.janusgraph.graphdb.management.JanusGraphManager;
 import org.janusgraph.graphdb.management.utils.ConfigurationManagementGraphNotEnabledException;
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -224,7 +225,7 @@ public abstract class AbstractConfiguredGraphFactoryTest {
 
             final Map<String, Object> map = graphConfig.getMap();
             map.put(STORAGE_BACKEND.toStringWithoutRoot(), "bogusBackend");
-            ConfiguredGraphFactory.updateConfiguration(graphName, new MapConfiguration(map));
+            ConfiguredGraphFactory.updateConfiguration(graphName, ConfigurationUtil.loadMapConfiguration(map));
             assertNull(gm.getGraph(graphName));
             // we should throw an error since the config has been updated and we are attempting
             // to open a bogus backend

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/diskstorage/SimpleScanJob.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/diskstorage/SimpleScanJob.java
@@ -25,7 +25,7 @@ import org.janusgraph.diskstorage.keycolumnvalue.scan.ScanMetrics;
 import org.janusgraph.diskstorage.util.BufferUtil;
 import org.janusgraph.diskstorage.util.Hex;
 import org.janusgraph.diskstorage.util.StaticArrayBuffer;
-import org.apache.commons.configuration.BaseConfiguration;
+import org.janusgraph.util.system.ConfigurationUtil;
 
 import java.io.IOException;
 import java.util.*;
@@ -271,7 +271,7 @@ public class SimpleScanJob implements ScanJob {
     public static Configuration getJobConf(List<SliceQuery> queries, Long modulus, Long modVal) {
         ModifiableConfiguration conf2 =
                 new ModifiableConfiguration(SimpleScanJob.ROOT_NS,
-                        new CommonsConfiguration(new BaseConfiguration()), BasicConfiguration.Restriction.NONE);
+                        new CommonsConfiguration(ConfigurationUtil.createBaseConfiguration()), BasicConfiguration.Restriction.NONE);
         if (null != queries)
             conf2.set(HEX_QUERIES, encodeQueries(queries));
         if (null != modulus)

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/GraphDatabaseConfigurationInstanceIdTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/GraphDatabaseConfigurationInstanceIdTest.java
@@ -18,11 +18,12 @@ import java.net.Inet4Address;
 import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.HashMap;
-import org.apache.commons.configuration.MapConfiguration;
+import org.apache.commons.configuration2.MapConfiguration;
 import org.janusgraph.core.JanusGraphException;
 import org.janusgraph.diskstorage.configuration.backend.CommonsConfiguration;
 import org.janusgraph.graphdb.configuration.builder.GraphDatabaseConfigurationBuilder;
 import org.janusgraph.graphdb.database.StandardJanusGraph;
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.junit.jupiter.api.Test;
 
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.REPLACE_INSTANCE_IF_EXISTS;
@@ -40,7 +41,7 @@ public class GraphDatabaseConfigurationInstanceIdTest {
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
         map.put(UNIQUE_INSTANCE_ID.toStringWithoutRoot(), "not-unique");
         map.put(REPLACE_INSTANCE_IF_EXISTS.toStringWithoutRoot(), true);
-        final MapConfiguration config = new MapConfiguration(map);
+        final MapConfiguration config = ConfigurationUtil.loadMapConfiguration(map);
         final StandardJanusGraph graph1 = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
 
         assertEquals(graph1.openManagement().getOpenInstances().size(), 1);
@@ -61,7 +62,7 @@ public class GraphDatabaseConfigurationInstanceIdTest {
         final Map<String, Object> map = new HashMap<>();
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
         map.put(UNIQUE_INSTANCE_ID.toStringWithoutRoot(), "not-unique");
-        final MapConfiguration config = new MapConfiguration(map);
+        final MapConfiguration config = ConfigurationUtil.loadMapConfiguration(map);
         final StandardJanusGraph graph1 = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
 
         assertEquals(graph1.openManagement().getOpenInstances().size(), 1);
@@ -78,7 +79,7 @@ public class GraphDatabaseConfigurationInstanceIdTest {
         final Map<String, Object> map = new HashMap<>();
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
         map.put(UNIQUE_INSTANCE_ID_HOSTNAME.toStringWithoutRoot(), true);
-        final MapConfiguration config = new MapConfiguration(map);
+        final MapConfiguration config = ConfigurationUtil.loadMapConfiguration(map);
         final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
         assertEquals(graph.openManagement().getOpenInstances().size(), 1);
         assertEquals(graph.openManagement().getOpenInstances().toArray()[0], Inet4Address.getLocalHost().getHostName());
@@ -91,7 +92,7 @@ public class GraphDatabaseConfigurationInstanceIdTest {
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
         map.put(UNIQUE_INSTANCE_ID_HOSTNAME.toStringWithoutRoot(), true);
         map.put(UNIQUE_INSTANCE_ID_SUFFIX.toStringWithoutRoot(), 1);
-				final MapConfiguration config = new MapConfiguration(map);
+				final MapConfiguration config = ConfigurationUtil.loadMapConfiguration(map);
         final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
         assertEquals(graph.openManagement().getOpenInstances().size(), 1);
         assertEquals(graph.openManagement().getOpenInstances().toArray()[0], Inet4Address.getLocalHost().getHostName() + "1");

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/olap/PageRankMapReduce.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/olap/PageRankMapReduce.java
@@ -20,7 +20,7 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 
 import java.util.Iterator;
 

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/olap/PageRankVertexProgram.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/olap/PageRankVertexProgram.java
@@ -25,7 +25,7 @@ import org.apache.tinkerpop.gremlin.process.computer.util.StaticVertexProgram;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 
 import java.util.Set;
 

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/olap/ShortestDistanceMapReduce.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/olap/ShortestDistanceMapReduce.java
@@ -20,7 +20,7 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 
 import java.util.Iterator;
 

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/olap/ShortestDistanceVertexProgram.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/olap/ShortestDistanceVertexProgram.java
@@ -14,7 +14,7 @@
 
 package org.janusgraph.olap;
 
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.computer.Memory;
 import org.apache.tinkerpop.gremlin.process.computer.MessageCombiner;

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/testutil/TestGraphConfigs.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/testutil/TestGraphConfigs.java
@@ -20,9 +20,9 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Preconditions;
 import org.janusgraph.diskstorage.util.time.Temporals;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +55,7 @@ public class TestGraphConfigs {
                 log.warn("Graph configuration overrides file {} does not exist or is not an ordinary file", overridesFile);
             } else {
                 try {
-                    Configuration cc = new  PropertiesConfiguration(overridesFile);
+                    PropertiesConfiguration cc = ConfigurationUtil.loadPropertiesConfig(overridesFile);
                     o = new CommonsConfiguration(cc);
                     log.info("Loaded configuration from file {}", overridesFile);
                 } catch (ConfigurationException e) {

--- a/janusgraph-berkeleyje/src/test/java/org/janusgraph/blueprints/process/BerkeleyProcessComputerSuite.java
+++ b/janusgraph-berkeleyje/src/test/java/org/janusgraph/blueprints/process/BerkeleyProcessComputerSuite.java
@@ -19,7 +19,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalInterruptionCompu
 
 import java.lang.reflect.Field;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.RunnerBuilder;
 

--- a/janusgraph-berkeleyje/src/test/java/org/janusgraph/blueprints/process/BerkeleyProcessStandardSuite.java
+++ b/janusgraph-berkeleyje/src/test/java/org/janusgraph/blueprints/process/BerkeleyProcessStandardSuite.java
@@ -14,7 +14,7 @@
 
 package org.janusgraph.blueprints.process;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.tinkerpop.gremlin.process.ProcessStandardSuite;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalInterruptionTest;
 import org.junit.runners.model.InitializationError;

--- a/janusgraph-core/src/main/java/org/janusgraph/core/ConfiguredGraphFactory.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/ConfiguredGraphFactory.java
@@ -25,8 +25,7 @@ import org.janusgraph.graphdb.management.utils.ConfigurationManagementGraphNotEn
 import static org.janusgraph.graphdb.management.JanusGraphManager.JANUS_GRAPH_MANAGER_EXPECTED_STATE_MSG;
 
 import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.MapConfiguration;
+import org.apache.commons.configuration2.Configuration;
 
 import com.google.common.base.Preconditions;
 
@@ -37,6 +36,8 @@ import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
+
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,9 +89,9 @@ public class ConfiguredGraphFactory {
 
         final JanusGraphManager jgm = JanusGraphManagerUtility.getInstance();
         Preconditions.checkNotNull(jgm, JANUS_GRAPH_MANAGER_EXPECTED_STATE_MSG);
-        final CommonsConfiguration config = new CommonsConfiguration(new MapConfiguration(templateConfigMap));
+        final CommonsConfiguration config = new CommonsConfiguration(ConfigurationUtil.loadMapConfiguration(templateConfigMap));
         final JanusGraph g = (JanusGraph) jgm.openGraph(graphName, (String gName) -> new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(config)));
-        configManagementGraph.createConfiguration(new MapConfiguration(templateConfigMap));
+        configManagementGraph.createConfiguration(ConfigurationUtil.loadMapConfiguration(templateConfigMap));
         return g;
     }
 
@@ -113,7 +114,7 @@ public class ConfiguredGraphFactory {
                                 "Please create configuration for this graph using the ConfigurationManagementGraph#createConfiguration API.");
         final JanusGraphManager jgm = JanusGraphManagerUtility.getInstance();
         Preconditions.checkNotNull(jgm, JANUS_GRAPH_MANAGER_EXPECTED_STATE_MSG);
-        final CommonsConfiguration config = new CommonsConfiguration(new MapConfiguration(graphConfigMap));
+        final CommonsConfiguration config = new CommonsConfiguration(ConfigurationUtil.loadMapConfiguration(graphConfigMap));
         return (JanusGraph) jgm.openGraph(graphName, (String gName) -> new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(config)));
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraph.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraph.java
@@ -36,6 +36,21 @@ import org.apache.tinkerpop.gremlin.util.Gremlin;
         method = "shouldHandleSetVertexProperties",
         reason = "JanusGraph can only handle SET cardinality for properties when defined in the schema.")
 @Graph.OptOut(
+        test = "org.apache.tinkerpop.gremlin.structure.VertexPropertyTest$VertexPropertyAddition",
+        method = "shouldHandleListVertexPropertiesWithoutNullPropertyValues",
+        reason = "This test case requires EmptyVertexProperty instance when setting null value to a property, while JanusGraph " +
+            "returns an EmptyJanusGraphVertexProperty instance in such case.")
+@Graph.OptOut(
+        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexTest",
+        method = "g_V_hasLabelXpersonX_propertyXname_nullX",
+        reason = "TinkerPop assumes cardinality is SINGLE when not explicitly given, while JanusGraph uses the cardinality " +
+            "already defined in the schema.")
+@Graph.OptOut(
+        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeTest",
+        method = "g_V_outE_propertyXweight_nullX",
+        reason = "TinkerPop assumes cardinality is SINGLE when not explicitly given, while JanusGraph uses the cardinality " +
+            "already defined in the schema.")
+@Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.computer.GraphComputerTest",
         method = "shouldOnlyAllowReadingVertexPropertiesInMapReduce",
         reason = "JanusGraph simply throws the wrong exception -- should not be a ReadOnly transaction exception but a specific one for MapReduce. This is too cumbersome to refactor in JanusGraph.")

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/Parameter.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/Parameter.java
@@ -15,7 +15,7 @@
 package org.janusgraph.core.schema;
 
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Objects;
 

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/Backend.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/Backend.java
@@ -15,8 +15,7 @@
 package org.janusgraph.diskstorage;
 
 import com.google.common.base.Preconditions;
-import org.apache.commons.configuration.BaseConfiguration;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.janusgraph.core.JanusGraphConfigurationException;
 import org.janusgraph.core.JanusGraphException;
 import org.janusgraph.core.schema.JanusGraphManagement;
@@ -597,9 +596,8 @@ public class Backend implements LockerProvider, AutoCloseable {
     }
 
     private ModifiableConfiguration buildJobConfiguration() {
-
         return new ModifiableConfiguration(JOB_NS,
-            new CommonsConfiguration(new BaseConfiguration()),
+            new CommonsConfiguration(ConfigurationUtil.createBaseConfiguration()),
             BasicConfiguration.Restriction.NONE);
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/BackendTransaction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/BackendTransaction.java
@@ -26,7 +26,7 @@ import java.util.stream.Stream;
 
 import org.janusgraph.diskstorage.keycolumnvalue.cache.KCVSCache;
 import org.janusgraph.diskstorage.log.kcvs.ExternalCachePersistor;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalInterruptedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/ResourceUnavailableException.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/ResourceUnavailableException.java
@@ -16,7 +16,7 @@ package org.janusgraph.diskstorage;
 
 import com.google.common.base.Preconditions;
 import org.janusgraph.core.JanusGraphException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * This exception is thrown if a resource is being accessed that is unavailable.

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/AbstractConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/AbstractConfiguration.java
@@ -15,7 +15,7 @@
 package org.janusgraph.diskstorage.configuration;
 
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashMap;
 import java.util.HashSet;

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/BasicConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/BasicConfiguration.java
@@ -15,7 +15,7 @@
 package org.janusgraph.diskstorage.configuration;
 
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/ConfigElement.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/ConfigElement.java
@@ -15,7 +15,7 @@
 package org.janusgraph.diskstorage.configuration;
 
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/backend/CommonsConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/backend/CommonsConfiguration.java
@@ -20,9 +20,10 @@ import org.janusgraph.diskstorage.util.time.Durations;
 import org.janusgraph.diskstorage.configuration.ReadConfiguration;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
 
-import org.apache.commons.configuration.BaseConfiguration;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.lang3.StringUtils;
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +46,8 @@ public class CommonsConfiguration implements WriteConfiguration {
             LoggerFactory.getLogger(CommonsConfiguration.class);
 
     public CommonsConfiguration() {
-        this(new BaseConfiguration());
+        BaseConfiguration baseConfiguration = ConfigurationUtil.createBaseConfiguration();
+        this.config = baseConfiguration;
     }
 
     public CommonsConfiguration(Configuration config) {
@@ -174,7 +176,7 @@ public class CommonsConfiguration implements WriteConfiguration {
 
     @Override
     public WriteConfiguration copy() {
-        BaseConfiguration copy = new BaseConfiguration();
+        BaseConfiguration copy = ConfigurationUtil.createBaseConfiguration();
         copy.copy(config);
         return new CommonsConfiguration(copy);
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/backend/KCVSConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/backend/KCVSConfiguration.java
@@ -35,7 +35,7 @@ import org.janusgraph.graphdb.database.serialize.StandardSerializer;
 
 import org.janusgraph.util.system.IOUtils;
 import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/converter/ReadConfigurationConverter.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/converter/ReadConfigurationConverter.java
@@ -14,8 +14,9 @@
 
 package org.janusgraph.diskstorage.configuration.converter;
 
-import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration2.BaseConfiguration;
 import org.janusgraph.diskstorage.configuration.ReadConfiguration;
+import org.janusgraph.util.system.ConfigurationUtil;
 
 /**
  * Converter from {@link ReadConfiguration} into {@link BaseConfiguration}
@@ -34,7 +35,7 @@ public class ReadConfigurationConverter {
     }
 
     public BaseConfiguration convert(ReadConfiguration readConfiguration) {
-        BaseConfiguration result = new BaseConfiguration();
+        BaseConfiguration result = ConfigurationUtil.createBaseConfiguration();
         for (String k : readConfiguration.getKeys("")) {
             result.setProperty(k, readConfiguration.get(k, Object.class));
         }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexEntry.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexEntry.java
@@ -18,7 +18,7 @@ import com.google.common.base.Preconditions;
 import org.janusgraph.diskstorage.EntryMetaData;
 import org.janusgraph.diskstorage.MetaAnnotatable;
 import org.janusgraph.diskstorage.MetaAnnotated;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexProvider.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexProvider.java
@@ -14,7 +14,7 @@
 
 package org.janusgraph.diskstorage.indexing;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.BaseTransaction;
 import org.janusgraph.diskstorage.BaseTransactionConfig;

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/RawQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/RawQuery.java
@@ -18,7 +18,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.janusgraph.core.schema.Parameter;
 import org.janusgraph.graphdb.query.BaseQuery;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/StandardScanner.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/StandardScanner.java
@@ -23,7 +23,7 @@ import org.janusgraph.diskstorage.keycolumnvalue.KeyColumnValueStoreManager;
 import org.janusgraph.diskstorage.keycolumnvalue.StoreTransaction;
 import org.janusgraph.diskstorage.util.StandardBaseTransactionConfig;
 import org.janusgraph.diskstorage.util.time.TimestampProvider;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashSet;
 import java.util.Map;

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/log/kcvs/KCVSLogManager.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/log/kcvs/KCVSLogManager.java
@@ -30,7 +30,7 @@ import org.janusgraph.graphdb.database.serialize.StandardSerializer;
 import org.janusgraph.util.encoding.ConversionHelper;
 import org.janusgraph.util.stats.NumberUtil;
 import org.janusgraph.util.system.IOUtils;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/MetricInstrumentedIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/MetricInstrumentedIterator.java
@@ -20,7 +20,7 @@ import com.google.common.base.Preconditions;
 import org.janusgraph.diskstorage.StaticBuffer;
 import org.janusgraph.diskstorage.Entry;
 import org.janusgraph.diskstorage.keycolumnvalue.KeyIterator;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * This class is used by {@code MetricInstrumentedStore} to measure wall clock

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/MetricInstrumentedSlicesIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/MetricInstrumentedSlicesIterator.java
@@ -15,7 +15,7 @@
 package org.janusgraph.diskstorage.util;
 
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.janusgraph.diskstorage.Entry;
 import org.janusgraph.diskstorage.StaticBuffer;
 import org.janusgraph.diskstorage.keycolumnvalue.KeySlicesIterator;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -54,7 +54,6 @@ import java.util.*;
 import javax.annotation.Nullable;
 import javax.management.MBeanServerFactory;
 
-import org.apache.commons.configuration.*;
 import org.apache.commons.lang3.ClassUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1151,7 +1150,7 @@ public class GraphDatabaseConfiguration {
 
     public static ModifiableConfiguration buildGraphConfiguration() {
         return new ModifiableConfiguration(ROOT_NS,
-            new CommonsConfiguration(new BaseConfiguration()),
+            new CommonsConfiguration(ConfigurationUtil.createBaseConfiguration()),
             BasicConfiguration.Restriction.NONE);
     }
 
@@ -1309,13 +1308,13 @@ public class GraphDatabaseConfiguration {
         else return new StandardSchemaCache(retriever);
     }
 
-    public org.apache.commons.configuration.Configuration getLocalConfiguration() {
-        org.apache.commons.configuration.Configuration config = ((CommonsConfiguration)localConfiguration.getConfiguration()).getCommonConfiguration();
+    public org.apache.commons.configuration2.Configuration getLocalConfiguration() {
+        org.apache.commons.configuration2.Configuration config = ((CommonsConfiguration)localConfiguration.getConfiguration()).getCommonConfiguration();
         config.setProperty(Graph.GRAPH, JanusGraphFactory.class.getName());
         return config;
     }
 
-    public org.apache.commons.configuration.Configuration getConfigurationAtOpen() {
+    public org.apache.commons.configuration2.Configuration getConfigurationAtOpen() {
         return ReadConfigurationConverter.getInstance().convert(configurationAtOpen);
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
@@ -51,7 +51,7 @@ import org.janusgraph.graphdb.relations.RelationIdentifier;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.janusgraph.graphdb.types.*;
 import org.janusgraph.util.encoding.LongEncoding;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/log/TransactionLogHeader.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/log/TransactionLogHeader.java
@@ -28,7 +28,7 @@ import org.janusgraph.graphdb.log.StandardTransactionId;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.janusgraph.graphdb.transaction.TransactionConfiguration;
 import org.janusgraph.diskstorage.util.time.TimestampProvider;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.time.Instant;
 import java.util.*;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
@@ -53,7 +53,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/idmanagement/UniqueInstanceIdRetriever.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/idmanagement/UniqueInstanceIdRetriever.java
@@ -16,7 +16,7 @@ package org.janusgraph.graphdb.idmanagement;
 
 import com.google.common.base.Preconditions;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.janusgraph.core.JanusGraphConfigurationException;
 import org.janusgraph.diskstorage.configuration.ConfigElement;
 import org.janusgraph.diskstorage.configuration.Configuration;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/internal/Order.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/internal/Order.java
@@ -64,8 +64,8 @@ public enum Order {
 
     public static Order convert(org.apache.tinkerpop.gremlin.process.traversal.Order order) {
         switch(order) {
-            case asc: case incr: return ASC;
-            case desc: case decr: return DESC;
+            case asc: return ASC;
+            case desc: return DESC;
             default: throw new AssertionError();
         }
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/internal/Token.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/internal/Token.java
@@ -16,7 +16,7 @@ package org.janusgraph.graphdb.internal;
 
 import com.google.common.base.Preconditions;
 import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/log/StandardLogProcessorFramework.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/log/StandardLogProcessorFramework.java
@@ -36,7 +36,7 @@ import org.janusgraph.graphdb.internal.InternalRelation;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.janusgraph.graphdb.types.system.BaseKey;
 import org.janusgraph.graphdb.vertices.StandardVertex;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/management/ConfigurationManagementGraph.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/management/ConfigurationManagementGraph.java
@@ -33,8 +33,8 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationConverter;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.ConfigurationConverter;
 import com.google.common.base.Preconditions;
 
 import org.slf4j.Logger;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/IndexQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/IndexQueryBuilder.java
@@ -25,7 +25,7 @@ import org.janusgraph.graphdb.query.BaseQuery;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.janusgraph.graphdb.util.StreamIterable;
 import org.apache.tinkerpop.gremlin.structure.Element;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BaseVertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BaseVertexCentricQueryBuilder.java
@@ -32,7 +32,7 @@ import org.janusgraph.graphdb.relations.RelationIdentifier;
 import org.janusgraph.graphdb.tinkerpop.ElementUtils;
 import org.janusgraph.graphdb.types.system.ImplicitKey;
 import org.janusgraph.graphdb.types.system.SystemRelationType;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/schema/SchemaElementDefinition.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/schema/SchemaElementDefinition.java
@@ -15,7 +15,7 @@
 package org.janusgraph.graphdb.schema;
 
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphBlueprintsGraph.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphBlueprintsGraph.java
@@ -18,7 +18,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.function.Consumer;
 
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphBlueprintsTransaction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphBlueprintsTransaction.java
@@ -29,7 +29,7 @@ import org.apache.tinkerpop.gremlin.structure.io.Io;
 import org.apache.tinkerpop.gremlin.structure.util.AbstractThreadedTransaction;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphFeatures.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphFeatures.java
@@ -144,6 +144,11 @@ public class JanusGraphFeatures implements Graph.Features {
         public boolean supportsUuidIds() {
             return false;
         }
+
+        @Override
+        public boolean supportsNullPropertyValues() {
+            return false;
+        }
     }
 
     private static class JanusGraphEdgePropertyFeatures extends JanusGraphDataTypeFeatures implements EdgePropertyFeatures {
@@ -200,6 +205,11 @@ public class JanusGraphFeatures implements Graph.Features {
         {
             return false;
         }
+
+        @Override
+        public boolean supportsNullPropertyValues() {
+            return false;
+        }
     }
 
     private static class JanusGraphEdgeFeatures implements EdgeFeatures {
@@ -235,6 +245,11 @@ public class JanusGraphFeatures implements Graph.Features {
         @Override
         public boolean supportsStringIds()
         {
+            return false;
+        }
+
+        @Override
+        public boolean supportsNullPropertyValues() {
             return false;
         }
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/step/HasStepFolder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/step/HasStepFolder.java
@@ -15,7 +15,7 @@
 package org.janusgraph.graphdb.tinkerpop.optimize.step;
 
 import org.apache.tinkerpop.gremlin.process.traversal.P;
-import org.apache.tinkerpop.gremlin.process.traversal.lambda.ElementValueTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.ValueTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TraversalFilterStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.FlatMapStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
@@ -98,9 +98,9 @@ public interface HasStepFolder<S, E> extends Step<S, E> {
         final List<Pair<Traversal.Admin, Object>> comparators = orderGlobalStep.getComparators();
         for(final Pair<Traversal.Admin, Object> comp : comparators) {
             final String key;
-            if (comp.getValue0() instanceof ElementValueTraversal &&
+            if (comp.getValue0() instanceof ValueTraversal &&
                 comp.getValue1() instanceof Order) {
-                key = ((ElementValueTraversal) comp.getValue0()).getPropertyKey();
+                key = ((ValueTraversal) comp.getValue0()).getPropertyKey();
             } else if (comp.getValue1() instanceof ElementValueComparator) {
                 final ElementValueComparator evc = (ElementValueComparator) comp.getValue1();
                 if (!(evc.getValueComparator() instanceof Order)) return false;
@@ -282,8 +282,8 @@ public interface HasStepFolder<S, E> extends Step<S, E> {
             for (final Pair<Traversal.Admin<Object, Comparable>, Comparator<Object>> comp : (List<Pair<Traversal.Admin<Object, Comparable>, Comparator<Object>>>) ((OrderGlobalStep) lastOrder).getComparators()) {
                 final String key;
                 final Order order;
-                if (comp.getValue0() instanceof ElementValueTraversal) {
-                    final ElementValueTraversal evt = (ElementValueTraversal) comp.getValue0();
+                if (comp.getValue0() instanceof ValueTraversal) {
+                    final ValueTraversal evt = (ValueTraversal) comp.getValue0();
                     key = evt.getPropertyKey();
                     order = (Order) comp.getValue1();
                 } else {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/strategy/AdjacentVertexHasUniquePropertyOptimizerStrategy.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/strategy/AdjacentVertexHasUniquePropertyOptimizerStrategy.java
@@ -26,7 +26,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.IdStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.janusgraph.core.Cardinality;
 import org.janusgraph.core.JanusGraphElement;
@@ -76,10 +75,10 @@ public class AdjacentVertexHasUniquePropertyOptimizerStrategy
             return;
         }
 
-        Graph graph = traversal.getGraph().get();
-        StandardJanusGraph janusGraph = graph instanceof StandardJanusGraph
-            ? (StandardJanusGraph) graph
-            : ((StandardJanusGraphTx) graph).getGraph();
+        final StandardJanusGraph janusGraph = JanusGraphTraversalUtil.getJanusGraph(traversal);
+        if (janusGraph == null) {
+            return;
+        }
 
         if (!janusGraph.getConfiguration().optimizerBackendAccess()) {
             return;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/strategy/JanusGraphLocalQueryOptimizerStrategy.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/strategy/JanusGraphLocalQueryOptimizerStrategy.java
@@ -20,7 +20,6 @@ import org.janusgraph.graphdb.database.StandardJanusGraph;
 import org.janusgraph.graphdb.query.QueryUtil;
 import org.janusgraph.graphdb.tinkerpop.optimize.*;
 import org.janusgraph.graphdb.tinkerpop.optimize.step.*;
-import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal.Admin;
@@ -31,7 +30,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
-import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.util.Collections;
@@ -54,10 +52,12 @@ public class JanusGraphLocalQueryOptimizerStrategy extends AbstractTraversalStra
         if (!traversal.getGraph().isPresent())
             return;
 
-        final Graph graph = traversal.getGraph().get();
+        final StandardJanusGraph janusGraph = JanusGraphTraversalUtil.getJanusGraph(traversal);
+        if (janusGraph == null) {
+            return;
+        }
 
         //If this is a compute graph then we can't apply local traversal optimisation at this stage.
-        final StandardJanusGraph janusGraph = graph instanceof StandardJanusGraphTx ? ((StandardJanusGraphTx) graph).getGraph() : (StandardJanusGraph) graph;
         final boolean useMultiQuery = !TraversalHelper.onGraphComputer(traversal) && janusGraph.getConfiguration().useMultiQuery();
 
         /*

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -77,7 +77,7 @@ import org.janusgraph.util.datastructures.Retriever;
 import org.janusgraph.util.stats.MetricManager;
 import org.apache.tinkerpop.gremlin.structure.*;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cliffc.high_scale_lib.NonBlockingHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -561,7 +561,6 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
     }
 
     public final Object verifyAttribute(PropertyKey key, Object attribute) {
-        if (attribute==null) throw new SchemaViolationException("Property value cannot be null");
         Class<?> datatype = key.dataType();
         if (datatype.equals(Object.class)) {
             if (!attributeHandler.validDataType(attribute.getClass())) {
@@ -1005,21 +1004,18 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
 
     @Override
     public PropertyKey getOrCreatePropertyKey(String name, Object value) {
-        RelationType et = getRelationType(name);
-        if (et == null) {
-            return config.getAutoSchemaMaker().makePropertyKey(makePropertyKey(name), value);
-        } else if (et.isPropertyKey()) {
-            return (PropertyKey) et;
-        } else {
-            throw new IllegalArgumentException("The type of given name is not a key: " + name);
-        }
+        return getOrCreatePropertyKey(name, value, null);
     }
 
     @Override
     public PropertyKey getOrCreatePropertyKey(String name, Object value, VertexProperty.Cardinality cardinality) {
         RelationType et = getRelationType(name);
         if (et == null) {
-            return config.getAutoSchemaMaker().makePropertyKey(makePropertyKey(name).cardinality(cardinality), value);
+            PropertyKeyMaker propertyKeyMaker = makePropertyKey(name);
+            if (cardinality != null) {
+                propertyKeyMaker = propertyKeyMaker.cardinality(cardinality);
+            }
+            return config.getAutoSchemaMaker().makePropertyKey(propertyKeyMaker, value);
         } else if (et.isPropertyKey()) {
             return (PropertyKey) et;
         } else {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/ParameterType.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/ParameterType.java
@@ -16,7 +16,7 @@ package org.janusgraph.graphdb.types;
 
 import com.google.common.base.Preconditions;
 import org.janusgraph.core.schema.Parameter;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
 import java.util.List;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/TypeUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/TypeUtil.java
@@ -25,7 +25,7 @@ import org.janusgraph.graphdb.internal.JanusGraphSchemaCategory;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Property;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/BaseRelationType.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/BaseRelationType.java
@@ -19,7 +19,7 @@ import org.janusgraph.core.schema.ConsistencyModifier;
 import org.janusgraph.graphdb.idmanagement.IDManager;
 import org.janusgraph.graphdb.internal.JanusGraphSchemaCategory;
 import org.janusgraph.graphdb.internal.Token;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public abstract class BaseRelationType extends EmptyRelationType implements SystemRelationType {
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/ImplicitKey.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/ImplicitKey.java
@@ -23,7 +23,7 @@ import org.janusgraph.diskstorage.EntryMetaData;
 import org.janusgraph.graphdb.internal.*;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Direction;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.time.Duration;
 import java.time.Instant;

--- a/janusgraph-core/src/main/java/org/janusgraph/util/system/ConfigurationFileFilter.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/util/system/ConfigurationFileFilter.java
@@ -15,10 +15,10 @@
 package org.janusgraph.util.system;
 
 import com.google.common.base.Preconditions;
+import org.apache.commons.text.WordUtils;
 import org.janusgraph.diskstorage.configuration.ConfigElement;
 import org.janusgraph.diskstorage.configuration.ConfigOption;
 import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
-import org.apache.commons.lang.WordUtils;
 import org.janusgraph.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/janusgraph-core/src/main/java/org/janusgraph/util/system/ConfigurationLint.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/util/system/ConfigurationLint.java
@@ -19,8 +19,8 @@ import org.janusgraph.diskstorage.configuration.ConfigElement;
 import org.janusgraph.diskstorage.configuration.ConfigOption;
 import org.janusgraph.diskstorage.configuration.backend.CommonsConfiguration;
 import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +57,7 @@ public class ConfigurationLint {
 
         final PropertiesConfiguration apc;
         try {
-            apc = new PropertiesConfiguration(filename);
+            apc = ConfigurationUtil.loadPropertiesConfig(filename);
         } catch (ConfigurationException e) {
             throw new IOException(e);
         }

--- a/janusgraph-core/src/main/java/org/janusgraph/util/system/ConfigurationUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/util/system/ConfigurationUtil.java
@@ -15,8 +15,17 @@
 package org.janusgraph.util.system;
 
 import com.google.common.base.Preconditions;
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.MapConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
+import org.apache.commons.configuration2.builder.fluent.Parameters;
+import org.apache.commons.configuration2.builder.fluent.PropertiesBuilderParameters;
+import org.apache.commons.configuration2.convert.DefaultListDelimiterHandler;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 
+import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
@@ -27,6 +36,7 @@ import java.util.*;
 public class ConfigurationUtil {
 
     private static final char CONFIGURATION_SEPARATOR = '.';
+    private static final DefaultListDelimiterHandler COMMA_DELIMITER_HANDLER = new DefaultListDelimiterHandler(',');
 
     public static List<String> getUniquePrefixes(Configuration config) {
         final Set<String> nameSet = new HashSet<>();
@@ -65,4 +75,55 @@ public class ConfigurationUtil {
         }
     }
 
+    /**
+     * Create a new BaseConfiguration object and set a comma delimiter handler, which interprets
+     * comma-delimited values as a list of values.
+     * @return
+     */
+    public static BaseConfiguration createBaseConfiguration() {
+        final BaseConfiguration baseConfiguration = new BaseConfiguration();
+        baseConfiguration.setListDelimiterHandler(COMMA_DELIMITER_HANDLER);
+        return baseConfiguration;
+    }
+
+    /**
+     * Load properties from a map object and return a MapConfiguration object. Comma-delimited values are interpreted as
+     * a list of values.
+     * @param configMap
+     * @return
+     */
+    public static MapConfiguration loadMapConfiguration(Map<String, Object> configMap) {
+        final MapConfiguration mapConfiguration = new MapConfiguration(configMap);
+        mapConfiguration.setListDelimiterHandler(COMMA_DELIMITER_HANDLER);
+        return mapConfiguration;
+    }
+
+    /**
+     * Load properties from a given file name and return a PropertiesConfiguration object. Comma-delimited values are
+     * interpreted as a list of values.
+     * @param filename
+     * @return
+     * @throws ConfigurationException
+     */
+    public static PropertiesConfiguration loadPropertiesConfig(String filename) throws ConfigurationException {
+        return loadPropertiesConfig(new Parameters().properties().setFileName(filename));
+    }
+
+    /**
+     * Load properties from a given file object and return a PropertiesConfiguration object. Comma-delimited values are
+     * interpreted as a list of values.
+     * @param file
+     * @return
+     * @throws ConfigurationException
+     */
+    public static PropertiesConfiguration loadPropertiesConfig(File file) throws ConfigurationException {
+        return loadPropertiesConfig(new Parameters().properties().setFile(file));
+    }
+
+    private static PropertiesConfiguration loadPropertiesConfig(PropertiesBuilderParameters params) throws ConfigurationException {
+        FileBasedConfigurationBuilder<PropertiesConfiguration> builder =
+            new FileBasedConfigurationBuilder<PropertiesConfiguration>(PropertiesConfiguration.class)
+                .configure(params.setListDelimiterHandler(COMMA_DELIMITER_HANDLER));
+        return builder.getConfiguration();
+    }
 }

--- a/janusgraph-cql/src/test/java/org/janusgraph/hadoop/CQLInputFormatIT.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/hadoop/CQLInputFormatIT.java
@@ -18,8 +18,9 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.util.GraphFactory;
 import org.janusgraph.JanusGraphCassandraContainer;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -35,7 +36,7 @@ public class CQLInputFormatIT extends AbstractInputFormatIT {
     private static JanusGraphCassandraContainer cql = new JanusGraphCassandraContainer();
 
     private PropertiesConfiguration getGraphConfiguration() throws ConfigurationException, IOException {
-        final PropertiesConfiguration config = new PropertiesConfiguration("target/test-classes/cql-read.properties");
+        final PropertiesConfiguration config = ConfigurationUtil.loadPropertiesConfig("target/test-classes/cql-read.properties");
         Path baseOutDir = Paths.get((String) config.getProperty("gremlin.hadoop.outputLocation"));
         baseOutDir.toFile().mkdirs();
         String outDir = Files.createTempDirectory(baseOutDir, null).toAbsolutePath().toString();

--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-berkeleyje-es.yaml
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-berkeleyje-es.yaml
@@ -14,7 +14,7 @@
 
 host: 0.0.0.0
 port: 8182
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
 graphs: {
     graph: conf/gremlin-server/janusgraph-berkeleyje-es-server.properties}

--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-berkeleyje.yaml
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-berkeleyje.yaml
@@ -14,7 +14,7 @@
 
 host: 0.0.0.0
 port: 8182
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
 graphs: {
   graph: conf/gremlin-server/janusgraph-berkeleyje-server.properties}

--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-configuration.yaml
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-configuration.yaml
@@ -14,7 +14,7 @@
 
 host: 0.0.0.0
 port: 8182
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
 graphManager: org.janusgraph.graphdb.management.JanusGraphManager
 graphs: {

--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-cql-es.yaml
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-cql-es.yaml
@@ -14,7 +14,7 @@
 
 host: 0.0.0.0
 port: 8182
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
 graphs: {
     graph: conf/gremlin-server/janusgraph-cql-es-server.properties

--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server.yaml
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server.yaml
@@ -14,7 +14,7 @@
 
 host: 0.0.0.0
 port: 8182
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
 graphs: {
   graph: conf/janusgraph-inmemory.properties

--- a/janusgraph-driver/src/main/java/org/janusgraph/core/attribute/Cmp.java
+++ b/janusgraph-driver/src/main/java/org/janusgraph/core/attribute/Cmp.java
@@ -17,7 +17,8 @@ package org.janusgraph.core.attribute;
 import com.google.common.base.Preconditions;
 import org.janusgraph.graphdb.database.serialize.AttributeUtils;
 import org.janusgraph.graphdb.query.JanusGraphPredicate;
-import org.apache.commons.lang.ArrayUtils;
+
+import java.util.Objects;
 
 /**
  * Basic comparison relations for comparable (i.e. linearly ordered) objects.
@@ -44,7 +45,7 @@ public enum Cmp implements JanusGraphPredicate {
             if (condition==null) {
                 return value==null;
             } else {
-                return condition.equals(value) || (condition.getClass().isArray() && ArrayUtils.isEquals(condition, value));
+                return condition.equals(value) || (condition.getClass().isArray() && Objects.deepEquals(condition, value));
             }
         }
 

--- a/janusgraph-driver/src/main/java/org/janusgraph/core/attribute/Text.java
+++ b/janusgraph-driver/src/main/java/org/janusgraph/core/attribute/Text.java
@@ -17,7 +17,7 @@ package org.janusgraph.core.attribute;
 import java.util.*;
 
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.janusgraph.graphdb.query.JanusGraphPredicate;
 import org.janusgraph.graphdb.tinkerpop.io.JanusGraphP;

--- a/janusgraph-driver/src/main/java/org/janusgraph/graphdb/tinkerpop/io/binary/JanusGraphTypeSerializer.java
+++ b/janusgraph-driver/src/main/java/org/janusgraph/graphdb/tinkerpop/io/binary/JanusGraphTypeSerializer.java
@@ -14,7 +14,7 @@
 
 package org.janusgraph.graphdb.tinkerpop.io.binary;
 
-import org.apache.commons.lang.SerializationException;
+import org.apache.commons.lang3.SerializationException;
 import org.apache.tinkerpop.gremlin.structure.io.Buffer;
 import org.apache.tinkerpop.gremlin.structure.io.binary.DataType;
 import org.apache.tinkerpop.gremlin.structure.io.binary.GraphBinaryReader;

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticsearchConfigTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticsearchConfigTest.java
@@ -34,7 +34,6 @@ import org.janusgraph.diskstorage.util.StandardBaseTransactionConfig;
 import org.janusgraph.diskstorage.util.time.TimestampProviders;
 import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
 import org.janusgraph.graphdb.query.condition.PredicateCondition;
-import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -47,6 +46,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.apache.tinkerpop.shaded.jackson.core.type.TypeReference;
 import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -144,7 +144,7 @@ public class ElasticsearchConfigTest {
     public void testIndexCreationOptions(Boolean useMappingsForES7) throws InterruptedException, BackendException, IOException {
         final int shards = 7;
 
-        final CommonsConfiguration cc = new CommonsConfiguration(new BaseConfiguration());
+        final CommonsConfiguration cc = new CommonsConfiguration(ConfigurationUtil.createBaseConfiguration());
         cc.set("index." + INDEX_NAME + ".elasticsearch.create.ext.number_of_shards", String.valueOf(shards));
         if(useMappingsForES7){
             cc.set("index." + INDEX_NAME + ".elasticsearch.use-mapping-for-es7", String.valueOf(true));

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticsearchIndexTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticsearchIndexTest.java
@@ -19,10 +19,9 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 
-import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.RandomStringUtils;
-import org.apache.commons.lang.reflect.FieldUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.client.methods.*;
@@ -47,6 +46,7 @@ import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
 import org.janusgraph.graphdb.internal.Order;
 import org.janusgraph.graphdb.query.condition.PredicateCondition;
 import org.janusgraph.graphdb.types.ParameterType;
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -126,7 +126,7 @@ public class ElasticsearchIndexTest extends IndexProviderTest {
 
     public Configuration getESTestConfig() {
         final String index = "es";
-        final CommonsConfiguration cc = new CommonsConfiguration(new BaseConfiguration());
+        final CommonsConfiguration cc = new CommonsConfiguration(ConfigurationUtil.createBaseConfiguration());
         cc.set("index." + index + ".elasticsearch.ingest-pipeline.ingestvertex", "pipeline_1");
         return makeESTestConfig(index, cc);
     }
@@ -449,11 +449,11 @@ public class ElasticsearchIndexTest extends IndexProviderTest {
         final String index1 = "es1";
         final String index2 = "es2";
 
-        final CommonsConfiguration cc1 = new CommonsConfiguration(new BaseConfiguration());
+        final CommonsConfiguration cc1 = new CommonsConfiguration(ConfigurationUtil.createBaseConfiguration());
         cc1.set("index." + index1 + ".elasticsearch.ingest-pipeline.ingestvertex", "pipeline_1");
         cc1.set("index." + index1 + ".elasticsearch.enable_index_names_cache", true);
 
-        final CommonsConfiguration cc2 = new CommonsConfiguration(new BaseConfiguration());
+        final CommonsConfiguration cc2 = new CommonsConfiguration(ConfigurationUtil.createBaseConfiguration());
         cc1.set("index." + index2 + ".elasticsearch.ingest-pipeline.ingestvertex", "pipeline_1");
         cc1.set("index." + index2 + ".elasticsearch.enable_index_names_cache", true);
 
@@ -493,7 +493,7 @@ public class ElasticsearchIndexTest extends IndexProviderTest {
     public void testShouldNotUseIndexStoreNameCache() throws BackendException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
         final String index = "es1";
 
-        final CommonsConfiguration cc = new CommonsConfiguration(new BaseConfiguration());
+        final CommonsConfiguration cc = new CommonsConfiguration(ConfigurationUtil.createBaseConfiguration());
         cc.set("index." + index + ".elasticsearch.ingest-pipeline.ingestvertex", "pipeline_1");
         cc.set("index." + index + ".elasticsearch.enable_index_names_cache", false);
 

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/rest/RestClientSetupTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/rest/RestClientSetupTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
@@ -49,6 +48,7 @@ import org.janusgraph.diskstorage.es.rest.util.HttpAuthTypes;
 import org.janusgraph.diskstorage.es.rest.util.RestClientAuthenticator;
 import org.janusgraph.diskstorage.es.rest.util.SSLConfigurationCallback;
 import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -108,7 +108,7 @@ public class RestClientSetupTest {
     }
 
     private ElasticSearchClient baseConfigTest(Map<String, String> extraConfigValues) throws Exception {
-        final CommonsConfiguration cc = new CommonsConfiguration(new BaseConfiguration());
+        final CommonsConfiguration cc = new CommonsConfiguration(ConfigurationUtil.createBaseConfiguration());
         cc.set("index." + INDEX_NAME + ".backend", "elasticsearch");
         cc.set("index." + INDEX_NAME + ".elasticsearch.interface", "REST_CLIENT");
         for(Map.Entry<String, String> me: extraConfigValues.entrySet()) {

--- a/janusgraph-examples/example-common/src/main/java/org/janusgraph/example/GraphApp.java
+++ b/janusgraph-examples/example-common/src/main/java/org/janusgraph/example/GraphApp.java
@@ -14,19 +14,20 @@
 
 package org.janusgraph.example;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.GraphFactory;
 import org.janusgraph.core.attribute.Geoshape;
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,9 +54,9 @@ public class GraphApp {
      * Opens the graph instance. If the graph instance does not exist, a new
      * graph instance is initialized.
      */
-    public GraphTraversalSource openGraph() throws ConfigurationException {
+    public GraphTraversalSource openGraph() throws ConfigurationException, IOException {
         LOGGER.info("opening graph");
-        conf = new PropertiesConfiguration(propFileName);
+        conf = ConfigurationUtil.loadPropertiesConfig(propFileName);
         graph = GraphFactory.open(conf);
         g = graph.traversal();
         return g;

--- a/janusgraph-examples/example-common/src/main/java/org/janusgraph/example/JanusGraphApp.java
+++ b/janusgraph-examples/example-common/src/main/java/org/janusgraph/example/JanusGraphApp.java
@@ -14,7 +14,7 @@
 
 package org.janusgraph.example;
 
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -26,6 +26,8 @@ import org.janusgraph.core.attribute.Geoshape;
 import org.janusgraph.core.schema.JanusGraphManagement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 public class JanusGraphApp extends GraphApp {
     private static final Logger LOGGER = LoggerFactory.getLogger(JanusGraphApp.class);
@@ -64,7 +66,7 @@ public class JanusGraphApp extends GraphApp {
     }
 
     @Override
-    public GraphTraversalSource openGraph() throws ConfigurationException {
+    public GraphTraversalSource openGraph() throws ConfigurationException, IOException {
         super.openGraph();
         useMixedIndex = useMixedIndex && conf.containsKey("index." + mixedIndexConfigName + ".backend");
         return g;

--- a/janusgraph-examples/example-common/src/test/java/org/janusgraph/example/GraphAppTest.java
+++ b/janusgraph-examples/example-common/src/test/java/org/janusgraph/example/GraphAppTest.java
@@ -14,12 +14,15 @@
 
 package org.janusgraph.example;
 
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -30,7 +33,7 @@ public class GraphAppTest {
     protected static GraphTraversalSource g;
 
     @BeforeAll
-    public static void setUpClass() throws ConfigurationException {
+    public static void setUpClass() throws ConfigurationException, IOException {
         app = new GraphApp(CONF_FILE);
         g = app.openGraph();
     }
@@ -55,12 +58,12 @@ public class GraphAppTest {
 
     @Test
     public void openGraphNullConfig() throws ConfigurationException {
-        assertThrows(ConfigurationException.class, () -> new GraphApp(null).openGraph());
+        assertThrows(NullPointerException.class, () -> new GraphApp(null).openGraph());
     }
 
     @Test
     public void openGraphConfigNotFound() throws ConfigurationException {
-        assertThrows(ConfigurationException.class, () -> new GraphApp("conf/foobar").openGraph());
+        assertThrows(FileNotFoundException.class, () -> new GraphApp("conf/foobar").openGraph());
     }
 
     @Test

--- a/janusgraph-examples/example-common/src/test/java/org/janusgraph/example/JanusGraphAppTest.java
+++ b/janusgraph-examples/example-common/src/test/java/org/janusgraph/example/JanusGraphAppTest.java
@@ -18,12 +18,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.janusgraph.core.Cardinality;
 import org.janusgraph.core.EdgeLabel;
@@ -41,7 +42,7 @@ public class JanusGraphAppTest {
     protected static final String CONF_FILE = "conf/jgex-inmemory.properties";
 
     @Test
-    public void createSchema() throws ConfigurationException {
+    public void createSchema() throws ConfigurationException, IOException {
         final JanusGraphApp app = new JanusGraphApp(CONF_FILE);
         final GraphTraversalSource g = app.openGraph();
         app.createSchema();

--- a/janusgraph-examples/example-remotegraph/src/main/java/org/janusgraph/example/RemoteGraphApp.java
+++ b/janusgraph-examples/example-remotegraph/src/main/java/org/janusgraph/example/RemoteGraphApp.java
@@ -14,11 +14,11 @@
 
 package org.janusgraph.example;
 
+import java.io.IOException;
 import java.util.stream.Stream;
 
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.Result;
@@ -28,6 +28,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.janusgraph.core.JanusGraph;
 import org.janusgraph.core.attribute.Geoshape;
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,9 +64,9 @@ public class RemoteGraphApp extends JanusGraphApp {
     }
 
     @Override
-    public GraphTraversalSource openGraph() throws ConfigurationException {
+    public GraphTraversalSource openGraph() throws ConfigurationException, IOException {
         LOGGER.info("opening graph");
-        conf = new PropertiesConfiguration(propFileName);
+        conf = ConfigurationUtil.loadPropertiesConfig(propFileName);
 
         // using the remote driver for schema
         try {

--- a/janusgraph-examples/example-tinkergraph/src/test/java/org/janusgraph/example/TinkerGraphAppTest.java
+++ b/janusgraph-examples/example-tinkergraph/src/test/java/org/janusgraph/example/TinkerGraphAppTest.java
@@ -17,9 +17,10 @@ package org.janusgraph.example;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.util.Set;
 
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerEdge;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
@@ -30,7 +31,7 @@ public class TinkerGraphAppTest {
     protected static final String CONF_FILE = "conf/jgex-tinkergraph.properties";
 
     @Test
-    public void createSchema() throws ConfigurationException {
+    public void createSchema() throws ConfigurationException, IOException {
         final TinkerGraphApp app = new TinkerGraphApp(CONF_FILE);
         final GraphTraversalSource g = app.openGraph();
         app.createSchema();

--- a/janusgraph-hadoop/src/assembly/example-data/FathersName.groovy
+++ b/janusgraph-hadoop/src/assembly/example-data/FathersName.groovy
@@ -14,12 +14,12 @@
 
 import org.janusgraph.core.JanusGraphFactory
 import com.tinkerpop.blueprints.Graph
-import org.apache.commons.configuration.BaseConfiguration
+import org.janusgraph.util.system.ConfigurationUtil
 
 Graph g
 
 def setup(args) {
-    conf = new BaseConfiguration()
+    conf = ConfigurationUtil.createBaseConfiguration()
     conf.setProperty('storage.backend', args[0])
     conf.setProperty('storage.hostname', 'localhost')
     g = JanusGraphFactory.open(conf)

--- a/janusgraph-hadoop/src/main/java/org/janusgraph/hadoop/MapReduceIndexJobs.java
+++ b/janusgraph-hadoop/src/main/java/org/janusgraph/hadoop/MapReduceIndexJobs.java
@@ -14,7 +14,6 @@
 
 package org.janusgraph.hadoop;
 
-import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.hadoop.conf.Configuration;
 import org.janusgraph.diskstorage.configuration.BasicConfiguration;
 import org.janusgraph.diskstorage.configuration.ConfigElement;
@@ -22,6 +21,7 @@ import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.janusgraph.diskstorage.configuration.backend.CommonsConfiguration;
 import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
 import org.janusgraph.hadoop.config.JanusGraphHadoopConfiguration;
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +35,7 @@ public class MapReduceIndexJobs {
 
     public static ModifiableConfiguration getIndexJobConf(String indexName, String relationType) {
         ModifiableConfiguration mc = new ModifiableConfiguration(GraphDatabaseConfiguration.JOB_NS,
-                new CommonsConfiguration(new BaseConfiguration()), BasicConfiguration.Restriction.NONE);
+                new CommonsConfiguration(ConfigurationUtil.createBaseConfiguration()), BasicConfiguration.Restriction.NONE);
         mc.set(org.janusgraph.graphdb.olap.job.IndexUpdateJob.INDEX_NAME, indexName);
         mc.set(org.janusgraph.graphdb.olap.job.IndexUpdateJob.INDEX_RELATION_TYPE, relationType);
         mc.set(GraphDatabaseConfiguration.JOB_START_TIME, System.currentTimeMillis());

--- a/janusgraph-hadoop/src/main/java/org/janusgraph/hadoop/MapReduceIndexManagement.java
+++ b/janusgraph-hadoop/src/main/java/org/janusgraph/hadoop/MapReduceIndexManagement.java
@@ -151,7 +151,7 @@ public class MapReduceIndexManagement {
         janusGraphMapReduceConfiguration.set(JanusGraphHadoopConfiguration.SCAN_JOB_CONFIG_ROOT,
                 GraphDatabaseConfiguration.class.getName() + "#JOB_NS");
         // Copy the StandardJanusGraph configuration under JanusGraphHadoopConfiguration.GRAPH_CONFIG_KEYS
-        org.apache.commons.configuration.Configuration localConfiguration = graph.getConfiguration().getConfigurationAtOpen();
+        org.apache.commons.configuration2.Configuration localConfiguration = graph.getConfiguration().getConfigurationAtOpen();
         localConfiguration.clearProperty(Graph.GRAPH);
         copyInputKeys(hadoopConf, localConfiguration);
 
@@ -164,7 +164,7 @@ public class MapReduceIndexManagement {
         }
     }
 
-    private static void copyInputKeys(org.apache.hadoop.conf.Configuration hadoopConf, org.apache.commons.configuration.Configuration source) {
+    private static void copyInputKeys(org.apache.hadoop.conf.Configuration hadoopConf, org.apache.commons.configuration2.Configuration source) {
         // Copy IndexUpdateJob settings into the hadoop-backed cfg
         Iterator<String> keyIter = source.getKeys();
         while (keyIter.hasNext()) {

--- a/janusgraph-hadoop/src/main/java/org/janusgraph/hadoop/serialize/JanusGraphKryoShimService.java
+++ b/janusgraph-hadoop/src/main/java/org/janusgraph/hadoop/serialize/JanusGraphKryoShimService.java
@@ -15,16 +15,17 @@
 package org.janusgraph.hadoop.serialize;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration2.BaseConfiguration;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.HadoopPoolShimService;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.HadoopPools;
 import org.apache.tinkerpop.gremlin.structure.io.IoRegistry;
 import org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry;
+import org.janusgraph.util.system.ConfigurationUtil;
 
 public class JanusGraphKryoShimService extends HadoopPoolShimService {
 
     public JanusGraphKryoShimService() {
-        final BaseConfiguration c = new BaseConfiguration();
+        final BaseConfiguration c = ConfigurationUtil.createBaseConfiguration();
         c.setProperty(IoRegistry.IO_REGISTRY, ImmutableList.of(JanusGraphIoRegistry.class.getCanonicalName()));
         HadoopPools.initialize(c);
     }

--- a/janusgraph-hadoop/src/test/java/org/janusgraph/hadoop/AbstractInputFormatIT.java
+++ b/janusgraph-hadoop/src/test/java/org/janusgraph/hadoop/AbstractInputFormatIT.java
@@ -18,7 +18,7 @@ import org.janusgraph.core.Cardinality;
 import org.janusgraph.core.JanusGraphVertex;
 import org.janusgraph.example.GraphOfTheGodsFactory;
 import org.janusgraph.graphdb.JanusGraphBaseTest;
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.tinkerpop.gremlin.process.computer.Computer;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;

--- a/janusgraph-hbase/src/test/java/org/janusgraph/hadoop/HBaseInputFormatIT.java
+++ b/janusgraph-hbase/src/test/java/org/janusgraph/hadoop/HBaseInputFormatIT.java
@@ -14,14 +14,15 @@
 
 package org.janusgraph.hadoop;
 
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.util.GraphFactory;
 
 import org.janusgraph.HBaseContainer;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
 
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -36,7 +37,7 @@ public class HBaseInputFormatIT extends AbstractInputFormatIT {
     public static final HBaseContainer hBaseContainer = new HBaseContainer();
 
     protected Graph getGraph() throws IOException, ConfigurationException {
-        final PropertiesConfiguration config = new PropertiesConfiguration("target/test-classes/hbase-read.properties");
+        final PropertiesConfiguration config = ConfigurationUtil.loadPropertiesConfig("target/test-classes/hbase-read.properties");
         Path baseOutDir = Paths.get((String) config.getProperty("gremlin.hadoop.outputLocation"));
         baseOutDir.toFile().mkdirs();
         String outDir = Files.createTempDirectory(baseOutDir, null).toAbsolutePath().toString();

--- a/janusgraph-hbase/src/test/java/org/janusgraph/hadoop/HBaseSnapshotInputFormatIT.java
+++ b/janusgraph-hbase/src/test/java/org/janusgraph/hadoop/HBaseSnapshotInputFormatIT.java
@@ -14,8 +14,8 @@
 
 package org.janusgraph.hadoop;
 
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.tinkerpop.gremlin.process.computer.Computer;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
@@ -30,6 +30,7 @@ import org.janusgraph.core.Cardinality;
 import org.janusgraph.core.JanusGraphVertex;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
 import org.janusgraph.example.GraphOfTheGodsFactory;
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
@@ -263,8 +264,7 @@ public class HBaseSnapshotInputFormatIT extends AbstractInputFormatIT {
     }
 
     protected Graph getGraph() throws IOException, ConfigurationException {
-        final PropertiesConfiguration config =
-                new PropertiesConfiguration("target/test-classes/hbase-read-snapshot.properties");
+        final PropertiesConfiguration config = ConfigurationUtil.loadPropertiesConfig("target/test-classes/hbase-read-snapshot.properties");
         Path baseOutDir = Paths.get((String) config.getProperty("gremlin.hadoop.outputLocation"));
         baseOutDir.toFile().mkdirs();
         String outDir = Files.createTempDirectory(baseOutDir, null).toAbsolutePath().toString();

--- a/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/InMemoryKeyColumnValueStore.java
+++ b/janusgraph-inmemory/src/main/java/org/janusgraph/diskstorage/inmemory/InMemoryKeyColumnValueStore.java
@@ -24,7 +24,7 @@ import org.janusgraph.diskstorage.EntryList;
 import org.janusgraph.diskstorage.StaticBuffer;
 import org.janusgraph.diskstorage.keycolumnvalue.*;
 import org.janusgraph.diskstorage.util.RecordIterator;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.janusgraph.diskstorage.util.StaticArrayBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/janusgraph-inmemory/src/test/java/org/janusgraph/core/inmemory/InmemoryConfiguredGraphFactoryTest.java
+++ b/janusgraph-inmemory/src/test/java/org/janusgraph/core/inmemory/InmemoryConfiguredGraphFactoryTest.java
@@ -14,8 +14,9 @@
 
 package org.janusgraph.core.inmemory;
 
-import org.apache.commons.configuration.MapConfiguration;
+import org.apache.commons.configuration2.MapConfiguration;
 import org.janusgraph.core.AbstractConfiguredGraphFactoryTest;
+import org.janusgraph.util.system.ConfigurationUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,7 +29,7 @@ public class InmemoryConfiguredGraphFactoryTest extends AbstractConfiguredGraphF
     protected MapConfiguration getManagementConfig() {
         final Map<String, Object> map = new HashMap<>();
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
-        return new MapConfiguration(map);
+        return ConfigurationUtil.loadMapConfiguration(map);
     }
 
     protected MapConfiguration getTemplateConfig() {
@@ -38,7 +39,7 @@ public class InmemoryConfiguredGraphFactoryTest extends AbstractConfiguredGraphF
     protected MapConfiguration getGraphConfig() {
         final Map<String, Object> map = getTemplateConfig().getMap();
         map.put(GRAPH_NAME.toStringWithoutRoot(), "inmemory_test_graph_name");
-        return new MapConfiguration(map);
+        return ConfigurationUtil.loadMapConfiguration(map);
     }
 }
 

--- a/janusgraph-inmemory/src/test/java/org/janusgraph/diskstorage/inmemory/InMemoryStoreManagerTest.java
+++ b/janusgraph-inmemory/src/test/java/org/janusgraph/diskstorage/inmemory/InMemoryStoreManagerTest.java
@@ -15,7 +15,7 @@
 package org.janusgraph.diskstorage.inmemory;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.janusgraph.diskstorage.Entry;
 import org.janusgraph.diskstorage.EntryList;
 import org.janusgraph.diskstorage.StaticBuffer;

--- a/janusgraph-lucene/src/main/java/org/janusgraph/diskstorage/lucene/LuceneIndex.java
+++ b/janusgraph-lucene/src/main/java/org/janusgraph/diskstorage/lucene/LuceneIndex.java
@@ -36,7 +36,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CachingTokenFilter;
 import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;

--- a/janusgraph-server/src/main/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/handler/SaslAndHMACAuthenticationHandler.java
+++ b/janusgraph-server/src/main/java/org/janusgraph/graphdb/tinkerpop/gremlin/server/handler/SaslAndHMACAuthenticationHandler.java
@@ -39,7 +39,7 @@ public class SaslAndHMACAuthenticationHandler extends SaslAuthenticationHandler 
     private final String HMAC_AUTH = "hmac_authenticator";
     private HMACAuthenticator hmacAuthenticator;
 
-    public SaslAndHMACAuthenticationHandler(final Authenticator authenticator, final Settings.AuthenticationSettings authenticationSettings) {
+    public SaslAndHMACAuthenticationHandler(final Authenticator authenticator, final Settings authenticationSettings) {
         super(((SaslAndHMACAuthenticator) authenticator).getSimpleAuthenticator(), authenticationSettings);
         hmacAuthenticator = ((SaslAndHMACAuthenticator) authenticator).getHMACAuthenticator();
     }

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/ConfigurationManagementGraphServerTest.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/ConfigurationManagementGraphServerTest.java
@@ -68,7 +68,8 @@ public class ConfigurationManagementGraphServerTest extends AbstractGremlinServe
 
         //create newGraph
         client.submit("Map<String, Object> map = new HashMap<String, Object>(); map.put(\"storage.backend\", \"inmemory\"); " +
-            "org.janusgraph.core.ConfiguredGraphFactory.createTemplateConfiguration(new MapConfiguration(map));" +
+            "org.janusgraph.core.ConfiguredGraphFactory.createTemplateConfiguration(" +
+            "org.janusgraph.util.system.ConfigurationUtil.loadMapConfiguration(map));" +
             "org.janusgraph.core.ConfiguredGraphFactory.create(\"newGraph\")");
 
         Thread.sleep(1000,0);

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/TestClientFactory.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/TestClientFactory.java
@@ -31,7 +31,6 @@
 package org.janusgraph.graphdb.tinkerpop;
 
 import org.apache.tinkerpop.gremlin.driver.Cluster;
-import org.apache.tinkerpop.gremlin.driver.simple.NioClient;
 import org.apache.tinkerpop.gremlin.driver.simple.WebSocketClient;
 
 import java.net.URI;
@@ -56,10 +55,6 @@ public final class TestClientFactory {
 
     public static WebSocketClient createWebSocketClient() {
         return new WebSocketClient(WEBSOCKET_URI);
-    }
-
-    public static NioClient createNioClient() {
-        return new NioClient(NIO_URI);
     }
 
     public static String createURLString() {

--- a/janusgraph-server/src/test/resources/gremlin-server-integration.yaml
+++ b/janusgraph-server/src/test/resources/gremlin-server-integration.yaml
@@ -14,7 +14,7 @@
 
 host: 0.0.0.0
 port: 45940
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
 graphs: {
   ConfigurationManagementGraph: "src/test/resources/conf/janusgraph-server-integration.properties"

--- a/janusgraph-server/src/test/resources/janusgraph-server-with-grpc.yaml
+++ b/janusgraph-server/src/test/resources/janusgraph-server-with-grpc.yaml
@@ -14,7 +14,7 @@
 
 host: 0.0.0.0
 port: 8182
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 grpcServer: {
     enabled: true,
     port: 8042

--- a/janusgraph-server/src/test/resources/janusgraph-server-with-serializers.yaml
+++ b/janusgraph-server/src/test/resources/janusgraph-server-with-serializers.yaml
@@ -14,7 +14,7 @@
 
 host: 0.0.0.0
 port: 8182
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
 graphs: {
     graph: "src/test/resources/conf/janusgraph-inmemory.properties"

--- a/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
+++ b/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
@@ -32,7 +32,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpRequestInterceptor;

--- a/janusgraph-test/src/test/java/org/janusgraph/diskstorage/common/LocalStoreManagerTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/diskstorage/common/LocalStoreManagerTest.java
@@ -34,7 +34,7 @@ import static org.janusgraph.diskstorage.configuration.BasicConfiguration.Restri
 import java.util.Map;
 import java.util.HashMap;
 import java.util.List;
-import org.apache.commons.configuration.BaseConfiguration;
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -89,7 +89,7 @@ public class LocalStoreManagerTest {
     }
 
     public LocalStoreManager getStoreManager(Map<ConfigOption, String> map) throws BackendException {
-        final ModifiableConfiguration mc = new ModifiableConfiguration(ROOT_NS, new CommonsConfiguration(new BaseConfiguration()), NONE);
+        final ModifiableConfiguration mc = new ModifiableConfiguration(ROOT_NS, new CommonsConfiguration(ConfigurationUtil.createBaseConfiguration()), NONE);
         map.forEach(mc::set);
         return new LocalStoreManagerSampleImplementation(mc);
     }

--- a/janusgraph-test/src/test/java/org/janusgraph/diskstorage/configuration/CommonConfigTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/diskstorage/configuration/CommonConfigTest.java
@@ -18,7 +18,8 @@ import com.google.common.collect.ImmutableMap;
 import org.janusgraph.diskstorage.configuration.backend.CommonsConfiguration;
 
 import org.janusgraph.diskstorage.util.time.Temporals;
-import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -36,12 +37,12 @@ public class CommonConfigTest extends WritableConfigurationTest {
 
     @Override
     public WriteConfiguration getConfig() {
-        return new CommonsConfiguration(new BaseConfiguration());
+        return new CommonsConfiguration(ConfigurationUtil.createBaseConfiguration());
     }
 
     @Test
     public void testDateParsing() {
-        BaseConfiguration base = new BaseConfiguration();
+        final BaseConfiguration base = ConfigurationUtil.createBaseConfiguration();
         CommonsConfiguration config = new CommonsConfiguration(base);
 
         for (ChronoUnit unit : Arrays.asList(ChronoUnit.NANOS, ChronoUnit.MICROS, ChronoUnit.MILLIS, ChronoUnit.SECONDS, ChronoUnit.MINUTES, ChronoUnit.HOURS, ChronoUnit.DAYS)) {

--- a/janusgraph-test/src/test/java/org/janusgraph/diskstorage/configuration/ConfigurationTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/diskstorage/configuration/ConfigurationTest.java
@@ -18,7 +18,7 @@ import com.google.common.collect.ImmutableSet;
 import org.janusgraph.core.util.ReflectiveConfigOptionLoader;
 import org.janusgraph.diskstorage.configuration.backend.CommonsConfiguration;
 import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
-import org.apache.commons.configuration.BaseConfiguration;
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.junit.jupiter.api.Test;
 
 import java.util.stream.StreamSupport;
@@ -60,7 +60,7 @@ public class ConfigurationTest {
                 ConfigOption.Type.LOCAL, false);
 
         //Local configuration
-        ModifiableConfiguration config = new ModifiableConfiguration(root,new CommonsConfiguration(new BaseConfiguration()), BasicConfiguration.Restriction.LOCAL);
+        ModifiableConfiguration config = new ModifiableConfiguration(root,new CommonsConfiguration(ConfigurationUtil.createBaseConfiguration()), BasicConfiguration.Restriction.LOCAL);
         UserModifiableConfiguration userconfig = new UserModifiableConfiguration(config);
         assertFalse(config.get(partition));
         assertEquals("false", userconfig.get("storage.partition"));
@@ -91,7 +91,7 @@ public class ConfigurationTest {
         userconfig.close();
         ReadConfiguration localConfig = userconfig.getConfiguration();
 
-        config = new ModifiableConfiguration(root,new CommonsConfiguration(new BaseConfiguration()), BasicConfiguration.Restriction.GLOBAL);
+        config = new ModifiableConfiguration(root,new CommonsConfiguration(ConfigurationUtil.createBaseConfiguration()), BasicConfiguration.Restriction.GLOBAL);
         userconfig = new UserModifiableConfiguration(config);
 
         userconfig.set("storage.locktime",1111);

--- a/janusgraph-test/src/test/java/org/janusgraph/diskstorage/configuration/converter/ReadConfigurationConverterTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/diskstorage/configuration/converter/ReadConfigurationConverterTest.java
@@ -16,7 +16,7 @@ package org.janusgraph.diskstorage.configuration.converter;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration2.BaseConfiguration;
 import org.janusgraph.diskstorage.configuration.ReadConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfigurationTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfigurationTest.java
@@ -16,7 +16,7 @@ package org.janusgraph.graphdb.configuration;
 
 import org.janusgraph.diskstorage.configuration.ConfigElement;
 import org.janusgraph.diskstorage.configuration.Configuration;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.janusgraph.graphdb.idmanagement.UniqueInstanceIdRetriever;
 import org.junit.jupiter.api.Test;
 

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/idmanagement/UniqueInstanceIdRetrieverTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/idmanagement/UniqueInstanceIdRetrieverTest.java
@@ -15,7 +15,7 @@
 package org.janusgraph.graphdb.idmanagement;
 
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.janusgraph.diskstorage.configuration.ConfigElement;
 import org.janusgraph.diskstorage.configuration.Configuration;
 import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/idmanagement/VariableLongTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/idmanagement/VariableLongTest.java
@@ -20,7 +20,7 @@ import org.janusgraph.diskstorage.StaticBuffer;
 import org.janusgraph.diskstorage.WriteBuffer;
 import org.janusgraph.diskstorage.util.WriteByteBuffer;
 import org.janusgraph.graphdb.database.idhandling.VariableLong;
-import org.apache.commons.lang.time.StopWatch;
+import org.apache.commons.lang3.time.StopWatch;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/management/ConfigurationManagementGraphTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/management/ConfigurationManagementGraphTest.java
@@ -29,11 +29,12 @@ import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.ST
 import static org.janusgraph.graphdb.management.ConfigurationManagementGraph.PROPERTY_GRAPH_NAME;
 
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.commons.configuration.MapConfiguration;
+import org.apache.commons.configuration2.MapConfiguration;
 
 import java.util.Map;
 import java.util.HashMap;
 
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -50,7 +51,7 @@ public class ConfigurationManagementGraphTest {
     public void shouldReindexIfPropertyKeyExists() {
         final Map<String, Object> map = new HashMap<>();
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
-        final MapConfiguration config = new MapConfiguration(map);
+        final MapConfiguration config = ConfigurationUtil.loadMapConfiguration(map);
         final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
 
         final String propertyKeyName = "Created_Using_Template";
@@ -98,7 +99,7 @@ public class ConfigurationManagementGraphTest {
         // Create a configuration
         final Map<String, Object> map = new HashMap<>();
         map.put(PROPERTY_GRAPH_NAME, "tx_test_graph");
-        configurationManagementGraph.createConfiguration(new MapConfiguration(map));
+        configurationManagementGraph.createConfiguration(ConfigurationUtil.loadMapConfiguration(map));
 
         // Get the vertex id from the new configuration
         long vertexId = (Long) graph.traversal().V().limit(1).next().id();

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/management/ManagementLoggerGraphCacheEvictionTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/management/ManagementLoggerGraphCacheEvictionTest.java
@@ -21,12 +21,13 @@ import org.janusgraph.graphdb.database.management.ManagementSystem;
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.GRAPH_NAME;
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.STORAGE_BACKEND;
 
-import org.apache.commons.configuration.MapConfiguration;
+import org.apache.commons.configuration2.MapConfiguration;
 import org.apache.tinkerpop.gremlin.server.Settings;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import org.janusgraph.util.system.ConfigurationUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -42,7 +43,7 @@ public class ManagementLoggerGraphCacheEvictionTest {
     public void shouldNotBeAbleToEvictGraphWhenJanusGraphManagerIsNull() {
         final Map<String, Object> map = new HashMap<>();
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
-        final MapConfiguration config = new MapConfiguration(map);
+        final MapConfiguration config = ConfigurationUtil.loadMapConfiguration(map);
         final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
         final ManagementSystem mgmt = (ManagementSystem) graph.openManagement();
         mgmt.evictGraphFromCache();
@@ -61,7 +62,7 @@ public class ManagementLoggerGraphCacheEvictionTest {
         final Map<String, Object> map = new HashMap<>();
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
         map.put(GRAPH_NAME.toStringWithoutRoot(), "graph1");
-        final MapConfiguration config = new MapConfiguration(map);
+        final MapConfiguration config = ConfigurationUtil.loadMapConfiguration(map);
         final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
         jgm.putGraph("graph1", graph);
         assertEquals("graph1", ((StandardJanusGraph) JanusGraphManager.getInstance().getGraph("graph1")).getGraphName());

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,6 +165,6 @@ nav:
 extra:
   latest_version: 0.6.0
   snapshot_version: 0.6.0-SNAPSHOT
-  tinkerpop_version: 3.4.10
+  tinkerpop_version: 3.5.0
   hadoop2_version: 2.8.5
   jamm_version: 0.3.0

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     </distributionManagement>
     <properties>
         <titan.compatible-versions>1.0.0,1.1.0-SNAPSHOT</titan.compatible-versions>
-        <tinkerpop.version>3.4.10</tinkerpop.version>
+        <tinkerpop.version>3.5.0</tinkerpop.version>
         <junit-platform.version>1.7.1</junit-platform.version>
         <junit.version>5.7.1</junit.version>
         <mockito.version>3.8.0</mockito.version>
@@ -88,7 +88,8 @@
         <scylladb.version>1.7.1</scylladb.version>
         <!-- align with org.apache.hbase:hbase -->
         <jackson1.version>1.9.13</jackson1.version>
-        <jackson2.version>2.12.2</jackson2.version>
+        <!-- align with org.apache.spark:spark-core_2.12 -->
+        <jackson2.version>2.10.0</jackson2.version>
         <lucene-solr.version>8.6.2</lucene-solr.version>
         <elasticsearch.version>7.12.0</elasticsearch.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
@@ -177,6 +178,8 @@
                                 <requireUpperBoundDeps>
                                     <excludes>
                                         <exclude>com.google.guava:guava</exclude>
+                                        <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
+                                        <exclude>com.fasterxml.jackson.core:jackson-core</exclude>
                                     </excludes>
                                 </requireUpperBoundDeps>
                                 <DependencyConvergence />
@@ -548,6 +551,14 @@
                         <groupId>junit</groupId>
                         <artifactId>junit</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.kerby</groupId>
+                        <artifactId>kerb-simplekdc</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -600,6 +611,11 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.module</groupId>
                 <artifactId>jackson-module-scala_2.11</artifactId>
+                <version>${jackson2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-paranamer</artifactId>
                 <version>${jackson2.version}</version>
             </dependency>
             <dependency>
@@ -783,6 +799,11 @@
                 <version>${netty4.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-unix-common</artifactId>
+                <version>${netty4.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.objenesis</groupId>
                 <artifactId>objenesis</artifactId>
                 <version>3.1</version>
@@ -850,11 +871,6 @@
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_annotations</artifactId>
                 <version>2.4.0</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>2.6</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>
@@ -1041,6 +1057,12 @@
                 <groupId>org.apache.velocity</groupId>
                 <artifactId>velocity</artifactId>
                 <version>1.7</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-lang</groupId>
+                        <artifactId>commons-lang</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.ant</groupId>
@@ -1069,6 +1091,10 @@
                     <exclusion>
                         <groupId>junit</groupId>
                         <artifactId>junit</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-annotations</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1107,6 +1133,31 @@
                 <groupId>io.github.artsok</groupId>
                 <artifactId>rerunner-jupiter</artifactId>
                 <version>2.1.6</version>
+            </dependency>
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>1.1.7.3</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.activation</groupId>
+                <artifactId>activation</artifactId>
+                <version>1.1.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>1.7.30</version>
+            </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>8.2.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>1.9</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
1. Bump TinkerPop dependency from 3.4.10 to 3.5.0 and resolve
dependency conflicts. Several jackson packages are ignored from
requireUpperBoundDeps maven enforce plugin now, because Spark 3.0.0
requires a lower version of jackson (2.10.0) while other libraries,
including CQL driver, require a higher version of jackson.
2. Support null value mutation semantics to comply with TinkerPop 3.5.0.
property(single, prop, null) removes the property while
property(list/set, prop, null) is simply ignored.
3. Introduce a workaround for traversal strategies which can be removed
once TINKERPOP-2568 is fixed.
4. Upgrade apache common configuration to configuration2 to comply
with the same TinkerPop breaking change. Now users won't experience the
problem reported at JanusGraph#1447 anymore, since configuration2 by default does
not read comma delimited string as a list of values.
5. Other minor changes mostly caused by breaking changes in TinkerPop.

Closes JanusGraph#2611, JanusGraph#2624, JanusGraph#1447

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
