### PR TITLE
Refactor JanusGraphSchemaVertex to return List instead of Iterable

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/SchemaSource.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/SchemaSource.java
@@ -18,6 +18,8 @@ import com.google.common.base.Preconditions;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.janusgraph.core.schema.SchemaStatus;
 
+import java.util.List;
+
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
  */
@@ -31,7 +33,7 @@ public interface SchemaSource {
 
     TypeDefinitionMap getDefinition();
 
-    Iterable<Entry> getRelated(TypeDefinitionCategory def, Direction dir);
+    List<Entry> getRelated(TypeDefinitionCategory def, Direction dir);
 
     /**
      * Resets the internal caches used to speed up lookups on this schema source.

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/VertexLabelVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/VertexLabelVertex.java
@@ -21,16 +21,16 @@ import org.janusgraph.core.VertexLabel;
 import org.janusgraph.graphdb.internal.InternalVertexLabel;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.janusgraph.graphdb.types.vertices.JanusGraphSchemaVertex;
+import org.janusgraph.graphdb.util.CollectionsUtil;
 
 import java.util.Collection;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
  */
 public class VertexLabelVertex extends JanusGraphSchemaVertex implements InternalVertexLabel {
 
+    private Integer ttl = null;
 
     public VertexLabelVertex(StandardJanusGraphTx tx, long id, byte lifecycle) {
         super(tx, id, lifecycle);
@@ -48,24 +48,24 @@ public class VertexLabelVertex extends JanusGraphSchemaVertex implements Interna
 
     @Override
     public Collection<PropertyKey> mappedProperties() {
-        return StreamSupport.stream( getRelated(TypeDefinitionCategory.PROPERTY_KEY_EDGE, Direction.OUT).spliterator(), false)
-            .map(entry -> (PropertyKey) entry.getSchemaType())
-            .collect(Collectors.toList());
+        return CollectionsUtil.toArrayList(
+            getRelated(TypeDefinitionCategory.PROPERTY_KEY_EDGE, Direction.OUT),
+            entry -> (PropertyKey) entry.getSchemaType()
+        );
     }
 
     @Override
     public Collection<Connection> mappedConnections() {
-        return StreamSupport.stream(getRelated(TypeDefinitionCategory.CONNECTION_EDGE, Direction.OUT).spliterator(), false)
-            .map(entry -> new Connection((String) entry.getModifier(), this, (VertexLabel) entry.getSchemaType()))
-            .collect(Collectors.toList());
+        return CollectionsUtil.toArrayList(
+            getRelated(TypeDefinitionCategory.CONNECTION_EDGE, Direction.OUT),
+            entry -> new Connection((String) entry.getModifier(), this, (VertexLabel) entry.getSchemaType())
+        );
     }
 
     @Override
     public boolean hasDefaultConfiguration() {
         return !isPartitioned() && !isStatic();
     }
-
-    private Integer ttl = null;
 
     @Override
     public int getTTL() {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/indextype/CompositeIndexTypeWrapper.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/indextype/CompositeIndexTypeWrapper.java
@@ -15,7 +15,6 @@
 package org.janusgraph.graphdb.types.indextype;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterables;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.janusgraph.core.Cardinality;
 import org.janusgraph.core.PropertyKey;
@@ -29,10 +28,14 @@ import org.janusgraph.graphdb.types.SchemaSource;
 import org.janusgraph.graphdb.types.TypeDefinitionCategory;
 import org.janusgraph.graphdb.types.TypeUtil;
 
+import java.util.List;
+
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
  */
 public class CompositeIndexTypeWrapper extends IndexTypeWrapper implements CompositeIndexType {
+
+    private IndexField[] fields = null;
 
     public CompositeIndexTypeWrapper(SchemaSource base) {
         super(base);
@@ -58,14 +61,12 @@ public class CompositeIndexTypeWrapper extends IndexTypeWrapper implements Compo
         return base.getStatus();
     }
 
-    IndexField[] fields = null;
-
     @Override
     public IndexField[] getFieldKeys() {
         IndexField[] result = fields;
         if (result==null) {
-            Iterable<SchemaSource.Entry> entries = base.getRelated(TypeDefinitionCategory.INDEX_FIELD,Direction.OUT);
-            int numFields = Iterables.size(entries);
+            List<SchemaSource.Entry> entries = base.getRelated(TypeDefinitionCategory.INDEX_FIELD,Direction.OUT);
+            int numFields = entries.size();
             result = new IndexField[numFields];
             for (SchemaSource.Entry entry : entries) {
                 Integer value = ParameterType.INDEX_POSITION.findParameter((Parameter[]) entry.getModifier(),null);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/indextype/MixedIndexTypeWrapper.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/indextype/MixedIndexTypeWrapper.java
@@ -14,7 +14,6 @@
 
 package org.janusgraph.graphdb.types.indextype;
 
-import com.google.common.collect.Iterables;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.janusgraph.core.PropertyKey;
 import org.janusgraph.core.schema.Parameter;
@@ -23,12 +22,15 @@ import org.janusgraph.graphdb.types.ParameterIndexField;
 import org.janusgraph.graphdb.types.SchemaSource;
 import org.janusgraph.graphdb.types.TypeDefinitionCategory;
 
+import java.util.List;
+
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
  */
 public class MixedIndexTypeWrapper extends IndexTypeWrapper implements MixedIndexType {
 
     public static final String NAME_PREFIX = "extindex";
+    private ParameterIndexField[] fields = null;
 
     public MixedIndexTypeWrapper(SchemaSource base) {
         super(base);
@@ -44,14 +46,12 @@ public class MixedIndexTypeWrapper extends IndexTypeWrapper implements MixedInde
         return true;
     }
 
-    ParameterIndexField[] fields = null;
-
     @Override
     public ParameterIndexField[] getFieldKeys() {
         ParameterIndexField[] result = fields;
         if (result==null) {
-            Iterable<SchemaSource.Entry> entries = base.getRelated(TypeDefinitionCategory.INDEX_FIELD,Direction.OUT);
-            int numFields = Iterables.size(entries);
+            List<SchemaSource.Entry> entries = base.getRelated(TypeDefinitionCategory.INDEX_FIELD,Direction.OUT);
+            int numFields = entries.size();
             result = new ParameterIndexField[numFields];
             int pos = 0;
             for (SchemaSource.Entry entry : entries) {
@@ -80,6 +80,5 @@ public class MixedIndexTypeWrapper extends IndexTypeWrapper implements MixedInde
     public String getStoreName() {
         return base.getDefinition().getValue(TypeDefinitionCategory.INDEXSTORE_NAME,String.class);
     }
-
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/vertices/EdgeLabelVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/vertices/EdgeLabelVertex.java
@@ -20,6 +20,7 @@ import org.janusgraph.core.EdgeLabel;
 import org.janusgraph.core.PropertyKey;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.janusgraph.graphdb.types.TypeDefinitionCategory;
+import org.janusgraph.graphdb.util.CollectionsUtil;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -44,15 +45,16 @@ public class EdgeLabelVertex extends RelationTypeVertex implements EdgeLabel {
 
     @Override
     public Collection<PropertyKey> mappedProperties() {
-        return StreamSupport.stream(getRelated(TypeDefinitionCategory.PROPERTY_KEY_EDGE, Direction.OUT).spliterator(), false)
-            .map(entry -> (PropertyKey) entry.getSchemaType())
-            .collect(Collectors.toList());
+        return CollectionsUtil.toArrayList(
+            getRelated(TypeDefinitionCategory.PROPERTY_KEY_EDGE, Direction.OUT),
+            entry -> (PropertyKey) entry.getSchemaType()
+        );
     }
 
     @Override
     public Collection<Connection> mappedConnections() {
         String name = name();
-        return StreamSupport.stream(getRelated(TypeDefinitionCategory.UPDATE_CONNECTION_EDGE, Direction.OUT).spliterator(), false)
+        return getRelated(TypeDefinitionCategory.UPDATE_CONNECTION_EDGE, Direction.OUT).stream()
             .map(entry -> (JanusGraphSchemaVertex) entry.getSchemaType())
             .flatMap(s -> StreamSupport.stream(s.getEdges(TypeDefinitionCategory.CONNECTION_EDGE, Direction.OUT).spliterator(), false))
             .map(Connection::new)

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/vertices/RelationTypeVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/vertices/RelationTypeVertex.java
@@ -22,20 +22,22 @@ import org.janusgraph.graphdb.internal.InternalRelationType;
 import org.janusgraph.graphdb.internal.Order;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.janusgraph.graphdb.types.IndexType;
-import org.janusgraph.graphdb.types.SchemaSource;
 import org.janusgraph.graphdb.types.TypeDefinitionCategory;
 import org.janusgraph.graphdb.types.TypeUtil;
+import org.janusgraph.graphdb.util.CollectionsUtil;
 
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
  */
 public abstract class RelationTypeVertex extends JanusGraphSchemaVertex implements InternalRelationType {
+
+    private ConsistencyModifier consistency = null;
+    private Integer ttl = null;
+    private List<IndexType> indexes = null;
 
     public RelationTypeVertex(StandardJanusGraphTx tx, long id, byte lifecycle) {
         super(tx, id, lifecycle);
@@ -66,16 +68,13 @@ public abstract class RelationTypeVertex extends JanusGraphSchemaVertex implemen
         return getDefinition().getValue(TypeDefinitionCategory.MULTIPLICITY, Multiplicity.class);
     }
 
-    private ConsistencyModifier consistency = null;
-
+    @Override
     public ConsistencyModifier getConsistencyModifier() {
         if (consistency==null) {
             consistency = TypeUtil.getConsistencyModifier(this);
         }
         return consistency;
     }
-
-    private Integer ttl = null;
 
     @Override
     public Integer getTTL() {
@@ -85,6 +84,7 @@ public abstract class RelationTypeVertex extends JanusGraphSchemaVertex implemen
         return ttl;
     }
 
+    @Override
     public InternalRelationType getBaseType() {
         Entry entry = Iterables.getOnlyElement(getRelated(TypeDefinitionCategory.RELATIONTYPE_INDEX,Direction.IN),null);
         if (entry==null) return null;
@@ -92,33 +92,34 @@ public abstract class RelationTypeVertex extends JanusGraphSchemaVertex implemen
         return (InternalRelationType)entry.getSchemaType();
     }
 
+    @Override
     public Iterable<InternalRelationType> getRelationIndexes() {
         return Stream.concat(
             Stream.of(this),
-            StreamSupport.stream(getRelated(TypeDefinitionCategory.RELATIONTYPE_INDEX, Direction.OUT).spliterator(), false)
+            getRelated(TypeDefinitionCategory.RELATIONTYPE_INDEX, Direction.OUT).stream()
                 .map(entry -> {
                     assert entry.getSchemaType() instanceof InternalRelationType;
                     return (InternalRelationType) entry.getSchemaType();
                 }))::iterator;
     }
 
-    private List<IndexType> indexes = null;
-
+    @Override
     public Iterable<IndexType> getKeyIndexes() {
         List<IndexType> result = indexes;
         if (result==null) {
-            result = new LinkedList<>();
-            for (Entry entry : getRelated(TypeDefinitionCategory.INDEX_FIELD,Direction.IN)) {
-                SchemaSource index = entry.getSchemaType();
-                result.add(index.asIndexType());
-            }
-            result = Collections.unmodifiableList(result);
+            result = Collections.unmodifiableList(
+                CollectionsUtil.toArrayList(
+                    getRelated(TypeDefinitionCategory.INDEX_FIELD,Direction.IN),
+                    entry -> entry.getSchemaType().asIndexType()
+                )
+            );
             indexes=result;
         }
         assert result!=null;
         return result;
     }
 
+    @Override
     public void resetCache() {
         super.resetCache();
         indexes=null;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/CollectionsUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/CollectionsUtil.java
@@ -1,0 +1,31 @@
+// Copyright 2021 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.function.Function;
+
+public class CollectionsUtil {
+
+    public static <T, R> ArrayList<R> toArrayList(Collection<T> collection, Function<? super T, ? extends R> mapFunction){
+        ArrayList<R> result = new ArrayList<>(collection.size());
+        for(T e : collection){
+            result.add(mapFunction.apply(e));
+        }
+        return result;
+    }
+
+}


### PR DESCRIPTION
getRelated is always computed as List so there is no sense to return Iterable instead of List.
In case the implementation of getRelated is changed to return Iterable then we can change the
dependant logic back to use Iterable instead of List.
Right now using List instead of Iterable allows us to create ArrayList in some places with correct size
instead of LinkedList which generally takes more space.

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
