### PR TITLE
installation.md: Fix command to start server with config

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -115,7 +115,7 @@ $ ./bin/janusgraph-server.sh start
 ```
 or
 ```bash
-$ ./bin/janusgraph-server.sh console ./conf/gremlin-server/gremlin-server-[...].yaml
+$ ./bin/janusgraph-server.sh ./conf/gremlin-server/gremlin-server-[...].yaml
 ```
 
 !!! info


### PR DESCRIPTION
When the server is started with a custom config path, the path
should be the only argument. The example given wrongly includes
a parameter, which makes the script ignore the given configuration
file completely.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
