### PR TITLE
Refactor: Use Object ID type rather than long type in APIs [tp-tests]

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphBaseTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphBaseTest.java
@@ -436,8 +436,8 @@ public abstract class JanusGraphBaseTest implements JanusGraphBaseStoreFeaturesT
         else return obj.toString();
     }
 
-    public static long getId(Element e) {
-        return ((JanusGraphElement)e).longId();
+    public static Object getId(Element e) {
+        return ((JanusGraphElement)e).id();
     }
 
     public static void verifyElementOrder(Iterable<? extends Element> elements, String key, Order order, int expectedCount) {

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphEventualGraphTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphEventualGraphTest.java
@@ -110,8 +110,8 @@ public abstract class JanusGraphEventualGraphTest extends JanusGraphBaseTest {
         tx1.commit();
 
         // Fetch vertex ids
-        long id1 = getId(v1);
-        long id2 = getId(v2);
+        Object id1 = getId(v1);
+        Object id2 = getId(v2);
 
         // Transaction 2: Remove "name" property from v1, set "address" property; create
         // an edge v2 -> v1
@@ -206,7 +206,7 @@ public abstract class JanusGraphEventualGraphTest extends JanusGraphBaseTest {
         tx.commit();
 
         tx = graph.buildTransaction().commitTime(Instant.ofEpochSecond(200)).start();
-        v1 = tx.getVertex(v1.longId());
+        v1 = tx.getVertex(v1.id());
         assertNotNull(v1);
         e = Iterators.getOnlyElement(v1.edges(Direction.OUT, "related"));
         assertNotNull(e);
@@ -215,7 +215,7 @@ public abstract class JanusGraphEventualGraphTest extends JanusGraphBaseTest {
         tx.commit();
 
         tx = graph.buildTransaction().commitTime(Instant.ofEpochSecond(300)).start();
-        v1 = tx.getVertex(v1.longId());
+        v1 = tx.getVertex(v1.id());
         assertNotNull(v1);
         e = Iterators.getOnlyElement(v1.edges(Direction.OUT, "related"));
         assertEquals(Integer.valueOf(125), e.value("time"));
@@ -310,7 +310,7 @@ public abstract class JanusGraphEventualGraphTest extends JanusGraphBaseTest {
         rs[5]=sign(v.addEdge("emf",u),transactionId);
 
         newTx();
-        long vid = getId(v), uid = getId(u);
+        Object vid = getId(v), uid = getId(u);
 
         JanusGraphTransaction tx1 = graph.newTransaction();
         JanusGraphTransaction tx2 = graph.newTransaction();
@@ -330,36 +330,36 @@ public abstract class JanusGraphEventualGraphTest extends JanusGraphBaseTest {
         assertEquals("Bob",p.value());
         assertEquals(wintx,p.<Integer>value("sig").intValue());
         p = getOnlyElement(v.properties("value"));
-        assertEquals(rs[2].longId(),getId(p));
+        assertEquals(rs[2].id(),getId(p));
         assertEquals(wintx,p.<Integer>value("sig").intValue());
         assertCount(2,v.properties("valuef"));
         for (Iterator<VertexProperty<Object>> ppiter = v.properties("valuef"); ppiter.hasNext(); ) {
             VertexProperty pp = ppiter.next();
-            assertNotEquals(rs[3].longId(),getId(pp));
+            assertNotEquals(rs[3].id(),getId(pp));
             assertEquals(2,pp.value());
         }
 
         Edge e = Iterables.getOnlyElement(v.query().direction(OUT).labels("es").edges());
         assertEquals(wintx,e.<Integer>value("sig").intValue());
-        assertNotEquals(rs[6].longId(),getId(e));
+        assertNotEquals(rs[6].id(),getId(e));
 
         e = Iterables.getOnlyElement(v.query().direction(OUT).labels("o2o").edges());
         assertEquals(wintx,e.<Integer>value("sig").intValue());
-        assertEquals(rs[7].longId(), getId(e));
+        assertEquals(rs[7].id(), getId(e));
         e = Iterables.getOnlyElement(v.query().direction(OUT).labels("o2m").edges());
         assertEquals(wintx,e.<Integer>value("sig").intValue());
-        assertNotEquals(rs[8].longId(),getId(e));
+        assertNotEquals(rs[8].id(),getId(e));
         e = Iterables.getOnlyElement(v.query().direction(OUT).labels("em").edges());
         assertEquals(wintx,e.<Integer>value("sig").intValue());
-        assertEquals(rs[4].longId(), getId(e));
+        assertEquals(rs[4].id(), getId(e));
         for (Edge o : v.query().direction(OUT).labels("emf").edges()) {
-            assertNotEquals(rs[5].longId(),getId(o));
+            assertNotEquals(rs[5].id(),getId(o));
             assertEquals(uid, o.inVertex().id());
         }
     }
 
 
-    private void processTx(JanusGraphTransaction tx, int transactionId, long vid, long uid) {
+    private void processTx(JanusGraphTransaction tx, int transactionId, Object vid, Object uid) {
         JanusGraphVertex v = getV(tx,vid);
         JanusGraphVertex u = getV(tx,uid);
         assertEquals(5.0, v.<Double>value("weight"),0.00001);

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphIndexTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphIndexTest.java
@@ -2592,7 +2592,7 @@ public abstract class JanusGraphIndexTest extends JanusGraphBaseTest {
         }
         StandardJanusGraphTx queryTx = (StandardJanusGraphTx) graph.newTransaction();
         for (JanusGraphVertex v : vertices) {
-            if (!graph.edgeQuery(v.longId(), graph.vertexExistenceQuery, queryTx.getTxHandle()).isEmpty()) {
+            if (!graph.edgeQuery(v.id(), graph.vertexExistenceQuery, queryTx.getTxHandle()).isEmpty()) {
                 queryTx.rollback();
                 return false;
             }

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphOperationCountingTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphOperationCountingTest.java
@@ -272,7 +272,7 @@ public abstract class JanusGraphOperationCountingTest extends JanusGraphBaseTest
 
 
         JanusGraphTransaction tx = graph.buildTransaction().checkExternalVertexExistence(false).groupName(metricsPrefix).start();
-        v = tx.getVertex(v.longId());
+        v = tx.getVertex(v.id());
         v.property("foo", "bus");
         long numLookupPropertyConstraints = 1;
         //printAllMetrics(metricsPrefix);
@@ -282,7 +282,7 @@ public abstract class JanusGraphOperationCountingTest extends JanusGraphBaseTest
         verifyStoreMetrics(METRICS_STOREMANAGER_NAME, ImmutableMap.of(M_MUTATE, 1L));
 
         tx = graph.buildTransaction().checkExternalVertexExistence(false).groupName(metricsPrefix).start();
-        v = tx.getVertex(v.longId());
+        v = tx.getVertex(v.id());
         v.property("foo", "band");
         numLookupPropertyConstraints +=1;
         assertEquals("band", v.property("foo").value());
@@ -496,7 +496,7 @@ public abstract class JanusGraphOperationCountingTest extends JanusGraphBaseTest
         finishSchema();
 
         final int numV = 100;
-        final long[] vertexIds = new long[numV];
+        final Object[] vertexIds = new Object[numV];
         for (int i=0;i<numV;i++) {
             JanusGraphVertex v = graph.addVertex(prop,0);
             graph.tx().commit();
@@ -521,7 +521,7 @@ public abstract class JanusGraphOperationCountingTest extends JanusGraphBaseTest
             int reads = 0;
             while (reads<numReads) {
                 final int pos = random.nextInt(vertexIds.length);
-                final long vid = vertexIds[pos];
+                final Object vid = vertexIds[pos];
                 JanusGraphVertex v = getV(graph,vid);
                 assertNotNull(v);
                 boolean postCommit = postcommit[pos].get();
@@ -608,7 +608,7 @@ public abstract class JanusGraphOperationCountingTest extends JanusGraphBaseTest
             previous = v;
         }
         graph.tx().commit();
-        long vertexId = getId(previous);
+        Object vertexId = getId(previous);
         assertCount(numV, graph.query().vertices());
 
         clopen(newConfig);
@@ -652,7 +652,7 @@ public abstract class JanusGraphOperationCountingTest extends JanusGraphBaseTest
         //assertTrue(timeWarmGlobal + " vs " + timeHotGlobal, timeWarmGlobal>timeHotGlobal); Sometimes, this is not true
     }
 
-    private double testAllVertices(long vid, int numV) {
+    private double testAllVertices(Object vid, int numV) {
         long start = System.nanoTime();
         JanusGraphVertex v = getV(graph,vid);
         for (int i=1; i<numV; i++) {

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/olap/OLAPTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/olap/OLAPTest.java
@@ -234,9 +234,9 @@ public abstract class OLAPTest extends JanusGraphBaseTest {
         v2.addEdge("knows",v3);
         v1.addEdge("knows",v2);
         newTx();
-        long v3id = getId(v3);
-        long v1id = getId(v1);
-        assertTrue(v3id>0);
+        Object v3id = getId(v3);
+        Object v1id = getId(v1);
+        assertTrue(!(v3id instanceof Number) || (long) v3id > 0);
 
         v3 = getV(tx, v3id);
         assertNotNull(v3);
@@ -256,7 +256,7 @@ public abstract class OLAPTest extends JanusGraphBaseTest {
         assertNull(getV(tx,v3id));
         v1 = getV(tx, v1id);
         assertNotNull(v1);
-        assertEquals(v3id, v1.query().direction(Direction.IN).labels("knows").vertices().iterator().next().longId());
+        assertEquals(v3id, v1.query().direction(Direction.IN).labels("knows").vertices().iterator().next().id());
         tx.commit();
         mgmt.commit();
 

--- a/janusgraph-core/src/main/java/org/janusgraph/core/EmptyJanusGraphVertexProperty.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/EmptyJanusGraphVertexProperty.java
@@ -50,6 +50,11 @@ public final class EmptyJanusGraphVertexProperty<V> implements JanusGraphVertexP
     }
 
     @Override
+    public Object id() {
+        return null;
+    }
+
+    @Override
     public long longId() {
         return 0;
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/core/Idfiable.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/Idfiable.java
@@ -15,7 +15,7 @@
 package org.janusgraph.core;
 
 /**
- * Represents an entity that can be uniquely identified by a long id.
+ * Represents an entity that can be uniquely identified by an id.
  *
  * @author Matthias Broecheler (me@matthiasb.com)
  */
@@ -24,8 +24,17 @@ public interface Idfiable {
     /**
      * Unique identifier for this entity.
      *
+     * @return Unique id for this entity
+     */
+    Object id();
+
+    /**
+     * Unique identifier for this entity.
+     *
+     * @deprecated Use id() instead
      * @return Unique long id for this entity
      */
+    @Deprecated
     long longId();
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphElement.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphElement.java
@@ -60,18 +60,20 @@ public interface JanusGraphElement extends Element, Idfiable, Removable {
      * @see #hasId
      */
     @Override
-    default Object id() {
-        return longId();
-    }
+    Object id();
 
     /**
      * Unique identifier for this entity. This id can be temporarily assigned and might change.
      * Use {@link #id()} for the permanent id.
      *
+     * @deprecated Deprecated since 1.0.0. Use id() instead unless for JanusGraphRelation.
      * @return Unique long id
      */
     @Override
-    long longId();
+    @Deprecated
+    default long longId() {
+        return (long) id();
+    }
 
     /**
      * Checks whether this entity has a unique identifier.
@@ -80,7 +82,6 @@ public interface JanusGraphElement extends Element, Idfiable, Removable {
      * assigned an identifier at the end of a transaction.
      *
      * @return true if this entity has been assigned a unique id, else false
-     * @see #longId()
      */
     boolean hasId();
 

--- a/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphRelation.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphRelation.java
@@ -100,5 +100,9 @@ public interface JanusGraphRelation extends JanusGraphElement {
      */
     boolean isEdge();
 
-
+    /**
+     * Returns the long-type representation of ID
+     * @return
+     */
+    long longId();
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphTransaction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphTransaction.java
@@ -61,7 +61,7 @@ public interface JanusGraphTransaction extends Transaction {
      * @param vertexLabel vertex label for this vertex - can be null if no vertex label should be set.
      * @return New vertex
      */
-    JanusGraphVertex addVertex(Long id, VertexLabel vertexLabel);
+    JanusGraphVertex addVertex(Object id, VertexLabel vertexLabel);
 
     /**
      * Retrieves the vertex for the specified id.
@@ -71,10 +71,10 @@ public interface JanusGraphTransaction extends Transaction {
      * @param id id of the vertex to retrieve
      * @return vertex with the given id if it exists, else null
      */
-    JanusGraphVertex getVertex(long id);
+    JanusGraphVertex getVertex(Object id);
 
 
-    Iterable<JanusGraphVertex> getVertices(long... ids);
+    Iterable<JanusGraphVertex> getVertices(Object... ids);
 
     Iterable<JanusGraphEdge> getEdges(RelationIdentifier... ids);
 

--- a/janusgraph-core/src/main/java/org/janusgraph/core/RelationType.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/RelationType.java
@@ -39,6 +39,15 @@ import org.janusgraph.core.schema.JanusGraphSchemaType;
 public interface RelationType extends JanusGraphVertex, JanusGraphSchemaType {
 
     /**
+     * Returns the long representation of the id.
+     *
+     * @return
+     */
+    default long longId() {
+        return ((Number) id()).longValue();
+    }
+
+    /**
      * Checks if this relation type is a property key
      *
      * @return true, if this relation type is a property key, else false.

--- a/janusgraph-core/src/main/java/org/janusgraph/core/VertexLabel.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/VertexLabel.java
@@ -29,6 +29,15 @@ import java.util.Collection;
 public interface VertexLabel extends JanusGraphVertex, JanusGraphSchemaType {
 
     /**
+     * Returns the long representation of id.
+     *
+     * @return
+     */
+    default long longId() {
+        return ((Number) id()).longValue();
+    }
+
+    /**
      * Whether vertices with this label are partitioned.
      *
      * @return

--- a/janusgraph-core/src/main/java/org/janusgraph/core/VertexList.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/VertexList.java
@@ -14,7 +14,7 @@
 
 package org.janusgraph.core;
 
-import com.carrotsearch.hppc.LongArrayList;
+import java.util.List;
 
 /**
  * List of {@link JanusGraphVertex}s.
@@ -72,12 +72,9 @@ public interface VertexList extends Iterable<JanusGraphVertex> {
     /**
      * Returns a list of ids of all vertices in this list of vertices in the same order of the original vertex list.
      * <p>
-     * Uses an efficient primitive variable-sized array.
-     *
      * @return A list of idAuthorities of all vertices in this list of vertices in the same order of the original vertex list.
-     * @see LongArrayList
      */
-    LongArrayList getIDs();
+    List<Object> getIDs();
 
     /**
      * Returns the id of the vertex at the specified position
@@ -85,6 +82,6 @@ public interface VertexList extends Iterable<JanusGraphVertex> {
      * @param pos The position of the vertex in the list
      * @return The id of that vertex
      */
-    long getID(int pos);
+    Object getID(int pos);
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/EdgeSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/EdgeSerializer.java
@@ -108,7 +108,7 @@ public class EdgeSerializer implements RelationReader {
         int startKeyPos = in.getPosition();
         int endKeyPos = 0;
         if (relationType.isEdgeLabel()) {
-            long otherVertexId;
+            Object otherVertexId;
             if (multiplicity.isConstrained()) {
                 if (multiplicity.isUnique(dir)) {
                     otherVertexId = VariableLong.readPositive(in);
@@ -177,7 +177,7 @@ public class EdgeSerializer implements RelationReader {
                     ImplicitKey key = ImplicitKey.MetaData2ImplicitKey.get(metas.getKey());
                     if (key != null) {
                         assert metas.getValue() != null;
-                        properties.put(key.longId(),metas.getValue());
+                        properties.put(key.longId(), metas.getValue());
                     }
                 }
             }
@@ -253,7 +253,6 @@ public class EdgeSerializer implements RelationReader {
         DirectionID dirID = getDirID(dir, relation.isProperty() ? RelationCategory.PROPERTY : RelationCategory.EDGE);
 
         DataOutput out = serializer.getDataOutput(DEFAULT_CAPACITY);
-        int valuePosition;
         IDHandler.writeRelationType(out, typeId, dirID, type.isInvisibleType());
         Multiplicity multiplicity = type.multiplicity();
 
@@ -268,8 +267,9 @@ public class EdgeSerializer implements RelationReader {
         long relationId = relation.longId();
 
         //How multiplicity is handled for edges and properties is slightly different
+        int valuePosition;
         if (relation.isEdge()) {
-            long otherVertexId = relation.getVertex((position + 1) % 2).longId();
+            long otherVertexId = ((Number) relation.getVertex((position + 1) % 2).id()).longValue();
             if (multiplicity.isConstrained()) {
                 if (multiplicity.isUnique(dir)) {
                     valuePosition = out.getPosition();
@@ -434,7 +434,7 @@ public class EdgeSerializer implements RelationReader {
 
                 } else {
                     assert !type.multiplicity().isConstrained();
-                    assert propertyKey.longId() == sortKeyIDs[i];
+                    assert propertyKey.id().equals(sortKeyIDs[i]);
                 }
 
                 if (interval == null || interval.isEmpty()) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
@@ -88,8 +88,8 @@ import javax.annotation.Nullable;
 
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.INDEX_NAME_MAPPING;
 import static org.janusgraph.graphdb.database.util.IndexRecordUtil.bytebuffer2RelationId;
-import static org.janusgraph.graphdb.database.util.IndexRecordUtil.getCompositeIndexUpdate;
 import static org.janusgraph.graphdb.database.util.IndexRecordUtil.element2String;
+import static org.janusgraph.graphdb.database.util.IndexRecordUtil.getCompositeIndexUpdate;
 import static org.janusgraph.graphdb.database.util.IndexRecordUtil.getIndexTTL;
 import static org.janusgraph.graphdb.database.util.IndexRecordUtil.getKeyInformation;
 import static org.janusgraph.graphdb.database.util.IndexRecordUtil.getKeysOfRecords;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/StandardJanusGraph.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/StandardJanusGraph.java
@@ -14,7 +14,6 @@
 
 package org.janusgraph.graphdb.database;
 
-import com.carrotsearch.hppc.LongArrayList;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
@@ -426,7 +425,7 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
                         StandardJanusGraph.this, customTxOptions).groupName(GraphDatabaseConfiguration.METRICS_SCHEMA_PREFIX_DEFAULT));
                 consistentTx.getTxHandle().disableCache();
                 JanusGraphVertex v = Iterables.getOnlyElement(QueryUtil.getVertices(consistentTx, BaseKey.SchemaName, typeName), null);
-                return v!=null?v.longId():null;
+                return v != null? ((Number) v.id()).longValue(): null;
             } finally {
                 TXUtils.rollbackQuietly(consistentTx);
             }
@@ -449,7 +448,7 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
 
     };
 
-    public RecordIterator<Long> getVertexIDs(final BackendTransaction tx) {
+    public RecordIterator<Object> getVertexIDs(final BackendTransaction tx) {
         Preconditions.checkArgument(backend.getStoreFeatures().hasOrderedScan() ||
                 backend.getStoreFeatures().hasUnorderedScan(),
                 "The configured storage backend does not support global graph operations - use Faunus instead");
@@ -461,7 +460,7 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
             keyIterator = tx.edgeStoreKeys(new KeyRangeQuery(IDHandler.MIN_KEY, IDHandler.MAX_KEY, vertexExistenceQuery));
         }
 
-        return new RecordIterator<Long>() {
+        return new RecordIterator<Object>() {
 
             @Override
             public boolean hasNext() {
@@ -469,7 +468,7 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
             }
 
             @Override
-            public Long next() {
+            public Object next() {
                 return idManager.getKeyID(keyIterator.next());
             }
 
@@ -485,17 +484,17 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
         };
     }
 
-    public EntryList edgeQuery(long vid, SliceQuery query, BackendTransaction tx) {
-        Preconditions.checkArgument(vid > 0);
+    public EntryList edgeQuery(Object vid, SliceQuery query, BackendTransaction tx) {
+        Preconditions.checkArgument(!(vid instanceof Number) || ((Number) vid).longValue() > 0);
         return tx.edgeStoreQuery(new KeySliceQuery(idManager.getKey(vid), query));
     }
 
-    public List<EntryList> edgeMultiQuery(LongArrayList vertexIdsAsLongs, SliceQuery query, BackendTransaction tx) {
-        Preconditions.checkArgument(vertexIdsAsLongs != null && !vertexIdsAsLongs.isEmpty());
-        final List<StaticBuffer> vertexIds = new ArrayList<>(vertexIdsAsLongs.size());
-        for (int i = 0; i < vertexIdsAsLongs.size(); i++) {
-            Preconditions.checkArgument(vertexIdsAsLongs.get(i) > 0);
-            vertexIds.add(idManager.getKey(vertexIdsAsLongs.get(i)));
+    public List<EntryList> edgeMultiQuery(List<Object> vertexIdsAsObjects, SliceQuery query, BackendTransaction tx) {
+        Preconditions.checkArgument(vertexIdsAsObjects != null && !vertexIdsAsObjects.isEmpty());
+        final List<StaticBuffer> vertexIds = new ArrayList<>(vertexIdsAsObjects.size());
+        for (int i = 0; i < vertexIdsAsObjects.size(); i++) {
+            Preconditions.checkArgument(vertexIdsAsObjects.get(i) instanceof String || ((Number) vertexIdsAsObjects.get(i)).longValue() > 0);
+            vertexIds.add(idManager.getKey(vertexIdsAsObjects.get(i)));
         }
         final Map<StaticBuffer,EntryList> result = tx.edgeStoreMultiQuery(vertexIds, query);
         final List<EntryList> resultList = new ArrayList<>(result.size());
@@ -555,7 +554,7 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
 
     public static int getTTL(InternalVertex v) {
         assert v.hasId();
-        if (IDManager.VertexIDType.UnmodifiableVertex.is(v.longId())) {
+        if (IDManager.VertexIDType.UnmodifiableVertex.is(v.id())) {
             assert v.isNew() : "Should not be able to add relations to existing static vertices: " + v;
             return ((InternalVertexLabel)v.vertexLabel()).getTTL();
         } else return 0;
@@ -579,7 +578,7 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
                                      final boolean acquireLocks) throws BackendException {
 
 
-        ListMultimap<Long, InternalRelation> mutations = ArrayListMultimap.create();
+        ListMultimap<Object, InternalRelation> mutations = ArrayListMultimap.create();
         ListMultimap<InternalVertex, InternalRelation> mutatedProperties = ArrayListMultimap.create();
         List<IndexUpdate> indexUpdates = Lists.newArrayList();
         //1) Collect deleted edges and their index updates and acquire edge locks
@@ -589,11 +588,11 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
                 InternalVertex vertex = del.getVertex(pos);
                 if (pos == 0 || !del.isLoop()) {
                     if (del.isProperty()) mutatedProperties.put(vertex,del);
-                    mutations.put(vertex.longId(), del);
+                    mutations.put(vertex.id(), del);
                 }
                 if (acquireLock(del,pos,acquireLocks)) {
                     Entry entry = edgeSerializer.writeRelation(del, pos, tx);
-                    mutator.acquireEdgeLock(idManager.getKey(vertex.longId()), entry);
+                    mutator.acquireEdgeLock(idManager.getKey(vertex.id()), entry);
                 }
             }
             indexUpdates.addAll(indexSerializer.getIndexUpdates(del));
@@ -607,11 +606,11 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
                 InternalVertex vertex = add.getVertex(pos);
                 if (pos == 0 || !add.isLoop()) {
                     if (add.isProperty()) mutatedProperties.put(vertex,add);
-                    mutations.put(vertex.longId(), add);
+                    mutations.put(vertex.id(), add);
                 }
                 if (!vertex.isNew() && acquireLock(add,pos,acquireLocks)) {
                     Entry entry = edgeSerializer.writeRelation(add, pos, tx);
-                    mutator.acquireEdgeLock(idManager.getKey(vertex.longId()), entry.getColumn());
+                    mutator.acquireEdgeLock(idManager.getKey(vertex.id()), entry.getColumn());
                 }
             }
             indexUpdates.addAll(indexSerializer.getIndexUpdates(add));
@@ -638,8 +637,8 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
         }
 
         //5) Add relation mutations
-        for (Long vertexId : mutations.keySet()) {
-            Preconditions.checkArgument(vertexId > 0, "Vertex has no id: %s", vertexId);
+        for (Object vertexId : mutations.keySet()) {
+            Preconditions.checkArgument(vertexId instanceof String || ((Number) vertexId).longValue() > 0, "Vertex id is invalid: %s", vertexId);
             final List<InternalRelation> edges = mutations.get(vertexId);
             final List<Entry> additions = new ArrayList<>(edges.size());
             final List<Entry> deletions = new ArrayList<>(Math.max(10, edges.size() / 10));
@@ -652,7 +651,7 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
                     for (int pos = 0; pos < edge.getArity(); pos++) {
                         if (!type.isUnidirected(Direction.BOTH) && !type.isUnidirected(EdgeDirection.fromPosition(pos)))
                             continue; //Directionality is not covered
-                        if (edge.getVertex(pos).longId()==vertexId) {
+                        if (edge.getVertex(pos).id().equals(vertexId)) {
                             StaticArrayEntry entry = edgeSerializer.writeRelation(edge, type, pos, tx);
                             if (edge.isRemoved()) {
                                 deletions.add(entry);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/cache/StandardSchemaCache.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/cache/StandardSchemaCache.java
@@ -137,7 +137,7 @@ public class StandardSchemaCache implements SchemaCache {
 
     @Override
     public EntryList getSchemaRelations(final long schemaId, final BaseRelationType type, final Direction dir) {
-        assert IDManager.isSystemRelationTypeId(type.longId()) && type.longId()>0;
+        assert IDManager.isSystemRelationTypeId(type.id()) && type.longId() > 0;
         Preconditions.checkArgument(IDManager.VertexIDType.Schema.is(schemaId));
         Preconditions.checkArgument((Long.MAX_VALUE>>>(SCHEMAID_TOTALFORW_SHIFT-SCHEMAID_BACK_SHIFT))>= schemaId);
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/idassigner/VertexIDAssigner.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/idassigner/VertexIDAssigner.java
@@ -179,7 +179,7 @@ public class VertexIDAssigner implements AutoCloseable {
                 if (attempt < relation.getLen()) { //On the first attempts, try to use partition of incident vertices
                     InternalVertex incident = relation.getVertex(attempt);
                     Preconditions.checkArgument(incident.hasId());
-                    if (!IDManager.VertexIDType.PartitionedVertex.is(incident.longId()) || relation.isProperty()) {
+                    if (!IDManager.VertexIDType.PartitionedVertex.is(incident.id()) || relation.isProperty()) {
                         partitionID = getPartitionID(incident);
                     } else {
                         continue;
@@ -209,7 +209,7 @@ public class VertexIDAssigner implements AutoCloseable {
                 if (relation.isProperty() && isPartitionedAt(relation,0)) {
                     //Always assign properties to the canonical representative of a partitioned vertex
                     InternalVertex vertex = relation.getVertex(0);
-                    ((ReassignableRelation)relation).setVertexAt(0,vertex.tx().getInternalVertex(idManager.getCanonicalVertexId(vertex.longId())));
+                    ((ReassignableRelation)relation).setVertexAt(0,vertex.tx().getInternalVertex(idManager.getCanonicalVertexId(((Number) vertex.id()).longValue())));
                 } else if (relation.isEdge()) {
                     for (int pos = 0; pos < relation.getArity(); pos++) {
                         if (isPartitionedAt(relation, pos)) {
@@ -218,7 +218,7 @@ public class VertexIDAssigner implements AutoCloseable {
                             int otherPosition = (pos+1)%2;
                             if (((InternalRelationType)relation.getType()).multiplicity().isUnique(EdgeDirection.fromPosition(pos))) {
                                 //If the relation is unique in the direction, we assign it to the canonical vertex...
-                                newPartition = idManager.getPartitionId(idManager.getCanonicalVertexId(incident.longId()));
+                                newPartition = idManager.getPartitionId(idManager.getCanonicalVertexId(((Number) incident.id()).longValue()));
                             } else if (!isPartitionedAt(relation,otherPosition)) {
                                 //...else, we assign it to the partition of the non-partitioned vertex...
                                 newPartition = getPartitionID(relation.getVertex(otherPosition));
@@ -226,7 +226,7 @@ public class VertexIDAssigner implements AutoCloseable {
                                 //...and if such does not exists (i.e. both end vertices are partitioned) we use the hash of the relation id
                                 newPartition = idManager.getPartitionHashForId(relation.longId());
                             }
-                            if (idManager.getPartitionId(incident.longId())!=newPartition) {
+                            if (idManager.getPartitionId((long) incident.id())!=newPartition) {
                                 ((ReassignableRelation)relation).setVertexAt(pos,incident.tx().getOtherPartitionVertex(incident, newPartition));
                             }
                         }
@@ -239,7 +239,7 @@ public class VertexIDAssigner implements AutoCloseable {
     }
 
     private boolean isPartitionedAt(InternalRelation relation, int position) {
-        return idManager.isPartitionedVertex(relation.getVertex(position).longId());
+        return idManager.isPartitionedVertex(relation.getVertex(position).id());
     }
 
     public void assignIDs(Iterable<InternalRelation> addedRelations) {
@@ -300,7 +300,7 @@ public class VertexIDAssigner implements AutoCloseable {
     }
 
     private long getPartitionID(final InternalVertex v) {
-        long vid = v.longId();
+        long vid = ((Number) v.id()).longValue();
         if (IDManager.VertexIDType.Schema.is(vid)) return IDManager.SCHEMA_PARTITION;
         else return idManager.getPartitionId(vid);
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/log/TransactionLogHeader.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/log/TransactionLogHeader.java
@@ -85,7 +85,7 @@ public class TransactionLogHeader {
     private static void logRelations(DataOutput out, final Collection<InternalRelation> relations, StandardJanusGraphTx tx) {
         VariableLong.writePositive(out,relations.size());
         for (InternalRelation rel : relations) {
-            VariableLong.writePositive(out,rel.getVertex(0).longId());
+            VariableLong.writePositive(out, ((Number) rel.getVertex(0).id()).longValue());
             org.janusgraph.diskstorage.Entry entry = tx.getEdgeSerializer().writeRelation(rel, 0, tx);
             BufferUtil.writeEntry(out,entry);
         }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
@@ -381,7 +381,7 @@ public class ManagementSystem implements JanusGraphManagement {
     }
 
     private static String composeRelationTypeIndexName(RelationType type, String name) {
-        return String.valueOf(type.longId()) + RELATION_INDEX_SEPARATOR + name;
+        return String.valueOf(type.id()) + RELATION_INDEX_SEPARATOR + name;
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/serialize/attribute/LongSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/serialize/attribute/LongSerializer.java
@@ -59,7 +59,7 @@ public class LongSerializer implements OrderPreservingSerializer<Long> {
         } else if (value instanceof String) {
             return Long.parseLong((String)value);
         } else if (value instanceof Idfiable) {
-            return ((Idfiable)value).longId();
+            return convert(((Idfiable)value).id());
         } else return null;
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/util/StaleIndexRecordUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/util/StaleIndexRecordUtil.java
@@ -154,7 +154,7 @@ public class StaleIndexRecordUtil {
      * @param graphIndexName name of the index for which to remove a record
      * @throws BackendException is thrown in case backend transaction cannot be mutated for any reason.
      */
-    public static void forceRemoveVertexFromGraphIndex(long vertexId,
+    public static void forceRemoveVertexFromGraphIndex(Object vertexId,
                                                        Map<String, Object> indexRecordPropertyValues,
                                                        JanusGraph graph,
                                                        String graphIndexName) throws BackendException {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/internal/InternalElement.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/internal/InternalElement.java
@@ -44,7 +44,7 @@ public interface InternalElement extends JanusGraphElement {
         return tx();
     }
 
-    void setId(long id);
+    void setId(Object id);
 
     /**
      * @see ElementLifeCycle

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/log/StandardTransactionLogProcessor.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/log/StandardTransactionLogProcessor.java
@@ -215,7 +215,7 @@ public class StandardTransactionLogProcessor implements TransactionRecovery {
                                 && isFailedIndex.apply(index.getBackingIndexName())) {
                                 assert rel.isProperty();
                                 indexRestores.put(index.getBackingIndexName(), new IndexRestore(
-                                    rel.getVertex(0).longId(), ElementCategory.VERTEX, getIndexId(index)));
+                                    rel.getVertex(0).id(), ElementCategory.VERTEX, getIndexId(index)));
                             }
                         }
                         //See if relation itself is affected

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/AbstractScanJob.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/AbstractScanJob.java
@@ -55,15 +55,15 @@ public abstract class AbstractScanJob implements ScanJob {
         graph.close();
     }
 
-    protected boolean isGhostVertex(long vertexId, EntryList firstEntries) {
-        if (idManager.isPartitionedVertex(vertexId) && !idManager.isCanonicalVertexId(vertexId)) return false;
+    protected boolean isGhostVertex(Object vertexId, EntryList firstEntries) {
+        if (idManager.isPartitionedVertex(vertexId) && !idManager.isCanonicalVertexId(((Number) vertexId).longValue())) return false;
 
         RelationCache relCache = tx.getEdgeSerializer().parseRelation(
             firstEntries.get(0), true, tx);
         return relCache.typeId != BaseKey.VertexExists.longId();
     }
 
-    protected long getVertexId(StaticBuffer key) {
+    protected Object getVertexId(StaticBuffer key) {
         return idManager.getKeyID(key);
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/VertexJobConverter.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/VertexJobConverter.java
@@ -93,7 +93,7 @@ public class VertexJobConverter extends AbstractScanJob {
 
     @Override
     public void process(StaticBuffer key, Map<SliceQuery, EntryList> entries, ScanMetrics metrics) {
-        long vertexId = getVertexId(key);
+        Object vertexId = getVertexId(key);
         assert entries.get(VERTEX_EXISTS_QUERY)!=null;
         if (isGhostVertex(vertexId, entries.get(VERTEX_EXISTS_QUERY))) {
             metrics.incrementCustom(GHOST_VERTEX_COUNT);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/FulgoraVertexProperty.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/FulgoraVertexProperty.java
@@ -71,6 +71,11 @@ public class FulgoraVertexProperty<V> implements JanusGraphVertexProperty<V> {
     }
 
     @Override
+    public Object id() {
+        return null;
+    }
+
+    @Override
     public long longId() {
         throw new IllegalStateException("An id has not been set for this property");
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/VertexMapJob.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/VertexMapJob.java
@@ -111,7 +111,7 @@ public class VertexMapJob implements VertexScanJob {
             v.setPropertyMixing(vh);
         }
         v.setAccessCheck(MAPREDUCE_CHECK);
-        if (idManager.isPartitionedVertex(v.longId()) && !idManager.isCanonicalVertexId(v.longId())) {
+        if (idManager.isPartitionedVertex(v.id()) && !idManager.isCanonicalVertexId(((Number) v.id()).longValue())) {
             return; //Only consider the canonical partition vertex representative
         }
         for (Map.Entry<MapReduce, FulgoraMapEmitter> mapJob : mapJobs.entrySet()) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/VertexMemoryHandler.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/VertexMemoryHandler.java
@@ -26,7 +26,6 @@ import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.janusgraph.core.JanusGraphEdge;
 import org.janusgraph.core.JanusGraphException;
-import org.janusgraph.core.JanusGraphVertex;
 import org.janusgraph.core.JanusGraphVertexProperty;
 import org.janusgraph.graphdb.vertices.PreloadedVertex;
 
@@ -46,14 +45,14 @@ class VertexMemoryHandler<M> implements PreloadedVertex.PropertyMixing, Messenge
 
     protected final FulgoraVertexMemory<M> vertexMemory;
     private final PreloadedVertex vertex;
-    protected final long vertexId;
+    protected final Object vertexId;
     private boolean inExecute;
 
     VertexMemoryHandler(FulgoraVertexMemory<M> vertexMemory, PreloadedVertex vertex) {
         assert vertex!=null && vertexMemory!=null;
         this.vertexMemory = vertexMemory;
         this.vertex = vertex;
-        this.vertexId = vertexMemory.getCanonicalId(vertex.longId());
+        this.vertexId = vertexMemory.getCanonicalId(vertex.id());
         this.inExecute = false;
     }
 
@@ -131,7 +130,7 @@ class VertexMemoryHandler<M> implements PreloadedVertex.PropertyMixing, Messenge
 
             return edges.stream()
                         .flatMap(e -> {
-                            long canonicalId = vertexMemory.getCanonicalId(((JanusGraphEdge) e).otherVertex(vertex).longId());
+                            Object canonicalId = vertexMemory.getCanonicalId(((JanusGraphEdge) e).otherVertex(vertex).id());
                             return vertexMemory.getMessage(canonicalId, localMessageScope)
                                                .map(msg -> msg == null ? null : edgeFct.apply(msg, e));
                         })
@@ -154,9 +153,7 @@ class VertexMemoryHandler<M> implements PreloadedVertex.PropertyMixing, Messenge
             vertexMemory.sendMessage(vertexId, m, messageScope);
         } else {
             ((MessageScope.Global) messageScope).vertices().forEach(v -> {
-                long vertexId;
-                if (v instanceof JanusGraphVertex) vertexId=((JanusGraphVertex)v).longId();
-                else vertexId = (Long)v.id();
+                long vertexId = ((Number) v.id()).longValue();
                 vertexMemory.sendMessage(vertexMemory.getCanonicalId(vertexId), m, messageScope);
             });
         }
@@ -174,7 +171,7 @@ class VertexMemoryHandler<M> implements PreloadedVertex.PropertyMixing, Messenge
                 return super.receiveMessages(messageScope);
             } else {
                 final MessageScope.Local<M> localMessageScope = (MessageScope.Local) messageScope;
-                return vertexMemory.getAggregateMessage(vertexId,localMessageScope);
+                return vertexMemory.getAggregateMessage(((Number) vertexId).longValue(), localMessageScope);
             }
         }
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/VertexProgramScanJob.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/VertexProgramScanJob.java
@@ -80,21 +80,21 @@ public class VertexProgramScanJob<M> implements VertexScanJob {
     @Override
     public void process(JanusGraphVertex vertex, ScanMetrics metrics) {
         PreloadedVertex v = (PreloadedVertex)vertex;
-        long vertexId = v.longId();
+        Object vertexId = v.id();
         VertexMemoryHandler<M> vh = new VertexMemoryHandler(vertexMemory,v);
         vh.setInExecute(true);
         v.setAccessCheck(PreloadedVertex.OPENSTAR_CHECK);
         if (idManager.isPartitionedVertex(vertexId)) {
-            if (idManager.isCanonicalVertexId(vertexId)) {
+            if (idManager.isCanonicalVertexId(((Number) vertexId).longValue())) {
                 EntryList results = v.getFromCache(SYSTEM_PROPS_QUERY);
                 if (results == null) results = EntryList.EMPTY_LIST;
-                vertexMemory.setLoadedProperties(vertexId,results);
+                vertexMemory.setLoadedProperties(((Number) vertexId).longValue(), results);
             }
             for (MessageScope scope : vertexMemory.getPreviousScopes()) {
                 if (scope instanceof MessageScope.Local) {
                     vh.receiveMessages(scope)
                       .iterator()
-                      .forEachRemaining(m -> vertexMemory.aggregateMessage(vertexId, m, scope));
+                      .forEachRemaining(m -> vertexMemory.aggregateMessage(((Number) vertexId).longValue(), m, scope));
                 }
             }
         } else {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/job/GhostVertexRemover.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/job/GhostVertexRemover.java
@@ -89,7 +89,7 @@ public class GhostVertexRemover extends AbstractScanJob {
 
     @Override
     public void process(StaticBuffer key, Map<SliceQuery, EntryList> entries, ScanMetrics metrics) {
-        long vertexId = getVertexId(key);
+        Object vertexId = getVertexId(key);
         assert entries.size() == 1;
         assert entries.get(everythingQueryLimit) != null;
         final EntryList everything = entries.get(everythingQueryLimit);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/job/IndexRepairJob.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/job/IndexRepairJob.java
@@ -158,14 +158,14 @@ public class IndexRepairJob extends IndexUpdateJob implements VertexScanJob {
                         } else {
                             assert pos == 1;
                             InternalVertex otherVertex = janusgraphRelation.getVertex(1);
-                            StaticBuffer otherVertexKey = writeTx.getIdInspector().getKey(otherVertex.longId());
+                            StaticBuffer otherVertexKey = writeTx.getIdInspector().getKey(otherVertex.id());
                             inAdditionsMap.computeIfAbsent(otherVertexKey, k -> new ArrayList<>()).add(entry);
                         }
                     }
                 }
 
                 //Mutating all OUT relationships for the current vertex
-                StaticBuffer vertexKey = writeTx.getIdInspector().getKey(vertex.longId());
+                StaticBuffer vertexKey = writeTx.getIdInspector().getKey(vertex.id());
                 mutator.mutateEdges(vertexKey, outAdditions, KCVSCache.NO_DELETIONS);
 
                 //Mutating all IN relationships for the current vertex

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BaseVertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BaseVertexCentricQueryBuilder.java
@@ -84,7 +84,7 @@ public abstract class BaseVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q>
 
     protected abstract Q getThis();
 
-    protected abstract JanusGraphVertex getVertex(long vertexId);
+    protected abstract JanusGraphVertex getVertex(Object vertexId);
 
 
     /* ---------------------------------------------------------------
@@ -106,8 +106,8 @@ public abstract class BaseVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q>
         //Treat special cases
         if (type.equals(ImplicitKey.ADJACENT_ID.name())) {
             Preconditions.checkArgument(rel == Cmp.EQUAL, "Only equality constraints are supported for %s", type);
-            long vertexId = ElementUtils.getVertexId(value);
-            Preconditions.checkArgument(vertexId > 0, "Expected valid vertex id: %s", value);
+            Object vertexId = ElementUtils.getVertexId(value);
+            Preconditions.checkArgument(vertexId instanceof String || ((Number) vertexId).longValue() > 0, "Expected valid vertex id: %s", value);
             return adjacent(getVertex(vertexId));
         } else if (type.equals(ImplicitKey.ID.name())) {
             RelationIdentifier rid = ElementUtils.getEdgeId(value);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
@@ -122,7 +122,7 @@ public abstract class BasicVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q
     }
 
     @Override
-    public JanusGraphVertex getVertex(long vertexId) {
+    public JanusGraphVertex getVertex(Object vertexId) {
         return tx.getVertex(vertexId);
     }
 
@@ -732,7 +732,7 @@ public abstract class BasicVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q
         }
         if (adjacentVertex!=null) {
             if (adjacentVertex.hasId()) {
-                constraintMap.put(ImplicitKey.ADJACENT_ID,new PointInterval(adjacentVertex.longId()));
+                constraintMap.put(ImplicitKey.ADJACENT_ID,new PointInterval(adjacentVertex.id()));
             }
             else isFitted=false;
         }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/SimpleVertexQueryProcessor.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/SimpleVertexQueryProcessor.java
@@ -14,7 +14,6 @@
 
 package org.janusgraph.graphdb.query.vertex;
 
-import com.carrotsearch.hppc.LongArrayList;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
@@ -29,8 +28,11 @@ import org.janusgraph.graphdb.query.BackendQueryHolder;
 import org.janusgraph.graphdb.query.profile.QueryProfiler;
 import org.janusgraph.graphdb.transaction.RelationConstructor;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
+import org.janusgraph.util.datastructures.AbstractIdListUtil;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import javax.annotation.Nullable;
 
 /**
@@ -96,20 +98,21 @@ public class SimpleVertexQueryProcessor implements Iterable<Entry> {
      * @return
      */
     public VertexList vertexIds() {
-        LongArrayList list = new LongArrayList();
-        long previousId = 0;
-        for (Long id : Iterables.transform(this,new Function<Entry, Long>() {
+        List<Object> list = new ArrayList<>();
+        boolean sorted = true;
+        for (Object id : Iterables.transform(this,new Function<Entry, Object>() {
             @Nullable
             @Override
-            public Long apply(@Nullable Entry entry) {
+            public Object apply(@Nullable Entry entry) {
                 return edgeSerializer.readRelation(entry,true,tx).getOtherVertexId();
             }
         })) {
+            if (!list.isEmpty() && AbstractIdListUtil.compare(list.get(list.size() - 1), id) > 0) {
+                sorted = false;
+            }
             list.add(id);
-            if (id>=previousId && previousId>=0) previousId=id;
-            else previousId=-1;
         }
-        return new VertexLongList(tx,list,previousId>=0);
+        return new VertexIdList(tx,list,sorted);
     }
 
     /**
@@ -118,7 +121,7 @@ public class SimpleVertexQueryProcessor implements Iterable<Entry> {
      * @return
      */
     private Iterator<Entry> getBasicIterator() {
-        final EntryList result = vertex.loadRelations(sliceQuery, query -> QueryProfiler.profile(profiler, query, q -> tx.getGraph().edgeQuery(vertex.longId(), q, tx.getTxHandle())));
+        final EntryList result = vertex.loadRelations(sliceQuery, query -> QueryProfiler.profile(profiler, query, q -> tx.getGraph().edgeQuery(vertex.id(), q, tx.getTxHandle())));
         return result.iterator();
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/AbstractTypedRelation.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/AbstractTypedRelation.java
@@ -48,8 +48,9 @@ public abstract class AbstractTypedRelation extends AbstractElement implements I
         if (isLoadedInThisTx()) {
             return this;
         }
-
-        InternalRelation next = (InternalRelation) RelationIdentifierUtils.findRelation(RelationIdentifierUtils.get(this), tx());
+        StandardJanusGraphTx tx = tx();
+        InternalRelation next = (InternalRelation) RelationIdentifierUtils.findRelation(
+            RelationIdentifierUtils.get(this, longId()), tx);
         if (next == null) {
             throw InvalidElementException.removedException(this);
         }
@@ -114,8 +115,13 @@ public abstract class AbstractTypedRelation extends AbstractElement implements I
     }
 
     @Override
+    public long longId() {
+        return ((Number) super.id()).longValue();
+    }
+
+    @Override
     public RelationIdentifier id() {
-        return RelationIdentifierUtils.get(this);
+        return RelationIdentifierUtils.get(this, longId());
     }
 
     /* ---------------------------------------------------------------
@@ -154,6 +160,11 @@ public abstract class AbstractTypedRelation extends AbstractElement implements I
             return ((ImplicitKey) key).computeProperty(this);
         }
         return it().getValueDirect(key);
+    }
+
+    @Override
+    protected Object getCompareId() {
+        return longId();
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/RelationCache.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/RelationCache.java
@@ -67,8 +67,8 @@ public class RelationCache implements Iterable<LongObjectCursor<Object>> {
         return other;
     }
 
-    public Long getOtherVertexId() {
-        return (Long) other;
+    public Object getOtherVertexId() {
+        return other;
     }
 
     public Iterator<LongObjectCursor<Object>> propertyIterator() {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/RelationIdentifierUtils.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/RelationIdentifierUtils.java
@@ -29,11 +29,12 @@ import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.janusgraph.graphdb.types.system.ImplicitKey;
 
 public class RelationIdentifierUtils {
-    public static RelationIdentifier get(InternalRelation r) {
-        if (r.hasId()) {
-            return new RelationIdentifier(r.getVertex(0).longId(),
+    public static RelationIdentifier get(InternalRelation r, long relationId) {
+        if (relationId > 0) {
+            RelationIdentifier rId = new RelationIdentifier(r.getVertex(0).id(),
                 r.getType().longId(),
-                r.longId(), (r.isEdge() ? r.getVertex(1).longId() : 0));
+                relationId, (r.isEdge() ? r.getVertex(1).id() : null));
+            return rId;
         } else return null;
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/ElementUtils.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/ElementUtils.java
@@ -18,7 +18,6 @@ import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.janusgraph.core.JanusGraphEdge;
-import org.janusgraph.core.JanusGraphVertex;
 import org.janusgraph.graphdb.relations.RelationIdentifier;
 
 /**
@@ -26,24 +25,19 @@ import org.janusgraph.graphdb.relations.RelationIdentifier;
  */
 public class ElementUtils {
 
-    public static long getVertexId(Object id) {
-        if (null == id) return 0;
+    public static Object getVertexId(Object id) {
+        if (null == id) return null;
 
-        if (id instanceof JanusGraphVertex) //allows vertices to be "re-attached" to the current transaction
-            return ((JanusGraphVertex) id).longId();
+        if (id instanceof Vertex) //allows vertices to be "re-attached" to the current transaction
+            return ((Vertex) id).id();
         if (id instanceof Long)
             return (Long) id;
         if (id instanceof Number)
             return ((Number) id).longValue();
-
         try {
-            // handles the case of a user passing a "detached" Vertex (DetachedVertex, StarVertex, etc).
-            if (id instanceof Vertex)
-                return Long.parseLong(((Vertex) id).id().toString());
-            else
-                return Long.parseLong(id.toString());
+            return Long.parseLong(id.toString());
         } catch (NumberFormatException e) {
-            return 0;
+            return null;
         }
     }
 
@@ -54,7 +48,7 @@ public class ElementUtils {
             if (id instanceof JanusGraphEdge) return (RelationIdentifier) ((JanusGraphEdge) id).id();
             else if (id instanceof RelationIdentifier) return (RelationIdentifier) id;
             else if (id instanceof String) return RelationIdentifier.parse((String) id);
-            else if (id instanceof long[]) return RelationIdentifier.get((long[]) id);
+            else if (id instanceof Object[]) return RelationIdentifier.get((Object[]) id);
             else if (id instanceof int[]) return RelationIdentifier.get((int[]) id);
         } catch (IllegalArgumentException e) {
             //swallow since null will be returned below

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphBlueprintsTransaction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphBlueprintsTransaction.java
@@ -122,8 +122,7 @@ public abstract class JanusGraphBlueprintsTransaction implements JanusGraphTrans
         if (labelValue!=null) {
             label = (labelValue instanceof VertexLabel)?(VertexLabel)labelValue:getOrCreateVertexLabel((String) labelValue);
         }
-
-        final Long id = idValue.map(Number.class::cast).map(Number::longValue).orElse(null);
+        Object id = idValue.map(Number.class::cast).map(Number::longValue).orElse(null);
         final JanusGraphVertex vertex = addVertex(id, label);
         org.janusgraph.graphdb.util.ElementHelper.attachProperties(vertex, keyValues);
         return vertex;
@@ -133,11 +132,11 @@ public abstract class JanusGraphBlueprintsTransaction implements JanusGraphTrans
     public Iterator<Vertex> vertices(Object... vertexIds) {
         if (vertexIds==null || vertexIds.length==0) return (Iterator)getVertices().iterator();
         ElementUtils.verifyArgsMustBeEitherIdOrElement(vertexIds);
-        long[] ids = new long[vertexIds.length];
+        Object[] ids = new Object[vertexIds.length];
         int pos = 0;
         for (Object vertexId : vertexIds) {
-            long id = ElementUtils.getVertexId(vertexId);
-            if (id > 0) ids[pos++] = id;
+            Object id = ElementUtils.getVertexId(vertexId);
+            if (!(id instanceof Number) || ((Number) id).longValue() > 0) ids[pos++] = id;
         }
         if (pos==0) return Collections.emptyIterator();
         if (pos<ids.length) ids = Arrays.copyOf(ids,pos);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/VertexFactory.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/VertexFactory.java
@@ -21,6 +21,6 @@ import org.janusgraph.graphdb.internal.InternalVertex;
  */
 public interface VertexFactory {
 
-    InternalVertex getInternalVertex(long id);
+    InternalVertex getInternalVertex(Object id);
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/VertexIterable.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/VertexIterable.java
@@ -40,13 +40,13 @@ public class VertexIterable implements Iterable<InternalVertex> {
     public Iterator<InternalVertex> iterator() {
         return new Iterator<InternalVertex>() {
 
-            final RecordIterator<Long> iterator = graph.getVertexIDs(tx.getTxHandle());
+            final RecordIterator<Object> iterator = graph.getVertexIDs(tx.getTxHandle());
             InternalVertex nextVertex = nextVertex();
 
             private InternalVertex nextVertex() {
                 InternalVertex v = null;
                 while (v == null && iterator.hasNext()) {
-                    final long nextId = iterator.next();
+                    final Object nextId = iterator.next();
                     //Filter out invisible vertices
                     if (IDManager.VertexIDType.Invisible.is(nextId)) continue;
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/vertexcache/EmptyVertexCache.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/vertexcache/EmptyVertexCache.java
@@ -40,19 +40,19 @@ public class EmptyVertexCache implements VertexCache {
     }
 
     @Override
-    public boolean contains(long id) {
+    public boolean contains(Object id) {
         logWarning();
         return false;
     }
 
     @Override
-    public InternalVertex get(final long id, final Retriever<Long, InternalVertex> retriever) {
+    public InternalVertex get(final Object id, final Retriever<Object, InternalVertex> retriever) {
         logWarning();
         return null;
     }
 
     @Override
-    public void add(InternalVertex vertex, long id) {
+    public void add(InternalVertex vertex, Object id) {
         logWarning();
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/vertexcache/VertexCache.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/vertexcache/VertexCache.java
@@ -27,7 +27,7 @@ public interface VertexCache {
      * @param id Vertex id
      * @return true if a vertex with the given id is contained, else false
      */
-    boolean contains(long id);
+    boolean contains(Object id);
 
     /**
      * Returns the vertex with the given id or null if it is not in the cache
@@ -35,7 +35,7 @@ public interface VertexCache {
      * @param id
      * @return
      */
-    InternalVertex get(long id, Retriever<Long, InternalVertex> retriever);
+    InternalVertex get(Object id, Retriever<Object, InternalVertex> retriever);
 
     /**
      * Adds the given vertex with the given id to the cache. The given vertex may already be in the cache.
@@ -45,7 +45,7 @@ public interface VertexCache {
      * @param id
      * @throws IllegalArgumentException if the vertex is null or the id negative
      */
-    void add(InternalVertex vertex, long id);
+    void add(InternalVertex vertex, Object id);
 
     /**
      * Returns an iterable over all new vertices in the cache

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/BaseKey.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/BaseKey.java
@@ -117,7 +117,7 @@ public class BaseKey extends BaseRelationType implements PropertyKey {
 
         @Override
         public long getID() {
-            return BaseKey.this.longId();
+            return ((Number) id()).longValue();
         }
 
         @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/BaseLabel.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/BaseLabel.java
@@ -44,7 +44,7 @@ public class BaseLabel extends BaseRelationType implements EdgeLabel {
 
     @Override
     public long[] getSignature() {
-        return new long[]{BaseKey.SchemaDefinitionDesc.longId()};
+        return new long[]{(long) BaseKey.SchemaDefinitionDesc.id()};
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/BaseRelationType.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/BaseRelationType.java
@@ -39,7 +39,7 @@ public abstract class BaseRelationType extends EmptyRelationType implements Syst
     }
 
     @Override
-    public long longId() {
+    public Object id() {
         return id;
     }
 
@@ -49,7 +49,7 @@ public abstract class BaseRelationType extends EmptyRelationType implements Syst
     }
 
     @Override
-    public void setId(long id) {
+    public void setId(Object id) {
         throw new IllegalStateException("SystemType has already been assigned an id");
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/EmptyVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/EmptyVertex.java
@@ -147,13 +147,8 @@ public class EmptyVertex implements InternalVertex {
 	 */
 
     @Override
-    public long longId() {
-        throw new UnsupportedOperationException(errorName + " don't have an ID");
-    }
-
-    @Override
     public Object id() {
-        return hasId() ? longId() : null;
+        return null;
     }
 
     @Override
@@ -172,7 +167,7 @@ public class EmptyVertex implements InternalVertex {
     }
 
     @Override
-    public void setId(long id) {
+    public void setId(Object id) {
         throw new UnsupportedOperationException(errorName + " don't have an id");
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/ImplicitKey.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/ImplicitKey.java
@@ -31,6 +31,7 @@ import org.janusgraph.graphdb.internal.InternalVertex;
 import org.janusgraph.graphdb.internal.InternalVertexLabel;
 import org.janusgraph.graphdb.internal.JanusGraphSchemaCategory;
 import org.janusgraph.graphdb.internal.Token;
+import org.janusgraph.graphdb.relations.AbstractTypedRelation;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -87,7 +88,8 @@ public class ImplicitKey extends EmptyRelationType implements SystemRelationType
         if (this==ID) {
             return (O)e.id();
         } else if (this==JANUSGRAPHID) {
-            return (O)Long.valueOf(e.longId());
+            assert e instanceof AbstractTypedRelation;
+            return (O)Long.valueOf(((AbstractTypedRelation) e).longId());
         } else if (this==LABEL) {
             return (O)e.label();
         } else if (this==KEY) {
@@ -169,7 +171,7 @@ public class ImplicitKey extends EmptyRelationType implements SystemRelationType
     }
 
     @Override
-    public long longId() {
+    public Object id() {
         return id;
     }
 
@@ -179,7 +181,7 @@ public class ImplicitKey extends EmptyRelationType implements SystemRelationType
     }
 
     @Override
-    public void setId(long id) {
+    public void setId(Object id) {
         throw new IllegalStateException("SystemType has already been assigned an id");
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/vertices/JanusGraphSchemaVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/vertices/JanusGraphSchemaVertex.java
@@ -44,7 +44,7 @@ import java.util.List;
 
 public class JanusGraphSchemaVertex extends CacheVertex implements SchemaSource {
 
-    public JanusGraphSchemaVertex(StandardJanusGraphTx tx, long id, byte lifecycle) {
+    public JanusGraphSchemaVertex(StandardJanusGraphTx tx, Object id, byte lifecycle) {
         super(tx, id, lifecycle);
     }
 
@@ -52,6 +52,11 @@ public class JanusGraphSchemaVertex extends CacheVertex implements SchemaSource 
     private TypeDefinitionMap definition = null;
     private ListMultimap<TypeDefinitionCategory,Entry> outRelations = null;
     private ListMultimap<TypeDefinitionCategory,Entry> inRelations = null;
+
+    @Override
+    public long longId() {
+        return ((Number) id()).longValue();
+    }
 
     @Override
     public String name() {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/vertices/RelationTypeVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/vertices/RelationTypeVertex.java
@@ -39,7 +39,7 @@ public abstract class RelationTypeVertex extends JanusGraphSchemaVertex implemen
     private Integer ttl = null;
     private List<IndexType> indexes = null;
 
-    public RelationTypeVertex(StandardJanusGraphTx tx, long id, byte lifecycle) {
+    public RelationTypeVertex(StandardJanusGraphTx tx, Object id, byte lifecycle) {
         super(tx, id, lifecycle);
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/AbstractVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/AbstractVertex.java
@@ -47,7 +47,7 @@ public abstract class AbstractVertex extends AbstractElement implements Internal
     private final StandardJanusGraphTx tx;
 
 
-    protected AbstractVertex(StandardJanusGraphTx tx, long id) {
+    protected AbstractVertex(StandardJanusGraphTx tx, Object id) {
         super(id);
         assert tx != null;
         this.tx = tx;
@@ -58,7 +58,7 @@ public abstract class AbstractVertex extends AbstractElement implements Internal
         if (tx.isOpen())
             return this;
 
-        InternalVertex next = (InternalVertex) tx.getNextTx().getVertex(longId());
+        InternalVertex next = (InternalVertex) tx.getNextTx().getVertex(id());
         if (next == null) throw InvalidElementException.removedException(this);
         else return next;
     }
@@ -73,19 +73,14 @@ public abstract class AbstractVertex extends AbstractElement implements Internal
     }
 
     @Override
-    public long getCompareId() {
-        if (tx.isPartitionedVertex(this)) return tx.getIdInspector().getCanonicalVertexId(longId());
-        else return longId();
+    public Object getCompareId() {
+        if (tx.isPartitionedVertex(this)) return tx.getIdInspector().getCanonicalVertexId(((Number) id()).longValue());
+        else return id();
     }
 
     @Override
     public String toString() {
         return StringFactory.vertexString(this);
-    }
-
-    @Override
-    public Object id() {
-        return longId();
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/CacheVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/CacheVertex.java
@@ -33,7 +33,7 @@ public class CacheVertex extends StandardVertex {
     // is super low in a single transaction
     protected final Map<SliceQuery, EntryList> queryCache;
 
-    public CacheVertex(StandardJanusGraphTx tx, long id, byte lifecycle) {
+    public CacheVertex(StandardJanusGraphTx tx, Object id, byte lifecycle) {
         super(tx, id, lifecycle);
         queryCache = new HashMap<>(4);
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/PreloadedVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/PreloadedVertex.java
@@ -46,7 +46,7 @@ public class PreloadedVertex extends CacheVertex {
     private PropertyMixing mixin = NO_MIXIN;
     private AccessCheck accessCheck = DEFAULT_CHECK;
 
-    public PreloadedVertex(StandardJanusGraphTx tx, long id, byte lifecycle) {
+    public PreloadedVertex(StandardJanusGraphTx tx, Object id, byte lifecycle) {
         super(tx, id, lifecycle);
         assert lifecycle == ElementLifeCycle.Loaded : "Invalid lifecycle encountered: " + lifecycle;
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/StandardVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/StandardVertex.java
@@ -36,7 +36,7 @@ public class StandardVertex extends AbstractVertex {
     private volatile byte lifecycle;
     private volatile AddedRelationsContainer addedRelations=AddedRelationsContainer.EMPTY;
 
-    public StandardVertex(final StandardJanusGraphTx tx, final long id, byte lifecycle) {
+    public StandardVertex(final StandardJanusGraphTx tx, final Object id, byte lifecycle) {
         super(tx, id);
         this.lifecycle=lifecycle;
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/util/datastructures/AbstractIdListUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/util/datastructures/AbstractIdListUtil.java
@@ -14,60 +14,85 @@
 
 package org.janusgraph.util.datastructures;
 
-import com.carrotsearch.hppc.LongArrayList;
 import com.google.common.base.Preconditions;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
 /**
- * Utility class for merging and sorting lists of longs
+ * Utility class for merging and sorting lists of ids
+ * An id can either be a String or a number
  *
  * @author Matthias Broecheler (me@matthiasb.com)
  */
-public class AbstractLongListUtil {
+public class AbstractIdListUtil {
+
+    private static void validateId(Object id) {
+        if (!(id instanceof Number || id instanceof String)) {
+            throw new IllegalArgumentException("id must be number or string, but get: " + id);
+        }
+    }
+
+    public static int compare(Object id1, Object id2) {
+        validateId(id1);
+        validateId(id2);
+        if (id1 instanceof Number && id2 instanceof String) return -1;
+        if (id1 instanceof String && id2 instanceof Number) return 1;
+        if (id1 instanceof String) {
+            assert id2 instanceof String;
+            return ((String) id1).compareTo((String) id2);
+        } else {
+            assert id1 instanceof Number;
+            assert id2 instanceof Number;
+            return Double.compare(((Number) id1).doubleValue(), ((Number) id2).doubleValue());
+        }
+    }
 
 
-    public static boolean isSorted(LongArrayList l, final boolean unique) {
+    public static boolean isSorted(List<Object> l, final boolean unique) {
         for (int i = 1; i < l.size(); i++) {
-            if (l.get(i) < l.get(i - 1) || (unique && l.get(i) == l.get(i - 1))) return false;
+            if (compare(l.get(i), l.get(i - 1)) < 0 || (unique && Objects.equals(l.get(i), l.get(i - 1)))) return false;
         }
         return true;
     }
 
-    public static boolean isSorted(LongArrayList l) {
+    public static boolean isSorted(List<Object> l) {
         return isSorted(l, false);
     }
 
-    public static LongArrayList mergeSort(LongArrayList a, LongArrayList b) {
+    public static List<Object> mergeSort(List<Object> a, List<Object> b) {
         int positionA=0, positionB=0;
-        LongArrayList result = new LongArrayList(a.size()+b.size());
+        List<Object> result = new ArrayList<>(a.size()+b.size());
         while (positionA<a.size() || positionB<b.size()) {
-            long next;
+            Object next;
             if (positionA>=a.size()) {
                 next=b.get(positionB++);
             } else if (positionB>=b.size()) {
                 next=a.get(positionA++);
-            } else if (a.get(positionA)<=b.get(positionB)) {
+            } else if (compare(a.get(positionA), b.get(positionB)) <= 0) {
                 next=a.get(positionA++);
             } else {
                 next=b.get(positionB++);
             }
-            Preconditions.checkArgument(result.isEmpty() || result.get(result.size()-1)<=next,
+            Preconditions.checkArgument(result.isEmpty() || compare(result.get(result.size()-1), next) <= 0,
                     "The input lists are not sorted");
             result.add(next);
         }
         return result;
     }
 
-    public static LongArrayList mergeJoin(LongArrayList a, LongArrayList b, final boolean unique) {
+    public static List<Object> mergeJoin(List<Object> a, List<Object> b, final boolean unique) {
         assert isSorted(a) : a.toString();
         assert isSorted(b) : b.toString();
         int counterA = 0, counterB = 0;
         int sizeA = a.size();
         int sizeB = b.size();
-        LongArrayList merge = new LongArrayList(Math.min(sizeA, sizeB));
+        List<Object> merge = new ArrayList<>(Math.min(sizeA, sizeB));
         int resultSize = 0;
         while (counterA < sizeA && counterB < sizeB) {
-            if (a.get(counterA) == b.get(counterB)) {
-                long value = a.get(counterA);
+            if (Objects.equals(a.get(counterA), b.get(counterB))) {
+                Object value = a.get(counterA);
                 if (!unique) {
                     merge.add(value);
                     resultSize++;
@@ -79,20 +104,12 @@ public class AbstractLongListUtil {
                 }
                 counterA++;
                 counterB++;
-            } else if (a.get(counterA) < b.get(counterB)) {
+            } else if (compare(a.get(counterA), b.get(counterB)) < 0) {
                 counterA++;
             } else {
-                assert a.get(counterA) > b.get(counterB);
                 counterB++;
             }
         }
         return merge;
     }
-
-    public static LongArrayList singleton(long el) {
-        LongArrayList l = new LongArrayList(1);
-        l.add(el);
-        return l;
-    }
-
 }

--- a/janusgraph-dist/src/test/expect/single-vertex.expect.vm
+++ b/janusgraph-dist/src/test/expect/single-vertex.expect.vm
@@ -36,7 +36,7 @@ send "g.tx().commit()\r"
 sleep 10
 # expect null
 expect gremlin>
-send "g.traversal().V(v.longId()).values('test')\r"
+send "g.traversal().V(v.id()).values('test')\r"
 expect "42"
 expect gremlin>
 send "g.close()\r"

--- a/janusgraph-dist/src/test/expect/spark-graph-computer.expect.vm
+++ b/janusgraph-dist/src/test/expect/spark-graph-computer.expect.vm
@@ -46,7 +46,7 @@ expect -re "hadoopgraph"
 expect gremlin>
 send "g = graph.traversal().withComputer(SparkGraphComputer)\r"
 expect gremlin>
-send "g.V(v.longId()).values('test')\r"
+send "g.V(v.id()).values('test')\r"
 expect "42"
 expect gremlin>
 send "g.V().count()\r"

--- a/janusgraph-driver/src/main/java/org/janusgraph/graphdb/tinkerpop/io/binary/RelationIdentifierGraphBinarySerializer.java
+++ b/janusgraph-driver/src/main/java/org/janusgraph/graphdb/tinkerpop/io/binary/RelationIdentifierGraphBinarySerializer.java
@@ -37,9 +37,9 @@ public class RelationIdentifierGraphBinarySerializer extends JanusGraphTypeSeria
 
     @Override
     protected void writeNonNullableValue(RelationIdentifier value, Buffer buffer, GraphBinaryWriter context) throws IOException {
-        buffer.writeLong(value.getOutVertexId());
+        buffer.writeLong(((Number) value.getOutVertexId()).longValue());
         buffer.writeLong(value.getTypeId());
         buffer.writeLong(value.getRelationId());
-        buffer.writeLong(value.getInVertexId());
+        buffer.writeLong(((Number) value.getInVertexId()).longValue());
     }
 }

--- a/janusgraph-hadoop/src/main/java/org/janusgraph/hadoop/formats/util/JanusGraphVertexDeserializer.java
+++ b/janusgraph-hadoop/src/main/java/org/janusgraph/hadoop/formats/util/JanusGraphVertexDeserializer.java
@@ -79,8 +79,8 @@ public class JanusGraphVertexDeserializer implements AutoCloseable {
     public TinkerVertex readHadoopVertex(final StaticBuffer key, Iterable<Entry> entries) {
 
         // Convert key to a vertex ID
-        final long vertexId = idManager.getKeyID(key);
-        Preconditions.checkArgument(vertexId > 0);
+        final Object vertexId = idManager.getKeyID(key);
+        Preconditions.checkArgument(vertexId instanceof String || ((Number) vertexId).longValue() > 0);
 
         // Partitioned vertex handling
         if (idManager.isPartitionedVertex(vertexId)) {
@@ -101,7 +101,7 @@ public class JanusGraphVertexDeserializer implements AutoCloseable {
             final RelationCache relation = relationReader.parseRelation(data, false, typeManager);
             if (systemTypes.isVertexLabelSystemType(relation.typeId)) {
                 // Found vertex Label
-                long vertexLabelId = relation.getOtherVertexId();
+                long vertexLabelId = ((Number) relation.getOtherVertexId()).longValue();
                 VertexLabel vl = typeManager.getExistingVertexLabel(vertexLabelId);
                 // Create TinkerVertex with this label
                 tv = getOrCreateVertex(vertexId, vl.name(), tg);
@@ -194,7 +194,7 @@ public class JanusGraphVertexDeserializer implements AutoCloseable {
         }
     }
 
-    public TinkerVertex getOrCreateVertex(final long vertexId, final String label, final TinkerGraph tg) {
+    public TinkerVertex getOrCreateVertex(final Object vertexId, final String label, final TinkerGraph tg) {
         TinkerVertex v;
 
         try {

--- a/janusgraph-hadoop/src/test/resources/org/janusgraph/hadoop/formats/graphson/incremental-custom-cerberus-load.groovy
+++ b/janusgraph-hadoop/src/test/resources/org/janusgraph/hadoop/formats/graphson/incremental-custom-cerberus-load.groovy
@@ -31,7 +31,7 @@ JanusGraphVertex getOrCreateVertex(faunusVertex, graph, context, log) {
           log.info("The unique key is not unique as more than one vertex with the value {}", uniqueValue)
       }
     } else {
-      janusgraphVertex = graph.addVertex(faunusVertex.longId(),faunusVertex.label())
+      janusgraphVertex = graph.addVertex(faunusVertex.id(),faunusVertex.label())
     }
     return janusgraphVertex
 }

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/VertexListTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/VertexListTest.java
@@ -19,8 +19,9 @@ import org.janusgraph.core.JanusGraph;
 import org.janusgraph.core.JanusGraphFactory;
 import org.janusgraph.core.JanusGraphVertex;
 import org.janusgraph.graphdb.query.vertex.VertexArrayList;
-import org.janusgraph.graphdb.query.vertex.VertexLongList;
+import org.janusgraph.graphdb.query.vertex.VertexIdList;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
+import org.janusgraph.util.datastructures.AbstractIdListUtil;
 import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
@@ -42,7 +43,7 @@ public class VertexListTest {
 
         JanusGraph g = JanusGraphFactory.open("inmemory");
         StandardJanusGraphTx tx = (StandardJanusGraphTx) g.newTransaction();
-        VertexLongList vll = new VertexLongList(tx);
+        VertexIdList vll = new VertexIdList(tx);
         VertexArrayList val = new VertexArrayList(tx);
         for (int i=0; i<num; i++) {
             JanusGraphVertex v = tx.addVertex();
@@ -63,7 +64,7 @@ public class VertexListTest {
             JanusGraphVertex previous = null;
             for (int i = 0; i < num; i++) {
                 JanusGraphVertex next = iterator.next();
-                if (previous!=null) assertTrue(previous.longId()<next.longId());
+                if (previous!=null) assertTrue(AbstractIdListUtil.compare(previous.id(), next.id()) < 0);
                 previous = next;
             }
             try {

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/idmanagement/IDManagementTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/idmanagement/IDManagementTest.java
@@ -208,7 +208,7 @@ public class IDManagementTest {
         int numTries = 100;
         WriteBuffer out = new WriteByteBuffer(8*numTries);
         for (SystemRelationType t : SYSTEM_TYPES) {
-            IDHandler.writeInlineRelationType(out, t.longId());
+            IDHandler.writeInlineRelationType(out, (long) t.id());
         }
         for (long i=1;i<=numTries;i++) {
             IDHandler.writeInlineRelationType(out, IDManager.getSchemaId(IDManager.VertexIDType.UserEdgeLabel, i * 1000));
@@ -239,7 +239,7 @@ public class IDManagementTest {
     @Test
     public void testEdgeTypeWriting() {
         for (SystemRelationType t : SYSTEM_TYPES) {
-            testEdgeTypeWriting(t.longId());
+            testEdgeTypeWriting((long) t.id());
         }
         for (int i=0;i<1000;i++) {
             IDManager.VertexIDType type = random.nextDouble()<0.5? IDManager.VertexIDType.UserPropertyKey: IDManager.VertexIDType.UserEdgeLabel;

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/idmanagement/VertexIDAssignerTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/idmanagement/VertexIDAssignerTest.java
@@ -175,7 +175,7 @@ public class VertexIDAssignerTest {
                     //Verify that ids are set and unique
                     for (JanusGraphVertex v : vertices) {
                         assertTrue(v.hasId());
-                        long id = v.longId();
+                        long id = (long) v.id();
                         assertTrue(id>0 && id<Long.MAX_VALUE);
                         assertTrue(vertexIds.add(id));
                     }
@@ -254,7 +254,7 @@ public class VertexIDAssignerTest {
                 //Verify that ids are set, unique and consistent with user id basis
                 for (JanusGraphVertex v : vertices) {
                     assertTrue(v.hasId());
-                    long id = v.longId();
+                    long id = (long) v.id();
                     assertTrue(id>0 && id<Long.MAX_VALUE);
                     assertTrue(vertexIds.add(id));
                     assertEquals((long) v.value("user_id"), idAssigner.getIDManager().fromVertexId(id));

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/query/QueryTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/query/QueryTest.java
@@ -129,8 +129,8 @@ public class QueryTest {
         Vertex v1 = tx.addVertex("pos", 0);
         Vertex v2 = tx.addVertex();
         Edge e = v1.addEdge("connects", v2, "prop", "val");
-        String vId = v1.id().toString();
-        String eId = e.id().toString();
+        Object vId = v1.id();
+        Object eId = e.id();
         tx.commit();
 
         tx = graph.newTransaction();

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/query/vertex/VertexIdListTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/query/vertex/VertexIdListTest.java
@@ -1,0 +1,110 @@
+// Copyright 2022 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.query.vertex;
+
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.janusgraph.core.JanusGraphVertex;
+import org.janusgraph.graphdb.internal.ElementLifeCycle;
+import org.janusgraph.graphdb.internal.InternalVertex;
+import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
+import org.janusgraph.graphdb.vertices.CacheVertex;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class VertexIdListTest {
+
+    @Mock
+    private StandardJanusGraphTx tx;
+
+    @Test
+    public void testMergeSortedLongIdLists() {
+        VertexIdList list = new VertexIdList(tx, Arrays.asList(1L, 2L, 3L), true);
+        VertexIdList otherList = new VertexIdList(tx, Arrays.asList(0L, 2L, 4L), true);
+        list.addAll(otherList);
+        assertEquals(Arrays.asList(0L, 1L, 2L, 2L, 3L, 4L), list.getIDs());
+        assertTrue(list.isSorted());
+    }
+
+    @Test
+    public void testMergeUnsortedLongIdLists() {
+        VertexIdList list = new VertexIdList(tx, new ArrayList<>(Arrays.asList(4L, 2L, 3L)), false);
+        VertexIdList otherList = new VertexIdList(tx, Arrays.asList(0L, 5L, 4L), false);
+        list.addAll(otherList);
+        assertEquals(Arrays.asList(4L, 2L, 3L, 0L, 5L, 4L), list.getIDs());
+        assertFalse(list.isSorted());
+    }
+
+    @Test
+    public void testMergeSortedStringIdLists() {
+        VertexIdList list = new VertexIdList(tx, Arrays.asList("x1", "x2", "y1"), true);
+        VertexIdList otherList = new VertexIdList(tx, Arrays.asList("x2", "x4"), true);
+        list.addAll(otherList);
+        assertEquals(Arrays.asList("x1", "x2", "x2", "x4", "y1"), list.getIDs());
+        assertTrue(list.isSorted());
+    }
+
+    @Test
+    public void testMergeSortedHeterogeneousIdLists() {
+        VertexIdList list = new VertexIdList(tx, Arrays.asList("x1", "x2", "y1"), true);
+        VertexIdList otherList = new VertexIdList(tx, Arrays.asList(2, 4), true);
+        list.addAll(otherList);
+        assertEquals(Arrays.asList(2, 4, "x1", "x2", "y1"), list.getIDs());
+        assertTrue(list.isSorted());
+    }
+
+    @Test
+    public void testMergeUnsortedHeterogeneousIdLists() {
+        VertexIdList list = new VertexIdList(tx, new ArrayList<>(Arrays.asList("x1", "x2", "y1")), true);
+        VertexIdList otherList = new VertexIdList(tx, Arrays.asList("x3", 4, 2), false);
+        list.addAll(otherList);
+        assertEquals(Arrays.asList("x1", "x2", "y1", "x3", 4, 2), list.getIDs());
+        assertFalse(list.isSorted());
+    }
+
+    @Test
+    public void testMergeSortedVertexLists() {
+        VertexIdList list = new VertexIdList(tx, Arrays.asList("x1", "x2", "y1"), true);
+        VertexArrayList otherList = new VertexArrayList(tx);
+        otherList.add(new CacheVertex(tx, "x2", ElementLifeCycle.Loaded));
+        otherList.add(new CacheVertex(tx, "x4", ElementLifeCycle.Loaded));
+        list.addAll(otherList);
+        assertEquals(Arrays.asList("x1", "x2", "x2", "x4", "y1"), list.getIDs());
+        assertTrue(list.isSorted());
+    }
+
+    @Test
+    public void testIterator() {
+        VertexIdList list = new VertexIdList(tx, Arrays.asList("x1", "x2"), true);
+        Iterator<JanusGraphVertex> iter = list.iterator();
+        Vertex v1 = new CacheVertex(tx, "x1", ElementLifeCycle.Loaded);
+        when(tx.getInternalVertex("x1")).thenReturn((InternalVertex) v1);
+        assertEquals(v1, iter.next());
+        Vertex v2 = new CacheVertex(tx, "x2", ElementLifeCycle.Loaded);
+        when(tx.getInternalVertex("x2")).thenReturn((InternalVertex) v2);
+        assertEquals(v2, iter.next());
+    }
+}

--- a/janusgraph-test/src/test/java/org/janusgraph/util/datastructures/AbstractIdListUtilTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/util/datastructures/AbstractIdListUtilTest.java
@@ -1,0 +1,65 @@
+// Copyright 2022 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.util.datastructures;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AbstractIdListUtilTest {
+
+    @Test
+    public void testCompare() {
+        assertTrue(AbstractIdListUtil.compare(123, "x") < 0);
+        assertTrue(AbstractIdListUtil.compare("x", 123) > 0);
+        assertTrue(AbstractIdListUtil.compare("x", "y") < 0);
+        assertTrue(AbstractIdListUtil.compare(123, 123L) == 0);
+        assertTrue(AbstractIdListUtil.compare(123, 123.2) < 0);
+        assertTrue(AbstractIdListUtil.compare(123L, 122.99) > 0);
+        UUID uuid = UUID.randomUUID();
+        Exception ex = assertThrows(IllegalArgumentException.class, () -> AbstractIdListUtil.compare(uuid, UUID.randomUUID()));
+        assertEquals("id must be number or string, but get: " + uuid, ex.getMessage());
+    }
+
+    @Test
+    public void testIsSortedNoUnique() {
+        assertTrue(AbstractIdListUtil.isSorted(Arrays.asList("a1", "a2", "b1")));
+        assertTrue(AbstractIdListUtil.isSorted(Arrays.asList(2.3, 3.0, 4L, 5, "a1", "a2", "b1")));
+        assertTrue(AbstractIdListUtil.isSorted(Arrays.asList(1, 1.0)));
+        assertFalse(AbstractIdListUtil.isSorted(Arrays.asList(2, 1.0)));
+    }
+
+    @Test
+    public void testIsSortedUnique() {
+        assertTrue(AbstractIdListUtil.isSorted(Arrays.asList("a1", "a2", "b1"), true));
+        assertTrue(AbstractIdListUtil.isSorted(Arrays.asList(2.3, 3.0, 4L, 5, "a1", "a2", "b1"), true));
+        assertFalse(AbstractIdListUtil.isSorted(Arrays.asList(1, 1), true));
+        assertFalse(AbstractIdListUtil.isSorted(Arrays.asList("x1", "x1", "x2"), true));
+    }
+
+    @Test
+    public void testMergeSort() {
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), AbstractIdListUtil.mergeSort(Arrays.asList(1, 2, 5), Arrays.asList(3, 4)));
+        assertEquals(Arrays.asList(1, 2, 3, "x", "y"), AbstractIdListUtil.mergeSort(Arrays.asList(1, 2, "x"), Arrays.asList(3, "y")));
+        assertEquals(Arrays.asList(1, 2, "x"), AbstractIdListUtil.mergeSort(Arrays.asList(1, 2), Arrays.asList("x")));
+        assertEquals(Arrays.asList(1, 2), AbstractIdListUtil.mergeSort(Arrays.asList(1, 2), Arrays.asList()));
+    }
+}


### PR DESCRIPTION
This commit refactors the codebase by changing all long-type IDs into Object-type in
all method signatures, method return types, etc. No functionality is affected, except that
IDs are now stored as objects rather than primitives in the memory, which increases
overhead. This is the first step to implementing #1221.

See https://github.com/JanusGraph/janusgraph/issues/1221#issuecomment-1007910018 for the full implementation.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
