### PR TITLE
Add possibility to use second argument as configuration path to janusgraph-server

### DIFF
--- a/docs/operations/server.md
+++ b/docs/operations/server.md
@@ -43,19 +43,22 @@ The JanusGraph Server can be started in the foreground with stdout logging or de
 
 ```txt
 $ ./bin/janusgraph-server.sh
-Usage: ./bin/janusgraph-server.sh {start|stop|restart|status|console|usage <group> <artifact> <version>|<conf file>}
+Usage: ./bin/janusgraph-server.sh {start [conf file]|stop|restart [conf file]|status|console|usage <group> <artifact> <version>|<conf file>}
 
-    start           Start the server in the background using conf/gremlin-server/gremlin-server.yaml as the
-                    default configuration file
+    start           Start the server in the background. Configuration file can be specified as a second argument
+                    or as JANUSGRAPH_YAML environment variable. If configuration file is not specified
+                    or has invalid path than JanusGraph server will try to use the default configuration file
+                    at relative location conf/gremlin-server/gremlin-server.yaml
     stop            Stop the server
-    restart         Stop and start the server
-    status          Check if the server is running using the pid file
-    console         Start the server in the foreground using conf/gremlin-server/gremlin-server.yaml as the
-                    default configuration file
+    restart         Stop and start the server. To use previously used configuration it should be specified again
+                    as described in "start" command
+    status          Check if the server is running
+    console         Start the server in the foreground. Same rules are applied for configurations as described
+                    in "start" command
     usage           Print out this help message
 
-If using a custom YAML configuration file then specify it as the only argument for a JanusGraph
-Server to run in the foreground or specify it via the JANUSGRAPH_YAML environment variable.
+In case command is not specified and the configuration is specified as the first argument, JanusGraph Server will
+ be started in the foreground using the specified configuration (same as with "console" command).
 ```
 
 ### Env variables
@@ -78,7 +81,7 @@ Server to run in the foreground or specify it via the JANUSGRAPH_YAML environmen
 
 ### Configure jvm.options
 
-JanusGraph runs on the JVM which is configureable for special use cases. Therefore, JanusGraph provides a `jvm.options` file with some default options.
+JanusGraph runs on the JVM which is configurable for special use cases. Therefore, JanusGraph provides a `jvm.options` file with some default options.
 
 ```bash
 # Copyright 2020 JanusGraph Authors

--- a/janusgraph-dist/src/assembly/cfilter/conf/janusgraph-berkeleyje-es.properties
+++ b/janusgraph-dist/src/assembly/cfilter/conf/janusgraph-berkeleyje-es.properties
@@ -26,3 +26,4 @@
 
 #JANUSGRAPHCFG{index.search.backend=elasticsearch}
 
+#JANUSGRAPHCFG{index.search.hostname=127.0.0.1}

--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-berkeleyje.yaml
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-berkeleyje.yaml
@@ -17,7 +17,8 @@ port: 8182
 evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
 graphs: {
-  graph: conf/gremlin-server/janusgraph-berkeleyje-server.properties}
+  graph: conf/janusgraph-berkeleyje.properties
+}
 scriptEngines: {
   gremlin-groovy: {
     plugins: { org.janusgraph.graphdb.tinkerpop.plugin.JanusGraphGremlinPlugin: {},
@@ -57,4 +58,3 @@ maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
 writeBufferLowWaterMark: 32768
 writeBufferHighWaterMark: 65536
-

--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-cql.yaml
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-cql.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 JanusGraph Authors
+# Copyright 2021 JanusGraph Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ port: 8182
 evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
 graphs: {
-  graph: conf/janusgraph-berkeleyje-es.properties
+  graph: conf/janusgraph-cql.properties
 }
 scriptEngines: {
   gremlin-groovy: {

--- a/janusgraph-dist/src/test/expect/janusgraph-server-sh.after.expect.vm
+++ b/janusgraph-dist/src/test/expect/janusgraph-server-sh.after.expect.vm
@@ -22,7 +22,7 @@ expect_after {
         exit 1
     }
 }
-expect "Usage: ./bin/janusgraph-server.sh {start|stop|restart|status|console|usage <group> <artifact> <version>|<conf file>}"
+expect "Usage: ./bin/janusgraph-server.sh {start \[conf file\]|stop|restart \[conf file\]|status|console|usage <group> <artifact> <version>|<conf file>}"
 
 spawn bin/janusgraph-server.sh status
 expect -re "Server running with PID *"

--- a/janusgraph-dist/src/test/expect/janusgraph-server-sh.before.expect.vm
+++ b/janusgraph-dist/src/test/expect/janusgraph-server-sh.before.expect.vm
@@ -22,14 +22,17 @@ expect_after {
         exit 1
     }
 }
-expect "Usage: ./bin/janusgraph-server.sh {start|stop|restart|status|console|usage <group> <artifact> <version>|<conf file>}"
+expect "Usage: ./bin/janusgraph-server.sh {start \[conf file\]|stop|restart \[conf file\]|status|console|usage <group> <artifact> <version>|<conf file>}"
 
 spawn bin/janusgraph-server.sh status
 expect "Server not running"
 catch wait result
 
 system bin/janusgraph-server.sh start ${janusgraphServerConfig}
-expect -re "Server started *"
+expect -re {
+    "${janusgraphServerConfig} will be used to start JanusGraph Server in background"
+    "Server started *"
+}
 catch wait result
 
 spawn bin/janusgraph-server.sh status


### PR DESCRIPTION
Fixes the bug when 2nd argument would be ignored to processed as configuration path. Thus the default inmemory configuration was used from `janusgraph.sh start` instead of Cassandra + ElasticSearch. This PR fixes it by allowing to pass optional 2nd argument which would represent configuration to be used.

The bug was reported by @FlorianHockmann here: https://lists.lfaidata.foundation/g/janusgraph-dev/message/1546

Tested these changes with `janusgraph.sh` (now it runs Cassandra + ElasticSearch as expected). Also tested `janusgraph-server.sh` with both default and custom configuration (works as expected).

Related to #2119

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
