### PR TITLE
Dependabot should target v0.6 by default

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
 - package-ecosystem: maven
   directory: "/"
+  target-branch: "v0.6"
   schedule:
     interval: daily
     time: "11:00"


### PR DESCRIPTION
This changes the target branch for Dependabot PRs to v0.6 so we can get dependency updates already for the next 0.6 release instead of having to wait for 1.0.0 or manually backport them from master to v0.6. That however of course means that we need to manually merge v0.6 into master after merging a Dependabot PR (like we already do for other PRs that target v0.6).

For major updates, we need to manually change the target branch of Dependabot PRs to master as we probably don't want those on v0.6. Unfortunately, it's not possible to configure Dependabot to treat major updates differently than, e.g., patch level updates, as far as I know.

Also note that Dependabot currently ignores this setting for security updates. It seems to even ignore all settings if this option is used:

> When you use this option, the settings for this package manager will
> no longer affect any pull requests raised for security updates.

Source: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#target-branch

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
