### PR TITLE
Ensure CQLSession is closed properly even on CQLStoreManager construction exception

### DIFF
--- a/janusgraph-backend-testutils/pom.xml
+++ b/janusgraph-backend-testutils/pom.xml
@@ -76,6 +76,11 @@
             <groupId>io.github.artsok</groupId>
             <artifactId>rerunner-jupiter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/testutil/TestLoggerUtils.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/testutil/TestLoggerUtils.java
@@ -1,0 +1,118 @@
+// Copyright 2021 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.testutil;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.slf4j.Logger;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+public class TestLoggerUtils {
+
+    private static final Constructor<ch.qos.logback.classic.Logger> LOGBACK_CONSTRUCTOR;
+    private static final LoggerContext LOGBACK_CONTEXT = new LoggerContext();
+    private static final ch.qos.logback.classic.Logger ROOT_LOGGER = LOGBACK_CONTEXT.getLogger("ROOT");
+    private static final Level DEFAULT_LOGGING_LEVEL = Level.DEBUG;
+
+    static {
+        try {
+            LOGBACK_CONSTRUCTOR = ch.qos.logback.classic.Logger.class.getDeclaredConstructor(
+                String.class, ch.qos.logback.classic.Logger.class, LoggerContext.class);
+            LOGBACK_CONSTRUCTOR.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public static ch.qos.logback.classic.Logger createLogbackLogger(Class<?> clazz, Level loggingLevel){
+        try {
+            ch.qos.logback.classic.Logger logger = LOGBACK_CONSTRUCTOR.newInstance(clazz.getName(), ROOT_LOGGER, LOGBACK_CONTEXT);
+            logger.setLevel(loggingLevel);
+            return logger;
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public static void processWithLoggerReplacement(Consumer<ch.qos.logback.classic.Logger> processWithLoggerReplacementFunction,
+                                                    Class<?> classWhereToReplaceLogger){
+        processWithLoggerReplacement(processWithLoggerReplacementFunction, classWhereToReplaceLogger, DEFAULT_LOGGING_LEVEL);
+    }
+
+    public static void processWithLoggerReplacement(Consumer<ch.qos.logback.classic.Logger> processWithLoggerReplacementFunction,
+                                                    Class<?> classWhereToReplaceLogger, Level loggingLevel){
+
+        Field loggerField = getModifiableLoggerField(classWhereToReplaceLogger);
+        Logger originalLogger = getLoggerFromField(loggerField);
+        try {
+
+            ch.qos.logback.classic.Logger loggerToUseInFunction = createLogbackLogger(classWhereToReplaceLogger, loggingLevel);
+            replaceLoggerField(loggerField, loggerToUseInFunction);
+
+            processWithLoggerReplacementFunction.accept(loggerToUseInFunction);
+
+            loggerToUseInFunction.detachAndStopAllAppenders();
+
+        } finally {
+            // revert back to original logger
+            replaceLoggerField(loggerField, originalLogger);
+        }
+    }
+
+    public static Field getModifiableLoggerField(Class<?> clazz){
+        Field loggerField = Arrays.stream(clazz.getDeclaredFields()).filter(field -> org.slf4j.Logger.class.isAssignableFrom(field.getType()))
+            .findFirst().orElseThrow(() -> new IllegalStateException("No logger found in class "+clazz.getName()));
+        try {
+            loggerField.setAccessible(true);
+            Field modifiersField = Field.class.getDeclaredField("modifiers");
+            modifiersField.setAccessible(true);
+            modifiersField.setInt(loggerField, loggerField.getModifiers() & ~Modifier.FINAL);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+        return loggerField;
+    }
+
+    public static Logger getLoggerFromField(Field loggerField){
+        try {
+            return (Logger) loggerField.get(null);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void replaceLoggerField(Field loggerField, Logger logger){
+        try {
+            loggerField.set(null, logger);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static ListAppender<ILoggingEvent> registerListAppender(ch.qos.logback.classic.Logger logger){
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.addAppender(listAppender);
+        return listAppender;
+    }
+}

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/builder/CQLMutateManyFunctionBuilder.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/builder/CQLMutateManyFunctionBuilder.java
@@ -1,0 +1,110 @@
+// Copyright 2021 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.cql.builder;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.janusgraph.diskstorage.common.DistributedStoreManager;
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.diskstorage.configuration.ExecutorServiceBuilder;
+import org.janusgraph.diskstorage.configuration.ExecutorServiceConfiguration;
+import org.janusgraph.diskstorage.configuration.ExecutorServiceInstrumentation;
+import org.janusgraph.diskstorage.cql.CQLKeyColumnValueStore;
+import org.janusgraph.diskstorage.cql.function.ConsumerWithBackendException;
+import org.janusgraph.diskstorage.cql.function.mutate.CQLExecutorServiceMutateManyLoggedFunction;
+import org.janusgraph.diskstorage.cql.function.mutate.CQLExecutorServiceMutateManyUnloggedFunction;
+import org.janusgraph.diskstorage.cql.function.mutate.CQLMutateManyFunction;
+import org.janusgraph.diskstorage.cql.function.mutate.CQLSimpleMutateManyLoggedFunction;
+import org.janusgraph.diskstorage.cql.function.mutate.CQLSimpleMutateManyUnloggedFunction;
+import org.janusgraph.diskstorage.util.time.TimestampProvider;
+
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.ATOMIC_BATCH_MUTATE;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.BATCH_STATEMENT_SIZE;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.EXECUTOR_SERVICE_CLASS;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.EXECUTOR_SERVICE_CORE_POOL_SIZE;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.EXECUTOR_SERVICE_ENABLED;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.EXECUTOR_SERVICE_KEEP_ALIVE_TIME;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.EXECUTOR_SERVICE_MAX_POOL_SIZE;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.BASIC_METRICS;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.METRICS_PREFIX;
+
+public class CQLMutateManyFunctionBuilder {
+
+    public CQLMutateManyFunctionWrapper build(final CqlSession session, final Configuration configuration,
+                                               final TimestampProvider times, final boolean assignTimestamp,
+                                               final Map<String, CQLKeyColumnValueStore> openStores,
+                                               ConsumerWithBackendException<DistributedStoreManager.MaskedTimestamp> sleepAfterWriteFunction){
+
+        ExecutorService executorService;
+        CQLMutateManyFunction mutateManyFunction;
+
+        int batchSize = configuration.get(BATCH_STATEMENT_SIZE);
+        boolean atomicBatch = configuration.get(ATOMIC_BATCH_MUTATE);
+
+        if(configuration.get(EXECUTOR_SERVICE_ENABLED)){
+            executorService = buildExecutorService(configuration);
+            try{
+                if(atomicBatch){
+                    mutateManyFunction = new CQLExecutorServiceMutateManyLoggedFunction(times,
+                        assignTimestamp, openStores, session, executorService, sleepAfterWriteFunction);
+                } else {
+                    mutateManyFunction = new CQLExecutorServiceMutateManyUnloggedFunction(batchSize,
+                        session, openStores, times, executorService, assignTimestamp, sleepAfterWriteFunction);
+                }
+            } catch (RuntimeException e){
+                executorService.shutdown();
+                throw e;
+            }
+        } else {
+            executorService = null;
+            if(atomicBatch){
+                mutateManyFunction = new CQLSimpleMutateManyLoggedFunction(times,
+                    assignTimestamp, openStores, session, sleepAfterWriteFunction);
+            } else {
+                mutateManyFunction = new CQLSimpleMutateManyUnloggedFunction(batchSize,
+                    session, openStores, times, assignTimestamp, sleepAfterWriteFunction);
+            }
+        }
+
+        return new CQLMutateManyFunctionWrapper(executorService, mutateManyFunction);
+    }
+
+    private ExecutorService buildExecutorService(Configuration configuration) {
+        Integer corePoolSize = configuration.getOrDefault(EXECUTOR_SERVICE_CORE_POOL_SIZE);
+        Integer maxPoolSize = configuration.getOrDefault(EXECUTOR_SERVICE_MAX_POOL_SIZE);
+        Long keepAliveTime = configuration.getOrDefault(EXECUTOR_SERVICE_KEEP_ALIVE_TIME);
+        String executorServiceClass = configuration.getOrDefault(EXECUTOR_SERVICE_CLASS);
+        ThreadFactory threadFactory = new ThreadFactoryBuilder()
+            .setDaemon(true)
+            .setNameFormat("CQLStoreManager[%02d]")
+            .build();
+        if (configuration.get(BASIC_METRICS)) {
+            threadFactory = ExecutorServiceInstrumentation.instrument(configuration.get(METRICS_PREFIX), "CqlStoreManager", threadFactory);
+        }
+
+        ExecutorServiceConfiguration executorServiceConfiguration =
+            new ExecutorServiceConfiguration(executorServiceClass, corePoolSize, maxPoolSize, keepAliveTime, threadFactory);
+        ExecutorService executorService = ExecutorServiceBuilder.build(executorServiceConfiguration);
+        if (configuration.get(BASIC_METRICS)) {
+            executorService = ExecutorServiceInstrumentation.instrument(configuration.get(METRICS_PREFIX), "CqlStoreManager", executorService);
+        }
+        return executorService;
+    }
+
+}

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/builder/CQLMutateManyFunctionWrapper.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/builder/CQLMutateManyFunctionWrapper.java
@@ -1,0 +1,38 @@
+// Copyright 2021 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.cql.builder;
+
+import org.janusgraph.diskstorage.cql.function.mutate.CQLMutateManyFunction;
+
+import java.util.concurrent.ExecutorService;
+
+public class CQLMutateManyFunctionWrapper {
+
+    private final ExecutorService executorService;
+    private final CQLMutateManyFunction mutateManyFunction;
+
+    public CQLMutateManyFunctionWrapper(ExecutorService executorService, CQLMutateManyFunction mutateManyFunction) {
+        this.executorService = executorService;
+        this.mutateManyFunction = mutateManyFunction;
+    }
+
+    public ExecutorService getExecutorService() {
+        return executorService;
+    }
+
+    public CQLMutateManyFunction getMutateManyFunction() {
+        return mutateManyFunction;
+    }
+}

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/builder/CQLStoreFeaturesBuilder.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/builder/CQLStoreFeaturesBuilder.java
@@ -1,0 +1,111 @@
+// Copyright 2021 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.cql.builder;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import org.janusgraph.diskstorage.common.DistributedStoreManager;
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.diskstorage.cql.CQLStoreManager;
+import org.janusgraph.diskstorage.keycolumnvalue.StandardStoreFeatures;
+import org.janusgraph.diskstorage.keycolumnvalue.StoreFeatures;
+import org.janusgraph.util.system.NetworkUtil;
+
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.METADATA_TOKEN_MAP_ENABLED;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.ONLY_USE_LOCAL_CONSISTENCY_FOR_SYSTEM_OPERATIONS;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.PARTITIONER_NAME;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.READ_CONSISTENCY;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.USE_EXTERNAL_LOCKING;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.WRITE_CONSISTENCY;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.METRICS_PREFIX;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.METRICS_SYSTEM_PREFIX_DEFAULT;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.buildGraphConfiguration;
+
+public class CQLStoreFeaturesBuilder {
+
+    public CQLStoreFeaturesWrapper build(final CqlSession session, final Configuration configuration, final String[] hostnames){
+
+        StoreFeatures storeFeatures;
+        DistributedStoreManager.Deployment deployment;
+
+        final Configuration global = buildGraphConfiguration()
+            .set(READ_CONSISTENCY, CQLStoreManager.CONSISTENCY_QUORUM)
+            .set(WRITE_CONSISTENCY, CQLStoreManager.CONSISTENCY_QUORUM)
+            .set(METRICS_PREFIX, METRICS_SYSTEM_PREFIX_DEFAULT);
+
+        final Configuration local = buildGraphConfiguration()
+            .set(READ_CONSISTENCY, CQLStoreManager.CONSISTENCY_LOCAL_QUORUM)
+            .set(WRITE_CONSISTENCY, CQLStoreManager.CONSISTENCY_LOCAL_QUORUM)
+            .set(METRICS_PREFIX, METRICS_SYSTEM_PREFIX_DEFAULT);
+
+        final Boolean onlyUseLocalConsistency = configuration.get(ONLY_USE_LOCAL_CONSISTENCY_FOR_SYSTEM_OPERATIONS);
+
+        final Boolean useExternalLocking = configuration.get(USE_EXTERNAL_LOCKING);
+
+        final StandardStoreFeatures.Builder fb = new StandardStoreFeatures.Builder();
+
+        fb.batchMutation(true).distributed(true);
+        fb.timestamps(true).cellTTL(true);
+        fb.keyConsistent((onlyUseLocalConsistency ? local : global), local);
+        fb.locking(useExternalLocking);
+        fb.optimisticLocking(true);
+        fb.multiQuery(false);
+
+        String partitioner = null;
+        if (configuration.has(PARTITIONER_NAME)) {
+            partitioner = getShortPartitionerName(configuration.get(PARTITIONER_NAME));
+        }
+        if (session.getMetadata().getTokenMap().isPresent()) {
+            String retrievedPartitioner = getShortPartitionerName(session.getMetadata().getTokenMap().get().getPartitionerName());
+            if (partitioner == null) {
+                partitioner = retrievedPartitioner;
+            } else if (!partitioner.equals(retrievedPartitioner)) {
+                throw new IllegalArgumentException(String.format("Provided partitioner (%s) does not match with server (%s)",
+                    partitioner, retrievedPartitioner));
+            }
+        } else if (partitioner == null) {
+            throw new IllegalArgumentException(String.format("Partitioner name not provided and cannot retrieve it from " +
+                "server, please check %s and %s options", PARTITIONER_NAME.getName(), METADATA_TOKEN_MAP_ENABLED.getName()));
+        }
+        switch (partitioner) {
+            case "DefaultPartitioner": // Amazon managed KeySpace uses com.amazonaws.cassandra.DefaultPartitioner
+                fb.timestamps(false).cellTTL(false);
+            case "RandomPartitioner":
+            case "Murmur3Partitioner": {
+                fb.keyOrdered(false).orderedScan(false).unorderedScan(true);
+                deployment = DistributedStoreManager.Deployment.REMOTE;
+                break;
+            }
+            case "ByteOrderedPartitioner": {
+                fb.keyOrdered(true).orderedScan(true).unorderedScan(false);
+                deployment = (hostnames.length == 1)// mark deployment as local only in case we have byte ordered partitioner and local
+                    // connection
+                    ? (NetworkUtil.isLocalConnection(hostnames[0])) ? DistributedStoreManager.Deployment.LOCAL : DistributedStoreManager.Deployment.REMOTE
+                    : DistributedStoreManager.Deployment.REMOTE;
+                break;
+            }
+            default: {
+                throw new IllegalArgumentException("Unrecognized partitioner: " + partitioner);
+            }
+        }
+        storeFeatures = fb.build();
+
+        return new CQLStoreFeaturesWrapper(storeFeatures, deployment);
+    }
+
+    private String getShortPartitionerName(String partitioner) {
+        if (partitioner == null) return null;
+        return partitioner.substring(partitioner.lastIndexOf('.') + 1);
+    }
+}

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/builder/CQLStoreFeaturesWrapper.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/builder/CQLStoreFeaturesWrapper.java
@@ -1,0 +1,37 @@
+// Copyright 2021 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.cql.builder;
+
+import org.janusgraph.diskstorage.common.DistributedStoreManager;
+import org.janusgraph.diskstorage.keycolumnvalue.StoreFeatures;
+
+public class CQLStoreFeaturesWrapper {
+
+    private final StoreFeatures storeFeatures;
+    private final DistributedStoreManager.Deployment deployment;
+
+    public CQLStoreFeaturesWrapper(StoreFeatures storeFeatures, DistributedStoreManager.Deployment deployment) {
+        this.storeFeatures = storeFeatures;
+        this.deployment = deployment;
+    }
+
+    public StoreFeatures getStoreFeatures() {
+        return storeFeatures;
+    }
+
+    public DistributedStoreManager.Deployment getDeployment() {
+        return deployment;
+    }
+}


### PR DESCRIPTION
This PR simply wraps the code after `CQLSession` is created in `try catch` and then trigger `close` method in case the exception was thrown later in the constructor.

From https://docs.datastax.com/en/developer/java-driver/4.13/manual/core/ it is noted that `CqlSession` must always be properly closed.

I found that CQLSession isn't properly closed if the exception is thrown during CQLStoreManager construction after CQLSession is initialized.
The next property helped to find the leak `advanced.session-leak.threshold` (you can read more about it here: https://docs.datastax.com/en/developer/java-driver/4.13/manual/core/configuration/reference/).

The test which will fail on master branch (similar one is included in this PR):
```
@Test
public void shouldProperlyCloseSessionOnException() throws NoSuchFieldException, IllegalAccessException {

    ModifiableConfiguration configuration = Mockito.spy(getBaseStorageConfiguration());

    configuration.set(METRICS_JMX_ENABLED, true);
    configuration.set(BASIC_METRICS, true);
    configuration.set(METRICS_SESSION_ENABLED, new String[]{"bytes-sent", "bytes-received", "connected-nodes"});

    MetricRegistry metricRegistrySpy = spyOnMetricsRegistry();

    verify(metricRegistrySpy, never()).remove(any());

    Mockito.doThrow(RuntimeException.class).when(configuration).get(BATCH_STATEMENT_SIZE);

    RuntimeException runtimeException = Assertions.assertThrows(RuntimeException.class, () ->
        new CQLStoreManager(configuration));
    
    verify(metricRegistrySpy, atLeastOnce()).remove(any());
}

private MetricRegistry spyOnMetricsRegistry() throws NoSuchFieldException, IllegalAccessException {
    MetricRegistry metricRegistrySpy = Mockito.spy(MetricManager.INSTANCE.getRegistry());
    Field registryField = MetricManager.INSTANCE.getClass().getDeclaredField("registry");
    registryField.setAccessible(true);
    registryField.set(MetricManager.INSTANCE, metricRegistrySpy);
    return metricRegistrySpy;
}
```

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
