### PR TITLE
Instrument ThreadPools when metrics.enabled is true

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/ExecutorServiceInstrumentation.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/ExecutorServiceInstrumentation.java
@@ -1,0 +1,72 @@
+// Copyright 2021 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.configuration;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.InstrumentedExecutorService;
+import com.codahale.metrics.InstrumentedThreadFactory;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.annotations.VisibleForTesting;
+import org.janusgraph.util.stats.MetricManager;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+
+public class ExecutorServiceInstrumentation {
+
+    private static final String METRICS_NAMESPACE = "threadpools";
+    private static final String METRICS_THREAD_FACTORY = "threadFactory";
+    private static final String METRICS_EXECUTOR_SERVICE = "executorService";
+    private static final String METRICS_QUEUE_SIZE = "queueSize";
+
+    private ExecutorServiceInstrumentation() {}
+
+    public static InstrumentedExecutorService instrument(String metricsPrefix, String name, ExecutorService executorService) {
+        return instrument(metricsPrefix, name, executorService, MetricManager.INSTANCE.getRegistry());
+    }
+
+    @VisibleForTesting
+    static InstrumentedExecutorService instrument(String metricsPrefix, String name, ExecutorService executorService, MetricRegistry registry) {
+        if (executorService instanceof ThreadPoolExecutor) {
+            registry.gauge(
+                fullMetricsName(metricsPrefix, name, METRICS_EXECUTOR_SERVICE, METRICS_QUEUE_SIZE),
+                () -> (Gauge<Integer>) () -> ((ThreadPoolExecutor) executorService).getQueue().size()
+            );
+        }
+        return new InstrumentedExecutorService(
+            executorService,
+            registry,
+            fullMetricsName(metricsPrefix, name, METRICS_EXECUTOR_SERVICE)
+        );
+    }
+
+    public static InstrumentedThreadFactory instrument(String metricsPrefix, String name, ThreadFactory threadFactory) {
+        return instrument(metricsPrefix, name, threadFactory, MetricManager.INSTANCE.getRegistry());
+    }
+
+    @VisibleForTesting
+    static InstrumentedThreadFactory instrument(String metricsPrefix, String name, ThreadFactory threadFactory, MetricRegistry registry) {
+        return new InstrumentedThreadFactory(
+            threadFactory,
+            registry,
+            fullMetricsName(metricsPrefix, name, METRICS_THREAD_FACTORY)
+        );
+    }
+
+    private static String fullMetricsName(String prefix, String... parts) {
+        return prefix + "." + METRICS_NAMESPACE + "." + String.join(".", parts);
+    }
+}

--- a/janusgraph-test/src/test/java/org/janusgraph/diskstorage/configuration/ExecutorServiceInstrumentationTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/diskstorage/configuration/ExecutorServiceInstrumentationTest.java
@@ -1,0 +1,101 @@
+// Copyright 2021 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.configuration;
+
+import com.codahale.metrics.InstrumentedExecutorService;
+import com.codahale.metrics.InstrumentedThreadFactory;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class ExecutorServiceInstrumentationTest {
+
+    @Test
+    public void shouldCreateInstrumentedExecutorService() throws InterruptedException {
+        MetricRegistry registry = new MetricRegistry();
+        InstrumentedExecutorService executorService = ExecutorServiceInstrumentation.instrument(
+            "org.janusgraph",
+            "test",
+            Executors.newFixedThreadPool(1),
+            registry
+        );
+        try {
+            Lock lock = new ReentrantLock();
+            lock.lock();
+            try {
+                // Spawn two threads: (1) will be running waiting for lock to be available ; (2) will wait in queue
+                executorService.execute(lock::lock);
+                executorService.execute(() -> {});
+                // Wait for the thread to start
+                Thread.sleep(100);
+
+                assertEquals(1, registry.getGauges().get("org.janusgraph.threadpools.test.executorService.queueSize").getValue());
+                assertEquals(1L, registry.getCounters().get("org.janusgraph.threadpools.test.executorService.running").getCount());
+                assertEquals(0L, registry.getMeters().get("org.janusgraph.threadpools.test.executorService.completed").getCount());
+                assertEquals(2L, registry.getMeters().get("org.janusgraph.threadpools.test.executorService.submitted").getCount());
+                assertNotNull(registry.getTimers().get("org.janusgraph.threadpools.test.executorService.duration"));
+            } finally {
+                lock.unlock();
+            }
+        } finally {
+            executorService.shutdown();
+        }
+        // Wait for the thread to stop
+        Thread.sleep(100);
+        assertEquals(2L, registry.getMeters().get("org.janusgraph.threadpools.test.executorService.completed").getCount());
+    }
+
+    @Test
+    public void shouldCreateInstrumentedThreadFactory() throws InterruptedException {
+        MetricRegistry registry = new MetricRegistry();
+        InstrumentedThreadFactory threadFactory = ExecutorServiceInstrumentation.instrument(
+            "org.janusgraph",
+            "test",
+            new ThreadFactoryBuilder().build(),
+            registry
+        );
+        ExecutorService executorService = Executors.newSingleThreadExecutor(threadFactory);
+        try {
+            Lock lock = new ReentrantLock();
+            lock.lock();
+            try {
+                // Spawn a thread that will wait for the lock to become available
+                executorService.submit(lock::lock);
+
+                // Wait for the thread to start
+                Thread.sleep(100);
+
+                assertEquals(1L, registry.getMeters().get("org.janusgraph.threadpools.test.threadFactory.created").getCount());
+                assertEquals(1L, registry.getCounters().get("org.janusgraph.threadpools.test.threadFactory.running").getCount());
+                assertEquals(0L, registry.getMeters().get("org.janusgraph.threadpools.test.threadFactory.terminated").getCount());
+            } finally {
+                lock.unlock();
+            }
+        } finally {
+            executorService.shutdown();
+        }
+        // Wait for the thread to stop
+        Thread.sleep(100);
+        assertEquals(1L, registry.getMeters().get("org.janusgraph.threadpools.test.threadFactory.terminated").getCount());
+    }
+}


### PR DESCRIPTION
Instrument ThreadPools when `metrics.enabled` is true.

Instrumentation is done by `com.codahale.metrics.{InstrumentedExecutorService,InstrumentedThreadFactory}`.
Metrics are logged to `<METRICS_PREFIX>.threadpools.<THREADPOOL_NAME>.{executorService,threadFactory}.*`

Mentioned in Discussion #2740.

Signed-off-by: Clement de Groc <clement.degroc@datadoghq.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [X] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
