### PR TITLE
Do not trigger iteration on small cache in JanusGraphEdgeVertexStep initialization

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.TextP;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
@@ -122,6 +123,8 @@ import org.janusgraph.graphdb.schema.SchemaContainer;
 import org.janusgraph.graphdb.schema.VertexLabelDefinition;
 import org.janusgraph.graphdb.serializer.SpecialInt;
 import org.janusgraph.graphdb.serializer.SpecialIntSerializer;
+import org.janusgraph.graphdb.tinkerpop.optimize.step.JanusGraphEdgeVertexStep;
+import org.janusgraph.graphdb.tinkerpop.optimize.step.JanusGraphVertexStep;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.janusgraph.graphdb.types.StandardEdgeLabelMaker;
 import org.janusgraph.graphdb.types.StandardPropertyKeyMaker;
@@ -204,9 +207,12 @@ import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.VE
 import static org.janusgraph.graphdb.internal.RelationCategory.EDGE;
 import static org.janusgraph.graphdb.internal.RelationCategory.PROPERTY;
 import static org.janusgraph.graphdb.internal.RelationCategory.RELATION;
+import static org.janusgraph.testutil.JanusGraphAssert.assertContains;
 import static org.janusgraph.testutil.JanusGraphAssert.assertCount;
 import static org.janusgraph.testutil.JanusGraphAssert.assertEmpty;
+import static org.janusgraph.testutil.JanusGraphAssert.assertNotContains;
 import static org.janusgraph.testutil.JanusGraphAssert.assertNotEmpty;
+import static org.janusgraph.testutil.JanusGraphAssert.getStepMetrics;
 import static org.janusgraph.testutil.JanusGraphAssert.queryProfilerAnnotationIsPresent;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -4720,12 +4726,64 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         GraphTraversalSource gts = graph.traversal();
 
         TraversalMetrics traversalMetrics = gts.V().has("id", 0).out("knows").has("id", P.within(4,5,6,7)).values("id").profile().next();
-        String traversalMetricsStr = traversalMetrics.toString();
+
+        Metrics janusGraphVertexStepMetrics = getStepMetrics(traversalMetrics, JanusGraphVertexStep.class);
+        assertNotNull(janusGraphVertexStepMetrics);
         if(expectedVerticesPrefetch>1 && !inmemoryBackend){
-            assertTrue(traversalMetricsStr.contains("multiPreFetch=true"));
-            assertTrue(traversalMetricsStr.contains("vertices="+expectedVerticesPrefetch));
+            assertContains(janusGraphVertexStepMetrics, "multiPreFetch", "true");
+            assertContains(janusGraphVertexStepMetrics, "vertices", expectedVerticesPrefetch);
         } else {
-            assertFalse(traversalMetricsStr.contains("multiPreFetch=true"));
+            assertNotContains(janusGraphVertexStepMetrics, "multiPreFetch", "true");
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 3, 10, 15, Integer.MAX_VALUE})
+    public void testBatchPropertiesPrefetchingFromEdges(int txCacheSize){
+        boolean inmemoryBackend = getConfig().get(STORAGE_BACKEND).equals("inmemory");
+        int numV = 10;
+        int expectedVerticesPrefetch = Math.min(txCacheSize, 4);
+        JanusGraphVertex mainVertex = graph.addVertex("id", 0);
+        for (int i = 1; i <= numV; i++) {
+            JanusGraphVertex adjacentVertex = graph.addVertex("id", i);
+            mainVertex.addEdge("knows", adjacentVertex, "id", i);
+        }
+        graph.tx().commit();
+
+        if(!inmemoryBackend){
+            clopen(option(BATCH_PROPERTY_PREFETCHING), true, option(TX_CACHE_SIZE), txCacheSize);
+        }
+        GraphTraversalSource gts = graph.traversal();
+
+        for(Direction direction : Direction.values()){
+            GraphTraversal<Vertex, Edge> graphEdgeTraversal = gts.V().has("id", 0).outE("knows")
+                .has("id", P.within(4,5,6,7));
+            GraphTraversal<Vertex, Vertex> graphVertexTraversal;
+
+            switch (direction){
+                case IN: graphVertexTraversal = graphEdgeTraversal.inV(); break;
+                case OUT: graphVertexTraversal = graphEdgeTraversal.outV(); break;
+                case BOTH: graphVertexTraversal = graphEdgeTraversal.bothV(); break;
+                default: throw new NotImplementedException("No implementation found for direction: "+direction.name());
+            }
+
+            TraversalMetrics traversalMetrics = graphVertexTraversal
+                .has("id", P.within(4,5,6,7)).values("id").profile().next();
+
+            Metrics janusGraphEdgeVertexStepMetrics = getStepMetrics(traversalMetrics, JanusGraphEdgeVertexStep.class);
+            if(inmemoryBackend){
+                assertNull(janusGraphEdgeVertexStepMetrics);
+            } else {
+                assertNotNull(janusGraphEdgeVertexStepMetrics);
+                assertTrue(janusGraphEdgeVertexStepMetrics.getName().endsWith("("+direction.name()+")"));
+                if(expectedVerticesPrefetch>1 && !OUT.equals(direction)){
+                    assertContains(janusGraphEdgeVertexStepMetrics, "multiPreFetch", "true");
+                    boolean withAdditionalOutVertex = BOTH.equals(direction) && txCacheSize > 4; // 4 is the number of retrieved IN vertices
+                    assertContains(janusGraphEdgeVertexStepMetrics, "vertices", expectedVerticesPrefetch + (withAdditionalOutVertex?1:0));
+                } else {
+                    assertNotContains(janusGraphEdgeVertexStepMetrics, "multiPreFetch", "true");
+                }
+            }
         }
     }
 

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/testutil/JanusGraphAssert.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/testutil/JanusGraphAssert.java
@@ -35,6 +35,7 @@ import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -42,6 +43,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -175,5 +177,28 @@ public class JanusGraphAssert {
     public static boolean queryProfilerAnnotationIsPresent(Traversal t, String queryProfilerAnnotation) {
         TraversalMetrics metrics = t.asAdmin().getSideEffects().get("~metrics");
         return metrics.toString().contains(queryProfilerAnnotation + "=true");
+    }
+
+    public static void assertContains(Metrics metrics, String annotationKey, Object annotationValue){
+        Map<String, Object> annotations = metrics.getAnnotations();
+        assertTrue(annotations.containsKey(annotationKey));
+        assertEquals(annotationValue, annotations.get(annotationKey));
+    }
+
+    public static void assertNotContains(Metrics metrics, String annotationKey, Object annotationValue){
+        Map<String, Object> annotations = metrics.getAnnotations();
+        if(annotations.containsKey(annotationKey)){
+            assertNotEquals(annotationValue, annotations.get(annotationKey));
+        }
+    }
+
+    public static Metrics getStepMetrics(TraversalMetrics traversalMetrics, Class<? extends Step> stepClass){
+        String stepMetricsName = stepClass.getSimpleName();
+        for(Metrics metrics : traversalMetrics.getMetrics()){
+            if(metrics.getName().startsWith(stepMetricsName)){
+                return metrics;
+            }
+        }
+        return null;
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/step/JanusGraphEdgeVertexStep.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/step/JanusGraphEdgeVertexStep.java
@@ -58,20 +58,30 @@ public class JanusGraphEdgeVertexStep extends EdgeVertexStep implements Profilin
         if (!starts.hasNext()) {
             throw FastNoSuchElementException.instance();
         }
+
+        if(txVertexCacheSize < 2){
+            return;
+        }
+
         List<Traverser.Admin<Edge>> edges = new ArrayList<>();
         Set<Vertex> vertices = new HashSet<>();
-        starts.forEachRemaining(e -> {
+
+        do{
+            Traverser.Admin<Edge> e = starts.next();
             edges.add(e);
 
-            if (vertices.size() < txVertexCacheSize) {
-                if (Direction.IN.equals(direction) || Direction.BOTH.equals(direction)) {
+            if(vertices.size() < txVertexCacheSize){
+                if(Direction.IN.equals(direction)){
                     vertices.add(e.get().inVertex());
-                }
-                if (Direction.OUT.equals(direction) || Direction.BOTH.equals(direction)) {
+                } else if(Direction.OUT.equals(direction)){
+                    vertices.add(e.get().outVertex());
+                } else if(Direction.BOTH.equals(direction)){
+                    vertices.add(e.get().inVertex());
                     vertices.add(e.get().outVertex());
                 }
             }
-        });
+
+        } while (starts.hasNext());
 
         // If there are multiple vertices then fetch the properties for all of them in a single multiQuery to
         // populate the vertex cache so subsequent queries of properties don't have to go to the storage back end


### PR DESCRIPTION
Very small change which won't trigger unnecessary loop if tx cache is less than 2. Also changed a loop to use vanilla java (very small change as well). Added a test to cover the logic which was not previously covered.

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
