### PR TITLE
MapReduceIndexManagement: Accept optional custom hadoop config

### DIFF
--- a/janusgraph-hadoop/src/main/java/org/janusgraph/hadoop/MapReduceIndexManagement.java
+++ b/janusgraph-hadoop/src/main/java/org/janusgraph/hadoop/MapReduceIndexManagement.java
@@ -17,6 +17,7 @@ package org.janusgraph.hadoop;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -67,17 +68,22 @@ public class MapReduceIndexManagement {
         this.graph = (StandardJanusGraph)g;
     }
 
+    public JanusGraphManagement.IndexJobFuture updateIndex(Index index, SchemaAction updateAction) throws BackendException {
+        return updateIndex(index, updateAction, new Configuration());
+    }
+
     /**
      * Updates the provided index according to the given {@link SchemaAction}.
      * Only {@link SchemaAction#REINDEX} and {@link SchemaAction#REMOVE_INDEX} are supported.
      *
      * @param index the index to process
      * @param updateAction either {@code REINDEX} or {@code REMOVE_INDEX}
+     * @param hadoopConf
      * @return a future that returns immediately;
      *         this method blocks until the Hadoop MapReduce job completes
      */
     // TODO make this future actually async and update javadoc @return accordingly
-    public JanusGraphManagement.IndexJobFuture updateIndex(Index index, SchemaAction updateAction)
+    public JanusGraphManagement.IndexJobFuture updateIndex(Index index, SchemaAction updateAction, Configuration hadoopConf)
             throws BackendException {
 
         Preconditions.checkNotNull(index, "Index parameter must not be null", index);
@@ -91,7 +97,6 @@ public class MapReduceIndexManagement {
                 "Index %s has class %s: must be a %s or %s (or subtype)",
                 index.getClass(), RelationTypeIndex.class.getSimpleName(), JanusGraphIndex.class.getSimpleName());
 
-        org.apache.hadoop.conf.Configuration hadoopConf = new org.apache.hadoop.conf.Configuration();
         ModifiableHadoopConfiguration janusGraphMapReduceConfiguration =
                 ModifiableHadoopConfiguration.of(JanusGraphHadoopConfiguration.MAPRED_NS, hadoopConf);
 

--- a/janusgraph-hadoop/src/test/java/org/janusgraph/hadoop/MapReduceRemoveIndexApp.java
+++ b/janusgraph-hadoop/src/test/java/org/janusgraph/hadoop/MapReduceRemoveIndexApp.java
@@ -1,0 +1,50 @@
+// Copyright 2021 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.hadoop;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.util.Tool;
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.core.schema.SchemaAction;
+import org.janusgraph.diskstorage.keycolumnvalue.scan.ScanMetrics;
+
+/**
+ * This class demonstrates how Apache ToolRunner can be used to launch a MapReduce job for index management.
+ */
+public class MapReduceRemoveIndexApp extends Configured implements Tool {
+    private JanusGraph graph;
+    private String indexName;
+    private ScanMetrics metrics;
+
+    public MapReduceRemoveIndexApp(JanusGraph graph, String indexName) {
+       this.graph = graph;
+       this.indexName = indexName;
+    }
+
+    @Override
+    public int run(String[] args) throws Exception {
+        Configuration hadoopConf = getConf();
+        MapReduceIndexManagement mr = new MapReduceIndexManagement(graph);
+        JanusGraphManagement mgmt = graph.openManagement();
+        metrics = mr.updateIndex(mgmt.getGraphIndex(indexName), SchemaAction.REMOVE_INDEX, hadoopConf).get();
+        return 0;
+    }
+
+    public ScanMetrics getMetrics() {
+        return this.metrics;
+    }
+}


### PR DESCRIPTION
Related to https://lists.lfaidata.foundation/g/janusgraph-users/topic/82821364

We used this to leverage Hadoop ToolRunner that can submit local files together with the MapReduce job, which will be available to all mappers on their working directories. The files are then used by mappers for authentication. So far, so good.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
