### PR TITLE
Fix mkdocs build is failing due to newer jinja2 releases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ markdown==3.2.2
 mkdocs-markdownextradata-plugin==0.1.7
 markdown-include==0.5.1
 mkdocs-redirects==1.0.1
+jinja2==3.0.3


### PR DESCRIPTION
Updates mkdocs and fixes the introduces jinja problem which right now fails all documentation builds in GitHub actions: https://github.com/porunov/janusgraph/runs/6027485201?check_suite_focus=true

The fix was explained here:
https://github.com/readthedocs/readthedocs.org/issues/9064

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
