### PR TITLE
Add clear way to disable db-cache per transaction

### DIFF
--- a/docs/interactions/transactions.md
+++ b/docs/interactions/transactions.md
@@ -322,6 +322,10 @@ following aspects of a transaction to be configured:
     confirmation at the application level to avoid inconsistencies. USE
     WITH GREAT CARE!
 
+-   `skipDBCacheRead()` - Disables JanusGraph database level 
+    cache access during read operations. Doesn't have any effect if database 
+    level cache was disabled via config `cache.db-cache`.
+
 Once, the desired configuration options have been specified, the new
 transaction is started via `start()` which returns a
 `JanusGraphTransaction`.

--- a/janusgraph-core/src/main/java/org/janusgraph/core/TransactionBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/TransactionBuilder.java
@@ -138,6 +138,14 @@ public interface TransactionBuilder {
      */
     TransactionBuilder commitTime(Instant instant);
 
+    /**
+     * Skips usage of JanusGraph database level cache during read operations.
+     * <p>
+     * Doesn't have any effect if database level cache was disabled via config `cache.db-cache`.
+     *
+     * @return Object with the skip db-cache reads check settings
+     */
+    TransactionBuilder skipDBCacheRead();
 
     /**
      * Sets the group name for this transaction which provides a way for gathering

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/Backend.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/Backend.java
@@ -582,7 +582,7 @@ public class Backend implements LockerProvider, AutoCloseable {
 
         return new BackendTransaction(cacheTx, configuration, storeFeatures,
                 edgeStore, indexStore, txLogStore,
-                maxReadTime, indexTx, threadPool);
+                maxReadTime, indexTx, threadPool, !configuration.isSkipDBCacheRead());
     }
 
     public synchronized void close() throws BackendException {

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/BackendTransaction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/BackendTransaction.java
@@ -80,12 +80,13 @@ public class BackendTransaction implements LoggableTransaction {
     private final Map<String, IndexTransaction> indexTx;
 
     private boolean acquiredLock = false;
-    private boolean cacheEnabled = true;
+    private boolean cacheEnabled;
 
     public BackendTransaction(CacheTransaction storeTx, BaseTransactionConfig txConfig,
                               StoreFeatures features, KCVSCache edgeStore, KCVSCache indexStore,
                               KCVSCache txLogStore, Duration maxReadTime,
-                              Map<String, IndexTransaction> indexTx, Executor threadPool) {
+                              Map<String, IndexTransaction> indexTx, Executor threadPool,
+                              boolean cacheEnabled) {
         this.storeTx = storeTx;
         this.txConfig = txConfig;
         this.storeFeatures = features;
@@ -95,6 +96,7 @@ public class BackendTransaction implements LoggableTransaction {
         this.maxReadTime = maxReadTime;
         this.indexTx = indexTx;
         this.threadPool = threadPool;
+        this.cacheEnabled = cacheEnabled;
     }
 
     public boolean hasAcquiredLock() {
@@ -130,6 +132,10 @@ public class BackendTransaction implements LoggableTransaction {
 
     public void enableCache() {
         this.cacheEnabled = true;
+    }
+
+    public boolean isCacheEnabled(){
+        return cacheEnabled;
     }
 
     public void commitStorage() throws BackendException {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardTransactionBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardTransactionBuilder.java
@@ -83,6 +83,8 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
 
     private String groupName;
 
+    private boolean skipDBCacheRead;
+
     private final boolean forceIndexUsage;
 
     private final ModifiableConfiguration writableCustomOptions;
@@ -224,6 +226,12 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
     }
 
     @Override
+    public TransactionBuilder skipDBCacheRead() {
+        this.skipDBCacheRead = true;
+        return this;
+    }
+
+    @Override
     public void setCommitTime(Instant time) {
         throw new UnsupportedOperationException("Use setCommitTime(long,TimeUnit)");
     }
@@ -269,7 +277,7 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
                 propertyPrefetching, multiQuery, singleThreaded, threadBound, getTimestampProvider(), userCommitTime,
                 indexCacheWeight, getVertexCacheSize(), getDirtyVertexSize(),
                 logIdentifier, restrictedPartitions, groupName,
-                defaultSchemaMaker, hasDisabledSchemaConstraints, customOptions);
+                defaultSchemaMaker, hasDisabledSchemaConstraints, skipDBCacheRead, customOptions);
         return graph.newTransaction(immutable);
     }
 
@@ -382,6 +390,11 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
     }
 
     @Override
+    public boolean isSkipDBCacheRead() {
+        return skipDBCacheRead;
+    }
+
+    @Override
     public String getGroupName() {
         return groupName;
     }
@@ -434,6 +447,8 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
         private final long indexCacheWeight;
         private final int vertexCacheSize;
         private final int dirtyVertexSize;
+
+        private final boolean skipDBCacheRead;
         private final String logIdentifier;
         private final int[] restrictedPartitions;
         private final DefaultSchemaMaker defaultSchemaMaker;
@@ -456,6 +471,7 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
                 String groupName,
                 DefaultSchemaMaker defaultSchemaMaker,
                 boolean hasDisabledSchemaConstraints,
+                boolean skipDBCacheRead,
                 Configuration customOptions) {
             this.isReadOnly = isReadOnly;
             this.hasEnabledBatchLoading = hasEnabledBatchLoading;
@@ -477,6 +493,7 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
             this.restrictedPartitions=restrictedPartitions;
             this.defaultSchemaMaker = defaultSchemaMaker;
             this.hasDisabledSchemaConstraints = hasDisabledSchemaConstraints;
+            this.skipDBCacheRead = skipDBCacheRead;
             this.handleConfig = new StandardBaseTransactionConfig.Builder()
                     .commitTime(commitTime)
                     .timestampProvider(times)
@@ -587,6 +604,11 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
         @Override
         public boolean hasRestrictedPartitions() {
             return restrictedPartitions.length>0;
+        }
+
+        @Override
+        public boolean isSkipDBCacheRead() {
+            return skipDBCacheRead;
         }
 
         @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/TransactionConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/TransactionConfiguration.java
@@ -190,4 +190,10 @@ public interface TransactionConfiguration extends BaseTransactionConfig {
      */
     boolean hasRestrictedPartitions();
 
+    /**
+     * Returns true if read queries should skip accessing JanusGraph database level cache (db-cache).
+     * Doesn't have any effect if database level cache was disabled via config `cache.db-cache`.
+     */
+    boolean isSkipDBCacheRead();
+
 }

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/transaction/StandardTransactionBuilderTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/transaction/StandardTransactionBuilderTest.java
@@ -16,6 +16,7 @@ package org.janusgraph.graphdb.transaction;
 
 import org.janusgraph.core.JanusGraphFactory;
 import org.janusgraph.core.ReadOnlyTransactionException;
+import org.janusgraph.diskstorage.BackendTransaction;
 import org.janusgraph.graphdb.database.StandardJanusGraph;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -87,4 +88,20 @@ public class StandardTransactionBuilderTest {
         tx = (StandardJanusGraphTx) graph.buildTransaction().consistencyChecks(false).start();
         assertFalse(tx.getConfiguration().hasVerifyUniqueness());
     }
+
+    @Test
+    public void testSkipDBCacheRead() {
+        StandardJanusGraphTx tx = (StandardJanusGraphTx) graph.newTransaction();
+        BackendTransaction backendTransaction = tx.getTxHandle();
+        assertFalse(tx.getConfiguration().isSkipDBCacheRead());
+        assertTrue(backendTransaction.isCacheEnabled());
+        tx.rollback();
+
+        tx = (StandardJanusGraphTx) graph.buildTransaction().skipDBCacheRead().start();
+        backendTransaction = tx.getTxHandle();
+        assertTrue(tx.getConfiguration().isSkipDBCacheRead());
+        assertFalse(backendTransaction.isCacheEnabled());
+        tx.rollback();
+    }
+
 }


### PR DESCRIPTION
Not sure if we necessary need this or not but thought this could be helpful for someone who needs to enable / disable db-cache access per transaction.
Another way to control db-cache access would be to control that option in the current running transaction which could allow enabling / disabling db-cache access even per query if necessary:
```
StandardJanusGraphTx tx = (StandardJanusGraphTx) graph.newTransaction();
BackendTransaction backendTransaction = tx.getTxHandle();
backendTransaction.disableCache();
tx.traversal().V().has("name", "hello").next();
backendTransaction.enableCache();
tx.traversal().V().has("name", "world").next();
```

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
