### PR TITLE
Add unordered scan annotation for CQL byteordered partitioner [cql-tests]

### DIFF
--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStore.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStore.java
@@ -461,7 +461,7 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
     @Override
     public KeyIterator getKeys(final SliceQuery query, final StoreTransaction txh) throws BackendException {
         if (!this.storeManager.getFeatures().hasUnorderedScan()) {
-            throw new PermanentBackendException("This operation is only allowed when a random partitioner (md5 or murmur3) is used.");
+            throw new PermanentBackendException("This operation is only allowed when partitioner supports unordered scan");
         }
 
         return Try.of(() -> new CQLResultSetKeyIterator(

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/builder/CQLStoreFeaturesBuilder.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/builder/CQLStoreFeaturesBuilder.java
@@ -88,7 +88,7 @@ public class CQLStoreFeaturesBuilder {
                 break;
             }
             case "ByteOrderedPartitioner": {
-                fb.keyOrdered(true).orderedScan(true).unorderedScan(false);
+                fb.keyOrdered(true).orderedScan(true).unorderedScan(true);
                 deployment = (hostnames.length == 1)// mark deployment as local only in case we have byte ordered partitioner and local
                     // connection
                     ? (NetworkUtil.isLocalConnection(hostnames[0])) ? DistributedStoreManager.Deployment.LOCAL : DistributedStoreManager.Deployment.REMOTE


### PR DESCRIPTION
CQL byteordered partitioner supports both ordered scan and unordered
scan, however, it is annotated as incapable of unordered scans. This
commit fixes this by marking unorderedscan as true for byteordered
partitioner.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
