### PR TITLE
Add an option to set Cassandra's gc_grace_seconds

### DIFF
--- a/docs/configs/janusgraph-cfg.md
+++ b/docs/configs/janusgraph-cfg.md
@@ -383,6 +383,7 @@ CQL storage backend options
 | storage.cql.compression | Whether the storage backend should use compression when storing the data | Boolean | true | FIXED |
 | storage.cql.compression-block-size | The size of the compression blocks in kilobytes | Integer | 64 | FIXED |
 | storage.cql.compression-type | The sstable_compression value JanusGraph uses when creating column families. This accepts any value allowed by Cassandra's sstable_compression option. Leave this unset to disable sstable_compression on JanusGraph-created CFs. | String | LZ4Compressor | MASKABLE |
+| storage.cql.gc-grace-seconds | The number of seconds before tombstones (deletion markers) are eligible for garbage-collection. | Integer | (no default value) | FIXED |
 | storage.cql.heartbeat-interval | The connection heartbeat interval in milliseconds. | Long | (no default value) | MASKABLE |
 | storage.cql.heartbeat-timeout | How long the driver waits for the response (in milliseconds) to a heartbeat. | Long | (no default value) | MASKABLE |
 | storage.cql.keyspace | The name of JanusGraph's keyspace.  It will be created if it does not exist. | String | janusgraph | LOCAL |

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
@@ -141,6 +141,13 @@ public interface CQLConfigOptions {
         ConfigOption.Type.FIXED,
         String.class);
 
+    ConfigOption<Integer> GC_GRACE_SECONDS = new ConfigOption<>(
+        CQL_NS,
+        "gc-grace-seconds",
+        "The number of seconds before tombstones (deletion markers) are eligible for garbage-collection.",
+        ConfigOption.Type.FIXED,
+        Integer.class);
+
     // Compression
     ConfigOption<Boolean> CF_COMPRESSION = new ConfigOption<>(
             CQL_NS,

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStore.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStore.java
@@ -87,6 +87,7 @@ import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CF_COMPRESSION_BLO
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CF_COMPRESSION_TYPE;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.COMPACTION_OPTIONS;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.COMPACTION_STRATEGY;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.GC_GRACE_SECONDS;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.SPECULATIVE_RETRY;
 import static org.janusgraph.diskstorage.cql.CQLTransaction.getTransaction;
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.STORE_META_TIMESTAMPS;
@@ -277,6 +278,7 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
 
         createTable = compactionOptions(createTable, configuration);
         createTable = compressionOptions(createTable, configuration);
+        createTable = gcGraceSeconds(createTable, configuration);
         createTable = speculativeRetryOptions(createTable, configuration);
 
         session.execute(createTable.build());
@@ -315,6 +317,14 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
         }
 
         return createTable.withCompaction(compactionStrategy);
+    }
+
+    private static CreateTableWithOptions gcGraceSeconds(final CreateTableWithOptions createTable,
+                                                         final Configuration configuration) {
+        if (!configuration.has(GC_GRACE_SECONDS)) {
+            return createTable;
+        }
+        return createTable.withGcGraceSeconds(configuration.get(GC_GRACE_SECONDS));
     }
 
     private static CreateTableWithOptions speculativeRetryOptions(final CreateTableWithOptions createTable,

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
@@ -399,6 +399,13 @@ public class CQLStoreManager extends DistributedStoreManager implements KeyColum
     }
 
     @VisibleForTesting
+    Integer getGcGraceSeconds(final String name) throws BackendException {
+        TableMetadata tableMetadata = getTableMetadata(name);
+        Object gcGraceSeconds = tableMetadata.getOptions().get(CqlIdentifier.fromCql("gc_grace_seconds"));
+        return (Integer) gcGraceSeconds;
+    }
+
+    @VisibleForTesting
     String getSpeculativeRetry(final String name) throws BackendException {
         TableMetadata tableMetadata = getTableMetadata(name);
         Object res = tableMetadata.getOptions().get(CqlIdentifier.fromCql("speculative_retry"));

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLStoreTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLStoreTest.java
@@ -52,6 +52,7 @@ import java.util.stream.Stream;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CF_COMPRESSION;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CF_COMPRESSION_BLOCK_SIZE;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CF_COMPRESSION_TYPE;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.GC_GRACE_SECONDS;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.SPECULATIVE_RETRY;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.USE_EXTERNAL_LOCKING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -177,6 +178,19 @@ public class CQLStoreTest extends KeyColumnValueStoreTest {
             opts.remove("enabled");
         }
         assertEquals(Collections.emptyMap(), opts);
+    }
+
+    @Test
+    public void testSetGcGraceSeconds() throws BackendException {
+        final String cf = TEST_CF_NAME + "_set_gc_grace_seconds";
+        final int oneDayInSeconds = 86400;
+
+        final ModifiableConfiguration config = getBaseStorageConfiguration();
+        config.set(GC_GRACE_SECONDS, oneDayInSeconds);
+
+        final CQLStoreManager cqlStoreManager = openStorageManager(config);
+        cqlStoreManager.openDatabase(cf);
+        assertEquals(oneDayInSeconds, cqlStoreManager.getGcGraceSeconds(cf));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
For applications doing a lot of deletes, C* will produce many tombstones, preventing large queries (e.g. reads from M/R or Spark) from succeeding. Adding an option to set `gc_grace_seconds` would allow users to tailor JanusGraph to their workload.

Customizing `gc_grace_seconds` is mentioned a few times on the ML [[1](https://lists.lfaidata.foundation/g/janusgraph-users/topic/79936500#3196),[2](https://lists.lfaidata.foundation/g/janusgraph-users/topic/79936784#3956)] or in IBM [documentation](https://www.ibm.com/docs/en/nasm/1.1.6?topic=performance-changing-gc-grace-seconds-icp) showing this feature might be helpful.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered?
