### PR TITLE
Log exception when JanusGraphServer fails to start

### DIFF
--- a/janusgraph-server/src/main/java/org/janusgraph/graphdb/server/JanusGraphServer.java
+++ b/janusgraph-server/src/main/java/org/janusgraph/graphdb/server/JanusGraphServer.java
@@ -51,7 +51,7 @@ public class JanusGraphServer {
         final String file = (args.length > 0) ? args[0] : "conf/janusgraph-server.yaml";
         JanusGraphServer janusGraphServer = new JanusGraphServer(file);
         janusGraphServer.start().exceptionally(t -> {
-            logger.error("JanusGraph Server was unable to start and will now begin shutdown: {}", t.getMessage());
+            logger.error("JanusGraph Server was unable to start and will now begin shutdown", t);
             janusGraphServer.stop().join();
             return null;
         }).join();


### PR DESCRIPTION
While trying out JanusGraph 0.6, I was stuck with JanusGraphServer failing to start and a log line saying:
```
ERROR org.janusgraph.graphdb.server.JanusGraphServer - 0 0 - JanusGraph Server was unable to start and will now begin shutdown: java.lang.reflect.InvocationTargetException
```

This is not very informative, so a user would typically have to build a custom version of JanusGraph to figure out what the root cause is.

With the proposed change, one can understand from the logs that the root cause is in fact Cassandra being unreachable:
```
ERROR org.janusgraph.graphdb.server.JanusGraphServer - 0 0 - JanusGraph Server was unable to start and will now begin shutdown
java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
    at org.apache.tinkerpop.gremlin.server.util.ServerGremlinExecutor.<init>(ServerGremlinExecutor.java:95) ~[gremlin-server-3.5.0.jar:3.5.0]
    at org.apache.tinkerpop.gremlin.server.GremlinServer.<init>(GremlinServer.java:124) ~[gremlin-server-3.5.0.jar:3.5.0]
    at org.apache.tinkerpop.gremlin.server.GremlinServer.<init>(GremlinServer.java:87) ~[gremlin-server-3.5.0.jar:3.5.0]
    at org.janusgraph.graphdb.server.JanusGraphServer.start(JanusGraphServer.java:85) ~[janusgraph-server-0.6.0-SNAPSHOT.jar:na]
    at org.janusgraph.graphdb.server.JanusGraphServer.main(JanusGraphServer.java:53) ~[janusgraph-server-0.6.0-SNAPSHOT.jar:na]
Caused by: java.lang.reflect.InvocationTargetException: null
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[na:1.8.0_292]
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[na:1.8.0_292]
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[na:1.8.0_292]
    at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[na:1.8.0_292]
    at org.apache.tinkerpop.gremlin.server.util.ServerGremlinExecutor.<init>(ServerGremlinExecutor.java:84) ~[gremlin-server-3.5.0.jar:3.5.0]
    ... 4 common frames omitted
Caused by: com.datastax.oss.driver.api.core.NoNodeAvailableException: No node was available to execute the query
    at com.datastax.oss.driver.api.core.NoNodeAvailableException.copy(NoNodeAvailableException.java:40) ~[java-driver-core-4.12.0.jar:na]
    at com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures.getUninterruptibly(CompletableFutures.java:149) ~[java-driver-core-4.12.0.jar:na]
    at com.datastax.oss.driver.internal.core.cql.CqlPrepareSyncProcessor.process(CqlPrepareSyncProcessor.java:59) ~[java-driver-core-4.12.0.jar:na]
    at com.datastax.oss.driver.internal.core.cql.CqlPrepareSyncProcessor.process(CqlPrepareSyncProcessor.java:31) ~[java-driver-core-4.12.0.jar:na]
    at com.datastax.oss.driver.internal.core.session.DefaultSession.execute(DefaultSession.java:230) ~[java-driver-core-4.12.0.jar:na]
    at com.datastax.oss.driver.api.core.cql.SyncCqlSession.prepare(SyncCqlSession.java:206) ~[java-driver-core-4.12.0.jar:na]
    at org.janusgraph.diskstorage.cql.CQLKeyColumnValueStore.<init>(CQLKeyColumnValueStore.java:169) ~[janusgraph-cql-0.6.0-SNAPSHOT.jar:na]
    at org.janusgraph.diskstorage.cql.CQLStoreManager.lambda$openDatabase$10(CQLStoreManager.java:462) ~[janusgraph-cql-0.6.0-SNAPSHOT.jar:na]
    at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1660) ~[na:1.8.0_292]
    at org.janusgraph.diskstorage.cql.CQLStoreManager.openDatabase(CQLStoreManager.java:462) ~[janusgraph-cql-0.6.0-SNAPSHOT.jar:na]
    at org.janusgraph.diskstorage.keycolumnvalue.KeyColumnValueStoreManager.openDatabase(KeyColumnValueStoreManager.java:43) ~[janusgraph-core-0.6.0-SNAPSHOT.jar:na]
    at org.janusgraph.diskstorage.configuration.backend.builder.KCVSConfigurationBuilder.buildStandaloneGlobalConfiguration(KCVSConfigurationBuilder.java:51) ~[janusgraph-core-0.6.0-SNAPSHOT.jar:na]
    at org.janusgraph.diskstorage.configuration.builder.ReadConfigurationBuilder.buildGlobalConfiguration(ReadConfigurationBuilder.java:71) ~[janusgraph-core-0.6.0-SNAPSHOT.jar:na]
    at org.janusgraph.graphdb.configuration.builder.GraphDatabaseConfigurationBuilder.build(GraphDatabaseConfigurationBuilder.java:67) ~[janusgraph-core-0.6.0-SNAPSHOT.jar:na]
    at org.janusgraph.core.JanusGraphFactory.lambda$open$0(JanusGraphFactory.java:165) ~[janusgraph-core-0.6.0-SNAPSHOT.jar:na]
    at org.janusgraph.graphdb.management.JanusGraphManager.openGraph(JanusGraphManager.java:239) ~[janusgraph-core-0.6.0-SNAPSHOT.jar:na]
    at org.janusgraph.core.JanusGraphFactory.open(JanusGraphFactory.java:165) ~[janusgraph-core-0.6.0-SNAPSHOT.jar:na]
    at org.janusgraph.core.JanusGraphFactory.open(JanusGraphFactory.java:115) ~[janusgraph-core-0.6.0-SNAPSHOT.jar:na]
    at org.janusgraph.graphdb.management.JanusGraphManager.lambda$new$0(JanusGraphManager.java:73) ~[janusgraph-core-0.6.0-SNAPSHOT.jar:na]
    at java.util.LinkedHashMap.forEach(LinkedHashMap.java:684) ~[na:1.8.0_292]
    at org.janusgraph.graphdb.management.JanusGraphManager.<init>(JanusGraphManager.java:72) ~[janusgraph-core-0.6.0-SNAPSHOT.jar:na]
    ... 9 common frames omitted
```

Signed-off-by: Clement de Groc <clement.degroc@datadoghq.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
