### PR TITLE
Update test dependencies

### DIFF
--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/rest/RestClientSetupTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/rest/RestClientSetupTest.java
@@ -63,7 +63,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.anyObject;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
@@ -306,7 +305,7 @@ public class RestClientSetupTest {
                 );
 
         final HttpAsyncClientBuilder hacb = mock(HttpAsyncClientBuilder.class);
-        doReturn(hacb).when(hacb).setDefaultCredentialsProvider(anyObject());
+        doReturn(hacb).when(hacb).setDefaultCredentialsProvider(any());
         hccc.customizeHttpClient(hacb);
 
         final ArgumentCaptor<BasicCredentialsProvider> cpCaptor = ArgumentCaptor.forClass(BasicCredentialsProvider.class);

--- a/janusgraph-inmemory/src/test/java/org/janusgraph/diskstorage/inmemory/InMemoryColumnValueStoreTest.java
+++ b/janusgraph-inmemory/src/test/java/org/janusgraph/diskstorage/inmemory/InMemoryColumnValueStoreTest.java
@@ -39,7 +39,7 @@ import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.ST
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/database/IndexSerializerTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/database/IndexSerializerTest.java
@@ -15,6 +15,7 @@
 package org.janusgraph.graphdb.database;
 
 import org.apache.tinkerpop.gremlin.structure.Property;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedProperty;
 import org.janusgraph.core.JanusGraphElement;
 import org.janusgraph.core.PropertyKey;
 import org.janusgraph.core.schema.Parameter;
@@ -126,7 +127,7 @@ public class IndexSerializerTest {
     private JanusGraphElement mockIndexableElement(String key, String value, boolean indexable) {
         StandardJanusGraphTx tx = mock(StandardJanusGraphTx.class);
         JanusGraphElement indexableElement = spy(new StandardVertex(tx, 1L, ElementLifeCycle.New));
-        Property pk2 = indexableElement.property(key, value);
+        Property pk2 = new DetachedProperty(key, value);
         Iterator it = Arrays.asList(pk2).iterator();
         doReturn(it).when(indexableElement).properties(key);
         if (indexable)

--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,9 @@
     <properties>
         <titan.compatible-versions>1.0.0,1.1.0-SNAPSHOT</titan.compatible-versions>
         <tinkerpop.version>3.5.3</tinkerpop.version>
-        <junit-platform.version>1.8.1</junit-platform.version>
-        <junit.version>5.8.1</junit.version>
-        <mockito.version>3.12.4</mockito.version>
+        <junit-platform.version>1.8.2</junit-platform.version>
+        <junit.version>5.8.2</junit.version>
+        <mockito.version>4.6.1</mockito.version>
         <jamm.version>0.3.0</jamm.version>
         <metrics.version>4.1.18</metrics.version>
         <slf4j.version>1.7.35</slf4j.version>
@@ -108,7 +108,7 @@
         <cassandra.version.sha256>bbe772956c841158e3228c3b6c8fc38cece6bceeface695473c59c0573039bf1</cassandra.version.sha256>
         <cassandra-driver.version>4.14.1</cassandra-driver.version>
         <scylladb.version>4.4.0</scylladb.version>
-        <testcontainers.version>1.16.2</testcontainers.version>
+        <testcontainers.version>1.17.2</testcontainers.version>
         <easymock.version>4.3</easymock.version>
         <protobuf.version>3.19.2</protobuf.version>
         <grpc.version>1.42.1</grpc.version>
@@ -1139,7 +1139,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.18</version>
+                <version>1.18.24</version>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>


### PR DESCRIPTION
This updates JUnit, TestContainers, Lombok, and Mockito together as it wasn't possible to only update TestContainers alone since it also depends on JUnit, see PR https://github.com/JanusGraph/janusgraph/pull/2972.
The same applies to Mockito.

These changes were necessary to update Mockito to v4:

Import of `org.mockito.Matchers` needed to be changed to `org.mockito.ArgumentMatchers`. `Matchers` was already only an alias for `ArgumentMatchers` before as described in the release notes:
https://github.com/mockito/mockito/releases/tag/v4.0.0

`any()` is the replacement for `anyObject()`:
https://github.com/mockito/mockito/pull/1931

 Calling `property()` on a mocked `StandardVertex` resulted in a `NullPointer` exception, but we can also simply use a `DetachedProperty` as all accesses to that property on the vertex are also already mocked.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
