### PR TITLE
Add cql.local-datacenter to sample properties file

### DIFF
--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/janusgraph-cql-es-server.properties
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/janusgraph-cql-es-server.properties
@@ -49,6 +49,13 @@ storage.hostname=127.0.0.1
 # Mutability: LOCAL
 storage.cql.keyspace=janusgraph
 
+# The name of the local or closest Cassandra datacenter.
+#
+# Default:    datacenter1
+# Data Type:  String
+# Mutability: MASKABLE
+storage.cql.local-datacenter=datacenter1
+
 # Whether to enable JanusGraph's database-level cache, which is shared across
 # all transactions. Enabling this option speeds up traversals by holding
 # hot graph elements in memory, but also increases the likelihood of


### PR DESCRIPTION
JanusGraph 0.6 with a ConfiguredGraphFactory won't start if `storage.cql.local-datacenter` is not defined and a custom Cassandra datacenter is used (i.e. not datacenter1).

Signed-off-by: Clement de Groc <clement.degroc@datadoghq.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
