### PR TITLE
Fix broken Casssandra link and update download-maven-plugin to 1.6.6 CTR

### DIFF
--- a/janusgraph-dist/pom.xml
+++ b/janusgraph-dist/pom.xml
@@ -122,7 +122,7 @@
             <artifactId>jamm</artifactId>
             <version>${jamm.version}</version>
         </dependency>
-        
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -198,7 +198,7 @@
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.6.3</version>
+                <version>1.6.6</version>
                 <executions>
                     <execution>
                         <id>get-elasticsearch</id>
@@ -219,7 +219,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>http://ftp.halifax.rwth-aachen.de/apache/cassandra/${cassandra.version}/apache-cassandra-${cassandra.version}-bin.tar.gz</url>
+                            <url>https://archive.apache.org/dist/cassandra/${cassandra.version}/apache-cassandra-${cassandra.version}-bin.tar.gz</url>
                             <outputFileName>apache-cassandra.tar.gz</outputFileName>
                             <outputDirectory>${project.build.directory}</outputDirectory>
                         </configuration>


### PR DESCRIPTION
Looks like the mirror which we were using for Cassandra removed the link to our managed version (3.11.10). Probably due to the release of 3.11.11 and 4.0.0.

This PR fixes: https://github.com/JanusGraph/janusgraph/runs/3196377838

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
