### PR TITLE
Explicitly add commons-configuration2 dependency

### DIFF
--- a/janusgraph-core/pom.xml
+++ b/janusgraph-core/pom.xml
@@ -61,6 +61,10 @@
             <artifactId>commons-configuration</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -598,6 +598,12 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <!-- align with TinkerPop -->
+                <version>2.7</version>
+            </dependency>
 
             <!-- Jackson 2.x -->
             <dependency>


### PR DESCRIPTION
org.apache.commons:commons-configuration2 is used widely in JanusGraph but it is not
explicitly included in pom.xml, which causes coexistence of two different versions,
one introduced by tinkerpop and the other introduced by solr-test-framework. Although
the released jars only include the tinkerpop version, which is correct, it is better to
explicitly define this dependency in pom.xml.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
