### PR TITLE
Use JanusGraphManager by default

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -41,6 +41,72 @@ The versions of JanusGraph listed below are outdated and will no longer receive 
 
 ## Release Notes
 
+### Version 0.6.1 (Release Date: ???)
+
+```xml tab='Maven'
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.6.1</version>
+</dependency>
+```
+
+```groovy tab='Gradle'
+compile "org.janusgraph:janusgraph-core:0.6.1"
+```
+
+**Tested Compatibility:**
+
+* Apache Cassandra 3.0.14, 3.11.10
+* Apache HBase 1.6.0, 2.2.7
+* Google Bigtable 1.3.0, 1.4.0, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.9.0, 1.10.0, 1.11.0, 1.14.0
+* Oracle BerkeleyJE 7.5.11
+* Elasticsearch 6.0.1, 6.6.0, 7.14.0
+* Apache Lucene 8.9.0
+* Apache Solr 7.7.2, 8.9.0
+* Apache TinkerPop 3.5.1
+* Java 1.8
+
+#### Changes
+
+For more information on features and bug fixes in 0.6.1, see the GitHub milestone:
+
+-   <https://github.com/JanusGraph/janusgraph/milestone/22?closed=1>
+
+#### Assets
+
+* [JavaDoc](https://javadoc.io/doc/org.janusgraph/janusgraph-core/0.6.1)
+* [GitHub Release](https://github.com/JanusGraph/janusgraph/releases/tag/v0.6.1)
+* [JanusGraph zip](https://github.com/JanusGraph/janusgraph/releases/download/v0.6.1/janusgraph-0.6.1.zip)
+* [JanusGraph zip with embedded Cassandra and ElasticSearch](https://github.com/JanusGraph/janusgraph/releases/download/v0.6.1/janusgraph-full-0.6.1.zip)
+
+#### Upgrade Instructions
+
+##### GraphManager changed to JanusGraphManager
+
+A `GraphManager` is used to instantiate graph instances. JanusGraph Server has used the
+`DefaultGraphManager` from TinkerPop for this by default if no other `GraphManager` was specified
+in the JanusGraph Server YAML config file.
+The behavior of this `DefaultGraphManager` was changed in TinkerPop 3.5.0 which is included in
+JanusGraph 0.6.0 in how it parses config values, making it impossible to provide comma separated
+values, e.g., to specify multiple hostnames for the storage backend. The `JanusGraphManager` does
+not have this limitation which is why it is now configured as the `GraphManager` in the
+JanusGraph Server config files:
+
+```yaml
+[...]
+channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
+graphManager: org.janusgraph.graphdb.management.JanusGraphManager
+graphs: {
+  graph: conf/janusgraph-berkeleyje-es.properties
+}
+[...]
+```
+
+If you however want to continue using the `DefaultGraphManager`, then you can simply remove the
+setting again or change it to the TinkerPop `GraphManager` that has been the default before:
+`org.apache.tinkerpop.gremlin.server.util.DefaultGraphManager`.
+
 ### Version 0.6.0 (Release Date: September 3, 2021)
 
 ```xml tab='Maven'

--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-berkeleyje-es.yaml
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-berkeleyje-es.yaml
@@ -16,6 +16,7 @@ host: 0.0.0.0
 port: 8182
 evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
+graphManager: org.janusgraph.graphdb.management.JanusGraphManager
 graphs: {
   graph: conf/janusgraph-berkeleyje-es.properties
 }

--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-berkeleyje.yaml
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-berkeleyje.yaml
@@ -16,6 +16,7 @@ host: 0.0.0.0
 port: 8182
 evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
+graphManager: org.janusgraph.graphdb.management.JanusGraphManager
 graphs: {
   graph: conf/janusgraph-berkeleyje.properties
 }

--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-cql-es.yaml
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-cql-es.yaml
@@ -16,6 +16,7 @@ host: 0.0.0.0
 port: 8182
 evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
+graphManager: org.janusgraph.graphdb.management.JanusGraphManager
 graphs: {
     graph: conf/janusgraph-cql-es.properties
 }

--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-cql.yaml
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server-cql.yaml
@@ -16,6 +16,7 @@ host: 0.0.0.0
 port: 8182
 evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
+graphManager: org.janusgraph.graphdb.management.JanusGraphManager
 graphs: {
   graph: conf/janusgraph-cql.properties
 }

--- a/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server.yaml
+++ b/janusgraph-dist/src/assembly/static/conf/gremlin-server/gremlin-server.yaml
@@ -16,6 +16,7 @@ host: 0.0.0.0
 port: 8182
 evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
+graphManager: org.janusgraph.graphdb.management.JanusGraphManager
 graphs: {
   graph: conf/janusgraph-inmemory.properties
 }

--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/AbstractGremlinServerIntegrationTest.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/AbstractGremlinServerIntegrationTest.java
@@ -48,7 +48,7 @@ public abstract class AbstractGremlinServerIntegrationTest {
     private static final Logger logger = LoggerFactory.getLogger(AbstractGremlinServerIntegrationTest.class);
 
     public String getSettingsPath() {
-        return "src/test/resources/gremlin-server-integration.yaml";
+        return "src/test/resources/janusgraph-server-integration.yaml";
     }
 
     @BeforeEach

--- a/janusgraph-server/src/test/resources/janusgraph-server-integration.yaml
+++ b/janusgraph-server/src/test/resources/janusgraph-server-integration.yaml
@@ -16,6 +16,7 @@ host: 0.0.0.0
 port: 45940
 evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
+graphManager: org.janusgraph.graphdb.management.JanusGraphManager
 graphs: {
   ConfigurationManagementGraph: "src/test/resources/conf/janusgraph-server-integration.properties"
 }


### PR DESCRIPTION
This makes it possible to use comma-separated config values again, e.g., for `storage.hostname`.
The `DefaultGraphManager` from TinkerPop used until now uses the TinkerPop `GraphFactory` which uses `DisabledListDelimiterHandler`. So, comma separated config values are not supported with that `GraphManager`. `JanusGraphFactory` however uses comma-delimited `DefaultListDelimiterHandler`.
So, switching from TinkerPop's `DefaultGraphManager` to `JanusGraphManager` which uses the `JanusGraphFactory` allows to use comma-separated config values again.

Fixes #2822

The tests in `JanusGraphServerTest` all initialize a graph manager instance which is why they cannot be moved to `JanusGraphManager` as that is a singleton implementation which throws when a second instance is requested and the instance is not returned at any point. So, I didn't change those tests to also use the `JanusGraphManager`.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
