### PR TITLE
Ensure Jetty versions are aligned

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,8 @@
         <grpc.version>1.42.1</grpc.version>
         <protoc.version>3.15.3</protoc.version>
         <jmh.version>1.33</jmh.version>
+        <!-- align with org.apache.solr:solr-solrj -->
+        <jetty.version>9.4.44.v20210927</jetty.version>
     </properties>
     <modules>
         <module>janusgraph-grpc</module>
@@ -1187,17 +1189,17 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlet</artifactId>
-                <version>9.4.44.v20210927</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
-                <version>9.4.44.v20210927</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-util</artifactId>
-                <version>9.4.44.v20210927</version>
+                <version>${jetty.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
We're not directly using Jetty but a few dependencies have a dependency on it which is why it's in the pom.xml so we can prevent dependency conflicts. We currently seem to use the same Jetty version as Solr which is also the newest Jetty version used by any of our dependencies right now.

Using a variable for the Jetty version also enables Dependabot to update the version for all three Jetty dependencies together.

My motivation for this PR is simply that I looked into why Dependabot isn't able to update Jetty at the moment (#2870 + #2923). But it looks like we're not using Jetty ourselves so we just have to ensure that we don't get dependency conflicts from our dependencies that depend on Jetty.

Signed-off-by: Florian Hockmann <fh@florian-hockmann.de>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
