### PR TITLE
Disable StaticArrayEntryListBenchmark and set FailOnError

### DIFF
--- a/janusgraph-benchmark/src/main/java/org/janusgraph/BenchmarkRunner.java
+++ b/janusgraph-benchmark/src/main/java/org/janusgraph/BenchmarkRunner.java
@@ -25,6 +25,7 @@ public class BenchmarkRunner {
         final ChainedOptionsBuilder builder = new OptionsBuilder()
             .forks(1)
             .measurementTime(TimeValue.seconds(5))
+            .shouldFailOnError(true)
             .warmupIterations(2)
             .warmupTime(TimeValue.seconds(1));
         if (args.length > 0) {
@@ -34,6 +35,7 @@ public class BenchmarkRunner {
         } else {
             builder.include(".*Benchmark");
         }
+        builder.exclude(".*StaticArrayEntryListBenchmark");
         new Runner(builder.build()).run();
     }
 }


### PR DESCRIPTION
Currently, StaticArrayEntryListBenchmark causes OOM but
benchmark CI job does not exit. This commit sets up
JMH's shouldFailOnError option so that the CI job will
fail in case of any error. Moreover, this commit excludes
StaticArrayEntryListBenchmark from the standard benchmark
suite because it only tests a low-level API that is rarely
changed and thus does not have much value in CI.

[This example](https://github.com/li-boxuan/janusgraph/runs/6362035397?check_suite_focus=true) shows how shouldFailOnError option leads to CI job failure.
[This example](https://github.com/JanusGraph/janusgraph/runs/6349131794?check_suite_focus=true#step:6:594) shows the status quo: OOM does not lead to CI job failure.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
