### PR TITLE
Document ConfiguredGraphFactory::getConfiguration method

### DIFF
--- a/docs/operations/configured-graph-factory.md
+++ b/docs/operations/configured-graph-factory.md
@@ -251,6 +251,10 @@ map.put("storage.hostname", "10.0.0.1");
 ConfiguredGraphFactory.updateConfiguration("graph1",
 map);
 
+// We can verify the configuration was updated by
+// retrieving the configuration for this graph
+ConfiguredGraphFactory.getConfiguration("graph1");
+
 // We are now guaranteed to use the updated configuration
 g1 = ConfiguredGraphFactory.open("graph1");
 ```
@@ -273,6 +277,10 @@ map.put("index.search.hostname", "127.0.0.1");
 map.put("index.search.elasticsearch.transport-scheme", "http");
 ConfiguredGraphFactory.updateConfiguration("graph1",
 map);
+
+// We can verify the configuration was updated by
+// retrieving the configuration for this graph
+ConfiguredGraphFactory.getConfiguration("graph1");
 
 // We are now guaranteed to use the updated configuration
 g1 = ConfiguredGraphFactory.open("graph1");
@@ -302,7 +310,10 @@ ConfiguredGraphFactory.removeConfiguration("graph1");
 
 // Recreate
 ConfiguredGraphFactory.create("graph1");
-// Now this graph's configuration is guaranteed to be updated
+
+// Now this graph's configuration is guaranteed to be updated.
+// We can verify it by retrieving the configuration for this graph
+ConfiguredGraphFactory.getConfiguration("graph1");
 ```
 
 ## JanusGraphManager


### PR DESCRIPTION
In configured-graph-factory.md, we didn't document how to
retrieve current configurations for a given graph. This commit
adds a simple example of how to retrieve graph configurations.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
