### PR TITLE
Fix g.E().hasId(eId) empty result bug

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/step/JanusGraphStep.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/step/JanusGraphStep.java
@@ -80,7 +80,8 @@ public class JanusGraphStep<S, E extends Element> extends GraphStep<S, E> implem
                 return Collections.emptyIterator();
             } else if (this.ids.length > 0) {
                 final Graph graph = (Graph)traversal.asAdmin().getGraph().get();
-                return iteratorList((Iterator)graph.vertices(this.ids));
+                return iteratorList((Iterator<E>) (Vertex.class.isAssignableFrom(getReturnClass())
+                    ? graph.vertices(ids) : graph.edges(ids)));
             }
 
             buildGlobalGraphCentricQuery();

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/query/QueryTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/query/QueryTest.java
@@ -125,6 +125,42 @@ public class QueryTest {
     }
 
     @Test
+    public void testIdLookUpQuery() {
+        Vertex v1 = tx.addVertex("pos", 0);
+        Vertex v2 = tx.addVertex();
+        Edge e = v1.addEdge("connects", v2, "prop", "val");
+        String vId = v1.id().toString();
+        String eId = e.id().toString();
+        tx.commit();
+
+        tx = graph.newTransaction();
+
+        // edges
+        assertTrue(tx.traversal().E(eId).hasNext());
+        assertFalse(tx.traversal().E(eId).hasId("wrong-id").hasNext());
+        assertFalse(tx.traversal().E("wrong-id").hasId(eId).hasNext());
+        assertFalse(tx.traversal().E(eId).has("prop", "non").hasNext());
+        assertTrue(tx.traversal().E(eId).has("prop", "val").hasNext());
+        assertTrue(tx.traversal().E().hasId(eId).hasNext());
+        assertFalse(tx.traversal().E().hasId(eId).has("prop", "non").hasNext());
+        assertTrue(tx.traversal().E().hasId(eId).has("prop", "val").hasNext());
+        assertEquals(tx.traversal().E(eId).next(), tx.traversal().E().hasId(eId).next());
+        assertEquals(tx.traversal().E(eId).next(), tx.traversal().E(eId).hasId(eId).next());
+
+        // vertices
+        assertTrue(tx.traversal().V(vId).hasNext());
+        assertFalse(tx.traversal().V(vId).hasId(123).hasNext());
+        assertFalse(tx.traversal().V(123).hasId(vId).hasNext());
+        assertFalse(tx.traversal().V(vId).has("pos", 1).hasNext());
+        assertTrue(tx.traversal().V(vId).has("pos", 0).hasNext());
+        assertTrue(tx.traversal().V().hasId(vId).hasNext());
+        assertFalse(tx.traversal().V().hasId(vId).has("pos", 1).hasNext());
+        assertTrue(tx.traversal().V().hasId(vId).has("pos", 0).hasNext());
+        assertEquals(tx.traversal().V(vId).next(), tx.traversal().V().hasId(vId).next());
+        assertEquals(tx.traversal().V(vId).next(), tx.traversal().V(vId).hasId(vId).next());
+    }
+
+    @Test
     public void testMultipleKeysQuery() {
         tx.makePropertyKey("name").dataType(String.class).make();
         tx.addVertex("name","vertex1");


### PR DESCRIPTION
JanusGraphStep wrongly assumes an id must be a vertex id.
In fact, it could be an edge id.

Fixes #2848

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
