### PR TITLE
Break vertices selection loop for properties prefetching when cache size is reached

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/step/JanusGraphVertexStep.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/step/JanusGraphVertexStep.java
@@ -194,13 +194,14 @@ public class JanusGraphVertexStep<E extends Element> extends VertexStep<E> imple
             result = (Vertex.class.isAssignableFrom(getReturnClass())) ? query.vertices() : query.edges();
         }
 
-        if (batchPropertyPrefetching) {
+        if (batchPropertyPrefetching && txVertexCacheSize > 1) {
             Set<Vertex> vertices = new HashSet<>();
-            result.forEach(v -> {
-                if (vertices.size() < txVertexCacheSize ) {
-                    vertices.add((Vertex) v);
+            for(JanusGraphElement v : result){
+                vertices.add((Vertex) v);
+                if (vertices.size() >= txVertexCacheSize) {
+                    break;
                 }
-            });
+            }
 
             // If there are multiple vertices then fetch the properties for all of them in a single multiQuery to
             // populate the vertex cache so subsequent queries of properties don't have to go to the storage back end


### PR DESCRIPTION
Break vertices selection loop for properties prefetching when cache size is reached

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
