### PR TITLE
Optimize profile result for values() step if query.batch=false

### DIFF
--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/query/VertexCentricQueryBenchmark.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/query/VertexCentricQueryBenchmark.java
@@ -1,0 +1,113 @@
+// Copyright 2021 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.query;
+
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalMetrics;
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.JanusGraphFactory;
+import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
+import org.janusgraph.diskstorage.configuration.WriteConfiguration;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Fork(1)
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class VertexCentricQueryBenchmark {
+    @Param({"10000", "100000"})
+    int size;
+
+    JanusGraph graph;
+
+    public WriteConfiguration getConfiguration() {
+        ModifiableConfiguration config = GraphDatabaseConfiguration.buildGraphConfiguration();
+        config.set(GraphDatabaseConfiguration.STORAGE_BACKEND, "inmemory");
+        return config.getConfiguration();
+    }
+
+    @Setup
+    public void setUp() throws Exception {
+        graph = JanusGraphFactory.open(getConfiguration());
+
+        final int batchSize = Math.min(10000, size);
+        for (int i = 0; i < size / batchSize; i++) {
+            for (int j = 0; j < batchSize; j++) {
+                graph.addVertex("key1", "value1", "key2", "value2", "key3", "value3");
+            }
+            graph.tx().commit();
+        }
+    }
+
+    @TearDown
+    public void tearDown() {
+        graph.close();
+    }
+
+    @Benchmark
+    public List<Object> getValues() {
+        List<Object> values = graph.traversal().V().values().toList();
+        graph.traversal().tx().rollback();
+        return values;
+    }
+
+    @Benchmark
+    public TraversalMetrics getValuesProfile() {
+        TraversalMetrics profile = graph.traversal().V().values().profile().next();
+        graph.traversal().tx().rollback();
+        return profile;
+    }
+
+    @Benchmark
+    public List<Map<Object, Object>> getValueMap() {
+        List<Map<Object, Object>> valueMaps = graph.traversal().V().valueMap().toList();
+        graph.traversal().tx().rollback();
+        return valueMaps;
+    }
+
+    @Benchmark
+    public TraversalMetrics getValueMapProfile() {
+        TraversalMetrics profile = graph.traversal().V().valueMap().profile().next();
+        graph.traversal().tx().rollback();
+        return profile;
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options options = new OptionsBuilder()
+            .include(VertexCentricQueryBenchmark.class.getSimpleName())
+            .warmupIterations(3)
+            .measurementIterations(5)
+            .build();
+        new Runner(options).run();
+    }
+
+}


### PR DESCRIPTION
When query.batch=false, we don't need to replace PropertiesStep with JanusGraphPropertiesStep which
aims to cache the traversers and fire multiple queries in batches.

Notice that JanusGraphPropertiesStep profiles every single query, which makes values().profile()
output extremely lengthy and slow. It also gives users an illusion that values() is much slower
than valueMap() step (provided query.batch=false) which is not true. By using the ordinary
TinkerPop propertiesStep here, the values().profile() becomes faster and produces more concise output.

Fixes #2185

This PR also contains a benchmark program. We can see that without this PR, getValuesProfile is significantly slower than getValueMapProfile, while getValues is as fast as getValueMap.

Before this PR,
```
Benchmark                                       (size)  Mode  Cnt     Score     Error  Units
VertexCentricQueryBenchmark.getValueMap          10000  avgt    5    43.872 ±   8.219  ms/op
VertexCentricQueryBenchmark.getValueMap         100000  avgt    5   523.589 ±  53.983  ms/op
VertexCentricQueryBenchmark.getValueMapProfile   10000  avgt    5    45.226 ±   0.501  ms/op
VertexCentricQueryBenchmark.getValueMapProfile  100000  avgt    5   516.469 ±   8.443  ms/op
VertexCentricQueryBenchmark.getValues            10000  avgt    5    36.449 ±   0.417  ms/op
VertexCentricQueryBenchmark.getValues           100000  avgt    5   499.776 ±   5.431  ms/op
VertexCentricQueryBenchmark.getValuesProfile     10000  avgt    5   122.361 ±   9.163  ms/op
VertexCentricQueryBenchmark.getValuesProfile    100000  avgt    5  1388.586 ± 119.154  ms/op
```

With this PR, getValuesProfile is as fast as getValueMapProfile.
```
Benchmark                                       (size)  Mode  Cnt    Score     Error  Units
VertexCentricQueryBenchmark.getValueMap          10000  avgt    5   40.883 ±   0.764  ms/op
VertexCentricQueryBenchmark.getValueMap         100000  avgt    5  490.148 ±  10.919  ms/op
VertexCentricQueryBenchmark.getValueMapProfile   10000  avgt    5   41.499 ±   0.357  ms/op
VertexCentricQueryBenchmark.getValueMapProfile  100000  avgt    5  574.121 ±  89.151  ms/op
VertexCentricQueryBenchmark.getValues            10000  avgt    5   36.851 ±   1.218  ms/op
VertexCentricQueryBenchmark.getValues           100000  avgt    5  516.501 ±  58.846  ms/op
VertexCentricQueryBenchmark.getValuesProfile     10000  avgt    5   47.177 ±   5.043  ms/op
VertexCentricQueryBenchmark.getValuesProfile    100000  avgt    5  572.094 ± 146.230  ms/op
```