### PR TITLE
Fix IndexOutOfBoundsException when read geoshape point by GraphBinary…

### DIFF
--- a/janusgraph-driver/src/main/java/org/janusgraph/graphdb/tinkerpop/io/binary/GeoshapeGraphBinarySerializer.java
+++ b/janusgraph-driver/src/main/java/org/janusgraph/graphdb/tinkerpop/io/binary/GeoshapeGraphBinarySerializer.java
@@ -40,6 +40,28 @@ public class GeoshapeGraphBinarySerializer extends JanusGraphTypeSerializer<Geos
         public int read() {
             return buffer.readInt();
         }
+
+        @Override
+        public int read(byte[] b, int off, int len) {
+            if (b == null) {
+                throw new NullPointerException();
+            } else if (off < 0 || len < 0 || len > b.length - off) {
+                throw new IndexOutOfBoundsException();
+            } else if (len == 0) {
+                return 0;
+            }
+
+            int c = read();
+            b[off] = (byte) c;
+
+            int i = 1;
+
+            for (; i < len; i++) {
+                c = read();
+                b[off + i] = (byte) c;
+            }
+            return i;
+        }
     }
 
     @Override

--- a/janusgraph-driver/src/test/java/org/janusgraph/graphdb/tinkerpop/io/binary/GeoshapeGraphBinarySerializerTest.java
+++ b/janusgraph-driver/src/test/java/org/janusgraph/graphdb/tinkerpop/io/binary/GeoshapeGraphBinarySerializerTest.java
@@ -44,9 +44,9 @@ public class GeoshapeGraphBinarySerializerTest {
 
     private static Stream<Geoshape> geoshapeProvider() {
         return Stream.of(
-            Geoshape.point(37.97, 23.72),
-            Geoshape.circle(37.97, 23.72, 10.0),
-            Geoshape.box(37.97, 23.72, 38.97, 24.72)
+            Geoshape.point(29.7154388159, 23.72),
+            Geoshape.circle(29.7154388159, 23.72, 10.0),
+            Geoshape.box(29.7154388159, 23.72, 38.97, 24.72)
         );
     }
 


### PR DESCRIPTION
…MessageSerializerV1.

The root cause of this problem is due to BufferInputStream.class in
GeoshapeGraphBinarySerializer.java extends InputStream.class, it overrides
the superclass's read() method, but not Overrides superclass's
read(byte b[], int off, int len) method.

If BufferInputStream.class's read() returns -1, InputStream::read(byte b[]
, int off, int len) will break its for loop, so cause IndexOutOfBoundsException
finally.

This PR fixes #3181.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
