### PR TITLE
Add possibility to remove composite index entries

### DIFF
--- a/docs/advanced-topics/eventual-consistency.md
+++ b/docs/advanced-topics/eventual-consistency.md
@@ -144,6 +144,9 @@ Index entries might point to nonexistent vertices or edges. Similarly, a
 vertex or edge appears in the graph but is not yet indexed and hence
 ignored by global graph queries.
 
+In some situations due to server failures permanent index inconsistency can 
+happen. See how to deal with permanent stale index entries [here](stale-index.md).
+
 **Half-Edges**  
 Only one direction of an edge gets persisted or deleted which might lead
 to the edge not being or incorrectly being retrieved.

--- a/docs/advanced-topics/stale-index.md
+++ b/docs/advanced-topics/stale-index.md
@@ -1,0 +1,47 @@
+# Permanent stale index inconsistency
+
+In some situations due to crashes of storage database, index database, or JanusGraph instances 
+permanent stale index may appear.  
+One of such cases could be a vertex removal from the graph but due to a crash during index persistence 
+there is a chance that index won't be updated ever. 
+In case we try to remove a vertex which is already gone from the storage database but which is still indexed then 
+the `IllegalStateException` will be thrown with the message `Vertex with id %vertexId% was removed.`. 
+For example, using `g.V().has("name", "HelloWorld").drop().iterate(); g.tx().commit();` we may receive an exception 
+noting that some vertex has already been removed nevertheless it's record is still in the index. 
+The exception will be thrown anytime we try to remove such vertex from the graph.  
+This problem is known and should be temporal limitation until this issue is fixed in JanusGraph.  
+As for now there is the utility tool which may be used to fix permanent stale indices.  
+
+## StaleIndexRecordUtil
+
+`StaleIndexRecordUtil.class` is available in `janusgraph-core` module and is meant to be used as a helper class 
+to fix permanent stale index entries. 
+
+`StaleIndexRecordUtil.forceRemoveVertexFromGraphIndex` can be used to force remove an index record for any vertex from 
+a graph index. Right now the limitations of this method is that it can be used with Composite indices only.  
+An example of using this method is below:
+```java
+// Let's say we want to remove non-existent vertex from a stale index. 
+// We will assume the next constraints: 
+// Vertex id is: `12345`
+// Composite index name is: `nameAgeIndex`
+// There are two indexed properties: `name` and `age`
+// Value of the name property is: `HelloWorld`
+// Value of the age property is: `123`
+
+JanusGraph graph = JanusGraphFactory.open(configuration);
+
+Map<String, Object> indexRecordPropertyValues = new HashMap<>();
+indexRecordPropertyValues.put("name", "HelloWorld");
+indexRecordPropertyValues.put("age", 123);
+
+// After the below method is executed index entry of the vertex 12345 should be removed from the index which 
+// effectively fixes permanent stale index inconsistency
+StaleIndexRecordUtil.forceRemoveVertexFromGraphIndex(
+    12345L, // vertex id of the index record to be removed
+    indexRecordPropertyValues, // index record property values
+    graph,
+    "nameAgeIndex" // composite index name for which to remove the index record
+);
+```
+For more in-depth information about usage of this tool see JavaDoc for `StaleIndexRecordUtil`.

--- a/janusgraph-berkeleyje/src/test/java/org/janusgraph/graphdb/berkeleyje/BerkeleyGraphTest.java
+++ b/janusgraph-berkeleyje/src/test/java/org/janusgraph/graphdb/berkeleyje/BerkeleyGraphTest.java
@@ -15,6 +15,7 @@
 package org.janusgraph.graphdb.berkeleyje;
 
 import com.google.common.base.Preconditions;
+import com.sleepycat.je.LockMode;
 import org.janusgraph.BerkeleyStorageSetup;
 import org.janusgraph.core.JanusGraphException;
 import org.janusgraph.core.JanusGraphFactory;
@@ -134,5 +135,12 @@ public class BerkeleyGraphTest extends JanusGraphTest {
         open(config);
 
         assertEquals(0L, (long)graph.traversal().V().count().next());
+    }
+
+    @Override
+    public void clopenForStaleIndex(){
+        // We set LOCK_MODE to READ_UNCOMMITTED here to mitigate an issue with deadlock problem described in
+        // https://github.com/JanusGraph/janusgraph/issues/1623
+        clopen(option(BerkeleyJEStoreManager.LOCK_MODE), LockMode.READ_UNCOMMITTED.toString());
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/util/StaleIndexRecordUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/util/StaleIndexRecordUtil.java
@@ -1,0 +1,311 @@
+// Copyright 2022 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.database.util;
+
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.JanusGraphElement;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.JanusGraphIndex;
+import org.janusgraph.diskstorage.BackendException;
+import org.janusgraph.diskstorage.BackendTransaction;
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.util.HashingUtil;
+import org.janusgraph.graphdb.database.IndexRecordEntry;
+import org.janusgraph.graphdb.database.StandardJanusGraph;
+import org.janusgraph.graphdb.database.index.IndexMutationType;
+import org.janusgraph.graphdb.database.index.IndexUpdate;
+import org.janusgraph.graphdb.database.management.ManagementSystem;
+import org.janusgraph.graphdb.database.serialize.Serializer;
+import org.janusgraph.graphdb.internal.ElementLifeCycle;
+import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
+import org.janusgraph.graphdb.types.CompositeIndexType;
+import org.janusgraph.graphdb.types.vertices.JanusGraphSchemaVertex;
+import org.janusgraph.graphdb.vertices.CacheVertex;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Helper class which simplifies stale index modification operations.
+ * This class should normally be never used because it may cause index corruption problems in case it is used incorrectly.
+ * <p>
+ * In case more complicated index record modifications are needed, for example a case when a stale index have missing
+ * added elements to the graph then it's possible to manually add or remove any index records of the index.
+ * To do so you will need to use `BackendTransaction` directly.
+ * Below is an example of direct `BackendTransaction` usage.
+ * <p>
+ * Vertex index record update:
+ * <pre>
+ * StandardJanusGraph graph = (StandardJanusGraph) JanusGraphFactory.open(configuration);
+ * StandardJanusGraphTx tx = (StandardJanusGraphTx) graph.newTransaction();
+ * ManagementSystem mgmt = (ManagementSystem) graph.openManagement();
+ * // Let's say we want to remove non-existent vertex from a stale index.
+ * // We will assume the next constraints:
+ * // vertex id is 12345;
+ * // Composite index name is: nameIndex
+ * // There is a single indexed property: name
+ * // Value of the vertex property is: HelloWorld
+ * long vertexId = 12345L;
+ * String compositeIndexName = "nameIndex";
+ * String propertyKeyName = "name";
+ * String value = "HelloWorld";
+ * PropertyKey propertyKey = mgmt.getPropertyKey(propertyKeyName);
+ * long propertyKeyId = propertyKey.longId();
+ * IndexRecordEntry namePropertyIndexRecord = new IndexRecordEntry(propertyKeyId, value, propertyKey);
+ * IndexRecordEntry[] fullIndexRecord = new IndexRecordEntry[]{namePropertyIndexRecord};
+ * JanusGraphElement elementToBeRemoved = new CacheVertex(tx, vertexId, ElementLifeCycle.New);
+ * JanusGraphIndex indexToBeUpdated = managementSystem.getGraphIndex(compositeIndexName);
+ * JanusGraphSchemaVertex indexSchemaVertex = managementSystem.getSchemaVertex(indexToBeUpdated);
+ * CompositeIndexType compositeIndexTypeToBeUpdated = (CompositeIndexType) indexSchemaVertex.asIndexType();
+ * Serializer serializer = graph.getDataSerializer();
+ * boolean hashKeys = graph.getIndexSerializer().isHashKeys();
+ * HashingUtil.HashLength hashLength = graph.getIndexSerializer().getHashLength();
+ * IndexUpdate<StaticBuffer, Entry> update = IndexRecordUtil.getCompositeIndexUpdate(
+ *     compositeIndexTypeToBeUpdated,
+ *     IndexMutationType.DELETE,
+ *     fullIndexRecord,
+ *     elementToBeRemoved,
+ *     serializer,
+ *     hashKeys,
+ *     hashLength
+ * );
+ * BackendTransaction backendTransaction = tx.getTxHandle();
+ * backendTransaction.mutateIndex(update.getKey(), Collections.emptyList(), Collections.singletonList(update.getEntry()));
+ * transaction.commit();
+ * tx.commit();
+ * mgmt.rollback();
+ * </pre>
+ *
+ * In case above you wanted to add index entry instead of removing it you would need to use {@link IndexMutationType#ADD IndexMutationType.ADD} instead
+ * of {@link IndexMutationType#DELETE IndexMutationType.DELETE} as provide entries collection as a second parameter into
+ * {@link BackendTransaction#mutateIndex mutateIndex} method instead of third parameter.
+ * I.e. {@code backendTransaction.mutateIndex(update.getKey(), Collections.emptyList(), Collections.singletonList(update.getEntry()));}
+ *
+ * <p>
+ * Edge index record update is currently more limited to Vertex index record update above as you will need to find `relationId`
+ * as well as both ids of the connected vertices. It may be more challenging in case you don't have those elements in the graph.
+ * Thus, below example shows how to remove index record of *existing* edge which leads to stale index. You shouldn't repeat
+ * below steps unless you want to force remove existing edge index record.
+ * <pre>
+ * StandardJanusGraph graph = (StandardJanusGraph) JanusGraphFactory.open(configuration);
+ * StandardJanusGraphTx tx = (StandardJanusGraphTx) graph.newTransaction();
+ * ManagementSystem mgmt = (ManagementSystem) graph.openManagement();
+ * // Let's say we want to remove existent edge from an index.
+ * // We will assume the next constraints:
+ * // Composite index name is: nameIndex
+ * // There is a single indexed property: name
+ * // Value of the vertex property is: HelloWorld
+ * String compositeIndexName = "nameIndex";
+ * String propertyKeyName = "name";
+ * String value = "HelloWorld";
+ * PropertyKey propertyKey = mgmt.getPropertyKey(propertyKeyName);
+ * Edge edge = tx.traversal().E().has(propertyKeyName, value).next();
+ * RelationIdentifier relationIdentifier = (RelationIdentifier) edge.id();
+ * long relationId = relationIdentifier.getRelationId();
+ * EdgeLabel edgeLabel = managementSystem.getEdgeLabel(edgeName);
+ * IndexRecordEntry[] fullIndexRecord = new IndexRecordEntry[]{new IndexRecordEntry(relationId, value, propertyKey)};
+ * InternalVertex internalVertex1 = (InternalVertex) edge.outVertex();
+ * InternalVertex internalVertex2 = (InternalVertex) edge.inVertex();
+ * JanusGraphElement elementToBeRemoved = new StandardEdge(relationId, edgeLabel, internalVertex1, internalVertex2, ElementLifeCycle.New);
+ * JanusGraphIndex indexToBeUpdated = managementSystem.getGraphIndex(compositeIndexName);
+ * JanusGraphSchemaVertex indexSchemaVertex = managementSystem.getSchemaVertex(indexToBeUpdated);
+ * CompositeIndexType compositeIndexTypeToBeUpdated = (CompositeIndexType) indexSchemaVertex.asIndexType();
+ * Serializer serializer = graph.getDataSerializer();
+ * boolean hashKeys = graph.getIndexSerializer().isHashKeys();
+ * HashingUtil.HashLength hashLength = graph.getIndexSerializer().getHashLength();
+ * IndexUpdate<StaticBuffer, Entry> update = IndexRecordUtil.getCompositeIndexUpdate(
+ *     compositeIndexTypeToBeUpdated,
+ *     IndexMutationType.DELETE,
+ *     fullIndexRecord,
+ *     elementToBeRemoved,
+ *     serializer,
+ *     hashKeys,
+ *     hashLength
+ * );
+ * BackendTransaction backendTransaction = tx.getTxHandle();
+ * backendTransaction.mutateIndex(update.getKey(), Collections.emptyList(), Collections.singletonList(update.getEntry()));
+ * transaction.commit();
+ * tx.commit();
+ * mgmt.rollback();
+ * </pre>
+ *
+ */
+public class StaleIndexRecordUtil {
+
+    /**
+     * Force removes vertex record from a graph index. Notice, only Composite indices are supported by this method at the moment.
+     *
+     * @param vertexId the vertex which should be removed from a specified index
+     * @param indexRecordPropertyValues all property values of the index record
+     * @param graph JanusGraph instance to be used to open graph management and new backend transaction for index removal.
+     * @param graphIndexName name of the index for which to remove a record
+     * @throws BackendException is thrown in case backend transaction cannot be mutated for any reason.
+     */
+    public static void forceRemoveVertexFromGraphIndex(long vertexId,
+                                                       Map<String, Object> indexRecordPropertyValues,
+                                                       JanusGraph graph,
+                                                       String graphIndexName) throws BackendException {
+
+        ManagementSystem managementSystem = (ManagementSystem) graph.openManagement();
+
+        try{
+            JanusGraphIndex index = managementSystem.getGraphIndex(graphIndexName);
+
+            PropertyKey[] propertyKeys = index.getFieldKeys();
+
+            IndexRecordEntry[] indexRecord = toIndexRecord(propertyKeys, indexRecordPropertyValues);
+
+            StandardJanusGraphTx tx = (StandardJanusGraphTx) graph.newTransaction();
+
+            try{
+                JanusGraphElement elementToBeRemoved = new CacheVertex(tx, vertexId, ElementLifeCycle.New);
+                forceRemoveElementFromGraphIndex(elementToBeRemoved, indexRecord, (StandardJanusGraph) graph, index, managementSystem);
+
+            } finally {
+                tx.rollback();
+            }
+
+        } finally {
+            managementSystem.rollback();
+        }
+    }
+
+    /**
+     * Force removes element record from a graph index. Notice, only Composite indices are supported by this method at the moment.
+     * <p>
+     * An example of using this method is below:
+     * <pre>
+     * StandardJanusGraph graph = (StandardJanusGraph) JanusGraphFactory.open(configuration);
+     * StandardJanusGraphTx tx = (StandardJanusGraphTx) graph.newTransaction();
+     * JanusGraphManagement mgmt = graph.openManagement();
+     * // Let's say we want to remove non-existent vertex from a stale index.
+     * // We will assume the next constraints:
+     * // vertex id is 12345;
+     * // Composite index name is: nameIndex
+     * // There is a single indexed property: name
+     * // Value of the vertex property is: HelloWorld
+     * long vertexId = 12345L;
+     * String compositeIndexName = "nameIndex";
+     * String propertyKeyName = "name";
+     * String value = "HelloWorld";
+     * PropertyKey propertyKey = mgmt.getPropertyKey(propertyKeyName);
+     * long propertyKeyId = propertyKey.longId();
+     * IndexRecordEntry namePropertyIndexRecord = new IndexRecordEntry(propertyKeyId, value, propertyKey);
+     * IndexRecordEntry[] fullIndexRecord = new IndexRecordEntry[]{namePropertyIndexRecord};
+     * JanusGraphElement elementToBeRemoved = new CacheVertex(tx, vertexId, ElementLifeCycle.New);
+     * // After the below method is executed index entry of the vertex 12345 should be removed from the index which
+     * // effectively fixes permanent stale index inconsistency
+     * StaleIndexRecordUtil.forceRemoveElementFromGraphIndex(
+     *     elementToBeRemoved,
+     *     fullIndexRecord,
+     *     graph,
+     *     compositeIndexName
+     * );
+     * tx.commit();
+     * mgmt.rollback();
+     * </pre>
+     *
+     * @param elementToRemoveFromIndex an element which should be removed.
+     * @param indexRecord an ordered array or index record properties which represent this index record.
+     * @param graph JanusGraph instance to be used to open graph management and new backend transaction for index removal.
+     * @param graphIndexName index name of the index for which to delete a specified indexRecord.
+     * @throws BackendException is thrown in case backend transaction cannot be mutated for any reason.
+     */
+    public static void forceRemoveElementFromGraphIndex(JanusGraphElement elementToRemoveFromIndex,
+                                                        IndexRecordEntry[] indexRecord,
+                                                        StandardJanusGraph graph,
+                                                        String graphIndexName) throws BackendException {
+
+        ManagementSystem managementSystem = (ManagementSystem) graph.openManagement();
+
+        try{
+            JanusGraphIndex index = managementSystem.getGraphIndex(graphIndexName);
+
+            forceRemoveElementFromGraphIndex(elementToRemoveFromIndex, indexRecord, graph, index, managementSystem);
+
+        } finally {
+            managementSystem.rollback();
+        }
+    }
+
+    private static IndexRecordEntry[] toIndexRecord(PropertyKey[] propertyKeys, Map<String, Object> indexRecordPropertyValues){
+
+        if(indexRecordPropertyValues.size() != propertyKeys.length){
+            throw new IllegalArgumentException("indexRecordPropertyValues contains "+indexRecordPropertyValues.size()
+                +" properties but provided index has "+propertyKeys.length+" indexed properties. " +
+                "It is necessary to include all but only indexed properties in indexRecordPropertyValues.");
+        }
+
+        IndexRecordEntry[] indexRecord = new IndexRecordEntry[propertyKeys.length];
+
+        for(int i=0; i<propertyKeys.length; i++){
+            PropertyKey propertyKey = propertyKeys[i];
+            String propertyKeyName = propertyKey.name();
+            if(!indexRecordPropertyValues.containsKey(propertyKeyName)){
+                throw new IllegalArgumentException("indexRecordPropertyValues doesn't contain property "+propertyKeyName
+                    +" but provided index has this property. It is necessary to include all but only indexed properties in indexRecordPropertyValues.");
+            }
+            Object propertyValue = indexRecordPropertyValues.get(propertyKeyName);
+            long propertyKeyId = propertyKey.longId();
+            indexRecord[i] = new IndexRecordEntry(propertyKeyId, propertyValue, propertyKey);
+        }
+
+        return indexRecord;
+    }
+
+    private static void forceRemoveElementFromGraphIndex(JanusGraphElement elementToRemoveFromIndex,
+                                                         IndexRecordEntry[] indexRecord,
+                                                         StandardJanusGraph graph,
+                                                         JanusGraphIndex index,
+                                                         ManagementSystem managementSystem) throws BackendException {
+
+        if(!index.isCompositeIndex()){
+            throw new IllegalArgumentException("Index ["+index.name()+"] is not a Composite index " +
+                "but only Composite index type is allowed in "+StaleIndexRecordUtil.class.getSimpleName()+" tool at this moment.");
+        }
+
+        Serializer serializer = graph.getDataSerializer();
+        boolean hashKeys = graph.getIndexSerializer().isHashKeys();
+        HashingUtil.HashLength hashLength = graph.getIndexSerializer().getHashLength();
+
+        JanusGraphSchemaVertex indexSchemaVertex = managementSystem.getSchemaVertex(index);
+
+        CompositeIndexType compositeIndexType = (CompositeIndexType) indexSchemaVertex.asIndexType();
+
+        IndexUpdate<StaticBuffer, Entry> update = IndexRecordUtil.getCompositeIndexUpdate(
+            compositeIndexType,
+            IndexMutationType.DELETE,
+            indexRecord,
+            elementToRemoveFromIndex,
+            serializer,
+            hashKeys,
+            hashLength
+        );
+
+        StandardJanusGraphTx tx = (StandardJanusGraphTx) graph.newTransaction();
+        BackendTransaction transaction = tx.getTxHandle();
+
+        try{
+            transaction.mutateIndex(update.getKey(), Collections.emptyList(), Collections.singletonList(update.getEntry()));
+        } finally {
+            try{
+                transaction.commit();
+            } finally {
+                tx.commit();
+            }
+        }
+    }
+}


### PR DESCRIPTION
With this change it will be possible to remove stale composite index entries from the graph.

Current limitations:
- Current approach didn't cover Mixed indices. I think it's possible to add this feature in the future PRs but I didn't dig into mixed index direct record changes yet.
- It's more challenging to change Edge composite index record but still possible in some cases. 
- Vertex centric indices were not covered. I guess it's more challenging but I didn't dig into changing entries of vertex centric indices yet. (not sure if that's needed at all)

Related to #1099

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
