### PR TITLE
Remove jctools version element as it's present in root pom

### DIFF
--- a/janusgraph-core/pom.xml
+++ b/janusgraph-core/pom.xml
@@ -74,7 +74,6 @@
        <dependency>
             <groupId>org.jctools</groupId>
             <artifactId>jctools-core</artifactId>
-            <version>3.3.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
I noticed in the dependabot PR #3112 that the version is present in the root pom.xml and additionally in `janusgraph-core` which shouldn't be necessary.

@farodin91 You've added the version in #2929. Was there any specific reason for it or was it more by accident?

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
