### PR TITLE
Guard against NPE when dropping non-existing graphs

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/core/AbstractConfiguredGraphFactoryTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/core/AbstractConfiguredGraphFactoryTest.java
@@ -292,6 +292,24 @@ public abstract class AbstractConfiguredGraphFactoryTest {
     }
 
     @Test
+    public void shouldBeAbleToDropBogusGraph() throws Exception {
+        final MapConfiguration graphConfig = getGraphConfig();
+        final String graphName = graphConfig.getString(GRAPH_NAME.toStringWithoutRoot());
+
+        try {
+            ConfiguredGraphFactory.createConfiguration(graphConfig);
+            final StandardJanusGraph graph = (StandardJanusGraph) ConfiguredGraphFactory.open(graphName);
+            assertNotNull(graph);
+
+            ConfiguredGraphFactory.drop(graphName);
+            RuntimeException exception = assertThrows(RuntimeException.class, () -> ConfiguredGraphFactory.open(graphName));
+            assertEquals("Please create configuration for this graph using the ConfigurationManagementGraph#createConfiguration API.", exception.getMessage());
+        } finally {
+            ConfiguredGraphFactory.drop(graphName);
+        }
+    }
+
+    @Test
     public void shouldCreateTwoGraphsUsingSameTemplateConfiguration() throws Exception {
         try {
             ConfiguredGraphFactory.createTemplateConfiguration(getTemplateConfig());

--- a/janusgraph-core/src/main/java/org/janusgraph/core/ConfiguredGraphFactory.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/ConfiguredGraphFactory.java
@@ -156,11 +156,16 @@ public class ConfiguredGraphFactory {
         Preconditions.checkNotNull(jgm, JANUS_GRAPH_MANAGER_EXPECTED_STATE_MSG);
 
         final StandardJanusGraph graph = (StandardJanusGraph) jgm.getGraph(graphName);
-        // Evict the graph from the cache in all nodes in the cluster
-        DropGraphOnEvictionTrigger dropTrigger = new DropGraphOnEvictionTrigger(graphName, graph, getConfigGraphManagementInstance());
-        removeGraphFromCache(graph, dropTrigger);
-        // Block the current thread until the drop operation finish
-        dropTrigger.waitUntilDropFinish();
+        if (graph != null) {
+            // Evict the graph from the cache in all nodes in the cluster
+            DropGraphOnEvictionTrigger dropTrigger = new DropGraphOnEvictionTrigger(graphName, graph, getConfigGraphManagementInstance());
+            removeGraphFromCache(graph, dropTrigger);
+            // Block the current thread until the drop operation finish
+            dropTrigger.waitUntilDropFinish();
+        } else {
+            // cannot open graph, do nothing
+            log.error(String.format("Failed to open graph %s. Thus, it and its traversal will not be bound on this server.", graphName));
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #3054

The added unit test fails with NPE when ran against the master branch.
Changes in ConfiguredGraphFactory make the unit test pass.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there an issue associated with this PR? Is it referenced in the commit message?
- [X] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
