### PR TITLE
Add distribution test for SparkGraphComputer traversal

### DIFF
--- a/janusgraph-dist/src/test/expect/spark-graph-computer.expect.vm
+++ b/janusgraph-dist/src/test/expect/spark-graph-computer.expect.vm
@@ -1,0 +1,57 @@
+#!/usr/bin/env expect
+# Copyright 2021 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+set timeout 30
+
+spawn bin/gremlin.sh
+expect_after {
+    timeout {
+        # Default timeout handler
+        exit 1
+    }
+}
+expect gremlin>
+send "g = JanusGraphFactory.open(\"${graphConfig}\")\r"
+expect -re "${graphToString}"
+expect gremlin>
+send "g.getBackend().clearStorage()\r"
+expect gremlin>
+send "g = JanusGraphFactory.open(\"${graphConfig}\")\r"
+expect gremlin>
+send "v = g.addVertex()\r"
+expect -re {v\[(\d+)\]} { set vertexid $expect_out(1,string) }
+expect gremlin>
+send "v.property('test', 42)\r"
+expect "vp\[test->42\]"
+expect gremlin>
+send "g.tx().commit()\r"
+sleep 10
+expect gremlin>
+send "g.close()\r"
+expect gremlin>
+send "graph = GraphFactory.open(\"${sparkGraphConfig}\")\r"
+expect -re "hadoopgraph"
+expect gremlin>
+send "g = graph.traversal().withComputer(SparkGraphComputer)\r"
+expect gremlin>
+send "g.V(v.longId()).values('test')\r"
+expect "42"
+expect gremlin>
+send "g.V().count()\r"
+expect "1"
+expect gremlin>
+send "graph.close()\r"
+expect gremlin>
+exit 0

--- a/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/AbstractJanusGraphAssemblyIT.java
+++ b/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/AbstractJanusGraphAssemblyIT.java
@@ -45,6 +45,14 @@ public abstract class AbstractJanusGraphAssemblyIT extends JanusGraphAssemblyBas
 
     protected abstract String getConfigPath();
 
+    /**
+     * Get the path to the configuration for local Spark
+     * @return path
+     */
+    protected String getLocalSparkGraphConfigPath() {
+        return null;
+    }
+
     protected abstract String getServerConfigPath();
 
     protected abstract String getGraphName();
@@ -74,6 +82,11 @@ public abstract class AbstractJanusGraphAssemblyIT extends JanusGraphAssemblyBas
     @Test
     public void testJanusGraphServerGremlin() throws Exception {
         testJanusGraphServer(false);
+    }
+
+    @Test
+    public void testSparkGraphComputerTraversalLocal() throws Exception {
+        unzipAndRunExpect("spark-graph-computer.expect.vm", getConfigPath(), getLocalSparkGraphConfigPath(), getGraphName(), false, false);
     }
 
     @Test

--- a/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/BerkeleyAssemblyIT.java
+++ b/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/BerkeleyAssemblyIT.java
@@ -67,4 +67,10 @@ public class BerkeleyAssemblyIT extends AbstractJanusGraphAssemblyIT {
     @Disabled
     @Override
     public void testGettingStartedAgainstGremlinShFull() {}
+
+    @Test
+    @Disabled
+    @Override
+    public void testSparkGraphComputerTraversalLocal() {
+    }
 }

--- a/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/BerkeleyESAssemblyIT.java
+++ b/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/BerkeleyESAssemblyIT.java
@@ -16,6 +16,8 @@ package org.janusgraph.pkgtest;
 
 import org.janusgraph.diskstorage.es.JanusGraphElasticsearchContainer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -62,5 +64,11 @@ public class BerkeleyESAssemblyIT extends AbstractJanusGraphAssemblyIT {
                 e.printStackTrace();
             }
         }
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void testSparkGraphComputerTraversalLocal() {
     }
 }

--- a/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/CqlAssemblyIT.java
+++ b/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/CqlAssemblyIT.java
@@ -50,4 +50,10 @@ public class CqlAssemblyIT extends AbstractJanusGraphAssemblyIT {
     @Disabled
     @Override
     public void testGettingStartedAgainstGremlinShFull() {}
+
+    @Test
+    @Disabled
+    @Override
+    public void testSparkGraphComputerTraversalLocal() {
+    }
 }

--- a/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/CqlESAssemblyIT.java
+++ b/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/CqlESAssemblyIT.java
@@ -39,6 +39,11 @@ public class CqlESAssemblyIT extends AbstractJanusGraphAssemblyIT {
     }
 
     @Override
+    protected String getLocalSparkGraphConfigPath() {
+        return "conf/hadoop-graph/read-cql.properties";
+    }
+
+    @Override
     protected String getGraphName() {
         return "cql";
     }

--- a/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/InMemoryAssemblyIT.java
+++ b/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/InMemoryAssemblyIT.java
@@ -43,4 +43,10 @@ public class InMemoryAssemblyIT extends AbstractJanusGraphAssemblyIT {
     @Disabled
     @Override
     public void testGettingStartedAgainstGremlinShFull() {}
+
+    @Test
+    @Disabled
+    @Override
+    public void testSparkGraphComputerTraversalLocal() {
+    }
 }

--- a/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/JanusGraphAssemblyBaseIT.java
+++ b/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/JanusGraphAssemblyBaseIT.java
@@ -111,7 +111,11 @@ public abstract class JanusGraphAssemblyBaseIT {
     }
 
     protected void unzipAndRunExpect(String expectTemplateName, String graphConfig, String graphToString, boolean full, boolean debug) throws Exception {
-        unzipAndRunExpect(expectTemplateName, ImmutableMap.of("graphConfig", graphConfig, "graphToString", graphToString), full, debug);
+        unzipAndRunExpect(expectTemplateName, graphConfig, "", graphToString, full, debug);
+    }
+
+    protected void unzipAndRunExpect(String expectTemplateName, String graphConfig, String sparkGraphConfig, String graphToString, boolean full, boolean debug) throws Exception {
+        unzipAndRunExpect(expectTemplateName, ImmutableMap.of("graphConfig", graphConfig, "sparkGraphConfig", sparkGraphConfig, "graphToString", graphToString), full, debug);
     }
 
     private static void expect(String dir, String expectScript, boolean debug) throws IOException, InterruptedException {


### PR DESCRIPTION
We have SparkGraphComputer tests in AbstractInputFormatIT, but not in distribution tests.
PR #2756 is an example which shows that dependency issues could damage the functionality even
if AbstractInputFormatIT passes. This commit aims to test basic SparkGraphComputer traversal
which leverages local Spark instance in gremlin console.

The new test fails without the fix in #2756.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
