### PR TITLE
Fix mixed index query for neq condition

### DIFF
--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
@@ -941,7 +941,7 @@ public class ElasticSearchIndex implements IndexProvider {
             case EQUAL:
                 return compat.term(key, value);
             case NOT_EQUAL:
-                return compat.boolMustNot(compat.term(key, value));
+                return compat.boolMust(ImmutableList.of(compat.exists(key), compat.boolMustNot(compat.term(key, value))));
             case LESS_THAN:
                 return compat.lt(key, value);
             case LESS_THAN_EQUAL:
@@ -1020,7 +1020,7 @@ public class ElasticSearchIndex implements IndexProvider {
                     return compat.boolMust(ImmutableList.of(compat.exists(fieldName),
                         compat.boolMustNot(compat.regexp(fieldName, value))));
                 } else if (predicate == Cmp.NOT_EQUAL) {
-                    return compat.boolMustNot(compat.match(fieldName, value));
+                    return compat.boolMust(ImmutableList.of(compat.exists(fieldName), compat.boolMustNot(compat.match(fieldName, value))));
                 } else if (predicate == Text.FUZZY || predicate == Text.CONTAINS_FUZZY) {
                     return compat.fuzzyMatch(fieldName, value);
                 } else if (predicate == Text.NOT_FUZZY || predicate == Text.NOT_CONTAINS_FUZZY) {
@@ -1128,7 +1128,7 @@ public class ElasticSearchIndex implements IndexProvider {
                     case EQUAL:
                         return compat.term(key, value);
                     case NOT_EQUAL:
-                        return compat.boolMustNot(compat.term(key, value));
+                        return compat.boolMust(ImmutableList.of(compat.exists(key), compat.boolMustNot(compat.term(key, value))));
                     default:
                         throw new IllegalArgumentException("Boolean types only support EQUAL or NOT_EQUAL");
                 }
@@ -1136,7 +1136,7 @@ public class ElasticSearchIndex implements IndexProvider {
                 if (predicate == Cmp.EQUAL) {
                     return compat.term(key, value);
                 } else if (predicate == Cmp.NOT_EQUAL) {
-                    return compat.boolMustNot(compat.term(key, value));
+                    return compat.boolMust(ImmutableList.of(compat.exists(key), compat.boolMustNot(compat.term(key, value))));
                 } else {
                     throw new IllegalArgumentException("Only equal or not equal is supported for UUIDs: "
                             + predicate);

--- a/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
+++ b/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
@@ -764,7 +764,7 @@ public class SolrIndex implements IndexProvider {
                     case EQUAL:
                         return (key + ":" + queryValue);
                     case NOT_EQUAL:
-                        return ("-" + key + ":" + queryValue);
+                        return (key + ":* -" + key + ":" + queryValue);
                     case LESS_THAN:
                         //use right curly to mean up to but not including value
                         return (key + ":[* TO " + queryValue + "}");
@@ -802,7 +802,7 @@ public class SolrIndex implements IndexProvider {
                     } else if (predicate == Cmp.EQUAL) {
                         return (key + ":\"" + escapeValue(value) + "\"");
                     } else { // Cmp.NOT_EQUAL case
-                        return ("-" + key + ":\"" + escapeValue(value) + "\"");
+                        return (key + ":* -" + key + ":\"" + escapeValue(value) + "\"");
                     }
                 } else if (predicate == Text.FUZZY || predicate == Text.CONTAINS_FUZZY) {
                     return (key + ":"+escapeValue(value)+"~"+Text.getMaxEditDistance(value.toString()));
@@ -849,7 +849,7 @@ public class SolrIndex implements IndexProvider {
                     case EQUAL:
                         return (key + ":" + queryValue);
                     case NOT_EQUAL:
-                        return ("-" + key + ":" + queryValue);
+                        return (key + ":* -" + key + ":" + queryValue);
                     case LESS_THAN:
                         //use right curly to mean up to but not including value
                         return (key + ":[* TO " + queryValue + "}");
@@ -869,7 +869,7 @@ public class SolrIndex implements IndexProvider {
                     case EQUAL:
                         return (key + ":" + queryValue);
                     case NOT_EQUAL:
-                        return ("-" + key + ":" + queryValue);
+                        return (key + ":* -" + key + ":" + queryValue);
                     default:
                         throw new IllegalArgumentException("Boolean types only support EQUAL or NOT_EQUAL");
                 }
@@ -877,7 +877,7 @@ public class SolrIndex implements IndexProvider {
                 if (predicate == Cmp.EQUAL) {
                     return (key + ":\"" + escapeValue(value) + "\"");
                 } else if (predicate == Cmp.NOT_EQUAL) {
-                    return ("-" + key + ":\"" + escapeValue(value) + "\"");
+                    return (key + ":* -" + key + ":\"" + escapeValue(value) + "\"");
                 } else {
                     throw new IllegalArgumentException("Relation is not supported for uuid value: " + predicate);
                 }
@@ -934,7 +934,7 @@ public class SolrIndex implements IndexProvider {
             return "";
         } else if (terms.size() == 1) {
             if (janusgraphPredicate == Cmp.NOT_EQUAL) {
-                return ("-" + key + ":(" + escapeValue(terms.get(0)) + ")");
+                return (key + ":* -" + key + ":(" + escapeValue(terms.get(0)) + ")");
             } else {
                 return (key + ":(" + escapeValue(terms.get(0)) + ")");
             }


### PR DESCRIPTION
If a mixed index consists of multiple properties, then an element can be
indexed as long as it contains one of these properties. In this case, a
query like `has(keyA, neq(val))` could match an element without `keyA`
as long as it is indexed by this mixed index. This commit fixes this bug
by adding an existence condition, i.e. matching an element only if it
has the given key present.

Fixes #3164

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
