### PR TITLE
Increase GraphComputer concurrency level to num of CPU cores

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/olap/OLAPTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/olap/OLAPTest.java
@@ -274,8 +274,19 @@ public abstract class OLAPTest extends JanusGraphBaseTest {
 
     @Test
     public void testBasicComputeJob() {
-        GraphTraversalSource g = graph.traversal().withComputer(FulgoraGraphComputer.class);
-        System.out.println(g.V().count().next());
+        int numV = 1000;
+        for (int i = 0; i < numV; i++) {
+            Vertex v = graph.addVertex();
+            v.addEdge("loop", v, "val", i % 2);
+        }
+        graph.tx().commit();
+        long startTime = System.currentTimeMillis();
+        // in JanusGraph, withComputer() is equivalent to withComputer(FulgoraGraphComputer.class)
+        GraphTraversalSource g = graph.traversal().withComputer();
+        long result = g.V().outE().has("val", 0).count().next();
+        long elapsedTime = System.currentTimeMillis() - startTime;
+        log.info("elapsed time = {}", elapsedTime);
+        assertEquals(numV / 2, result);
     }
 
     @Test

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/FulgoraGraphComputer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/computer/FulgoraGraphComputer.java
@@ -83,7 +83,7 @@ public class FulgoraGraphComputer implements JanusGraphComputer {
     private FulgoraVertexMemory vertexMemory;
     private boolean executed = false;
 
-    private int numThreads = 1;//Math.max(1,Runtime.getRuntime().availableProcessors());
+    private int numThreads = Runtime.getRuntime().availableProcessors();
     private final int readBatchSize;
     private final int writeBatchSize;
 


### PR DESCRIPTION
In JanusGraph, graph.traversal().withComputer() traversal utilizes
the built-in FulgoraGraphComputer which uses a thread pool to execute
traversals in parallel. This thread pool, by default, however, only
has one thread. This commit makes the number of concurrency level to
the number of available processors.

I ran the test case locally a few times, and saw evident performance improvement after this fix.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
