### PR TITLE
Optimize getHasContainers usage

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/step/JanusGraphStep.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/step/JanusGraphStep.java
@@ -282,12 +282,17 @@ public class JanusGraphStep<S, E extends Element> extends GraphStep<S, E> implem
     }
 
     private <A extends Element> Iterator<A> iteratorList(final Iterator<A> iterator) {
-        final List<A> list = new ArrayList<>();
-        while (iterator.hasNext()) {
-            final A e = iterator.next();
-            if (HasContainer.testAll(e, this.getHasContainers()))
-                list.add(e);
+        if(!iterator.hasNext()){
+            return Collections.emptyIterator();
         }
+        List<HasContainer> hasContainers = getHasContainers();
+        final List<A> list = new ArrayList<>(hasContainers.size());
+        do {
+            final A e = iterator.next();
+            if (HasContainer.testAll(e, hasContainers)){
+                list.add(e);
+            }
+        } while (iterator.hasNext());
         return list.iterator();
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/strategy/AdjacentVertexFilterOptimizerStrategy.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/strategy/AdjacentVertexFilterOptimizerStrategy.java
@@ -110,13 +110,14 @@ public class AdjacentVertexFilterOptimizerStrategy
             return OptimizableQueryType.IS;
         } else if (steps.get(1) instanceof HasStep) {
             // Check if this filter traversal matches the pattern: _.inV/outV/otherV.hasId(x)
-            HasStep hasStep = (HasStep) steps.get(1);
-            if (hasStep.getHasContainers().size() != 1) {
+            HasStep<?> hasStep = (HasStep<?>) steps.get(1);
+            List<HasContainer> hasContainers = hasStep.getHasContainers();
+            if (hasContainers.size() != 1) {
                 // TODO does it make sense to allow steps with > 1 containers here?
                 return OptimizableQueryType.NONE;
             }
 
-            HasContainer has = (HasContainer) hasStep.getHasContainers().get(0);
+            HasContainer has = hasContainers.get(0);
             if (has.getKey().equals(T.id.getAccessor())) {
                 return OptimizableQueryType.HASID;
             } else {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/strategy/AdjacentVertexHasIdOptimizerStrategy.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/strategy/AdjacentVertexHasIdOptimizerStrategy.java
@@ -57,7 +57,7 @@ public class AdjacentVertexHasIdOptimizerStrategy
             return null; // TODO does it make sense to allow steps with >1 containers here?
         }
 
-        HasContainer hc = hasStep.getHasContainers().get(0);
+        HasContainer hc = hasContainers.get(0);
         if (hc.getKey().equals(T.id.getAccessor())) {
             return hc.getPredicate();
         } else {


### PR DESCRIPTION
Calls to `getHasContainers` of `JanusGraphStep` create new `ArrayList` and also spends time to populate that list. So, this commit tries to reduce calls to this method when not needed (i.e. reuse already computed values). Also, this PR reduces unnecessary creation of some collections (no need to create lists when they are used only once as Iterable. It would make sense to create lists if they are used more than once).

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
