### PR TITLE
Remove QNF check for vertex centric query constraints

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/QueryUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/QueryUtil.java
@@ -150,10 +150,9 @@ public class QueryUtil {
         return condition.getType() == Condition.Type.LITERAL && (!(condition instanceof PredicateCondition) || ((PredicateCondition) condition).getPredicate().isQNF());
     }
 
-    public static <E extends JanusGraphElement> Condition<E> simplifyQNF(Condition<E> condition) {
-        Preconditions.checkArgument(isQueryNormalForm(condition));
+    public static <E extends JanusGraphElement> Condition<E> simplifyAnd(And<E> condition) {
         if (condition.numChildren() == 1) {
-            final Condition<E> child = ((And<E>) condition).get(0);
+            final Condition<E> child = condition.get(0);
             if (child.getType() == Condition.Type.LITERAL) return child;
         }
         return condition;
@@ -224,6 +223,7 @@ public class QueryUtil {
                 }
             } else if (predicate instanceof OrJanusPredicate) {
                 final List<Object> values = (List<Object>) (value);
+                // FIXME: this might generate a non QNF-compliant form, e.g. nested = PredicateCondition OR (PredicateCondition AND PredicateCondition)
                 final Or<E> nested = addConstraint(type, (OrJanusPredicate) predicate, values, new Or<>(values.size()), tx);
                 if (nested == null) {
                     return null;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BaseVertexCentricQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BaseVertexCentricQuery.java
@@ -21,7 +21,6 @@ import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
 import org.janusgraph.graphdb.internal.OrderList;
 import org.janusgraph.graphdb.query.BackendQueryHolder;
 import org.janusgraph.graphdb.query.BaseQuery;
-import org.janusgraph.graphdb.query.QueryUtil;
 import org.janusgraph.graphdb.query.condition.Condition;
 import org.janusgraph.graphdb.query.condition.FixedCondition;
 import org.janusgraph.graphdb.query.profile.ProfileObservable;
@@ -43,7 +42,7 @@ import java.util.List;
 public class BaseVertexCentricQuery extends BaseQuery implements ProfileObservable {
 
     /**
-     * The condition of this query in QNF
+     * The condition of this query
      */
     protected final Condition<JanusGraphRelation> condition;
     /**
@@ -67,7 +66,6 @@ public class BaseVertexCentricQuery extends BaseQuery implements ProfileObservab
                                   int limit) {
         super(limit);
         Preconditions.checkArgument(condition != null && queries != null && direction != null);
-        Preconditions.checkArgument(QueryUtil.isQueryNormalForm(condition) && limit>=0);
         this.condition = condition;
         this.queries = queries;
         this.orders = orders;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
@@ -624,7 +624,7 @@ public abstract class BasicVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q
 
             conditions.add(getTypeCondition(ts));
         }
-        return new BaseVertexCentricQuery(QueryUtil.simplifyQNF(conditions), dir, queries, orders, limit);
+        return new BaseVertexCentricQuery(QueryUtil.simplifyAnd(conditions), dir, queries, orders, limit);
     }
 
     private void constructSliceQueries(PropertyKey[] extendedSortKey, EdgeSerializer.TypedInterval[] sortKeyConstraints,


### PR DESCRIPTION
QNF constraint form, JanusGraph variant of CNF (conjunctive normal form) with negation inlined,
is not required for vertex centric queries. This commit removes the checks for QNF, otherwise
queries like `has("duration", P.eq(0d).or(not(P.outside(0.1d, 0.3d))))` would fail.

Fixes #2773

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
