### PR TITLE
Use all hosts available in CqlBinaryInputFormat config

### DIFF
--- a/janusgraph-cql/src/main/java/org/janusgraph/hadoop/formats/cql/CqlBinaryInputFormat.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/hadoop/formats/cql/CqlBinaryInputFormat.java
@@ -64,7 +64,7 @@ public class CqlBinaryInputFormat extends AbstractBinaryInputFormat {
         super.setConf(config);
 
         // Copy some JanusGraph configuration keys to the Hadoop Configuration keys used by Cassandra's ColumnFamilyInputFormat
-        ConfigHelper.setInputInitialAddress(config, janusgraphConf.get(GraphDatabaseConfiguration.STORAGE_HOSTS)[0]);
+        ConfigHelper.setInputInitialAddress(config, String.join(",", janusgraphConf.get(GraphDatabaseConfiguration.STORAGE_HOSTS)));
         if (janusgraphConf.has(GraphDatabaseConfiguration.STORAGE_PORT))
             CqlConfigHelper.setInputNativePort(config, String.valueOf(janusgraphConf.get(GraphDatabaseConfiguration.STORAGE_PORT)));
         if (janusgraphConf.has(GraphDatabaseConfiguration.AUTH_USERNAME) && janusgraphConf.has(GraphDatabaseConfiguration.AUTH_PASSWORD)) {


### PR DESCRIPTION
When setting up connections to Cassandra cluster for OLAP traversal,
it is recommended to provide all contact points, such that even if
some of them are unavailable at that time, the connections can still
be established.

This has been running for some time in our production cluster. So far, so good.
I also verified that even if one Cassandra node is not available when submitting
the MapReduce job, everything still works smoothly.

This is a follow-up of https://github.com/JanusGraph/janusgraph/pull/1436#discussion_r629018494

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
