### PR TITLE
Add CVE-2021-44228 mitigation for ES

### DIFF
--- a/janusgraph-dist/src/assembly/static/elasticsearch/config/jvm.options
+++ b/janusgraph-dist/src/assembly/static/elasticsearch/config/jvm.options
@@ -89,3 +89,6 @@
 
 # JDK 9+ GC logging
 9-:-Xlog:gc*,gc+age=trace,safepoint:file=../logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+
+# CVE-2021-44228 (aka “log4shell”) mitigation 
+-Dlog4j2.formatMsgNoLookups=true


### PR DESCRIPTION
This only mitigates the CVE for ES included the pre-packaged distribution. Users who maintain their own ES (or Solr) installation, need to apply the mitigation there by themselves.

The mitigation is recommended in the summary provided by Elasticsearch:
https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476

Fixes #2891

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
