### PR TITLE
Add Management API to run ghost vertex remover

### DIFF
--- a/docs/operations/management.md
+++ b/docs/operations/management.md
@@ -1,15 +1,54 @@
 # Management System
 
-!!! warning
-    This site is massivly under development.
+JanusGraph Management System provides methods to define, update, and inspect the schema of
+a JanusGraph graph, and more. Checkout the
+JanusGraph Management [API documentation](https://javadoc.io/doc/org.janusgraph/janusgraph-core/{{ latest_version }}/org/janusgraph/core/schema/JanusGraphManagement.html)
+for all core APIs available.
 
-This section will describe how to interact with the ManagementSystem. 
-Therefore, if you want interact with the ManagementSystem checkout the 
-JanusGraph [API documentation](https://javadoc.io/doc/org.janusgraph/janusgraph-core/{{ latest_version }}) which shows all core APIs exposed by JanusGraph. 
-
-You can checkout the schema and index management pages for some examples, see [schema management](../schema/index.md) and [index management](../schema/index-management/index-lifecycle.md).
+JanusGraph Management System behaves like a transaction in that it opens a transactional scope. As such, it needs to
+be closed via its commit or rollback methods, unless otherwise specified.
+```groovy
+mgmt = graph.openManagement()
+// do something
+mgmt.commit()
+```
 
 !!! note
-    We **strongly** encourage all users of JanusGraph to use the Gremlin query
-    language for any queries executed on JanusGraph and to not use
-    JanusGraph’s APIs outside of the management system.
+    We **strongly** encourage all users of JanusGraph not to use JanusGraph’s APIs outside of the management system,
+    and always use standard Gremlin query language for any queries.
+
+## Schema Management
+
+Management System allows you to view, update, and create vertex labels, edge labels, and property keys.
+See [schema management](../schema/index.md) for details.
+
+## Index Management
+
+Management System allows you to manage both vertex-centric indexes and graph indexes. See
+[index management](../schema/index-management/index-performance.md) for details.
+
+## Consistency Management
+
+Management System allows you to set the consistency level of individual schema elements. See
+[Eventual Consistency](../advanced-topics/eventual-consistency.md) for details.
+
+## Ghost Vertex Removal
+
+Management System allows you to purge [ghost vertices](../advanced-topics/eventual-consistency.md#ghost-vertices)
+in the graph. It uses a local thread pool to initiate multiple threads to scan your entire graph, detecting and
+purging ghost vertices as well as their incident edges, leveraging
+[GhostVertexRemover](https://javadoc.io/doc/org.janusgraph/janusgraph-core/{{ latest_version }}/org/janusgraph/graphdb/olap/job/GhostVertexRemover.html)
+By default, the concurrency level is the number of available
+processors on your machine. You can also configure the number of threads as shown in the example below. If your graph
+is huge, you could consider running GhostVertexRemover on a MapReduce cluster.
+```groovy
+mgmt = graph.openManagement()
+// by default, concurrency level = the number of available processors
+mgmt.removeGhostVertices().get()
+// alternatively, you could also configure the concurrency
+mgmt.removeGhostVertices(4).get()
+// it is not necessary to commit here, since GhostVertexRemover commits
+// periodically and automatically, but it is a good habit to do so
+// calling rollback() won't really rollback the ghost vertex removal process
+mgmt.commit()
+```

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/JanusGraphManagement.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/JanusGraphManagement.java
@@ -283,6 +283,21 @@ public interface JanusGraphManagement extends JanusGraphConfiguration, SchemaMan
     void setTTL(JanusGraphSchemaType type, Duration duration);
 
     /*
+    ##################### CONSISTENCY MANAGEMENT #################
+     */
+
+    /**
+     * Remove all ghost vertices (a.k.a. phantom vertices) from the graph
+     */
+    ScanJobFuture removeGhostVertices();
+
+    /**
+     * Remove all ghost vertices (a.k.a. phantom vertices) from the graph,
+     * with the given concurrency level
+     */
+    ScanJobFuture removeGhostVertices(int numOfThreads);
+
+    /*
     ##################### SCHEMA UPDATE ##########################
      */
 


### PR DESCRIPTION
This commit allows users to use ManagementSystem to run GhostVertexRemover,
leveraging a local thread pool to purge ghost vertices concurrently. It is
not very suitable for huge graphs which typically require a MapReduce cluster.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
