### PR TITLE
Bump Elasticsearch to 7.16.3

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -62,7 +62,7 @@ compile "org.janusgraph:janusgraph-core:1.0.0"
 * Apache HBase 1.6.0, 2.2.7
 * Google Bigtable 1.3.0, 1.4.0, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.9.0, 1.10.0, 1.11.0, 1.14.0
 * Oracle BerkeleyJE 7.5.11
-* Elasticsearch 6.0.1, 6.6.0, 7.14.0
+* Elasticsearch 6.0.1, 6.6.0, 7.16.3
 * Apache Lucene 8.11.1
 * Apache Solr 8.11.1
 * Apache TinkerPop 3.5.3

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/JanusGraphElasticsearchContainer.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/JanusGraphElasticsearchContainer.java
@@ -33,7 +33,7 @@ import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.IN
 public class JanusGraphElasticsearchContainer extends ElasticsearchContainer {
 
     private static final Integer ELASTIC_PORT = 9200;
-    private static final String DEFAULT_VERSION = "7.14.0";
+    private static final String DEFAULT_VERSION = "7.16.3";
     private static final String DEFAULT_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch";
 
     public static ElasticMajorVersion getEsMajorVersion() {

--- a/pom.xml
+++ b/pom.xml
@@ -76,9 +76,9 @@
         <jackson2.version>2.13.3</jackson2.version>
         <lucene-solr.version>8.11.2</lucene-solr.version>
         <!-- When this version updated please also update sha512 -->
-        <elasticsearch.version>7.14.0</elasticsearch.version>
-        <!-- https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.14.0-linux-x86_64.tar.gz.sha512 -->
-        <elasticsearch.version.sha512>30764d5838009dc36d8f5c6c7249e65f323b5bd843027b47b37b91566d28cac95c4b5e6db1decce748f9ccd404a7ca4ba4fa9632bcd8b43fb27b0d93cc7b8f27</elasticsearch.version.sha512>
+        <elasticsearch.version>7.16.3</elasticsearch.version>
+        <!-- https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.16.3-linux-x86_64.tar.gz.sha512 -->
+        <elasticsearch.version.sha512>d9ad7a510b8bad63788f5081b9431519e0581242499394f7a2c59f6097f8956603b28881e30697c50fe440b0ced7a2eb66afadb0e12bf97126db1d468d3818ff</elasticsearch.version.sha512>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <zookeeper.version>3.6.2</zookeeper.version>


### PR DESCRIPTION
Version >= 7.16.2 has a fix for CVE-2021-44228 (lo4j2 vulnerability) 

see: https://www.elastic.co/blog/log4j2-vulnerability-what-to-know-security-vulnerability-learn-more-elastic-support

Signed-off-by: Lionel Fleury <lionel_fleury@hotmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?


### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
