### PR TITLE
Allow removal of global configuration properties

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -121,6 +121,18 @@ to this change, JanusGraph automatically casts IDs of string type to long type i
 auto conversion is disabled. If you have a vertex with ID 1234, `g.V("1234")` would no longer help you
 find the vertex - you would have to do `g.V(1234)` now.
 
+##### Allow removal of global config
+
+Users could now remove global config keys by setting its value to null as follows:
+
+```groovy
+mgmt = graph.openManagement()
+mgmt.set("<config_key>", null)
+mgmt.commit()
+```
+
+Note that you cannot use the above command to drop an external index backend if it has mixed indexes.
+
 ##### New index management
 
 The index management has received an overhaul which enables proper index removal.

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/UserModifiableConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/UserModifiableConfiguration.java
@@ -96,24 +96,28 @@ public class UserModifiableConfiguration implements JanusGraphConfiguration {
         Preconditions.checkArgument(pp.element.isOption(),"Need to provide configuration option - not namespace: %s",path);
         ConfigOption option = (ConfigOption)pp.element;
         verifier.verifyModification(option);
-        if (option.getDatatype().isArray()) {
-            Class arrayType = option.getDatatype().getComponentType();
-            Object arr;
-            if (value.getClass().isArray()) {
-                int size = Array.getLength(value);
-                arr = Array.newInstance(arrayType,size);
-                for (int i=0;i<size;i++) {
-                    Array.set(arr,i,convertBasic(Array.get(value,i),arrayType));
-                }
-            } else {
-                arr = Array.newInstance(arrayType,1);
-                Array.set(arr,0,convertBasic(value,arrayType));
-            }
-            value = arr;
+        if (value == null) {
+            config.remove(option, pp.umbrellaElements);
         } else {
-            value = convertBasic(value,option.getDatatype());
+            if (option.getDatatype().isArray()) {
+                Class arrayType = option.getDatatype().getComponentType();
+                Object arr;
+                if (value.getClass().isArray()) {
+                    int size = Array.getLength(value);
+                    arr = Array.newInstance(arrayType, size);
+                    for (int i = 0; i < size; i++) {
+                        Array.set(arr, i, convertBasic(Array.get(value, i), arrayType));
+                    }
+                } else {
+                    arr = Array.newInstance(arrayType, 1);
+                    Array.set(arr, 0, convertBasic(value, arrayType));
+                }
+                value = arr;
+            } else {
+                value = convertBasic(value, option.getDatatype());
+            }
+            config.set(option, value, pp.umbrellaElements);
         }
-        config.set(option,value,pp.umbrellaElements);
         return this;
     }
 

--- a/janusgraph-test/src/test/java/org/janusgraph/diskstorage/configuration/UserModifiableConfigurationTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/diskstorage/configuration/UserModifiableConfigurationTest.java
@@ -1,0 +1,48 @@
+// Copyright 2022 JanusGraph Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.configuration;
+
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.janusgraph.diskstorage.configuration.backend.CommonsConfiguration;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.janusgraph.util.system.ConfigurationUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UserModifiableConfigurationTest {
+
+    private UserModifiableConfiguration newBaseConfiguration() {
+        final BaseConfiguration base = ConfigurationUtil.createBaseConfiguration();
+        final CommonsConfiguration config = new CommonsConfiguration(base);
+        return new UserModifiableConfiguration(new ModifiableConfiguration(GraphDatabaseConfiguration.ROOT_NS, config.copy(), BasicConfiguration.Restriction.NONE));
+    }
+
+    @Test
+    public void testRemove() {
+        UserModifiableConfiguration configuration = newBaseConfiguration();
+        configuration.set("storage.backend", "inmemory");
+        assertEquals("inmemory", configuration.get("storage.backend"));
+
+        configuration.set("storage.backend", null);
+        assertEquals("null", configuration.get("storage.backend"));
+
+        configuration.set("index.search.backend", "lucene");
+        assertEquals("lucene", configuration.get("index.search.backend"));
+        assertEquals("+ search\n", configuration.get("index"));
+
+        configuration.set("index.search.backend", null);
+        assertEquals("", configuration.get("index"));
+    }
+}


### PR DESCRIPTION
Fixes #555

Usage
```
mgmt = graph.openManagement()
mgmt.set(<config_key>, null)
mgmt.commit()
```

I've confirmed locally that, once removed, configuration keys can't be retrieved using `ManagementSystem#get()` and don't appear anymore in `graph.getBackend().getGlobalSystemConfig()`.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there an issue associated with this PR? Is it referenced in the commit message?
- [X] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
