### PR TITLE
Fix scala dependency conflict in spark traversal [cql-tests]

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,7 +27,7 @@ All currently supported verions of JanusGraph are listed below.
 | JanusGraph | Storage Version | Cassandra | HBase | Bigtable | Elasticsearch | Solr | TinkerPop | Spark | Scala |
 | ----- | ---- | ---- | ---- | ---- | ---- | ---- | --- | ---- | ---- |
 | 0.5.z | 2 | 2.1.z, 2.2.z, 3.0.z, 3.11.z | 1.2.z, 1.3.z, 1.4.z, 2.1.z | 1.3.0, 1.4.0, 1.5.z, 1.6.z, 1.7.z, 1.8.z, 1.9.z, 1.10.z, 1.11.z, 1.14.z | 6.y, 7.y | 7.y | 3.4.z | 2.2.z | 2.11.z | 
-| 0.6.z | 2 | 3.0.z, 3.11.z | 1.6.z, 2.2.z | 1.3.0, 1.4.0, 1.5.z, 1.6.z, 1.7.z, 1.8.z, 1.9.z, 1.10.z, 1.11.z, 1.14.z | 6.y, 7.y | 7.y, 8.y | 3.5.z | 2.2.z | 2.11.z | 
+| 0.6.z | 2 | 3.0.z, 3.11.z | 1.6.z, 2.2.z | 1.3.0, 1.4.0, 1.5.z, 1.6.z, 1.7.z, 1.8.z, 1.9.z, 1.10.z, 1.11.z, 1.14.z | 6.y, 7.y | 7.y, 8.y | 3.5.z | 3.0.z | 2.12.z |
 
 #### End-of-Life
 The versions of JanusGraph listed below are outdated and will no longer receive bugfixes.

--- a/janusgraph-cql/pom.xml
+++ b/janusgraph-cql/pom.xml
@@ -71,7 +71,6 @@
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
-            <optional>true</optional>
             <exclusions>
                 <!-- Use more recent version of jbcrypt from gremlin-groovy -->
                 <exclusion>

--- a/janusgraph-hadoop/pom.xml
+++ b/janusgraph-hadoop/pom.xml
@@ -59,10 +59,6 @@
             <artifactId>spark-gremlin</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>com.fasterxml.jackson.module</groupId>
-                    <artifactId>jackson-module-scala_2.11</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-compress</artifactId>
                 </exclusion>
@@ -74,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-scala_2.11</artifactId>
+            <artifactId>jackson-module-scala_2.12</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.scala-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@
                                 <requireUpperBoundDeps>
                                     <excludes>
                                         <exclude>com.google.guava:guava</exclude>
+                                        <exclude>com.fasterxml.jackson.core:jackson-annotations</exclude>
                                         <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
                                         <exclude>com.fasterxml.jackson.core:jackson-core</exclude>
                                     </excludes>
@@ -622,7 +623,7 @@
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-scala_2.11</artifactId>
+                <artifactId>jackson-module-scala_2.12</artifactId>
                 <version>${jackson2.version}</version>
             </dependency>
             <dependency>
@@ -1103,10 +1104,6 @@
                     <exclusion>
                         <groupId>junit</groupId>
                         <artifactId>junit</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-annotations</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
This aims to fix Spark traversal caused by scala version mismatch. Tested locally using the following steps:

```
:plugin use tinkerpop.hadoop
:plugin use tinkerpop.spark
graph = GraphFactory.open('conf/hadoop-graph/read-cql.properties')
g = graph.traversal().withComputer(SparkGraphComputer)
g.V().count()
```

TODOs:

- [x] Check if Spark traversal works for HBase
- [x] Check if Spark traversal works on a Spark standalone cluster
- [ ] Check if Spark traversal works on a Spark yarn cluster