### PR TITLE
Abort transaction if mixed index schema gets updated concurrently

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphTransaction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphTransaction.java
@@ -124,6 +124,4 @@ public interface JanusGraphTransaction extends Transaction {
      * @return true, if the transaction contains updates, else false.
      */
     boolean hasModifications();
-
-    void expireSchemaElement(final long id);
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/core/SchemaViolationException.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/SchemaViolationException.java
@@ -15,7 +15,8 @@
 package org.janusgraph.core;
 
 /**
- * JanusGraph represents element identifiers as longs, but not all numbers
+ * Thrown to indicate that schema is violated.
+ * For example, JanusGraph represents element identifiers as longs, but not all numbers
  * in the representable space of longs are valid.  This exception can
  * be thrown when an invalid long ID is encountered.
  */

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
@@ -31,6 +31,7 @@ import org.janusgraph.core.JanusGraphRelation;
 import org.janusgraph.core.JanusGraphVertex;
 import org.janusgraph.core.JanusGraphVertexProperty;
 import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.SchemaViolationException;
 import org.janusgraph.core.attribute.Geoshape;
 import org.janusgraph.core.schema.Parameter;
 import org.janusgraph.core.schema.SchemaStatus;
@@ -380,7 +381,11 @@ public class IndexSerializer {
                         updates.add(update);
                     }
                 } else { //Update mixed indexes
-                    if (((MixedIndexType)index).getField(p.propertyKey()).getStatus()== SchemaStatus.DISABLED) continue;
+                    ParameterIndexField field = ((MixedIndexType)index).getField(p.propertyKey());
+                    if (field == null) {
+                        throw new SchemaViolationException(p.propertyKey() + " is not available in mixed index " + index);
+                    }
+                    if (field.getStatus() == SchemaStatus.DISABLED) continue;
                     final IndexUpdate update = getMixedIndexUpdate(vertex, p.propertyKey(), p.value(), (MixedIndexType) index, updateType);
                     final int ttl = getIndexTTL(vertex,p.propertyKey());
                     if (ttl>0 && updateType== IndexUpdate.Type.ADD) update.setTTL(ttl);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementLogger.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementLogger.java
@@ -93,9 +93,6 @@ public class ManagementLogger implements MessageReader {
                 for (int i = 0; i < numEvictions; i++) {
                     long typeId = VariableLong.readPositive(in);
                     schemaCache.expireSchemaElement(typeId);
-                    for (JanusGraphTransaction tx : graph.getOpenTransactions()) {
-                        tx.expireSchemaElement(typeId);
-                    }
                 }
                 final GraphCacheEvictionAction action = serializer.readObjectNotNull(in, GraphCacheEvictionAction.class);
                 Preconditions.checkNotNull(action);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
@@ -28,7 +28,6 @@ import org.janusgraph.core.JanusGraph;
 import org.janusgraph.core.JanusGraphEdge;
 import org.janusgraph.core.JanusGraphElement;
 import org.janusgraph.core.JanusGraphException;
-import org.janusgraph.core.JanusGraphTransaction;
 import org.janusgraph.core.JanusGraphVertex;
 import org.janusgraph.core.JanusGraphVertexProperty;
 import org.janusgraph.core.Multiplicity;
@@ -248,9 +247,6 @@ public class ManagementSystem implements JanusGraphManagement {
             managementLogger.sendCacheEviction(updatedTypes, evictGraphFromCache, updatedTypeTriggers, getOpenInstancesInternal());
             for (JanusGraphSchemaVertex schemaVertex : updatedTypes) {
                 schemaCache.expireSchemaElement(schemaVertex.longId());
-                for (JanusGraphTransaction tx : graph.getOpenTransactions()) {
-                    tx.expireSchemaElement(schemaVertex.longId());
-                }
             }
         }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -1582,14 +1582,4 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
     public boolean hasModifications() {
         return !addedRelations.isEmpty() || !deletedRelations.isEmpty();
     }
-
-    @Override
-    public void expireSchemaElement(final long id) {
-        if (vertexCache.contains(id)) {
-            final InternalVertex v = vertexCache.get(id, externalVertexRetriever);
-            if (v instanceof JanusGraphSchemaVertex) {
-                ((JanusGraphSchemaVertex) v).resetCache();
-            }
-        }
-    }
 }


### PR DESCRIPTION
An update to the mixed index would cause open transactions to fail and throw
NullPointerException if they happen to touch the same index. #2688 fixes this
by making schema changes transparent to all transactions. The fix is, however,
incomplete in the sense that transaction now still fails but fails silently.

Generally, there are two solutions:

1) Do not attempt to fix this issue, but provide a better error message.
2) Continue the fix in #2688 and make sure schema caches are cleared.

This commit reverts #2688 and provides a better error message when aborting
the transaction. Note that even if we choose 2) later, this commit still
remains valuable, because schema updates are propagated asynchronously
among JanusGraph instances.

This commit does not judge whether we should do 2) or not. It reverts #2688
simply because the fix is incomplete and can possibly cause more trouble than it
attempts to fix.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
