### PR TITLE
Properly invalidate stale cached index data

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/diskstorage/indexing/IndexProviderTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/diskstorage/indexing/IndexProviderTest.java
@@ -109,6 +109,11 @@ public abstract class IndexProviderTest {
             public KeyInformation.StoreRetriever get(String store) {
                 return mappings::get;
             }
+
+            @Override
+            public void invalidate(String store) {
+                mappings.remove(store);
+            }
         };
     }
 

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphIndexTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphIndexTest.java
@@ -44,7 +44,6 @@ import org.janusgraph.core.JanusGraphTransaction;
 import org.janusgraph.core.JanusGraphVertex;
 import org.janusgraph.core.JanusGraphVertexProperty;
 import org.janusgraph.core.PropertyKey;
-import org.janusgraph.core.SchemaViolationException;
 import org.janusgraph.core.VertexLabel;
 import org.janusgraph.core.attribute.Cmp;
 import org.janusgraph.core.attribute.Geo;
@@ -3031,7 +3030,7 @@ public abstract class JanusGraphIndexTest extends JanusGraphBaseTest {
     }
 
     @Test
-    public void shouldAbortTransactionAfterIndexModification() throws InterruptedException, ExecutionException {
+    public void shouldUpdateIndexFieldsAfterIndexModification() throws InterruptedException, ExecutionException {
         clopen(option(FORCE_INDEX_USAGE), true);
         String key1 = "testKey1";
         String key2 = "testKey2";
@@ -3083,13 +3082,6 @@ public abstract class JanusGraphIndexTest extends JanusGraphBaseTest {
 
         vertex = graph.addVertex(T.label, vertexL, key1, 1L, key2, 2L, key3, 3L);
 
-        JanusGraphException ex = assertThrows(JanusGraphException.class, () -> graph.tx().commit());
-        assertTrue(ex.getCause() instanceof SchemaViolationException);
-        assertEquals("testKey3 is not available in mixed index mixed", ex.getCause().getMessage());
-
-        // after rolling back the previous commit and open a new one (implicitly), commit succeeds
-        graph.tx().rollback();
-        vertex = graph.addVertex(T.label, vertexL, key1, 1L, key2, 2L, key3, 3L);
         graph.tx().commit();
         assertTrue(graph.traversal().V().hasLabel(vertexL).has(key3, 3L).hasNext());
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphTransaction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphTransaction.java
@@ -124,4 +124,6 @@ public interface JanusGraphTransaction extends Transaction {
      * @return true, if the transaction contains updates, else false.
      */
     boolean hasModifications();
+
+    void expireSchemaElement(final long id);
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/BackendTransaction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/BackendTransaction.java
@@ -113,6 +113,11 @@ public class BackendTransaction implements LoggableTransaction {
         return txConfig;
     }
 
+    public boolean hasIndexTransaction(String index) {
+        Preconditions.checkArgument(StringUtils.isNotBlank(index), "index cannot be blank");
+        return indexTx.containsKey(index);
+    }
+
     public IndexTransaction getIndexTransaction(String index) {
         Preconditions.checkArgument(StringUtils.isNotBlank(index), "index cannot be blank");
         IndexTransaction itx = indexTx.get(index);

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexTransaction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/IndexTransaction.java
@@ -197,4 +197,7 @@ public class IndexTransaction implements BaseTransaction, LoggableTransaction {
         out.writeClassAndObject(entry.value);
     }
 
+    public void invalidate(String store) {
+        keyInformation.invalidate(store);
+    }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/KeyInformation.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/indexing/KeyInformation.java
@@ -90,6 +90,7 @@ public interface KeyInformation {
          */
         StoreRetriever get(String store);
 
+        void invalidate(String store);
     }
 
     interface Retriever {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
@@ -222,6 +222,10 @@ public class IndexSerializer {
                     return indexes.get(store);
                 }
 
+                @Override
+                public void invalidate(final String store) {
+                    indexes.remove(store);
+                }
             };
         }
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementLogger.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementLogger.java
@@ -93,6 +93,9 @@ public class ManagementLogger implements MessageReader {
                 for (int i = 0; i < numEvictions; i++) {
                     long typeId = VariableLong.readPositive(in);
                     schemaCache.expireSchemaElement(typeId);
+                    for (JanusGraphTransaction tx : graph.getOpenTransactions()) {
+                        tx.expireSchemaElement(typeId);
+                    }
                 }
                 final GraphCacheEvictionAction action = serializer.readObjectNotNull(in, GraphCacheEvictionAction.class);
                 Preconditions.checkNotNull(action);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
@@ -28,6 +28,7 @@ import org.janusgraph.core.JanusGraph;
 import org.janusgraph.core.JanusGraphEdge;
 import org.janusgraph.core.JanusGraphElement;
 import org.janusgraph.core.JanusGraphException;
+import org.janusgraph.core.JanusGraphTransaction;
 import org.janusgraph.core.JanusGraphVertex;
 import org.janusgraph.core.JanusGraphVertexProperty;
 import org.janusgraph.core.Multiplicity;
@@ -247,6 +248,9 @@ public class ManagementSystem implements JanusGraphManagement {
             managementLogger.sendCacheEviction(updatedTypes, evictGraphFromCache, updatedTypeTriggers, getOpenInstancesInternal());
             for (JanusGraphSchemaVertex schemaVertex : updatedTypes) {
                 schemaCache.expireSchemaElement(schemaVertex.longId());
+                for (JanusGraphTransaction tx : graph.getOpenTransactions()) {
+                    tx.expireSchemaElement(schemaVertex.longId());
+                }
             }
         }
 


### PR DESCRIPTION
This is a continuation PR to https://github.com/JanusGraph/janusgraph/pull/2688, that properly invalidates stale cached data from index transactions.