### PR TITLE
Add test for HadoopGraph loading comma delimited values

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/util/system/ConfigurationUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/util/system/ConfigurationUtil.java
@@ -111,7 +111,19 @@ public class ConfigurationUtil {
      * @throws ConfigurationException
      */
     public static PropertiesConfiguration loadPropertiesConfig(String filename) throws ConfigurationException {
-        return loadPropertiesConfig(new Parameters().properties().setFileName(filename));
+        return loadPropertiesConfig(filename, true);
+    }
+
+    /**
+     * Load properties from a given file name and return a PropertiesConfiguration object.
+     * @param filename
+     * @param setCommaDelimiterHandler
+     * @return
+     * @throws ConfigurationException
+     */
+    public static PropertiesConfiguration loadPropertiesConfig(String filename,
+                                                               boolean setCommaDelimiterHandler) throws ConfigurationException {
+        return loadPropertiesConfig(new Parameters().properties().setFileName(filename), setCommaDelimiterHandler);
     }
 
     /**
@@ -122,13 +134,17 @@ public class ConfigurationUtil {
      * @throws ConfigurationException
      */
     public static PropertiesConfiguration loadPropertiesConfig(File file) throws ConfigurationException {
-        return loadPropertiesConfig(new Parameters().properties().setFile(file));
+        return loadPropertiesConfig(new Parameters().properties().setFile(file), true);
     }
 
-    private static PropertiesConfiguration loadPropertiesConfig(PropertiesBuilderParameters params) throws ConfigurationException {
+    private static PropertiesConfiguration loadPropertiesConfig(PropertiesBuilderParameters params,
+                                                                boolean setCommaDelimiterHandler) throws ConfigurationException {
         FileBasedConfigurationBuilder<PropertiesConfiguration> builder =
-            new FileBasedConfigurationBuilder<PropertiesConfiguration>(PropertiesConfiguration.class)
-                .configure(params.setListDelimiterHandler(COMMA_DELIMITER_HANDLER));
-        return builder.getConfiguration();
+            new FileBasedConfigurationBuilder<PropertiesConfiguration>(PropertiesConfiguration.class);
+        PropertiesBuilderParameters newParams = params;
+        if (setCommaDelimiterHandler) {
+            newParams = newParams.setListDelimiterHandler(COMMA_DELIMITER_HANDLER);
+        }
+        return builder.configure(newParams).getConfiguration();
     }
 }

--- a/janusgraph-cql/src/test/resources/cql-read-multi-hosts.properties
+++ b/janusgraph-cql/src/test/resources/cql-read-multi-hosts.properties
@@ -1,0 +1,38 @@
+# Copyright 2019 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+gremlin.graph=org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph
+gremlin.hadoop.graphReader=org.janusgraph.hadoop.formats.cql.CqlInputFormat
+gremlin.hadoop.graphWriter=org.apache.hadoop.mapreduce.lib.output.NullOutputFormat
+gremlin.hadoop.jarsInDistributedCache=true
+gremlin.hadoop.inputLocation=none
+gremlin.hadoop.outputLocation=target/output
+
+janusgraphmr.ioformat.conf.storage.backend=cql
+janusgraphmr.ioformat.conf.storage.cql.keyspace=cqlinputformatit
+# this file is almost the same as cql-read.properties, except the line below, which has multiple hosts separated by comma
+janusgraphmr.ioformat.conf.storage.hostname=invalid-host,localhost
+janusgraphmr.ioformat.conf.storage.port=9042
+
+cassandra.input.partitioner.class=org.apache.cassandra.dht.Murmur3Partitioner
+cassandra.input.widerows=true
+
+####################################
+# SparkGraphComputer Configuration #
+####################################
+spark.master=local[4]
+spark.driver.host=127.0.0.1
+spark.executor.memory=1g
+spark.serializer=org.apache.spark.serializer.KryoSerializer
+spark.kryo.registrator=org.janusgraph.hadoop.serialize.JanusGraphKryoRegistrator

--- a/janusgraph-hbase/src/test/java/org/janusgraph/hadoop/HBaseInputFormatIT.java
+++ b/janusgraph-hbase/src/test/java/org/janusgraph/hadoop/HBaseInputFormatIT.java
@@ -35,7 +35,7 @@ public class HBaseInputFormatIT extends AbstractInputFormatIT {
     public static final HBaseContainer hBaseContainer = new HBaseContainer();
 
     protected Graph getGraph() throws IOException, ConfigurationException {
-        final PropertiesConfiguration config = ConfigurationUtil.loadPropertiesConfig("target/test-classes/hbase-read.properties");
+        final PropertiesConfiguration config = ConfigurationUtil.loadPropertiesConfig("target/test-classes/hbase-read.properties", false);
         Path baseOutDir = Paths.get((String) config.getProperty("gremlin.hadoop.outputLocation"));
         baseOutDir.toFile().mkdirs();
         String outDir = Files.createTempDirectory(baseOutDir, null).toAbsolutePath().toString();

--- a/janusgraph-hbase/src/test/java/org/janusgraph/hadoop/HBaseSnapshotInputFormatIT.java
+++ b/janusgraph-hbase/src/test/java/org/janusgraph/hadoop/HBaseSnapshotInputFormatIT.java
@@ -264,7 +264,7 @@ public class HBaseSnapshotInputFormatIT extends AbstractInputFormatIT {
     }
 
     protected Graph getGraph() throws IOException, ConfigurationException {
-        final PropertiesConfiguration config = ConfigurationUtil.loadPropertiesConfig("target/test-classes/hbase-read-snapshot.properties");
+        final PropertiesConfiguration config = ConfigurationUtil.loadPropertiesConfig("target/test-classes/hbase-read-snapshot.properties", false);
         Path baseOutDir = Paths.get((String) config.getProperty("gremlin.hadoop.outputLocation"));
         baseOutDir.toFile().mkdirs();
         String outDir = Files.createTempDirectory(baseOutDir, null).toAbsolutePath().toString();


### PR DESCRIPTION
This adds test cases to demonstrate that comma-delimited values can
be loaded by HadoopGraph in Spark usecase.

Prior to TinkerPop 3.5.0 upgrade, if config file has
`gremlin.graph=org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph`,
which is typically the case for MapReduce/Spark traversals,
then `GraphFactory.open(filename)` would first read all comma delimited values
into a list, and then only retain the last value. A workaround is to
create a `PropertiesConfiguration` config object, disable comma delimiter, and
then call `GraphFactory.open(config)`.

This is auto-resolved by #2619 because since TinkerPop 3.5.0, comma-delimited
values are by default loaded as they are. This commit adds some test cases
to demonstrate this behaviour. The same tests fail without #2619.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
