### PR TITLE
Fix NPE when updating mixed index

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphTransaction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphTransaction.java
@@ -125,4 +125,6 @@ public interface JanusGraphTransaction extends Transaction {
      */
     boolean hasModifications();
 
+
+    void expireSchemaElement(final long id);
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphTransaction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphTransaction.java
@@ -125,6 +125,5 @@ public interface JanusGraphTransaction extends Transaction {
      */
     boolean hasModifications();
 
-
     void expireSchemaElement(final long id);
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementLogger.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementLogger.java
@@ -93,6 +93,9 @@ public class ManagementLogger implements MessageReader {
                 for (int i = 0; i < numEvictions; i++) {
                     long typeId = VariableLong.readPositive(in);
                     schemaCache.expireSchemaElement(typeId);
+                    for (JanusGraphTransaction tx : graph.getOpenTransactions()) {
+                        tx.expireSchemaElement(typeId);
+                    }
                 }
                 final GraphCacheEvictionAction action = serializer.readObjectNotNull(in, GraphCacheEvictionAction.class);
                 Preconditions.checkNotNull(action);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
@@ -28,6 +28,7 @@ import org.janusgraph.core.JanusGraph;
 import org.janusgraph.core.JanusGraphEdge;
 import org.janusgraph.core.JanusGraphElement;
 import org.janusgraph.core.JanusGraphException;
+import org.janusgraph.core.JanusGraphTransaction;
 import org.janusgraph.core.JanusGraphVertex;
 import org.janusgraph.core.JanusGraphVertexProperty;
 import org.janusgraph.core.Multiplicity;
@@ -247,6 +248,9 @@ public class ManagementSystem implements JanusGraphManagement {
             managementLogger.sendCacheEviction(updatedTypes, evictGraphFromCache, updatedTypeTriggers, getOpenInstancesInternal());
             for (JanusGraphSchemaVertex schemaVertex : updatedTypes) {
                 schemaCache.expireSchemaElement(schemaVertex.longId());
+                for (JanusGraphTransaction tx : graph.getOpenTransactions()) {
+                    tx.expireSchemaElement(schemaVertex.longId());
+                }
             }
         }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -1576,4 +1576,11 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
         return !addedRelations.isEmpty() || !deletedRelations.isEmpty();
     }
 
+    @Override
+    public void expireSchemaElement(final long id) {
+        final InternalVertex v = vertexCache.get(id, externalVertexRetriever);
+        if (v instanceof JanusGraphSchemaVertex) {
+            ((JanusGraphSchemaVertex) v).resetCache();
+        }
+    }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -1578,9 +1578,11 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
 
     @Override
     public void expireSchemaElement(final long id) {
-        final InternalVertex v = vertexCache.get(id, externalVertexRetriever);
-        if (v instanceof JanusGraphSchemaVertex) {
-            ((JanusGraphSchemaVertex) v).resetCache();
+        if (vertexCache.contains(id)) {
+            final InternalVertex v = vertexCache.get(id, externalVertexRetriever);
+            if (v instanceof JanusGraphSchemaVertex) {
+                ((JanusGraphSchemaVertex) v).resetCache();
+            }
         }
     }
 }


### PR DESCRIPTION
Fix NPE when updating mixed index by ensuring the cache is not stale.  Fixes #1876.


