### PR TITLE
Refactor index updates to prepare for #3022

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexRecordEntry.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexRecordEntry.java
@@ -1,0 +1,46 @@
+// Copyright 2022 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.database;
+
+import org.janusgraph.core.JanusGraphVertexProperty;
+import org.janusgraph.core.PropertyKey;
+
+public class IndexRecordEntry {
+    final long relationId;
+    final Object value;
+    final PropertyKey key;
+
+    public IndexRecordEntry(long relationId, Object value, PropertyKey key) {
+        this.relationId = relationId;
+        this.value = value;
+        this.key = key;
+    }
+
+    public IndexRecordEntry(JanusGraphVertexProperty property) {
+        this(property.longId(),property.value(),property.propertyKey());
+    }
+
+    public long getRelationId() {
+        return relationId;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public PropertyKey getKey() {
+        return key;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
@@ -17,16 +17,9 @@ package org.janusgraph.graphdb.database;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
-import org.janusgraph.core.Cardinality;
 import org.janusgraph.core.JanusGraphElement;
-import org.janusgraph.core.JanusGraphException;
 import org.janusgraph.core.JanusGraphRelation;
 import org.janusgraph.core.JanusGraphVertex;
 import org.janusgraph.core.JanusGraphVertexProperty;
@@ -39,8 +32,6 @@ import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.BackendTransaction;
 import org.janusgraph.diskstorage.Entry;
 import org.janusgraph.diskstorage.EntryList;
-import org.janusgraph.diskstorage.EntryMetaData;
-import org.janusgraph.diskstorage.MetaAnnotatable;
 import org.janusgraph.diskstorage.ReadBuffer;
 import org.janusgraph.diskstorage.StaticBuffer;
 import org.janusgraph.diskstorage.configuration.Configuration;
@@ -49,19 +40,18 @@ import org.janusgraph.diskstorage.indexing.IndexFeatures;
 import org.janusgraph.diskstorage.indexing.IndexInformation;
 import org.janusgraph.diskstorage.indexing.IndexProvider;
 import org.janusgraph.diskstorage.indexing.IndexQuery;
-import org.janusgraph.diskstorage.indexing.KeyInformation;
 import org.janusgraph.diskstorage.indexing.RawQuery;
 import org.janusgraph.diskstorage.indexing.StandardKeyInformation;
 import org.janusgraph.diskstorage.keycolumnvalue.KeySliceQuery;
 import org.janusgraph.diskstorage.util.BufferUtil;
 import org.janusgraph.diskstorage.util.HashingUtil;
-import org.janusgraph.diskstorage.util.StaticArrayEntry;
 import org.janusgraph.graphdb.database.idhandling.VariableLong;
-import org.janusgraph.graphdb.database.management.ManagementSystem;
-import org.janusgraph.graphdb.database.serialize.DataOutput;
-import org.janusgraph.graphdb.database.serialize.InternalAttributeUtil;
+import org.janusgraph.graphdb.database.index.IndexInfoRetriever;
+import org.janusgraph.graphdb.database.index.IndexMutationType;
+import org.janusgraph.graphdb.database.index.IndexRecords;
+import org.janusgraph.graphdb.database.index.IndexUpdate;
 import org.janusgraph.graphdb.database.serialize.Serializer;
-import org.janusgraph.graphdb.idmanagement.IDManager;
+import org.janusgraph.graphdb.database.util.IndexRecordUtil;
 import org.janusgraph.graphdb.internal.ElementCategory;
 import org.janusgraph.graphdb.internal.InternalRelation;
 import org.janusgraph.graphdb.internal.InternalRelationType;
@@ -75,32 +65,42 @@ import org.janusgraph.graphdb.query.graph.IndexQueryBuilder;
 import org.janusgraph.graphdb.query.graph.JointIndexQuery;
 import org.janusgraph.graphdb.query.graph.MultiKeySliceQuery;
 import org.janusgraph.graphdb.query.index.IndexSelectionUtil;
-import org.janusgraph.graphdb.query.vertex.VertexCentricQueryBuilder;
 import org.janusgraph.graphdb.relations.RelationIdentifier;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.janusgraph.graphdb.types.CompositeIndexType;
-import org.janusgraph.graphdb.types.IndexField;
 import org.janusgraph.graphdb.types.IndexType;
 import org.janusgraph.graphdb.types.MixedIndexType;
 import org.janusgraph.graphdb.types.ParameterIndexField;
 import org.janusgraph.graphdb.types.ParameterType;
-import org.janusgraph.util.encoding.LongEncoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.INDEX_NAME_MAPPING;
+import static org.janusgraph.graphdb.database.util.IndexRecordUtil.bytebuffer2RelationId;
+import static org.janusgraph.graphdb.database.util.IndexRecordUtil.getCompositeIndexUpdate;
+import static org.janusgraph.graphdb.database.util.IndexRecordUtil.element2String;
+import static org.janusgraph.graphdb.database.util.IndexRecordUtil.getIndexTTL;
+import static org.janusgraph.graphdb.database.util.IndexRecordUtil.getKeyInformation;
+import static org.janusgraph.graphdb.database.util.IndexRecordUtil.getKeysOfRecords;
+import static org.janusgraph.graphdb.database.util.IndexRecordUtil.getMixedIndexUpdate;
+import static org.janusgraph.graphdb.database.util.IndexRecordUtil.getUpdateType;
+import static org.janusgraph.graphdb.database.util.IndexRecordUtil.indexAppliesTo;
+import static org.janusgraph.graphdb.database.util.IndexRecordUtil.indexMatch;
+import static org.janusgraph.graphdb.database.util.IndexRecordUtil.indexMatches;
+import static org.janusgraph.graphdb.database.util.IndexRecordUtil.key2Field;
+import static org.janusgraph.graphdb.database.util.IndexRecordUtil.keyID2Name;
+import static org.janusgraph.graphdb.database.util.IndexRecordUtil.string2ElementId;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
@@ -109,9 +109,6 @@ import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.IN
 public class IndexSerializer {
 
     private static final Logger log = LoggerFactory.getLogger(IndexSerializer.class);
-
-    private static final int DEFAULT_OBJECT_BYTELEN = 30;
-    private static final byte FIRST_INDEX_COLUMN_BYTE = 0;
 
     private final Serializer serializer;
     private final Configuration configuration;
@@ -127,7 +124,6 @@ public class IndexSerializer {
         this.hashKeys=hashKeys;
         if (hashKeys) log.info("Hashing index keys");
     }
-
 
     /* ################################################
                Index Information
@@ -174,159 +170,19 @@ public class IndexSerializer {
         return indexinfo;
     }
 
-    private static StandardKeyInformation getKeyInformation(final ParameterIndexField field) {
-        return new StandardKeyInformation(field.getFieldKey(),field.getParameters());
-    }
-
     public IndexInfoRetriever getIndexInfoRetriever(StandardJanusGraphTx tx) {
         return new IndexInfoRetriever(tx);
-    }
-
-    public static class IndexInfoRetriever implements KeyInformation.Retriever {
-
-        private final StandardJanusGraphTx transaction;
-
-        private IndexInfoRetriever(StandardJanusGraphTx tx) {
-            Preconditions.checkNotNull(tx);
-            transaction=tx;
-        }
-
-        @Override
-        public KeyInformation.IndexRetriever get(final String index) {
-            return new KeyInformation.IndexRetriever() {
-
-                final Map<String,KeyInformation.StoreRetriever> indexes = new ConcurrentHashMap<>();
-
-                @Override
-                public KeyInformation get(String store, String key) {
-                    return get(store).get(key);
-                }
-
-                @Override
-                public KeyInformation.StoreRetriever get(final String store) {
-                    if (indexes.get(store)==null) {
-                        Preconditions.checkNotNull(transaction,"Retriever has not been initialized");
-                        final MixedIndexType extIndex = getMixedIndex(store, transaction);
-                        assert extIndex.getBackingIndexName().equals(index);
-                        final ImmutableMap.Builder<String,KeyInformation> b = ImmutableMap.builder();
-                        for (final ParameterIndexField field : extIndex.getFieldKeys()) b.put(key2Field(field),getKeyInformation(field));
-                        ImmutableMap<String,KeyInformation> infoMap;
-                        try {
-                            infoMap = b.build();
-                        } catch (IllegalArgumentException e) {
-                            throw new JanusGraphException("Duplicate index field names found, likely you have multiple properties mapped to the same index field", e);
-                        }
-                        final KeyInformation.StoreRetriever storeRetriever = infoMap::get;
-                        indexes.put(store,storeRetriever);
-                    }
-                    return indexes.get(store);
-                }
-
-                @Override
-                public void invalidate(final String store) {
-                    indexes.remove(store);
-                }
-            };
-        }
     }
 
     /* ################################################
                Index Updates
     ################################################### */
 
-    public static class IndexUpdate<K,E> {
-
-        private enum Type { ADD, DELETE }
-
-        private final IndexType index;
-        private final Type mutationType;
-        private final K key;
-        private final E entry;
-        private final JanusGraphElement element;
-
-        private IndexUpdate(IndexType index, Type mutationType, K key, E entry, JanusGraphElement element) {
-            assert index!=null && mutationType!=null && key!=null && entry!=null && element!=null;
-            assert !index.isCompositeIndex() || (key instanceof StaticBuffer && entry instanceof Entry);
-            assert !index.isMixedIndex() || (key instanceof String && entry instanceof IndexEntry);
-            this.index = index;
-            this.mutationType = mutationType;
-            this.key = key;
-            this.entry = entry;
-            this.element = element;
-        }
-
-        public JanusGraphElement getElement() {
-            return element;
-        }
-
-        public IndexType getIndex() {
-            return index;
-        }
-
-        public Type getType() {
-            return mutationType;
-        }
-
-        public K getKey() {
-            return key;
-        }
-
-        public E getEntry() {
-            return entry;
-        }
-
-        public boolean isAddition() {
-            return mutationType==Type.ADD;
-        }
-
-        public boolean isDeletion() {
-            return mutationType==Type.DELETE;
-        }
-
-        public boolean isCompositeIndex() {
-            return index.isCompositeIndex();
-        }
-
-        public boolean isMixedIndex() {
-            return index.isMixedIndex();
-        }
-
-        public void setTTL(int ttl) {
-            Preconditions.checkArgument(ttl>0 && mutationType==Type.ADD);
-            ((MetaAnnotatable)entry).setMetaData(EntryMetaData.TTL,ttl);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(index, mutationType, key, entry);
-        }
-
-        @Override
-        public boolean equals(Object other) {
-            if (this==other) return true;
-            else if (other==null || !(other instanceof IndexUpdate)) return false;
-            final IndexUpdate oth = (IndexUpdate)other;
-            return index.equals(oth.index) && mutationType==oth.mutationType && key.equals(oth.key) && entry.equals(oth.entry);
-        }
-    }
-
-    private static IndexUpdate.Type getUpdateType(InternalRelation relation) {
-        assert relation.isNew() || relation.isRemoved();
-        return (relation.isNew()? IndexUpdate.Type.ADD : IndexUpdate.Type.DELETE);
-    }
-
-    private static boolean indexAppliesTo(IndexType index, JanusGraphElement element) {
-        return index.getElement().isInstance(element) &&
-            (!(index instanceof CompositeIndexType) || ((CompositeIndexType)index).getStatus()!=SchemaStatus.DISABLED) &&
-            (!index.hasSchemaTypeConstraint() ||
-                index.getElement().matchesConstraint(index.getSchemaTypeConstraint(),element));
-    }
-
     public Collection<IndexUpdate> getIndexUpdates(InternalRelation relation) {
         assert relation.isNew() || relation.isRemoved();
-        final Set<IndexUpdate> updates = Sets.newHashSet();
-        final IndexUpdate.Type updateType = getUpdateType(relation);
-        final int ttl = updateType==IndexUpdate.Type.ADD?StandardJanusGraph.getTTL(relation):0;
+        final Set<IndexUpdate> updates = new HashSet<>();
+        final IndexMutationType updateType = getUpdateType(relation);
+        final int ttl = updateType==IndexMutationType.ADD?StandardJanusGraph.getTTL(relation):0;
         for (final PropertyKey type : relation.getPropertyKeysDirect()) {
             if (type == null) continue;
             for (final IndexType index : ((InternalRelationType) type).getKeyIndexes()) {
@@ -334,9 +190,9 @@ public class IndexSerializer {
                 IndexUpdate update;
                 if (index instanceof CompositeIndexType) {
                     final CompositeIndexType iIndex= (CompositeIndexType) index;
-                    final RecordEntry[] record = indexMatch(relation, iIndex);
+                    final IndexRecordEntry[] record = indexMatch(relation, iIndex);
                     if (record==null) continue;
-                    update = new IndexUpdate<>(iIndex, updateType, getIndexKey(iIndex, record), getIndexEntry(iIndex, record, relation), relation);
+                    update = getCompositeIndexUpdate(iIndex, updateType, record, relation, serializer, hashKeys, hashLength);
                 } else {
                     assert relation.valueOrNull(type)!=null;
                     if (((MixedIndexType)index).getField(type).getStatus()== SchemaStatus.DISABLED) continue;
@@ -349,39 +205,24 @@ public class IndexSerializer {
         return updates;
     }
 
-    private static PropertyKey[] getKeysOfRecords(RecordEntry[] record) {
-        final PropertyKey[] keys = new PropertyKey[record.length];
-        for (int i=0;i<record.length;i++) keys[i]=record[i].key;
-        return keys;
-    }
-
-    private static int getIndexTTL(InternalVertex vertex, PropertyKey... keys) {
-        int ttl = StandardJanusGraph.getTTL(vertex);
-        for (final PropertyKey key : keys) {
-            final int kttl = ((InternalRelationType) key).getTTL();
-            if (kttl > 0 && (kttl < ttl || ttl <= 0)) ttl = kttl;
-        }
-        return ttl;
-    }
-
     public Collection<IndexUpdate> getIndexUpdates(InternalVertex vertex, Collection<InternalRelation> updatedProperties) {
         if (updatedProperties.isEmpty()) return Collections.emptyList();
-        final Set<IndexUpdate> updates = Sets.newHashSet();
+        final Set<IndexUpdate> updates = new HashSet<>();
 
         for (final InternalRelation rel : updatedProperties) {
             assert rel.isProperty();
             final JanusGraphVertexProperty p = (JanusGraphVertexProperty)rel;
             assert rel.isNew() || rel.isRemoved(); assert rel.getVertex(0).equals(vertex);
-            final IndexUpdate.Type updateType = getUpdateType(rel);
+            final IndexMutationType updateType = getUpdateType(rel);
             for (final IndexType index : ((InternalRelationType)p.propertyKey()).getKeyIndexes()) {
                 if (!indexAppliesTo(index,vertex)) continue;
                 if (index.isCompositeIndex()) { //Gather composite indexes
                     final CompositeIndexType cIndex = (CompositeIndexType)index;
-                    final IndexRecords updateRecords = indexMatches(vertex,cIndex,updateType==IndexUpdate.Type.DELETE,p.propertyKey(),new RecordEntry(p));
-                    for (final RecordEntry[] record : updateRecords) {
-                        final IndexUpdate update = new IndexUpdate<>(cIndex, updateType, getIndexKey(cIndex, record), getIndexEntry(cIndex, record, vertex), vertex);
+                    final IndexRecords updateRecords = indexMatches(vertex,cIndex,updateType==IndexMutationType.DELETE,p.propertyKey(),new IndexRecordEntry(p));
+                    for (final IndexRecordEntry[] record : updateRecords) {
+                        final IndexUpdate update = getCompositeIndexUpdate(cIndex, updateType, record, vertex, serializer, hashKeys, hashLength);
                         final int ttl = getIndexTTL(vertex,getKeysOfRecords(record));
-                        if (ttl>0 && updateType== IndexUpdate.Type.ADD) update.setTTL(ttl);
+                        if (ttl>0 && updateType== IndexMutationType.ADD) update.setTTL(ttl);
                         updates.add(update);
                     }
                 } else { //Update mixed indexes
@@ -392,7 +233,7 @@ public class IndexSerializer {
                     if (field.getStatus() == SchemaStatus.DISABLED) continue;
                     final IndexUpdate update = getMixedIndexUpdate(vertex, p.propertyKey(), p.value(), (MixedIndexType) index, updateType);
                     final int ttl = getIndexTTL(vertex,p.propertyKey());
-                    if (ttl>0 && updateType== IndexUpdate.Type.ADD) update.setTTL(ttl);
+                    if (ttl>0 && updateType== IndexMutationType.ADD) update.setTTL(ttl);
                     updates.add(update);
                 }
             }
@@ -400,15 +241,10 @@ public class IndexSerializer {
         return updates;
     }
 
-    private IndexUpdate<String,IndexEntry> getMixedIndexUpdate(JanusGraphElement element, PropertyKey key, Object value,
-                                                               MixedIndexType index, IndexUpdate.Type updateType)  {
-        return new IndexUpdate<>(index, updateType, element2String(element), new IndexEntry(key2Field(index.getField(key)), value), element);
-    }
-
     public boolean reindexElement(JanusGraphElement element, MixedIndexType index, Map<String,Map<String,List<IndexEntry>>> documentsPerStore) {
         if (!indexAppliesTo(index, element))
             return false;
-        final List<IndexEntry> entries = Lists.newArrayList();
+        final List<IndexEntry> entries = new ArrayList<>();
         for (final ParameterIndexField field: index.getFieldKeys()) {
             final PropertyKey key = field.getFieldKey();
             if (field.getStatus()==SchemaStatus.DISABLED) continue;
@@ -423,149 +259,33 @@ public class IndexSerializer {
     }
 
     private Map<String,List<IndexEntry>> getDocuments(Map<String,Map<String,List<IndexEntry>>> documentsPerStore, MixedIndexType index) {
-        return documentsPerStore.computeIfAbsent(index.getStoreName(), k -> Maps.newHashMap());
+        return documentsPerStore.computeIfAbsent(index.getStoreName(), k -> new HashMap<>());
     }
 
     public void removeElement(Object elementId, MixedIndexType index, Map<String,Map<String,List<IndexEntry>>> documentsPerStore) {
         Preconditions.checkArgument((index.getElement()==ElementCategory.VERTEX && elementId instanceof Long) ||
             (index.getElement().isRelation() && elementId instanceof RelationIdentifier),"Invalid element id [%s] provided for index: %s",elementId,index);
-        getDocuments(documentsPerStore,index).put(element2String(elementId),Lists.newArrayList());
+        getDocuments(documentsPerStore,index).put(element2String(elementId),new ArrayList<>());
     }
 
     public Set<IndexUpdate<StaticBuffer,Entry>> reindexElement(JanusGraphElement element, CompositeIndexType index) {
-        final Set<IndexUpdate<StaticBuffer,Entry>> indexEntries = Sets.newHashSet();
-        if (!indexAppliesTo(index,element)) return indexEntries;
-        Iterable<RecordEntry[]> records;
-        if (element instanceof JanusGraphVertex) records = indexMatches((JanusGraphVertex)element,index);
-        else {
-            assert element instanceof JanusGraphRelation;
-            records = Collections.EMPTY_LIST;
-            final RecordEntry[] record = indexMatch((JanusGraphRelation)element,index);
-            if (record!=null) records = ImmutableList.of(record);
+        final Set<IndexUpdate<StaticBuffer,Entry>> indexEntries = new HashSet<>();
+        if (!indexAppliesTo(index,element)) {
+            return indexEntries;
         }
-        for (final RecordEntry[] record : records) {
-            indexEntries.add(new IndexUpdate<>(index, IndexUpdate.Type.ADD, getIndexKey(index, record), getIndexEntry(index, record, element), element));
+        Iterable<IndexRecordEntry[]> records;
+        if (element instanceof JanusGraphVertex) {
+            records = indexMatches((JanusGraphVertex)element,index);
+        } else {
+            assert element instanceof JanusGraphRelation;
+            final IndexRecordEntry[] record = indexMatch((JanusGraphRelation)element,index);
+            records = (record == null) ? Collections.emptyList() : Collections.singletonList(record);
+        }
+        for (final IndexRecordEntry[] record : records) {
+            indexEntries.add(getCompositeIndexUpdate(index, IndexMutationType.ADD, record, element, serializer, hashKeys, hashLength));
         }
         return indexEntries;
     }
-
-    public static RecordEntry[] indexMatch(JanusGraphRelation relation, CompositeIndexType index) {
-        final IndexField[] fields = index.getFieldKeys();
-        final RecordEntry[] match = new RecordEntry[fields.length];
-        for (int i = 0; i <fields.length; i++) {
-            final IndexField f = fields[i];
-            final Object value = relation.valueOrNull(f.getFieldKey());
-            if (value==null) return null; //No match
-            match[i] = new RecordEntry(relation.longId(),value,f.getFieldKey());
-        }
-        return match;
-    }
-
-    public static class IndexRecords extends ArrayList<RecordEntry[]> {
-
-        @Override
-        public boolean add(RecordEntry[] record) {
-            return super.add(Arrays.copyOf(record,record.length));
-        }
-
-        public Iterable<Object[]> getRecordValues() {
-            return Iterables.transform(this, new Function<RecordEntry[], Object[]>() {
-                @Nullable
-                @Override
-                public Object[] apply(final RecordEntry[] record) {
-                    return getValues(record);
-                }
-            });
-        }
-
-        private static Object[] getValues(RecordEntry[] record) {
-            final Object[] values = new Object[record.length];
-            for (int i = 0; i < values.length; i++) {
-                values[i]=record[i].value;
-            }
-            return values;
-        }
-
-    }
-
-    private static class RecordEntry {
-
-        final long relationId;
-        final Object value;
-        final PropertyKey key;
-
-        private RecordEntry(long relationId, Object value, PropertyKey key) {
-            this.relationId = relationId;
-            this.value = value;
-            this.key = key;
-        }
-
-        private RecordEntry(JanusGraphVertexProperty property) {
-            this(property.longId(),property.value(),property.propertyKey());
-        }
-    }
-
-    public static IndexRecords indexMatches(JanusGraphVertex vertex, CompositeIndexType index) {
-        return indexMatches(vertex,index,null,null);
-    }
-
-    public static IndexRecords indexMatches(JanusGraphVertex vertex, CompositeIndexType index,
-                                            PropertyKey replaceKey, Object replaceValue) {
-        final IndexRecords matches = new IndexRecords();
-        final IndexField[] fields = index.getFieldKeys();
-        if (indexAppliesTo(index,vertex)) {
-            indexMatches(vertex,new RecordEntry[fields.length],matches,fields,0,false,
-                replaceKey,new RecordEntry(0,replaceValue,replaceKey));
-        }
-        return matches;
-    }
-
-    private static IndexRecords indexMatches(JanusGraphVertex vertex, CompositeIndexType index,
-                                             boolean onlyLoaded, PropertyKey replaceKey, RecordEntry replaceValue) {
-        final IndexRecords matches = new IndexRecords();
-        final IndexField[] fields = index.getFieldKeys();
-        indexMatches(vertex,new RecordEntry[fields.length],matches,fields,0,onlyLoaded,replaceKey,replaceValue);
-        return matches;
-    }
-
-    private static void indexMatches(JanusGraphVertex vertex, RecordEntry[] current, IndexRecords matches,
-                                     IndexField[] fields, int pos,
-                                     boolean onlyLoaded, PropertyKey replaceKey, RecordEntry replaceValue) {
-        if (pos>= fields.length) {
-            matches.add(current);
-            return;
-        }
-
-        final PropertyKey key = fields[pos].getFieldKey();
-
-        List<RecordEntry> values;
-        if (key.equals(replaceKey)) {
-            values = ImmutableList.of(replaceValue);
-        } else {
-            values = new ArrayList<>();
-            Iterable<JanusGraphVertexProperty> props;
-            if (onlyLoaded ||
-                (!vertex.isNew() && IDManager.VertexIDType.PartitionedVertex.is(vertex.longId()))) {
-                //going through transaction so we can query deleted vertices
-                final VertexCentricQueryBuilder qb = ((InternalVertex)vertex).tx().query(vertex);
-                qb.noPartitionRestriction().type(key);
-                if (onlyLoaded) qb.queryOnlyLoaded();
-                props = qb.properties();
-            } else {
-                props = vertex.query().keys(key.name()).properties();
-            }
-            for (final JanusGraphVertexProperty p : props) {
-                assert !onlyLoaded || p.isLoaded() || p.isRemoved();
-                assert key.dataType().equals(p.value().getClass()) : key + " -> " + p;
-                values.add(new RecordEntry(p));
-            }
-        }
-        for (final RecordEntry value : values) {
-            current[pos]=value;
-            indexMatches(vertex,current,matches,fields,pos+1,onlyLoaded,replaceKey,replaceValue);
-        }
-    }
-
 
     /* ################################################
                 Querying
@@ -593,7 +313,7 @@ public class IndexSerializer {
             }
             return results.stream();
         } else {
-            return tx.indexQuery(index.getBackingIndexName(), query.getMixedQuery()).map(IndexSerializer::string2ElementId);
+            return tx.indexQuery(index.getBackingIndexName(), query.getMixedQuery()).map(IndexRecordUtil::string2ElementId);
         }
     }
 
@@ -606,7 +326,8 @@ public class IndexSerializer {
     public MultiKeySliceQuery getQuery(final CompositeIndexType index, List<Object[]> values) {
         final List<KeySliceQuery> ksqs = new ArrayList<>(values.size());
         for (final Object[] value : values) {
-            ksqs.add(new KeySliceQuery(getIndexKey(index,value), BufferUtil.zeroBuffer(1), BufferUtil.oneBuffer(1)));
+            ksqs.add(new KeySliceQuery(IndexRecordUtil.getIndexKey(index, value, serializer, hashKeys, hashLength),
+                BufferUtil.zeroBuffer(1), BufferUtil.oneBuffer(1)));
         }
         return new MultiKeySliceQuery(ksqs);
     }
@@ -721,7 +442,7 @@ public class IndexSerializer {
 
     public Stream<RawQuery.Result> executeQuery(IndexQueryBuilder query, final ElementCategory resultType,
                                                 final BackendTransaction backendTx, final StandardJanusGraphTx transaction) {
-        final MixedIndexType index = getMixedIndex(query.getIndex(), transaction);
+        final MixedIndexType index = IndexRecordUtil.getMixedIndex(query.getIndex(), transaction);
         final String queryStr = createQueryString(query, resultType, transaction, index);
         ImmutableList<IndexQuery.OrderEntry> orders = getOrders(query, resultType, transaction, index);
         final RawQuery rawQuery = new RawQuery(index.getStoreName(),queryStr,orders,query.getParameters());
@@ -732,7 +453,7 @@ public class IndexSerializer {
 
     public Long executeTotals(IndexQueryBuilder query, final ElementCategory resultType,
                               final BackendTransaction backendTx, final StandardJanusGraphTx transaction) {
-        final MixedIndexType index = getMixedIndex(query.getIndex(), transaction);
+        final MixedIndexType index = IndexRecordUtil.getMixedIndex(query.getIndex(), transaction);
         final String queryStr = createQueryString(query, resultType, transaction, index);
         final RawQuery rawQuery = new RawQuery(index.getStoreName(),queryStr,query.getParameters());
         if (query.hasLimit()) rawQuery.setLimit(query.getLimit());
@@ -740,116 +461,15 @@ public class IndexSerializer {
         return backendTx.totals(index.getBackingIndexName(), rawQuery);
     }
 
-    /* ################################################
-                Utility Functions
-    ################################################### */
-
-    private static MixedIndexType getMixedIndex(String indexName, StandardJanusGraphTx transaction) {
-        final IndexType index = ManagementSystem.getGraphIndexDirect(indexName, transaction);
-        Preconditions.checkArgument(index!=null,"Index with name [%s] is unknown or not configured properly",indexName);
-        Preconditions.checkArgument(index.isMixedIndex());
-        return (MixedIndexType)index;
-    }
-
-    private static String element2String(JanusGraphElement element) {
-        return element2String(element.id());
-    }
-
-    private static String element2String(Object elementId) {
-        Preconditions.checkArgument(elementId instanceof Long || elementId instanceof RelationIdentifier);
-        if (elementId instanceof Long) return longID2Name((Long)elementId);
-        else return ((RelationIdentifier) elementId).toString();
-    }
-
-    private static Object string2ElementId(String str) {
-        if (str.contains(RelationIdentifier.TOSTRING_DELIMITER)) return RelationIdentifier.parse(str);
-        else return name2LongID(str);
-    }
-
-    private static String key2Field(MixedIndexType index, PropertyKey key) {
-        return key2Field(index.getField(key));
-    }
-
-    private static String key2Field(ParameterIndexField field) {
-        assert field!=null;
-        return ParameterType.MAPPED_NAME.findParameter(field.getParameters(),keyID2Name(field.getFieldKey()));
-    }
-
-    private static String keyID2Name(PropertyKey key) {
-        return longID2Name(key.longId());
-    }
-
-    private static String longID2Name(long id) {
-        Preconditions.checkArgument(id > 0);
-        return LongEncoding.encode(id);
-    }
-
-    private static long name2LongID(String name) {
-        return LongEncoding.decode(name);
-    }
-
-
-    private StaticBuffer getIndexKey(CompositeIndexType index, RecordEntry[] record) {
-        return getIndexKey(index,IndexRecords.getValues(record));
-    }
-
-    private StaticBuffer getIndexKey(CompositeIndexType index, Object[] values) {
-        final DataOutput out = serializer.getDataOutput(8*DEFAULT_OBJECT_BYTELEN + 8);
-        VariableLong.writePositive(out, index.getID());
-        final IndexField[] fields = index.getFieldKeys();
-        Preconditions.checkArgument(fields.length>0 && fields.length==values.length);
-        for (int i = 0; i < fields.length; i++) {
-            final IndexField f = fields[i];
-            final Object value = values[i];
-            Preconditions.checkNotNull(value);
-            if (InternalAttributeUtil.hasGenericDataType(f.getFieldKey())) {
-                out.writeClassAndObject(value);
-            } else {
-                assert value.getClass().equals(f.getFieldKey().dataType()) : value.getClass() + " - " + f.getFieldKey().dataType();
-                out.writeObjectNotNull(value);
-            }
-        }
-        StaticBuffer key = out.getStaticBuffer();
-        if (hashKeys) key = HashingUtil.hashPrefixKey(hashLength,key);
-        return key;
-    }
-
     public long getIndexIdFromKey(StaticBuffer key) {
-        if (hashKeys) key = HashingUtil.getKey(hashLength,key);
-        return VariableLong.readPositive(key.asReadBuffer());
+        return IndexRecordUtil.getIndexIdFromKey(key, hashKeys, hashLength);
     }
 
-    private Entry getIndexEntry(CompositeIndexType index, RecordEntry[] record, JanusGraphElement element) {
-        final DataOutput out = serializer.getDataOutput(1+8+8*record.length+4*8);
-        out.putByte(FIRST_INDEX_COLUMN_BYTE);
-        if (index.getCardinality()!=Cardinality.SINGLE) {
-            VariableLong.writePositive(out,element.longId());
-            if (index.getCardinality()!=Cardinality.SET) {
-                for (final RecordEntry re : record) {
-                    VariableLong.writePositive(out,re.relationId);
-                }
-            }
-        }
-        final int valuePosition=out.getPosition();
-        if (element instanceof JanusGraphVertex) {
-            VariableLong.writePositive(out,element.longId());
-        } else {
-            assert element instanceof JanusGraphRelation;
-            final RelationIdentifier rid = (RelationIdentifier)element.id();
-            final long[] longs = rid.getLongRepresentation();
-            Preconditions.checkArgument(longs.length == 3 || longs.length == 4);
-            for (final long aLong : longs) VariableLong.writePositive(out, aLong);
-        }
-        return new StaticArrayEntry(out.getStaticBuffer(),valuePosition);
+    public boolean isHashKeys() {
+        return hashKeys;
     }
 
-    private static RelationIdentifier bytebuffer2RelationId(ReadBuffer b) {
-        long[] relationId = new long[4];
-        for (int i = 0; i < 3; i++) relationId[i] = VariableLong.readPositive(b);
-        if (b.hasRemaining()) relationId[3] = VariableLong.readPositive(b);
-        else relationId = Arrays.copyOfRange(relationId,0,3);
-        return RelationIdentifier.get(relationId);
+    public HashingUtil.HashLength getHashLength() {
+        return hashLength;
     }
-
-
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/index/IndexInfoRetriever.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/index/IndexInfoRetriever.java
@@ -1,0 +1,75 @@
+// Copyright 2022 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.database.index;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import org.janusgraph.core.JanusGraphException;
+import org.janusgraph.diskstorage.indexing.KeyInformation;
+import org.janusgraph.graphdb.database.util.IndexRecordUtil;
+import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
+import org.janusgraph.graphdb.types.MixedIndexType;
+import org.janusgraph.graphdb.types.ParameterIndexField;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class IndexInfoRetriever implements KeyInformation.Retriever {
+
+    private final StandardJanusGraphTx transaction;
+
+    public IndexInfoRetriever(StandardJanusGraphTx tx) {
+        Preconditions.checkNotNull(tx);
+        transaction=tx;
+    }
+
+    @Override
+    public KeyInformation.IndexRetriever get(final String index) {
+        return new KeyInformation.IndexRetriever() {
+
+            final Map<String,KeyInformation.StoreRetriever> indexes = new ConcurrentHashMap<>();
+
+            @Override
+            public KeyInformation get(String store, String key) {
+                return get(store).get(key);
+            }
+
+            @Override
+            public KeyInformation.StoreRetriever get(final String store) {
+                if (indexes.get(store)==null) {
+                    Preconditions.checkNotNull(transaction,"Retriever has not been initialized");
+                    final MixedIndexType extIndex = IndexRecordUtil.getMixedIndex(store, transaction);
+                    assert extIndex.getBackingIndexName().equals(index);
+                    final ImmutableMap.Builder<String,KeyInformation> b = ImmutableMap.builder();
+                    for (final ParameterIndexField field : extIndex.getFieldKeys()) b.put(IndexRecordUtil.key2Field(field),IndexRecordUtil.getKeyInformation(field));
+                    ImmutableMap<String,KeyInformation> infoMap;
+                    try {
+                        infoMap = b.build();
+                    } catch (IllegalArgumentException e) {
+                        throw new JanusGraphException("Duplicate index field names found, likely you have multiple properties mapped to the same index field", e);
+                    }
+                    final KeyInformation.StoreRetriever storeRetriever = infoMap::get;
+                    indexes.put(store,storeRetriever);
+                }
+                return indexes.get(store);
+            }
+
+            @Override
+            public void invalidate(final String store) {
+                indexes.remove(store);
+            }
+        };
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/index/IndexMutationType.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/index/IndexMutationType.java
@@ -1,0 +1,20 @@
+// Copyright 2022 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.database.index;
+
+public enum IndexMutationType {
+    ADD,
+    DELETE
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/index/IndexRecords.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/index/IndexRecords.java
@@ -1,0 +1,35 @@
+// Copyright 2022 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.database.index;
+
+import org.janusgraph.graphdb.database.IndexRecordEntry;
+import org.janusgraph.graphdb.database.util.IndexRecordUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class IndexRecords extends ArrayList<IndexRecordEntry[]> {
+
+    @Override
+    public boolean add(IndexRecordEntry[] record) {
+        return super.add(Arrays.copyOf(record,record.length));
+    }
+
+    public Iterable<Object[]> getRecordValues() {
+        return this.stream().map(IndexRecordUtil::getValues).collect(Collectors.toList());
+    }
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/index/IndexUpdate.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/index/IndexUpdate.java
@@ -1,0 +1,100 @@
+// Copyright 2022 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.database.index;
+
+import com.google.common.base.Preconditions;
+import org.janusgraph.core.JanusGraphElement;
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.EntryMetaData;
+import org.janusgraph.diskstorage.MetaAnnotatable;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.indexing.IndexEntry;
+import org.janusgraph.graphdb.types.IndexType;
+
+import java.util.Objects;
+
+public class IndexUpdate<K,E> {
+
+    private final IndexType index;
+    private final IndexMutationType mutationType;
+    private final K key;
+    private final E entry;
+    private final JanusGraphElement element;
+
+    public IndexUpdate(IndexType index, IndexMutationType mutationType, K key, E entry, JanusGraphElement element) {
+        assert index!=null && mutationType!=null && key!=null && entry!=null && element!=null;
+        assert !index.isCompositeIndex() || (key instanceof StaticBuffer && entry instanceof Entry);
+        assert !index.isMixedIndex() || (key instanceof String && entry instanceof IndexEntry);
+        this.index = index;
+        this.mutationType = mutationType;
+        this.key = key;
+        this.entry = entry;
+        this.element = element;
+    }
+
+    public JanusGraphElement getElement() {
+        return element;
+    }
+
+    public IndexType getIndex() {
+        return index;
+    }
+
+    public IndexMutationType getType() {
+        return mutationType;
+    }
+
+    public K getKey() {
+        return key;
+    }
+
+    public E getEntry() {
+        return entry;
+    }
+
+    public boolean isAddition() {
+        return mutationType== IndexMutationType.ADD;
+    }
+
+    public boolean isDeletion() {
+        return mutationType== IndexMutationType.DELETE;
+    }
+
+    public boolean isCompositeIndex() {
+        return index.isCompositeIndex();
+    }
+
+    public boolean isMixedIndex() {
+        return index.isMixedIndex();
+    }
+
+    public void setTTL(int ttl) {
+        Preconditions.checkArgument(ttl>0 && mutationType == IndexMutationType.ADD);
+        ((MetaAnnotatable)entry).setMetaData(EntryMetaData.TTL,ttl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index, mutationType, key, entry);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this==other) return true;
+        else if (other==null || !(other instanceof IndexUpdate)) return false;
+        final IndexUpdate oth = (IndexUpdate)other;
+        return index.equals(oth.index) && mutationType==oth.mutationType && key.equals(oth.key) && entry.equals(oth.entry);
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/util/IndexRecordUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/util/IndexRecordUtil.java
@@ -1,0 +1,296 @@
+// Copyright 2022 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.database.util;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import org.janusgraph.core.Cardinality;
+import org.janusgraph.core.JanusGraphElement;
+import org.janusgraph.core.JanusGraphRelation;
+import org.janusgraph.core.JanusGraphVertex;
+import org.janusgraph.core.JanusGraphVertexProperty;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.SchemaStatus;
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.ReadBuffer;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.indexing.IndexEntry;
+import org.janusgraph.diskstorage.indexing.StandardKeyInformation;
+import org.janusgraph.diskstorage.util.HashingUtil;
+import org.janusgraph.diskstorage.util.StaticArrayEntry;
+import org.janusgraph.graphdb.database.IndexRecordEntry;
+import org.janusgraph.graphdb.database.StandardJanusGraph;
+import org.janusgraph.graphdb.database.idhandling.VariableLong;
+import org.janusgraph.graphdb.database.index.IndexMutationType;
+import org.janusgraph.graphdb.database.index.IndexRecords;
+import org.janusgraph.graphdb.database.index.IndexUpdate;
+import org.janusgraph.graphdb.database.management.ManagementSystem;
+import org.janusgraph.graphdb.database.serialize.DataOutput;
+import org.janusgraph.graphdb.database.serialize.InternalAttributeUtil;
+import org.janusgraph.graphdb.database.serialize.Serializer;
+import org.janusgraph.graphdb.idmanagement.IDManager;
+import org.janusgraph.graphdb.internal.InternalRelation;
+import org.janusgraph.graphdb.internal.InternalRelationType;
+import org.janusgraph.graphdb.internal.InternalVertex;
+import org.janusgraph.graphdb.query.vertex.VertexCentricQueryBuilder;
+import org.janusgraph.graphdb.relations.RelationIdentifier;
+import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
+import org.janusgraph.graphdb.types.CompositeIndexType;
+import org.janusgraph.graphdb.types.IndexField;
+import org.janusgraph.graphdb.types.IndexType;
+import org.janusgraph.graphdb.types.MixedIndexType;
+import org.janusgraph.graphdb.types.ParameterIndexField;
+import org.janusgraph.graphdb.types.ParameterType;
+import org.janusgraph.util.encoding.LongEncoding;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class IndexRecordUtil {
+
+    private static final int DEFAULT_OBJECT_BYTELEN = 30;
+    private static final byte FIRST_INDEX_COLUMN_BYTE = 0;
+
+    public static Object[] getValues(IndexRecordEntry[] record) {
+        final Object[] values = new Object[record.length];
+        for (int i = 0; i < values.length; i++) {
+            values[i]=record[i].getValue();
+        }
+        return values;
+    }
+
+    public static MixedIndexType getMixedIndex(String indexName, StandardJanusGraphTx transaction) {
+        final IndexType index = ManagementSystem.getGraphIndexDirect(indexName, transaction);
+        Preconditions.checkArgument(index!=null,"Index with name [%s] is unknown or not configured properly",indexName);
+        Preconditions.checkArgument(index.isMixedIndex());
+        return (MixedIndexType)index;
+    }
+
+    public static String element2String(JanusGraphElement element) {
+        return element2String(element.id());
+    }
+
+    public static String element2String(Object elementId) {
+        Preconditions.checkArgument(elementId instanceof Long || elementId instanceof RelationIdentifier);
+        if (elementId instanceof Long) return longID2Name((Long)elementId);
+        else return ((RelationIdentifier) elementId).toString();
+    }
+
+    public static Object string2ElementId(String str) {
+        if (str.contains(RelationIdentifier.TOSTRING_DELIMITER)) return RelationIdentifier.parse(str);
+        else return name2LongID(str);
+    }
+
+    public static String key2Field(MixedIndexType index, PropertyKey key) {
+        return key2Field(index.getField(key));
+    }
+
+    public static String key2Field(ParameterIndexField field) {
+        assert field!=null;
+        return ParameterType.MAPPED_NAME.findParameter(field.getParameters(),keyID2Name(field.getFieldKey()));
+    }
+
+    public static String keyID2Name(PropertyKey key) {
+        return longID2Name(key.longId());
+    }
+
+    public static String longID2Name(long id) {
+        Preconditions.checkArgument(id > 0);
+        return LongEncoding.encode(id);
+    }
+
+    public static long name2LongID(String name) {
+        return LongEncoding.decode(name);
+    }
+
+    public static RelationIdentifier bytebuffer2RelationId(ReadBuffer b) {
+        long[] relationId = new long[4];
+        for (int i = 0; i < 3; i++) relationId[i] = VariableLong.readPositive(b);
+        if (b.hasRemaining()) relationId[3] = VariableLong.readPositive(b);
+        else relationId = Arrays.copyOfRange(relationId,0,3);
+        return RelationIdentifier.get(relationId);
+    }
+
+    public static StandardKeyInformation getKeyInformation(final ParameterIndexField field) {
+        return new StandardKeyInformation(field.getFieldKey(),field.getParameters());
+    }
+
+    public static IndexMutationType getUpdateType(InternalRelation relation) {
+        assert relation.isNew() || relation.isRemoved();
+        return (relation.isNew()? IndexMutationType.ADD : IndexMutationType.DELETE);
+    }
+
+    public static boolean indexAppliesTo(IndexType index, JanusGraphElement element) {
+        return index.getElement().isInstance(element) &&
+            (!(index instanceof CompositeIndexType) || ((CompositeIndexType)index).getStatus()!= SchemaStatus.DISABLED) &&
+            (!index.hasSchemaTypeConstraint() ||
+                index.getElement().matchesConstraint(index.getSchemaTypeConstraint(),element));
+    }
+
+    public static PropertyKey[] getKeysOfRecords(IndexRecordEntry[] record) {
+        final PropertyKey[] keys = new PropertyKey[record.length];
+        for (int i=0;i<record.length;i++) keys[i]=record[i].getKey();
+        return keys;
+    }
+
+    public static int getIndexTTL(InternalVertex vertex, PropertyKey... keys) {
+        int ttl = StandardJanusGraph.getTTL(vertex);
+        for (final PropertyKey key : keys) {
+            final int kttl = ((InternalRelationType) key).getTTL();
+            if (kttl > 0 && (kttl < ttl || ttl <= 0)) ttl = kttl;
+        }
+        return ttl;
+    }
+
+    public static IndexRecordEntry[] indexMatch(JanusGraphRelation relation, CompositeIndexType index) {
+        final IndexField[] fields = index.getFieldKeys();
+        final IndexRecordEntry[] match = new IndexRecordEntry[fields.length];
+        for (int i = 0; i <fields.length; i++) {
+            final IndexField f = fields[i];
+            final Object value = relation.valueOrNull(f.getFieldKey());
+            if (value==null) return null; //No match
+            match[i] = new IndexRecordEntry(relation.longId(),value,f.getFieldKey());
+        }
+        return match;
+    }
+
+    public static IndexRecords indexMatches(JanusGraphVertex vertex, CompositeIndexType index) {
+        return indexMatches(vertex,index,null,null);
+    }
+
+    public static IndexRecords indexMatches(JanusGraphVertex vertex, CompositeIndexType index,
+                                            PropertyKey replaceKey, Object replaceValue) {
+        final IndexRecords matches = new IndexRecords();
+        final IndexField[] fields = index.getFieldKeys();
+        if (indexAppliesTo(index,vertex)) {
+            indexMatches(vertex,new IndexRecordEntry[fields.length],matches,fields,0,false,
+                replaceKey,new IndexRecordEntry(0,replaceValue,replaceKey));
+        }
+        return matches;
+    }
+
+    public static IndexRecords indexMatches(JanusGraphVertex vertex, CompositeIndexType index,
+                                             boolean onlyLoaded, PropertyKey replaceKey, IndexRecordEntry replaceValue) {
+        final IndexRecords matches = new IndexRecords();
+        final IndexField[] fields = index.getFieldKeys();
+        indexMatches(vertex,new IndexRecordEntry[fields.length],matches,fields,0,onlyLoaded,replaceKey,replaceValue);
+        return matches;
+    }
+
+    public static void indexMatches(JanusGraphVertex vertex, IndexRecordEntry[] current, IndexRecords matches,
+                                     IndexField[] fields, int pos,
+                                     boolean onlyLoaded, PropertyKey replaceKey, IndexRecordEntry replaceValue) {
+        if (pos>= fields.length) {
+            matches.add(current);
+            return;
+        }
+
+        final PropertyKey key = fields[pos].getFieldKey();
+
+        List<IndexRecordEntry> values;
+        if (key.equals(replaceKey)) {
+            values = ImmutableList.of(replaceValue);
+        } else {
+            values = new ArrayList<>();
+            Iterable<JanusGraphVertexProperty> props;
+            if (onlyLoaded ||
+                (!vertex.isNew() && IDManager.VertexIDType.PartitionedVertex.is(vertex.longId()))) {
+                //going through transaction so we can query deleted vertices
+                final VertexCentricQueryBuilder qb = ((InternalVertex)vertex).tx().query(vertex);
+                qb.noPartitionRestriction().type(key);
+                if (onlyLoaded) qb.queryOnlyLoaded();
+                props = qb.properties();
+            } else {
+                props = vertex.query().keys(key.name()).properties();
+            }
+            for (final JanusGraphVertexProperty p : props) {
+                assert !onlyLoaded || p.isLoaded() || p.isRemoved();
+                assert key.dataType().equals(p.value().getClass()) : key + " -> " + p;
+                values.add(new IndexRecordEntry(p));
+            }
+        }
+        for (final IndexRecordEntry value : values) {
+            current[pos]=value;
+            indexMatches(vertex,current,matches,fields,pos+1,onlyLoaded,replaceKey,replaceValue);
+        }
+    }
+
+    public static Entry getIndexEntry(CompositeIndexType index, IndexRecordEntry[] record, JanusGraphElement element, Serializer serializer) {
+        final DataOutput out = serializer.getDataOutput(1+8+8*record.length+4*8);
+        out.putByte(FIRST_INDEX_COLUMN_BYTE);
+        if (index.getCardinality()!= Cardinality.SINGLE) {
+            VariableLong.writePositive(out,element.longId());
+            if (index.getCardinality()!=Cardinality.SET) {
+                for (final IndexRecordEntry re : record) {
+                    VariableLong.writePositive(out,re.getRelationId());
+                }
+            }
+        }
+        final int valuePosition=out.getPosition();
+        if (element instanceof JanusGraphVertex) {
+            VariableLong.writePositive(out,element.longId());
+        } else {
+            assert element instanceof JanusGraphRelation;
+            final RelationIdentifier rid = (RelationIdentifier)element.id();
+            final long[] longs = rid.getLongRepresentation();
+            Preconditions.checkArgument(longs.length == 3 || longs.length == 4);
+            for (final long aLong : longs) VariableLong.writePositive(out, aLong);
+        }
+        return new StaticArrayEntry(out.getStaticBuffer(),valuePosition);
+    }
+
+    public static StaticBuffer getIndexKey(CompositeIndexType index, IndexRecordEntry[] record, Serializer serializer, boolean hashKeys, HashingUtil.HashLength hashLength) {
+        return getIndexKey(index, IndexRecordUtil.getValues(record), serializer, hashKeys, hashLength);
+    }
+
+    public static StaticBuffer getIndexKey(CompositeIndexType index, Object[] values, Serializer serializer, boolean hashKeys, HashingUtil.HashLength hashLength) {
+        final DataOutput out = serializer.getDataOutput(8*DEFAULT_OBJECT_BYTELEN + 8);
+        VariableLong.writePositive(out, index.getID());
+        final IndexField[] fields = index.getFieldKeys();
+        Preconditions.checkArgument(fields.length>0 && fields.length==values.length);
+        for (int i = 0; i < fields.length; i++) {
+            final IndexField f = fields[i];
+            final Object value = values[i];
+            Preconditions.checkNotNull(value);
+            if (InternalAttributeUtil.hasGenericDataType(f.getFieldKey())) {
+                out.writeClassAndObject(value);
+            } else {
+                assert value.getClass().equals(f.getFieldKey().dataType()) : value.getClass() + " - " + f.getFieldKey().dataType();
+                out.writeObjectNotNull(value);
+            }
+        }
+        StaticBuffer key = out.getStaticBuffer();
+        if (hashKeys) key = HashingUtil.hashPrefixKey(hashLength,key);
+        return key;
+    }
+
+    public static long getIndexIdFromKey(StaticBuffer key, boolean hashKeys, HashingUtil.HashLength hashLength) {
+        if (hashKeys) key = HashingUtil.getKey(hashLength,key);
+        return VariableLong.readPositive(key.asReadBuffer());
+    }
+
+    public static IndexUpdate<StaticBuffer, Entry> getCompositeIndexUpdate(CompositeIndexType index, IndexMutationType indexMutationType, IndexRecordEntry[] record,
+                                                                           JanusGraphElement element, Serializer serializer, boolean hashKeys, HashingUtil.HashLength hashLength){
+        return new IndexUpdate<>(index, indexMutationType,
+            getIndexKey(index, record, serializer, hashKeys, hashLength),
+            getIndexEntry(index, record, element, serializer), element);
+    }
+
+    public static IndexUpdate<String, IndexEntry> getMixedIndexUpdate(JanusGraphElement element, PropertyKey key, Object value,
+                                                                      MixedIndexType index, IndexMutationType updateType)  {
+        return new IndexUpdate<>(index, updateType, element2String(element), new IndexEntry(key2Field(index.getField(key)), value), element);
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/job/IndexRepairJob.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/job/IndexRepairJob.java
@@ -36,6 +36,7 @@ import org.janusgraph.diskstorage.keycolumnvalue.cache.KCVSCache;
 import org.janusgraph.diskstorage.keycolumnvalue.scan.ScanMetrics;
 import org.janusgraph.graphdb.database.EdgeSerializer;
 import org.janusgraph.graphdb.database.IndexSerializer;
+import org.janusgraph.graphdb.database.index.IndexUpdate;
 import org.janusgraph.graphdb.database.management.RelationTypeIndexWrapper;
 import org.janusgraph.graphdb.internal.InternalRelation;
 import org.janusgraph.graphdb.internal.InternalRelationType;
@@ -198,9 +199,9 @@ public class IndexRepairJob extends IndexUpdateJob implements VertexScanJob {
                 }
                 if (indexType.isCompositeIndex()) {
                     for (JanusGraphElement element : elements) {
-                        Set<IndexSerializer.IndexUpdate<StaticBuffer,Entry>> updates =
+                        Set<IndexUpdate<StaticBuffer,Entry>> updates =
                                 indexSerializer.reindexElement(element, (CompositeIndexType) indexType);
-                        for (IndexSerializer.IndexUpdate<StaticBuffer,Entry> update : updates) {
+                        for (IndexUpdate<StaticBuffer,Entry> update : updates) {
                             log.debug("Mutating index {}: {}", indexType, update.getEntry());
                             mutator.mutateIndex(update.getKey(), new ArrayList<Entry>(1){{add(update.getEntry());}}, KCVSCache.NO_DELETIONS);
                             metrics.incrementCustom(ADDED_RECORDS_COUNT);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -53,6 +53,8 @@ import org.janusgraph.diskstorage.BackendTransaction;
 import org.janusgraph.diskstorage.EntryList;
 import org.janusgraph.diskstorage.indexing.IndexTransaction;
 import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
+import org.janusgraph.graphdb.database.index.IndexRecords;
+import org.janusgraph.graphdb.database.util.IndexRecordUtil;
 import org.janusgraph.graphdb.query.graph.MixedIndexCountQueryBuilder;
 import org.janusgraph.diskstorage.util.time.TimestampProvider;
 import org.janusgraph.graphdb.database.EdgeSerializer;
@@ -856,7 +858,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
         //Determine unique indexes
         final List<IndexLockTuple> uniqueIndexTuples = new ArrayList<>();
         for (CompositeIndexType index : TypeUtil.getUniqueIndexes(key)) {
-            IndexSerializer.IndexRecords matches = IndexSerializer.indexMatches(vertex, index, key, normalizedValue);
+            IndexRecords matches = IndexRecordUtil.indexMatches(vertex, index, key, normalizedValue);
             for (Object[] match : matches.getRecordValues()) uniqueIndexTuples.add(new IndexLockTuple(index,match));
         }
 


### PR DESCRIPTION
This PR contains refactoring only to prepare for #3022 . After this PR is merged I will rebase #3022 

What this refactoring does:
- Moves all nested classes from `IndexSerializer.java` to normal classes.
- Moves all static methods from `IndexSerializer.java` to a new class `IndexRecordUtil.java`.
- Converts some `IndexSerializer.java` class methods which will be shared in in #3022 into static methods and moves those methods to `IndexRecordUtil.java`.

Related to #1099

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
