### PR TITLE
 Fix NullPointerException caused by transaction release

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -95,8 +95,10 @@ import org.janusgraph.graphdb.relations.StandardVertexProperty;
 import org.janusgraph.graphdb.tinkerpop.JanusGraphBlueprintsTransaction;
 import org.janusgraph.graphdb.transaction.addedrelations.AddedRelationsContainer;
 import org.janusgraph.graphdb.transaction.addedrelations.ConcurrentAddedRelations;
+import org.janusgraph.graphdb.transaction.addedrelations.EmptyAddedRelations;
 import org.janusgraph.graphdb.transaction.addedrelations.SimpleAddedRelations;
 import org.janusgraph.graphdb.transaction.indexcache.ConcurrentIndexCache;
+import org.janusgraph.graphdb.transaction.indexcache.EmptyIndexCache;
 import org.janusgraph.graphdb.transaction.indexcache.IndexCache;
 import org.janusgraph.graphdb.transaction.indexcache.SimpleIndexCache;
 import org.janusgraph.graphdb.transaction.lock.CombinerLock;
@@ -105,8 +107,10 @@ import org.janusgraph.graphdb.transaction.lock.IndexLockTuple;
 import org.janusgraph.graphdb.transaction.lock.LockTuple;
 import org.janusgraph.graphdb.transaction.lock.ReentrantTransactionLock;
 import org.janusgraph.graphdb.transaction.lock.TransactionLock;
+import org.janusgraph.graphdb.transaction.subquerycache.EmptySubqueryCache;
 import org.janusgraph.graphdb.transaction.subquerycache.GuavaSubqueryCache;
 import org.janusgraph.graphdb.transaction.subquerycache.SubqueryCache;
+import org.janusgraph.graphdb.transaction.vertexcache.EmptyVertexCache;
 import org.janusgraph.graphdb.transaction.vertexcache.GuavaVertexCache;
 import org.janusgraph.graphdb.transaction.vertexcache.VertexCache;
 import org.janusgraph.graphdb.types.CompositeIndexType;
@@ -229,7 +233,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
      * Transaction-local data structure for unique lock applications so that conflicting applications can be discovered
      * at the transactional level.
      */
-    private volatile ConcurrentMap<LockTuple, TransactionLock> uniqueLocks;
+    private volatile Map<LockTuple, TransactionLock> uniqueLocks;
 
     //####### Other Data structures
     /**
@@ -699,7 +703,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
 
     private TransactionLock getLock(final LockTuple la) {
         if (config.isSingleThreaded()) return FakeLock.INSTANCE;
-        ConcurrentMap<LockTuple, TransactionLock> result = uniqueLocks;
+        Map<LockTuple, TransactionLock> result = uniqueLocks;
         if (result == UNINITIALIZED_LOCKS) {
             Preconditions.checkArgument(!config.isSingleThreaded());
             synchronized (this) {
@@ -1561,13 +1565,13 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
     private void releaseTransaction() {
         isOpen = false;
         graph.closeTransaction(this);
-        vertexCache = null;
-        indexCache = null;
-        addedRelations = null;
-        deletedRelations = null;
-        uniqueLocks = null;
-        newVertexIndexEntries = null;
-        newTypeCache = null;
+        vertexCache = EmptyVertexCache.getInstance();
+        indexCache = EmptySubqueryCache.getInstance();
+        addedRelations = EmptyAddedRelations.getInstance();
+        deletedRelations = Collections.emptyMap();
+        uniqueLocks = Collections.emptyMap();
+        newVertexIndexEntries = EmptyIndexCache.getInstance();
+        newTypeCache = Collections.emptyMap();
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/addedrelations/EmptyAddedRelations.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/addedrelations/EmptyAddedRelations.java
@@ -1,0 +1,62 @@
+// Copyright 2022 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.transaction.addedrelations;
+
+import com.google.common.base.Predicate;
+import org.janusgraph.graphdb.internal.InternalRelation;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class EmptyAddedRelations implements AddedRelationsContainer {
+
+    private static final EmptyAddedRelations INSTANCE = new EmptyAddedRelations();
+
+    private EmptyAddedRelations() {
+    }
+
+    public static EmptyAddedRelations getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public boolean add(InternalRelation relation) {
+        return false;
+    }
+
+    @Override
+    public boolean remove(InternalRelation relation) {
+        return false;
+    }
+
+    @Override
+    public Iterable<InternalRelation> getView(Predicate<InternalRelation> filter) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return true;
+    }
+
+    @Override
+    public Collection<InternalRelation> getAll() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void clear() {
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/indexcache/EmptyIndexCache.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/indexcache/EmptyIndexCache.java
@@ -1,0 +1,60 @@
+// Copyright 2022 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.transaction.indexcache;
+
+import org.janusgraph.core.JanusGraphVertexProperty;
+import org.janusgraph.core.PropertyKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+
+public class EmptyIndexCache implements IndexCache {
+
+    private static final EmptyIndexCache INSTANCE = new EmptyIndexCache();
+
+    private static final Logger log = LoggerFactory.getLogger(EmptyIndexCache.class);
+
+    private EmptyIndexCache() {
+    }
+
+    public static EmptyIndexCache getInstance() {
+        return INSTANCE;
+    }
+
+    private void logWarning() {
+        log.warn("Index cache is already closed");
+    }
+
+    @Override
+    public void add(JanusGraphVertexProperty property) {
+        logWarning();
+    }
+
+    @Override
+    public void remove(JanusGraphVertexProperty property) {
+        logWarning();
+    }
+
+    @Override
+    public Iterable<JanusGraphVertexProperty> get(final Object value, final PropertyKey key) {
+        logWarning();
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/subquerycache/EmptySubqueryCache.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/subquerycache/EmptySubqueryCache.java
@@ -1,0 +1,62 @@
+// Copyright 2022 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.transaction.subquerycache;
+
+import org.janusgraph.graphdb.query.graph.JointIndexQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+public class EmptySubqueryCache implements SubqueryCache {
+
+    private static final EmptySubqueryCache INSTANCE = new EmptySubqueryCache();
+
+    private static final Logger log = LoggerFactory.getLogger(EmptySubqueryCache.class);
+
+    private EmptySubqueryCache() {
+    }
+
+    public static EmptySubqueryCache getInstance() {
+        return INSTANCE;
+    }
+
+    private void logWarning() {
+        log.warn("Subquery cache is already closed");
+    }
+
+    @Override
+    public List<Object> getIfPresent(JointIndexQuery.Subquery query) {
+        logWarning();
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void put(JointIndexQuery.Subquery query, List<Object> values) {
+        logWarning();
+    }
+
+    @Override
+    public List<Object> get(JointIndexQuery.Subquery query, Callable<? extends List<Object>> valueLoader) throws Exception {
+        logWarning();
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/vertexcache/EmptyVertexCache.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/vertexcache/EmptyVertexCache.java
@@ -1,0 +1,68 @@
+// Copyright 2022 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.transaction.vertexcache;
+
+import org.janusgraph.graphdb.internal.InternalVertex;
+import org.janusgraph.util.datastructures.Retriever;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+
+public class EmptyVertexCache implements VertexCache {
+
+    private static final EmptyVertexCache INSTANCE = new EmptyVertexCache();
+
+    private static final Logger log = LoggerFactory.getLogger(EmptyVertexCache.class);
+
+    private EmptyVertexCache() {
+    }
+
+    public static EmptyVertexCache getInstance() {
+        return INSTANCE;
+    }
+
+    private void logWarning() {
+        log.warn("Vertex cache is already closed");
+    }
+
+    @Override
+    public boolean contains(long id) {
+        logWarning();
+        return false;
+    }
+
+    @Override
+    public InternalVertex get(final long id, final Retriever<Long, InternalVertex> retriever) {
+        logWarning();
+        return null;
+    }
+
+    @Override
+    public void add(InternalVertex vertex, long id) {
+        logWarning();
+    }
+
+    @Override
+    public List<InternalVertex> getAllNew() {
+        logWarning();
+        return Collections.emptyList();
+    }
+
+    @Override
+    public synchronized void close() {
+    }
+}

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/transaction/addedrelations/EmptyAddedRelationsTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/transaction/addedrelations/EmptyAddedRelationsTest.java
@@ -1,0 +1,52 @@
+// Copyright 2022 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.transaction.addedrelations;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EmptyAddedRelationsTest {
+    @Test
+    public void instanceIsSingleton() {
+        assertTrue(EmptyAddedRelations.getInstance() == EmptyAddedRelations.getInstance());
+    }
+
+    @Test
+    public void cannotAdd() {
+        assertFalse(EmptyAddedRelations.getInstance().add(null));
+    }
+
+    @Test
+    public void cannotRemove() {
+        assertFalse(EmptyAddedRelations.getInstance().remove(null));
+    }
+
+    @Test
+    public void isEmpty() {
+        assertTrue(EmptyAddedRelations.getInstance().isEmpty());
+    }
+
+    @Test
+    public void getAllReturnsEmpty() {
+        assertTrue(EmptyAddedRelations.getInstance().getAll().isEmpty());
+    }
+
+    @Test
+    public void getViewReturnsEmpty() {
+        assertFalse(EmptyAddedRelations.getInstance().getView(null).iterator().hasNext());
+    }
+}

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/transaction/indexcache/EmptyIndexCacheTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/transaction/indexcache/EmptyIndexCacheTest.java
@@ -1,0 +1,40 @@
+// Copyright 2022 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package org.janusgraph.graphdb.transaction.indexcache;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EmptyIndexCacheTest {
+    @Test
+    public void instanceIsSingleton() {
+        assertTrue(EmptyIndexCache.getInstance() == EmptyIndexCache.getInstance());
+    }
+
+    @Test
+    public void addOrRemoveDoesNotThrowException() {
+        assertDoesNotThrow(() -> EmptyIndexCache.getInstance().add(null));
+        assertDoesNotThrow(() -> EmptyIndexCache.getInstance().remove(null));
+    }
+
+    @Test
+    public void getReturnsEmpty() {
+        assertFalse(EmptyIndexCache.getInstance().get(null, null).iterator().hasNext());
+    }
+}

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/transaction/subquerycache/EmptySubqueryCacheTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/transaction/subquerycache/EmptySubqueryCacheTest.java
@@ -1,0 +1,38 @@
+// Copyright 2022 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.transaction.subquerycache;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EmptySubqueryCacheTest {
+    @Test
+    public void instanceIsSingleton() {
+        assertTrue(EmptySubqueryCache.getInstance() == EmptySubqueryCache.getInstance());
+    }
+
+    @Test
+    public void getReturnsEmpty() throws Exception {
+        assertTrue(EmptySubqueryCache.getInstance().getIfPresent(null).isEmpty());
+        assertTrue(EmptySubqueryCache.getInstance().get(null, null).isEmpty());
+    }
+
+    @Test
+    public void putDoesNotThrowException() {
+        assertDoesNotThrow(() -> EmptySubqueryCache.getInstance().put(null, null));
+    }
+}

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/transaction/vertexcache/EmptyVertexCacheTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/transaction/vertexcache/EmptyVertexCacheTest.java
@@ -1,0 +1,49 @@
+// Copyright 2022 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.transaction.vertexcache;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EmptyVertexCacheTest {
+    @Test
+    public void instanceIsSingleton() {
+        assertTrue(EmptyVertexCache.getInstance() == EmptyVertexCache.getInstance());
+    }
+
+    @Test
+    public void containsReturnsFalse() {
+        assertFalse(EmptyVertexCache.getInstance().contains(1));
+    }
+
+    @Test
+    public void getReturnsFalse() {
+        assertEquals(null, EmptyVertexCache.getInstance().get(1, null));
+    }
+
+    @Test
+    public void addDoesNotThrowException() {
+        assertDoesNotThrow(() -> EmptyVertexCache.getInstance().add(null, 1));
+    }
+
+    @Test
+    public void getAllNewReturnsEmpty() {
+        assertTrue(EmptyVertexCache.getInstance().getAllNew().isEmpty());
+    }
+}


### PR DESCRIPTION
Fixes JanusGraph#2898. Due to a race condition, vertexCache could be cleared before
it is accessed. To avoid NPEs, we cannot simply assign null to vertexCache
to release the memory.

This commit also surpresses https://lists.lfaidata.foundation/g/janusgraph-users/topic/potential_transaction_issue/85970858
by using a dummy empty vertexCache after transaction release. The root cause
for this bug is unknown, but likely it is due to another race condition.
To keep the behavior consistent with v0.5 and before, this commit surpresses
this issue and writes a warning log whenever the issue happens.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
