### PR TITLE
Allow CQL compaction-strategy-class without options

### DIFF
--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStore.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStore.java
@@ -306,8 +306,8 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
             ImmutableMap.of("sstable_compression", compressionType, "chunk_length_kb", chunkLengthInKb));
     }
 
-    private static CreateTableWithOptions compactionOptions(final CreateTableWithOptions createTable,
-                                                            final Configuration configuration) {
+    static CreateTableWithOptions compactionOptions(final CreateTableWithOptions createTable,
+                                                    final Configuration configuration) {
         if (!configuration.has(COMPACTION_STRATEGY)) {
             return createTable;
         }
@@ -317,13 +317,14 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
                 Case($("SizeTieredCompactionStrategy"), sizeTieredCompactionStrategy()),
                 Case($("TimeWindowCompactionStrategy"), timeWindowCompactionStrategy()),
                 Case($("LeveledCompactionStrategy"), leveledCompactionStrategy()));
-        Iterator<Array<String>> groupedOptions = Array.of(configuration.get(COMPACTION_OPTIONS))
-            .grouped(2);
 
-        for(Array<String> keyValue: groupedOptions){
-            compactionStrategy = compactionStrategy.withOption(keyValue.get(0), keyValue.get(1));
+        if (configuration.has(COMPACTION_OPTIONS)) {
+            Iterator<Array<String>> groupedOptions = Array.of(configuration.get(COMPACTION_OPTIONS))
+                                                          .grouped(2);
+            for (Array<String> keyValue : groupedOptions) {
+                compactionStrategy = compactionStrategy.withOption(keyValue.get(0), keyValue.get(1));
+            }
         }
-
         return createTable.withCompaction(compactionStrategy);
     }
 

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStoreTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStoreTest.java
@@ -1,0 +1,53 @@
+// Copyright 2017 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.cql;
+
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.querybuilder.schema.CreateTableWithOptions;
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.junit.Test;
+
+import static com.datastax.oss.driver.api.querybuilder.SchemaBuilder.createTable;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.COMPACTION_OPTIONS;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.COMPACTION_STRATEGY;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.buildGraphConfiguration;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class CQLKeyColumnValueStoreTest {
+    @Test
+    public void testCompactionStrategyWithoutOptions() {
+        CreateTableWithOptions createTable = createTable("tableName")
+            .withPartitionKey("column", DataTypes.BLOB);
+        Configuration configuration = buildGraphConfiguration()
+            .set(COMPACTION_STRATEGY, "LeveledCompactionStrategy");
+
+        assertDoesNotThrow(() -> {
+            CQLKeyColumnValueStore.compactionOptions(createTable, configuration);
+        });
+    }
+
+    @Test
+    public void testCompactionStrategyWithOptions() {
+        CreateTableWithOptions createTable = createTable("tableName")
+            .withPartitionKey("column", DataTypes.BLOB);
+        Configuration configuration = buildGraphConfiguration()
+            .set(COMPACTION_OPTIONS, new String[]{"enabled", "false"})
+            .set(COMPACTION_STRATEGY, "LeveledCompactionStrategy");
+
+        assertDoesNotThrow(() -> {
+            CQLKeyColumnValueStore.compactionOptions(createTable, configuration);
+        });
+    }
+}


### PR DESCRIPTION
When a user specifies a `cql.compaction-strategy-class`, JanusGraph enforces that `cql.compaction-strategy-options` be set. This PR makes `cql.compaction-strategy-options` optional.

Unit test `testCompactionStrategyWithoutOptions` fails without this change.

Fixes #2908

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there an issue associated with this PR? Is it referenced in the commit message?
- [X] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
