### PR TITLE
Add support for ElasticSearch 8

### DIFF
--- a/.github/workflows/ci-index-es.yml
+++ b/.github/workflows/ci-index-es.yml
@@ -65,6 +65,10 @@ jobs:
       matrix:
         include:
           - module: es
+            args: "-Pelasticsearch8"
+            name: es8
+            java: 8
+          - module: es
             args: "-Pelasticsearch7"
             name: es7
             java: 8
@@ -76,6 +80,11 @@ jobs:
             args: "-Pelasticsearch60"
             name: es60
             java: 8
+          - module: es
+            install-args: "-Pjava-11"
+            args: "-Pelasticsearch8"
+            name: es8
+            java: 11
           - module: es
             install-args: "-Pjava-11"
             args: "-Pelasticsearch7"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,7 +28,7 @@ All currently supported versions of JanusGraph are listed below.
 | JanusGraph | Storage Version | Cassandra | HBase | Bigtable | Elasticsearch | Solr | TinkerPop | Spark | Scala |
 | ----- | ---- | ---- | ---- | ---- | ---- | ---- | --- | ---- | ---- |
 | 0.6.z | 2 | 3.0.z, 3.11.z | 1.6.z, 2.2.z | 1.3.0, 1.4.0, 1.5.z, 1.6.z, 1.7.z, 1.8.z, 1.9.z, 1.10.z, 1.11.z, 1.14.z | 6.y, 7.y | 7.y, 8.y | 3.5.z | 3.0.z | 2.12.z |
-| 1.0.z | 2 | 3.11.z, 4.0.z | 2.5.z | 1.3.0, 1.4.0, 1.5.z, 1.6.z, 1.7.z, 1.8.z, 1.9.z, 1.10.z, 1.11.z, 1.14.z | 6.y, 7.y | 8.y | 3.6.z | 3.2.z | 2.12.z |
+| 1.0.z | 2 | 3.11.z, 4.0.z | 2.5.z | 1.3.0, 1.4.0, 1.5.z, 1.6.z, 1.7.z, 1.8.z, 1.9.z, 1.10.z, 1.11.z, 1.14.z | 6.y, 7.y, 8.y | 8.y | 3.6.z | 3.2.z | 2.12.z |
 
 #### End-of-Life
 
@@ -63,7 +63,7 @@ compile "org.janusgraph:janusgraph-core:1.0.0"
 * Apache Cassandra 3.11.10, 4.0.6
 * Apache HBase 2.5.0
 * Oracle BerkeleyJE 7.5.11
-* Elasticsearch 6.0.1, 6.6.0, 7.17.5
+* Elasticsearch 6.0.1, 6.6.0, 7.17.8, 8.6.0
 * Apache Lucene 8.11.1
 * Apache Solr 8.11.1
 * Apache TinkerPop 3.6.1
@@ -204,6 +204,20 @@ In this case, if the accurate result is essential, the optimization can be disab
 * RemovableRelationIterable class
 * RemovableRelationIterator class
 * ImmutableConfiguration class
+
+##### Add support for ElasticSearch 8
+
+JanusGraph now supports ElasticSearch 8.   
+Notice, `Mapping.PREFIX_TREE` mapping is no longer available for Geoshape mappings using new ElasticSearch 8 indices.  
+`Mapping.PREFIX_TREE` is still supported in ElasticSearch 6, ElasticSearch 7, Solr, Lucene.     
+For ElasticSearch the new Geoshape mapping was added `Mapping.BKD`.  
+It's recommended to use `Mapping.BKD` mapping due to better performance characteristics over `Mapping.PREFIX_TREE`.   
+The downside of `Mapping.BKD` is that it doesn't support Circle shapes. Thus, JanusGraph provides BKD Circle processors 
+to convert Circle into other shapes for indexing but use Circle at the storage level. More information about 
+Circle processors available under configuration namespace `index.[X].bkd-circle-processor`.    
+ElasticSearch 8 doesn't allow creating new indexes with `Mapping.PREFIX_TREE` mapping, but the existing indices 
+using `Mapping.PREFIX_TREE` will work in ElasticSearch 8 after migration. See 
+[ElasticSearch 8 migration guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-8.0.html#geo-shape-strategy).
 
 ### Version 0.6.3 (Release Date: ???)
 

--- a/docs/configs/janusgraph-cfg.md
+++ b/docs/configs/janusgraph-cfg.md
@@ -117,6 +117,32 @@ Configuration options for the individual indexing backends
 | index.[X].max-result-set-size | Maximum number of results to return if no limit is specified. For index backends that support scrolling, it represents the number of results in each batch | Integer | 50 | MASKABLE |
 | index.[X].port | The port on which to connect to index backend servers | Integer | (no default value) | MASKABLE |
 
+### index.[X].bkd-circle-processor
+Configuration for BKD circle processors which is used for BKD Geoshape mapping.
+
+
+| Name | Description | Datatype | Default Value | Mutability |
+| ---- | ---- | ---- | ---- | ---- |
+| index.[X].bkd-circle-processor.class | Full class name of circle processor that implements `CircleProcessor` interface. The class is used for transformation of a Circle shape to another shape when BKD mapping is used. The provided implementation class should have either a public constructor which accepts configuration as a parameter (`org.janusgraph.diskstorage.configuration.Configuration`) or a public constructor with no parameters. Usually the transforming shape is a Polygon. <br>Following shorthands can be used: <br> - `noTransformation` Circle processor which is not transforming a circle, but instead keep the circle shape unchanged. This implementation may be useful in situations when the user wants to control circle transformation logic on ElasticSearch side instead of application side. For example, using <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-circle-processor.html">ElasticSearch Circle Processor</a> or any custom plugin. <br> - `fixedErrorDistance` Circle processor which transforms the provided Circle into Polygon, Box, or Point depending on the configuration provided in `index.bkd-circle-processor.fixed`. The processing logic is similar to <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-circle-processor.html">ElasticSearch Circle Processor</a> except for some edge cases when the Circle is transformed into Box or Point. <br> - `dynamicErrorDistance` Circle processor which calculates error distance dynamically depending on the circle radius and the specified multiplier value. The error distance calculation formula is `log(radius) * multiplier`. Configuration for this class can be provided via `index.bkd-circle-processor.dynamic`. The processing logic is similar to <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-circle-processor.html">ElasticSearch Circle Processor</a> except for some edge cases when the Circle is transformed into Box or Point. | String | dynamicErrorDistance | MASKABLE |
+
+### index.[X].bkd-circle-processor.dynamic
+Configuration for Elasticsearch dynamic circle processor which is used for BKD Geoshape mapping.
+
+
+| Name | Description | Datatype | Default Value | Mutability |
+| ---- | ---- | ---- | ---- | ---- |
+| index.[X].bkd-circle-processor.dynamic.bounding-box-fallback | Allows to return bounding box for the circle which cannot be converted to proper shape with the specified error distance. In case `false` is set for this configuration an exception will be thrown whenever circle cannot be converted to another shape following error distance. | Boolean | true | MASKABLE |
+| index.[X].bkd-circle-processor.dynamic.error-distance-multiplier | Multiplier variable for dynamic error distance calculation in the formula `log(radius) * multiplier`. Radius and error distance specified in meters. | Double | 2.0 | MASKABLE |
+
+### index.[X].bkd-circle-processor.fixed
+Configuration for Elasticsearch fixed circle processor which is used for BKD Geoshape mapping.
+
+
+| Name | Description | Datatype | Default Value | Mutability |
+| ---- | ---- | ---- | ---- | ---- |
+| index.[X].bkd-circle-processor.fixed.bounding-box-fallback | Allows to return bounding box for the circle which cannot be converted to proper shape with the specified error distance. In case `false` is set for this configuration an exception will be thrown whenever circle cannot be converted to another shape following error distance. | Boolean | true | MASKABLE |
+| index.[X].bkd-circle-processor.fixed.error-distance | The difference between the resulting inscribed distance from center to side and the circle’s radius. Specified in meters. | Double | 10.0 | MASKABLE |
+
 ### index.[X].elasticsearch
 Elasticsearch index configuration
 

--- a/docs/index-backend/text-search.md
+++ b/docs/index-backend/text-search.md
@@ -163,19 +163,20 @@ g.V().has('bookname', containing('nico'))
 By default, JanusGraph supports indexing geo properties with point type
 and querying geo properties by circle or box. To index a non-point geo
 property with support for querying by any geoshape type, specify the
-mapping as `Mapping.PREFIX_TREE`:
+mapping as `Mapping.BKD` (preferred for ElasticSearch) or `Mapping.PREFIX_TREE` (Supported in Solr, Lucene, and ElasticSearch 6. 
+Deprecated in ElasticSearch 7. Support was removed in ElasticSearch 8):
 
 ```groovy
 mgmt = graph.openManagement()
 name = mgmt.makePropertyKey('border').dataType(Geoshape.class).make()
-mgmt.buildIndex('borderIndex', Vertex.class).addKey(name, Mapping.PREFIX_TREE.asParameter()).buildMixedIndex("search")
+mgmt.buildIndex('borderIndex', Vertex.class).addKey(name, Mapping.BKD.asParameter()).buildMixedIndex("search")
 mgmt.commit()
 ```
 
-Additional parameters can be specified to tune the configuration of the
-underlying prefix tree mapping. These optional parameters include the
-number of levels used in the prefix tree as well as the associated
-precision.
+When `Mapping.PREFIX_TREE` is used it is possible to specify additional 
+parameters to tune the configuration of the underlying prefix tree mapping. 
+These optional parameters include the number of levels used in the prefix 
+tree as well as the associated precision.
 
 ```groovy
 mgmt = graph.openManagement()
@@ -187,3 +188,12 @@ mgmt.commit()
 Note that some indexing backends (e.g. Solr) may require additional
 external schema configuration to support and tune indexing non-point
 properties.
+
+!!! info
+    `Mapping.BKD` mapping which is preferred for ElasticSearch doesn't support Circle shape. 
+    Instead of indexing a Circle as it was with `Mapping.PREFIX_TREE` there are Circle 
+    processors available which transform Circle into other shapes and index those shapes instead. 
+    Depending on the precision configuration used, search for such circles may behave differently. 
+    The higher the precision the more points is used during indexing which may affect storage size
+    and index time. See `index.[X].bkd-circle-processor` configuration properties for more information
+    about BKD circle processors.

--- a/janusgraph-all/pom.xml
+++ b/janusgraph-all/pom.xml
@@ -108,6 +108,11 @@
             <artifactId>janusgraph-lucene</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.janusgraph</groupId>
+            <artifactId>janusgraph-mixed-index-utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- Jackson 2.x -->
         <dependency>

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphIndexTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphIndexTest.java
@@ -215,6 +215,8 @@ public abstract class JanusGraphIndexTest extends JanusGraphBaseTest {
 
     public abstract boolean supportsGeoPointExistsQuery();
 
+    public abstract boolean supportsGeoShapePrefixTreeMapping();
+
     public String getStringField(String propertyKey) {
         return propertyKey;
     }
@@ -630,8 +632,13 @@ public abstract class JanusGraphIndexTest extends JanusGraphBaseTest {
         createExternalEdgeIndex(location, INDEX);
 
         final PropertyKey boundary = makeKey("boundary", Geoshape.class);
-        mgmt.addIndexKey(getExternalIndex(Vertex.class,INDEX),boundary, Parameter.of("mapping", Mapping.PREFIX_TREE), Parameter.of("index-geo-dist-error-pct", 0.0025));
-        mgmt.addIndexKey(getExternalIndex(Edge.class,INDEX),boundary, Parameter.of("mapping", Mapping.PREFIX_TREE), Parameter.of("index-geo-dist-error-pct", 0.0025));
+        if(supportsGeoShapePrefixTreeMapping()){
+            mgmt.addIndexKey(getExternalIndex(Vertex.class,INDEX),boundary, Parameter.of("mapping", Mapping.PREFIX_TREE), Parameter.of("index-geo-dist-error-pct", 0.0025));
+            mgmt.addIndexKey(getExternalIndex(Edge.class,INDEX),boundary, Parameter.of("mapping", Mapping.PREFIX_TREE), Parameter.of("index-geo-dist-error-pct", 0.0025));
+        } else {
+            mgmt.addIndexKey(getExternalIndex(Vertex.class,INDEX),boundary, Parameter.of("mapping", Mapping.BKD));
+            mgmt.addIndexKey(getExternalIndex(Edge.class,INDEX),boundary, Parameter.of("mapping", Mapping.BKD));
+        }
 
         final PropertyKey time = makeKey("time", Long.class);
         createExternalVertexIndex(time, INDEX);

--- a/janusgraph-core/pom.xml
+++ b/janusgraph-core/pom.xml
@@ -91,6 +91,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <directory>${basedir}/target</directory>

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/Mapping.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/Mapping.java
@@ -33,7 +33,11 @@ public enum Mapping {
     TEXT,
     STRING,
     TEXTSTRING,
-    PREFIX_TREE;
+    PREFIX_TREE,
+    // BKD is the default ElasticSearch (geo-shape index strategy)[https://www.elastic.co/guide/en/elasticsearch/reference/8.1/geo-shape.html#geoshape-indexing-approach].
+    // (More information about this strategy)[https://github.com/elastic/elasticsearch/issues/32039].
+    // PREFIX_TREE strategy was deprecated in ElasticSearch 7 and was removed in ElasticSearch 8. PREFIX_TREE is available in Solr 8 and Lucene 8.
+    BKD;
 
     /**
      * Returns the mapping as a parameter so that it can be passed to {@link JanusGraphManagement#addIndexKey(JanusGraphIndex, org.janusgraph.core.PropertyKey, Parameter[])}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/util/ReflectiveConfigOptionLoader.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/util/ReflectiveConfigOptionLoader.java
@@ -133,7 +133,8 @@ public enum ReflectiveConfigOptionLoader {
             "org.janusgraph.graphdb.query.index.ThresholdBasedIndexSelectionStrategy",
             //"org.janusgraph.graphdb.TestMockIndexProvider",
             //"org.janusgraph.graphdb.TestMockLog",
-            "org.janusgraph.diskstorage.berkeleyje.BerkeleyJEStoreManager"));
+            "org.janusgraph.diskstorage.berkeleyje.BerkeleyJEStoreManager",
+            "org.janusgraph.diskstorage.mixed.utils.MixedIndexUtilsConfigOptions"));
 
         Timer t = new Timer(TimestampProviders.MILLI);
         t.start();

--- a/janusgraph-core/src/main/java/org/janusgraph/util/system/ConfigurationUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/util/system/ConfigurationUtil.java
@@ -80,6 +80,28 @@ public class ConfigurationUtil {
         }
     }
 
+    public static boolean hasConstructor(String className, Class[] constructorArgumentClasses) {
+        Preconditions.checkArgument(constructorArgumentClasses!=null);
+        try {
+            Class<?> clazz = Class.forName(className);
+            for (Constructor<?> constructor : clazz.getDeclaredConstructors()) {
+                if (constructor.getParameterCount() == constructorArgumentClasses.length){
+
+                    for(int i=0; i<constructorArgumentClasses.length; i++){
+                        if(!constructor.getParameterTypes()[i].isAssignableFrom(constructorArgumentClasses[i])){
+                            break;
+                        }
+                    }
+
+                    return true;
+                }
+            }
+            return false;
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException("Could not find implementation class: " + className, e);
+        }
+    }
+
     /**
      * Create a new BaseConfiguration object and set a comma delimiter handler, which interprets
      * comma-delimited values as a list of values.

--- a/janusgraph-core/src/test/java/org/janusgraph/util/system/ConfigurationUtilTest.java
+++ b/janusgraph-core/src/test/java/org/janusgraph/util/system/ConfigurationUtilTest.java
@@ -1,0 +1,41 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.util.system;
+
+import org.janusgraph.util.datastructures.PowerSet;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+public class ConfigurationUtilTest {
+
+    @Test
+    public void testThrowExceptionIfNonExistingClassIsChecked(){
+        IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () ->
+            ConfigurationUtil.hasConstructor("NonExistingJanusGraphClass", new Class[0]));
+        Assertions.assertTrue(exception.getMessage().contains("Could not find implementation class"));
+    }
+
+    @Test
+    public void testNonExistingConstructorIsChecked(){
+        Assertions.assertFalse(ConfigurationUtil.hasConstructor(ConfigurationUtil.class.getName(), new Class[]{ConfigurationUtil.class}));
+    }
+
+    @Test
+    public void testExistingConstructorIsChecked(){
+        Assertions.assertTrue(ConfigurationUtil.hasConstructor(PowerSet.class.getName(), new Class[]{Set.class}));
+    }
+}

--- a/janusgraph-dist/pom.xml
+++ b/janusgraph-dist/pom.xml
@@ -21,7 +21,7 @@
         <assembly.descriptor.dir>${project.basedir}/src/assembly/descriptor</assembly.descriptor.dir>
         <assembly.static.dir>${project.basedir}/src/assembly/static</assembly.static.dir>
         <assembly.resources.dir>${project.basedir}/src/assembly/resources</assembly.resources.dir>
-        <assembly.es.dir>${project.build.directory}/elasticsearch-${elasticsearch.version}</assembly.es.dir>
+        <assembly.es.dir>${project.build.directory}/elasticsearch-7.17.8</assembly.es.dir>
         <assembly.cassandra.dir>${project.build.directory}/apache-cassandra-${cassandra-dist.version}</assembly.cassandra.dir>
 
         <packname.standard>janusgraph-${project.version}</packname.standard>
@@ -171,11 +171,17 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${elasticsearch.version}-linux-x86_64.tar.gz</url>
-                            <outputFileName>elasticsearch-${elasticsearch.version}-linux-x86_64.tar.gz</outputFileName>
+                            <!-- ElasticSearch Server 8 doesn't support Java 8 and Java 11.
+                            Thus, we use here the latest ElasticSearch Server which supports both Java 8 and Java 11 (which is 7.17.8 as for now).
+                            We should probably re-think dist tests and re-develop them using docker containers instead of
+                            relying on the JanusGraph running environment.
+                            -->
+                            <url>https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.17.8-linux-x86_64.tar.gz</url>
+                            <outputFileName>elasticsearch-7.17.8-linux-x86_64.tar.gz</outputFileName>
                             <outputDirectory>${project.build.directory}/</outputDirectory>
                             <unpack>true</unpack>
-                            <sha512>${elasticsearch.version.sha512}</sha512>
+                            <!-- https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.17.8-linux-x86_64.tar.gz.sha512 -->
+                            <sha512>cd02b40e8b32e78f17bac12245326e10482214ab452b2e5d1745ddc7944e60a5b07c01c949c68625d78640bdd46806aeece4e8d620788133993055732d388443</sha512>
                         </configuration>
                     </execution>
                     <execution>

--- a/janusgraph-driver/src/main/java/org/janusgraph/core/attribute/Geoshape.java
+++ b/janusgraph-driver/src/main/java/org/janusgraph/core/attribute/Geoshape.java
@@ -215,6 +215,14 @@ public class Geoshape {
         return DistanceUtils.degrees2Dist(radiusInDeg, DistanceUtils.EARTH_MEAN_RADIUS_KM);
     }
 
+    /**
+     * Returns the radius in meters of this circle. Only applicable to circle shapes.
+     * @return
+     */
+    public double getRadiusMeters() {
+        return getRadius() * 1000;
+    }
+
     private SpatialRelation getSpatialRelation(Geoshape other) {
         Preconditions.checkNotNull(other);
         return shape.relate(other.shape);

--- a/janusgraph-es/pom.xml
+++ b/janusgraph-es/pom.xml
@@ -13,8 +13,9 @@
         <top.level.basedir>${basedir}/..</top.level.basedir>
         <elasticsearch60.docker.version>6.0.1</elasticsearch60.docker.version>
         <elasticsearch6.docker.version>6.6.0</elasticsearch6.docker.version>
-        <elasticsearch7.docker.version>${elasticsearch.version}</elasticsearch7.docker.version>
-        <elasticsearch.docker.version>${elasticsearch7.docker.version}</elasticsearch.docker.version>
+        <elasticsearch7.docker.version>7.17.8</elasticsearch7.docker.version>
+        <elasticsearch8.docker.version>${elasticsearch.version}</elasticsearch8.docker.version>
+        <elasticsearch.docker.version>${elasticsearch8.docker.version}</elasticsearch.docker.version>
         <skip.es.test>${skipTests}</skip.es.test>
         <elasticsearch.docker.image>docker.elastic.co/elasticsearch/elasticsearch</elasticsearch.docker.image>
     </properties>
@@ -22,6 +23,11 @@
         <dependency>
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.janusgraph</groupId>
+            <artifactId>janusgraph-mixed-index-utils</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -186,11 +192,17 @@
         </profile>
         <profile>
             <id>elasticsearch7</id>
+            <properties>
+                <elasticsearch.docker.version>${elasticsearch7.docker.version}</elasticsearch.docker.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>elasticsearch8</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <elasticsearch.docker.version>${elasticsearch7.docker.version}</elasticsearch.docker.version>
+                <elasticsearch.docker.version>${elasticsearch8.docker.version}</elasticsearch.docker.version>
             </properties>
         </profile>
 

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticMajorVersion.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticMajorVersion.java
@@ -23,6 +23,8 @@ public enum ElasticMajorVersion {
 
     SEVEN(7),
 
+    EIGHT(8),
+
     ;
 
     static final Pattern PATTERN = Pattern.compile("(\\d+)\\.\\d+\\.\\d+.*");
@@ -44,6 +46,8 @@ public enum ElasticMajorVersion {
                 return ElasticMajorVersion.SIX;
             case 7:
                 return ElasticMajorVersion.SEVEN;
+            case 8:
+                return ElasticMajorVersion.EIGHT;
             default:
                 throw new IllegalArgumentException("Unsupported Elasticsearch server major version: " + value);
         }

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/compat/ES8Compat.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/compat/ES8Compat.java
@@ -1,0 +1,29 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.es.compat;
+
+import org.janusgraph.diskstorage.indexing.IndexFeatures;
+
+import static org.janusgraph.diskstorage.es.ElasticSearchConstants.CUSTOM_ALL_FIELD;
+
+public class ES8Compat extends AbstractESCompat {
+
+    private static final IndexFeatures FEATURES = coreFeatures().setWildcardField(CUSTOM_ALL_FIELD).supportsGeoContains().build();
+
+    @Override
+    public IndexFeatures getIndexFeatures() {
+        return FEATURES;
+    }
+}

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/compat/ESCompatUtils.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/compat/ESCompatUtils.java
@@ -26,6 +26,8 @@ public class ESCompatUtils {
                 return new ES6Compat();
             case SEVEN:
                 return new ES7Compat();
+            case EIGHT:
+                return new ES8Compat();
             default:
                 throw new PermanentBackendException("Unsupported Elasticsearch version: " + elasticMajorVersion);
         }

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestElasticSearchClient.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestElasticSearchClient.java
@@ -89,7 +89,7 @@ public class RestElasticSearchClient implements ElasticSearchClient {
         mapWriter = mapper.writerWithView(Map.class);
     }
 
-    private static final ElasticMajorVersion DEFAULT_VERSION = ElasticMajorVersion.SEVEN;
+    private static final ElasticMajorVersion DEFAULT_VERSION = ElasticMajorVersion.EIGHT;
 
     private static final Function<StringBuilder, StringBuilder> APPEND_OP = sb -> sb.append(sb.length() == 0 ? REQUEST_PARAM_BEGINNING : REQUEST_PARAM_SEPARATOR);
 

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticsearchIndexTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/ElasticsearchIndexTest.java
@@ -139,6 +139,14 @@ public class ElasticsearchIndexTest extends IndexProviderTest {
         return "keyword";
     }
 
+    @Override
+    public Mapping preferredGeoShapeMapping() {
+        if(JanusGraphElasticsearchContainer.getEsMajorVersion().value <= 6){
+            return Mapping.PREFIX_TREE;
+        }
+        return Mapping.BKD;
+    }
+
     public Configuration getESTestConfig() {
         final String index = "es";
         final CommonsConfiguration cc = new CommonsConfiguration(ConfigurationUtil.createBaseConfiguration());
@@ -199,6 +207,10 @@ public class ElasticsearchIndexTest extends IndexProviderTest {
         assertTrue(index.supports(of(Geoshape.class, Cardinality.SINGLE, Mapping.PREFIX_TREE.asParameter()), Geo.INTERSECT));
         assertTrue(index.supports(of(Geoshape.class, Cardinality.SINGLE, Mapping.PREFIX_TREE.asParameter()), Geo.CONTAINS));
         assertTrue(index.supports(of(Geoshape.class, Cardinality.SINGLE, Mapping.PREFIX_TREE.asParameter()), Geo.DISJOINT));
+        assertTrue(index.supports(of(Geoshape.class, Cardinality.SINGLE, Mapping.BKD.asParameter()), Geo.WITHIN));
+        assertTrue(index.supports(of(Geoshape.class, Cardinality.SINGLE, Mapping.BKD.asParameter()), Geo.INTERSECT));
+        assertTrue(index.supports(of(Geoshape.class, Cardinality.SINGLE, Mapping.BKD.asParameter()), Geo.CONTAINS));
+        assertTrue(index.supports(of(Geoshape.class, Cardinality.SINGLE, Mapping.BKD.asParameter()), Geo.DISJOINT));
     }
 
     @Test
@@ -217,6 +229,7 @@ public class ElasticsearchIndexTest extends IndexProviderTest {
         String message = Throwables.getRootCause(janusGraphException).getMessage();
 
         switch (JanusGraphElasticsearchContainer.getEsMajorVersion().value){
+            case 8:
             case 7:
             case 6:
                 assertTrue(message.contains("mapper_parsing_exception"));
@@ -331,8 +344,8 @@ public class ElasticsearchIndexTest extends IndexProviderTest {
 
         String mappingTypeName = "vertex";
         String indexPrefix = "janusgraph";
-        String parameterName = "boost";
-        Double parameterValue = 5.5;
+        String parameterName = "store";
+        Boolean parameterValue = true;
 
         String field = "field_with_custom_prop";
 

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/JanusGraphElasticsearchContainer.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/JanusGraphElasticsearchContainer.java
@@ -37,14 +37,14 @@ import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.IN
 public class JanusGraphElasticsearchContainer extends ElasticsearchContainer {
 
     private static final Integer ELASTIC_PORT = 9200;
-    private static final String DEFAULT_VERSION = "7.17.5";
+    private static final String DEFAULT_VERSION = "8.6.0";
     private static final String DEFAULT_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch";
 
     public static ElasticMajorVersion getEsMajorVersion() {
         return ElasticMajorVersion.parse(getVersion());
     }
 
-    private static String getVersion() {
+    public static String getVersion() {
         String property = System.getProperty("elasticsearch.docker.version");
         if (property != null)
             return property;
@@ -66,6 +66,10 @@ public class JanusGraphElasticsearchContainer extends ElasticsearchContainer {
         super(getElasticImage() + ":" + getVersion());
         withEnv("transport.host", "0.0.0.0");
         withEnv("xpack.security.enabled", "false");
+        withEnv("action.destructive_requires_name", "false");
+        if (getEsMajorVersion().value > 6) {
+            withEnv("ingest.geoip.downloader.enabled", "false");
+        }
         withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m");
         if (getEsMajorVersion().value == 5) {
             withEnv("script.max_compilations_per_minute", "30");

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/TestCircleProcessor.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/TestCircleProcessor.java
@@ -1,0 +1,54 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.es;
+
+import org.janusgraph.core.attribute.Geoshape;
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.diskstorage.mixed.utils.processor.CircleProcessor;
+import org.janusgraph.diskstorage.mixed.utils.processor.FixedErrorDistanceCircleProcessor;
+
+import java.util.function.Consumer;
+
+public class TestCircleProcessor implements CircleProcessor {
+
+    private static Consumer<Geoshape> preProcessConsumer;
+    private static Consumer<Geoshape> postProcessConsumer;
+
+    private final CircleProcessor wrappedCircleProcessor;
+
+    public TestCircleProcessor(Configuration config) {
+        wrappedCircleProcessor = new FixedErrorDistanceCircleProcessor(config);
+    }
+
+    @Override
+    public Geoshape process(Geoshape circle) {
+        if(preProcessConsumer != null){
+            preProcessConsumer.accept(circle);
+        }
+        Geoshape transformedGeoshape = wrappedCircleProcessor.process(circle);
+        if(postProcessConsumer != null){
+            postProcessConsumer.accept(transformedGeoshape);
+        }
+        return transformedGeoshape;
+    }
+
+    public static void setPreProcessConsumer(Consumer<Geoshape> preProcessConsumer){
+        TestCircleProcessor.preProcessConsumer = preProcessConsumer;
+    }
+
+    public static void setPostProcessConsumer(Consumer<Geoshape> postProcessConsumer){
+        TestCircleProcessor.postProcessConsumer = postProcessConsumer;
+    }
+}

--- a/janusgraph-lucene/src/test/java/org/janusgraph/diskstorage/lucene/BerkeleyLuceneTest.java
+++ b/janusgraph-lucene/src/test/java/org/janusgraph/diskstorage/lucene/BerkeleyLuceneTest.java
@@ -58,6 +58,11 @@ public class BerkeleyLuceneTest extends JanusGraphIndexTest {
     }
 
     @Override
+    public boolean supportsGeoShapePrefixTreeMapping() {
+        return true;
+    }
+
+    @Override
     public boolean supportsWildcardQuery() {
         return false;
     }

--- a/janusgraph-lucene/src/test/java/org/janusgraph/diskstorage/lucene/LuceneIndexTest.java
+++ b/janusgraph-lucene/src/test/java/org/janusgraph/diskstorage/lucene/LuceneIndexTest.java
@@ -72,6 +72,11 @@ public class LuceneIndexTest extends IndexProviderTest {
         return org.apache.lucene.analysis.core.KeywordAnalyzer.class.getName();
     }
 
+    @Override
+    public Mapping preferredGeoShapeMapping() {
+        return Mapping.PREFIX_TREE;
+    }
+
     public static Configuration getLocalLuceneTestConfig() {
         final String index = "lucene";
         ModifiableConfiguration config = GraphDatabaseConfiguration.buildGraphConfiguration();

--- a/janusgraph-mixed-index-utils/pom.xml
+++ b/janusgraph-mixed-index-utils/pom.xml
@@ -1,0 +1,45 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.janusgraph</groupId>
+        <artifactId>janusgraph</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>janusgraph-mixed-index-utils</artifactId>
+    <name>JanusGraph-Mixed-Index-Utils: JanusGraph Utils for mixed index storage implementations</name>
+    <url>https://janusgraph.org</url>
+
+    <properties>
+        <top.level.basedir>${basedir}/..</top.level.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.janusgraph</groupId>
+            <artifactId>janusgraph-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+            <version>${lucene-solr.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.janusgraph</groupId>
+            <artifactId>janusgraph-backend-testutils</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+</project>
+

--- a/janusgraph-mixed-index-utils/src/main/java/org/janusgraph/diskstorage/mixed/utils/CircleUtils.java
+++ b/janusgraph-mixed-index-utils/src/main/java/org/janusgraph/diskstorage/mixed/utils/CircleUtils.java
@@ -1,0 +1,137 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.mixed.utils;
+
+import org.apache.lucene.util.SloppyMath;
+
+/**
+ * Utility class for storing different helpful re-usable spatial functions. <br>
+ * The implementation of this class is mostly taken from
+ * <a href="https://github.com/elastic/elasticsearch/blob/8.6/libs/geo/src/main/java/org/elasticsearch/geometry/utils/CircleUtils.java">CircleUtils.java</a>
+ * class available in `elasticsearch-geo 8.6.0` library. <br>
+ * The main different is that this util class doesn't use ElasticSearch internal Geometry data structures.
+ * Another difference is that this class reuses `SloppyMath.haversinMeters` from Lucene instead of relying on slowHaversin implementation.
+ */
+public class CircleUtils {
+
+    static final int CIRCLE_TO_POLYGON_MINIMUM_NUMBER_OF_SIDES = 4;
+    static final int CIRCLE_TO_POLYGON_MAXIMUM_NUMBER_OF_SIDES = 1000;
+
+    private CircleUtils() {}
+
+    /**
+     * Makes an n-gon, centered at the provided circle's center, and each vertex approximately
+     * `circleRadius` away from the center.
+     *
+     * It throws an IllegalArgumentException if the circle contains a pole.
+     *
+     * This does not split the polygon across the date-line.
+     *
+     * Adapted from from org.apache.lucene.tests.geo.GeoTestUtil
+     *
+     * @return matrix containing 2 arrays. Array with index 0 are Longitude coordinates and array with index 1 are Latitude coordinates.
+     */
+    public static double[][] createRegularGeoShapePolygon(double centerCenterLat, double circleCenterLon, double circleRadiusMeters, int gons) {
+        if (SloppyMath.haversinMeters(centerCenterLat, circleCenterLon, 90, 0) < circleRadiusMeters) {
+            throw new IllegalArgumentException(
+                "circle [lat: " + centerCenterLat + " lon: "+circleCenterLon+" radius: "+circleRadiusMeters+"] contains the north pole. It cannot be translated to a polygon"
+            );
+        }
+        if (SloppyMath.haversinMeters(centerCenterLat, circleCenterLon, -90, 0) < circleRadiusMeters) {
+            throw new IllegalArgumentException(
+                "circle [lat: " + centerCenterLat + " lon: "+circleCenterLon+" radius: "+circleRadiusMeters+"] contains the south pole. It cannot be translated to a polygon"
+            );
+        }
+
+        double[][] result = new double[2][];
+        result[0] = new double[gons + 1];
+        result[1] = new double[gons + 1];
+        for (int i = 0; i < gons; i++) {
+            // make sure we do not start at angle 0 or we have issues at the poles
+            double angle = i * (360.0 / gons);
+            double x = Math.cos(Math.toRadians(angle));
+            double y = Math.sin(Math.toRadians(angle));
+            double factor = 2.0;
+            double step = 1.0;
+            int last = 0;
+
+            // Iterate out along one spoke until we hone in on the point that's nearly exactly radiusMeters from the center:
+            while (true) {
+                double lat = centerCenterLat + y * factor;
+                double lon = circleCenterLon + x * factor;
+                double distanceMeters = SloppyMath.haversinMeters(centerCenterLat, circleCenterLon, lat, lon);
+
+                if (Math.abs(distanceMeters - circleRadiusMeters) < 0.1) {
+                    // Within 10 cm: close enough!
+                    // lon/lat are left de-normalized so that indexing can properly detect dateline crossing.
+                    result[0][i] = lon;
+                    result[1][i] = lat;
+                    break;
+                }
+
+                if (distanceMeters > circleRadiusMeters) {
+                    // too big
+                    factor -= step;
+                    if (last == 1) {
+                        step /= 2.0;
+                    }
+                    last = -1;
+                } else if (distanceMeters < circleRadiusMeters) {
+                    // too small
+                    factor += step;
+                    if (last == -1) {
+                        step /= 2.0;
+                    }
+                    last = 1;
+                }
+            }
+        }
+
+        // close poly
+        result[0][gons] = result[0][0];
+        result[1][gons] = result[1][0];
+        return result;
+    }
+
+    /**
+     * Makes an n-gon, centered at the provided circle's center. This assumes
+     * distance measured in cartesian geometry.
+     *
+     * @return matrix containing 2 arrays. Array with index 0 are X coordinates and array with index 1 are Y coordinates.
+     **/
+    public static double[][] createRegularShapePolygon(double circleCenterX, double circleCenterY, double circleRadius, int gons) {
+        double[][] result = new double[2][];
+        result[0] = new double[gons + 1];
+        result[1] = new double[gons + 1];
+        for (int i = 0; i < gons; i++) {
+            double angle = i * (360.0 / gons);
+            double x = circleRadius * Math.cos(Math.toRadians(angle));
+            double y = circleRadius * Math.sin(Math.toRadians(angle));
+
+            result[0][i] = x + circleCenterX;
+            result[1][i] = y + circleCenterY;
+        }
+        // close poly
+        result[0][gons] = result[0][0];
+        result[1][gons] = result[1][0];
+        return result;
+    }
+
+    public static int circleToPolygonNumSides(double radiusMeters, double errorDistanceMeters) {
+        int val = (int) Math.ceil(2 * Math.PI / Math.acos(1 - errorDistanceMeters / radiusMeters));
+        return Math.min(CIRCLE_TO_POLYGON_MAXIMUM_NUMBER_OF_SIDES, Math.max(CIRCLE_TO_POLYGON_MINIMUM_NUMBER_OF_SIDES, val));
+    }
+
+}

--- a/janusgraph-mixed-index-utils/src/main/java/org/janusgraph/diskstorage/mixed/utils/MixedIndexUtilsConfigOptions.java
+++ b/janusgraph-mixed-index-utils/src/main/java/org/janusgraph/diskstorage/mixed/utils/MixedIndexUtilsConfigOptions.java
@@ -1,0 +1,126 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.mixed.utils;
+
+import org.apache.commons.lang3.ClassUtils;
+import org.janusgraph.diskstorage.configuration.ConfigNamespace;
+import org.janusgraph.diskstorage.configuration.ConfigOption;
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.diskstorage.mixed.utils.processor.CircleProcessor;
+import org.janusgraph.diskstorage.mixed.utils.processor.DynamicErrorDistanceCircleProcessor;
+import org.janusgraph.diskstorage.mixed.utils.processor.FixedErrorDistanceCircleProcessor;
+import org.janusgraph.diskstorage.mixed.utils.processor.NoTransformCircleProcessor;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.janusgraph.graphdb.configuration.PreInitializeConfigOptions;
+import org.janusgraph.util.system.ConfigurationUtil;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@PreInitializeConfigOptions
+public class MixedIndexUtilsConfigOptions {
+
+    public static final ConfigNamespace BKD_CIRCLE_PROCESSOR_NS =
+        new ConfigNamespace(GraphDatabaseConfiguration.INDEX_NS, "bkd-circle-processor",
+            "Configuration for BKD circle processors which is used for BKD Geoshape mapping.");
+
+    public static final Map<String, String> PREREGISTERED_CIRCLE_PROCESSORS = Collections.unmodifiableMap(
+        new HashMap<String, String>(3) {{
+            put(NoTransformCircleProcessor.SHORTHAND, NoTransformCircleProcessor.class.getName());
+            put(FixedErrorDistanceCircleProcessor.SHORTHAND, FixedErrorDistanceCircleProcessor.class.getName());
+            put(DynamicErrorDistanceCircleProcessor.SHORTHAND, DynamicErrorDistanceCircleProcessor.class.getName());
+        }}
+    );
+
+    public static final ConfigNamespace BKD_FIXED_CIRCLE_PROCESSOR_NS =
+        new ConfigNamespace(BKD_CIRCLE_PROCESSOR_NS, "fixed",
+            "Configuration for Elasticsearch fixed circle processor which is used for BKD Geoshape mapping.");
+
+    public static final ConfigOption<Double> BKD_FIXED_CIRCLE_PROCESSOR_ERROR_DISTANCE =
+        new ConfigOption<>(BKD_FIXED_CIRCLE_PROCESSOR_NS, "error-distance",
+            "The difference between the resulting inscribed distance from center to side and the circle’s radius. " +
+                "Specified in meters.",
+            ConfigOption.Type.MASKABLE, 10d, e -> e > 0d);
+
+    private static final String BOUNDING_BOX_FALLBACK_NAME = "bounding-box-fallback";
+    private static final String BOUNDING_BOX_FALLBACK_DESCRIPTION = "Allows to return bounding box for the circle which " +
+        "cannot be converted to proper shape with the specified error distance. In case `false` is set for this configuration " +
+        "an exception will be thrown whenever circle cannot be converted to another shape following error distance.";
+
+    public static final ConfigOption<Boolean> BKD_FIXED_CIRCLE_PROCESSOR_BOUNDING_BOX_FALLBACK =
+        new ConfigOption<>(BKD_FIXED_CIRCLE_PROCESSOR_NS, BOUNDING_BOX_FALLBACK_NAME,
+            BOUNDING_BOX_FALLBACK_DESCRIPTION,
+            ConfigOption.Type.MASKABLE, true);
+
+    public static final ConfigNamespace BKD_DYNAMIC_CIRCLE_PROCESSOR_NS =
+        new ConfigNamespace(BKD_CIRCLE_PROCESSOR_NS, "dynamic",
+            "Configuration for Elasticsearch dynamic circle processor which is used for BKD Geoshape mapping.");
+
+    public static final ConfigOption<Double> BKD_DYNAMIC_CIRCLE_PROCESSOR_MULTIPLIER =
+        new ConfigOption<>(BKD_DYNAMIC_CIRCLE_PROCESSOR_NS, "error-distance-multiplier",
+            "Multiplier variable for dynamic error distance calculation in the formula `log(radius) * multiplier`. " +
+                "Radius and error distance specified in meters.",
+            ConfigOption.Type.MASKABLE, 2d, e -> e > 0d);
+
+    public static final ConfigOption<Boolean> BKD_DYNAMIC_CIRCLE_PROCESSOR_BOUNDING_BOX_FALLBACK =
+        new ConfigOption<>(BKD_DYNAMIC_CIRCLE_PROCESSOR_NS, BOUNDING_BOX_FALLBACK_NAME,
+            BOUNDING_BOX_FALLBACK_DESCRIPTION,
+            ConfigOption.Type.MASKABLE, true);
+
+    public static final ConfigOption<String> BKD_CIRCLE_PROCESSOR_CLASS =
+        new ConfigOption<>(BKD_CIRCLE_PROCESSOR_NS, "class",
+            "Full class name of circle processor that implements `CircleProcessor` interface. " +
+                "The class is used for transformation of a Circle shape to another shape when BKD mapping is used. " +
+                "The provided implementation class should have either a public constructor which accepts configuration " +
+                "as a parameter (`org.janusgraph.diskstorage.configuration.Configuration`) or a public constructor with no parameters. " +
+                "Usually the transforming shape is a Polygon. <br>" +
+                "Following shorthands can be used: <br> " +
+                "- `"+NoTransformCircleProcessor.SHORTHAND+"` Circle processor which is not transforming a circle, but instead keep the circle shape unchanged. " +
+                "This implementation may be useful in situations when the user wants to control circle transformation logic on ElasticSearch " +
+                "side instead of application side. For example, using " +
+                "<a href=\"https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-circle-processor.html\">ElasticSearch Circle Processor</a> " +
+                "or any custom plugin. <br> " +
+                "- `"+FixedErrorDistanceCircleProcessor.SHORTHAND+"` Circle processor which transforms the provided Circle into Polygon, Box, or Point depending on the configuration provided in `"
+                +BKD_FIXED_CIRCLE_PROCESSOR_NS.toStringWithoutRoot()+"`. The processing logic is similar to <a href=\"https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-circle-processor.html\">ElasticSearch Circle Processor</a> " +
+                "except for some edge cases when the Circle is transformed into Box or Point. <br> " +
+                "- `"+DynamicErrorDistanceCircleProcessor.SHORTHAND+"` Circle processor which calculates error distance dynamically depending on the circle radius and the specified multiplier value. " +
+                "The error distance calculation formula is `log(radius) * multiplier`. Configuration for this class can be provided via `" +
+                BKD_DYNAMIC_CIRCLE_PROCESSOR_NS.toStringWithoutRoot()+"`. The processing logic is similar to <a href=\"https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-circle-processor.html\">ElasticSearch Circle Processor</a> " +
+                "except for some edge cases when the Circle is transformed into Box or Point.",
+            ConfigOption.Type.MASKABLE, DynamicErrorDistanceCircleProcessor.SHORTHAND, className -> {
+            if (className == null) return false;
+            if (PREREGISTERED_CIRCLE_PROCESSORS.containsKey(className)) return true;
+            try {
+                Class<?> clazz = ClassUtils.getClass(className);
+                return CircleProcessor.class.isAssignableFrom(clazz);
+            } catch (ClassNotFoundException e) {
+                return false;
+            }
+        });
+
+    public static CircleProcessor buildBKDCircleProcessor(Configuration config){
+        String circleProcessorClassName = config.get(BKD_CIRCLE_PROCESSOR_CLASS);
+        if(PREREGISTERED_CIRCLE_PROCESSORS.containsKey(circleProcessorClassName)){
+            circleProcessorClassName = PREREGISTERED_CIRCLE_PROCESSORS.get(circleProcessorClassName);
+        }
+
+        if(ConfigurationUtil.hasConstructor(circleProcessorClassName, new Class[]{Configuration.class})){
+            return ConfigurationUtil.instantiate(circleProcessorClassName, new Object[]{config}, new Class[]{Configuration.class});
+        }
+
+        return ConfigurationUtil.instantiate(circleProcessorClassName);
+    }
+}

--- a/janusgraph-mixed-index-utils/src/main/java/org/janusgraph/diskstorage/mixed/utils/processor/CircleProcessor.java
+++ b/janusgraph-mixed-index-utils/src/main/java/org/janusgraph/diskstorage/mixed/utils/processor/CircleProcessor.java
@@ -1,0 +1,23 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.mixed.utils.processor;
+
+import org.janusgraph.core.attribute.Geoshape;
+
+public interface CircleProcessor {
+
+    Geoshape process(Geoshape circle);
+
+}

--- a/janusgraph-mixed-index-utils/src/main/java/org/janusgraph/diskstorage/mixed/utils/processor/DynamicErrorDistanceCircleProcessor.java
+++ b/janusgraph-mixed-index-utils/src/main/java/org/janusgraph/diskstorage/mixed/utils/processor/DynamicErrorDistanceCircleProcessor.java
@@ -1,0 +1,43 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.mixed.utils.processor;
+
+import org.janusgraph.core.attribute.Geoshape;
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.diskstorage.mixed.utils.MixedIndexUtilsConfigOptions;
+
+/**
+ * Circle processor which calculates error distance dynamically depending on the circle radius and the specified
+ * multiplier value. The error distance calculation formula is `log(radius) * multiplier` <br>
+ * Error distance multiplier can be specified using {@link  MixedIndexUtilsConfigOptions#BKD_DYNAMIC_CIRCLE_PROCESSOR_MULTIPLIER} configuration.
+ */
+public class DynamicErrorDistanceCircleProcessor extends ErrorDistanceCircleProcessor {
+
+    public static final String SHORTHAND = "dynamicErrorDistance";
+
+    private final double errorDistanceMultiplier;
+
+    public DynamicErrorDistanceCircleProcessor(Configuration config) {
+        super(config.get(MixedIndexUtilsConfigOptions.BKD_DYNAMIC_CIRCLE_PROCESSOR_BOUNDING_BOX_FALLBACK));
+        errorDistanceMultiplier = config.get(MixedIndexUtilsConfigOptions.BKD_DYNAMIC_CIRCLE_PROCESSOR_MULTIPLIER);
+    }
+
+    @Override
+    double getErrorDistanceMeters(Geoshape circle) {
+        double radius = circle.getRadiusMeters();
+        double errorDistance = (radius <= 2d ? 1d : Math.log(radius)) * errorDistanceMultiplier;
+        return errorDistance <= 0d ? Double.MIN_VALUE : errorDistance;
+    }
+}

--- a/janusgraph-mixed-index-utils/src/main/java/org/janusgraph/diskstorage/mixed/utils/processor/ErrorDistanceCircleProcessor.java
+++ b/janusgraph-mixed-index-utils/src/main/java/org/janusgraph/diskstorage/mixed/utils/processor/ErrorDistanceCircleProcessor.java
@@ -1,0 +1,115 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.mixed.utils.processor;
+
+import org.janusgraph.core.attribute.Geoshape;
+import org.janusgraph.diskstorage.mixed.utils.CircleUtils;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.shape.Circle;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.Rectangle;
+import org.locationtech.spatial4j.shape.Shape;
+import org.locationtech.spatial4j.shape.ShapeFactory;
+import org.locationtech.spatial4j.shape.impl.PointImpl;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class ErrorDistanceCircleProcessor implements CircleProcessor {
+
+    private final boolean boundingBoxFallback;
+
+    public ErrorDistanceCircleProcessor(boolean boundingBoxFallback){
+        this.boundingBoxFallback = boundingBoxFallback;
+    }
+
+    abstract double getErrorDistanceMeters(Geoshape circle);
+
+    @Override
+    public Geoshape process(Geoshape circle) {
+        Shape shape = circle.getShape();
+        if(!(shape instanceof Circle)){
+            throw new IllegalArgumentException("Cannot process non-circle shape but received "+shape.getClass().getName()
+                +". Shape: "+circle.toGeoJson());
+        }
+
+        SpatialContext ctx = shape.getContext();
+
+        Circle circleShape = (Circle) shape;
+
+        double circleDegree = circleShape.getRadius();
+        if (circleDegree >= 180d){
+            // Circle radius is covering the whole Earth. Thus, returning enclosing rectangle
+            // (-90,-180,90,180) to cover the whole earth.
+            return Geoshape.geoshape(circleShape.getBoundingBox());
+        }
+
+        double radiusMeters = circle.getRadiusMeters();
+        double errorDistanceMeters = getErrorDistanceMeters(circle);
+        int numSides = CircleUtils.circleToPolygonNumSides(radiusMeters, errorDistanceMeters);
+
+        Point center = circleShape.getCenter();
+
+        Shape fallbackShape = fallbackShape(errorDistanceMeters, radiusMeters, boundingBoxFallback, center, circleShape.getBoundingBox());
+        Shape resultShape;
+
+        try{
+            double[][] rawPolygon = CircleUtils.createRegularGeoShapePolygon(center.getLat(), center.getLon(), radiusMeters, numSides);
+            int duplicatePoints = 0;
+            final ShapeFactory.PolygonBuilder builder = ctx.getShapeFactory().polygon();
+
+            Set<Point> addedPoints = new HashSet<>(rawPolygon[0].length);
+            for(int i=0; i<rawPolygon[0].length; i++){
+                Point point = new PointImpl(rawPolygon[0][i], rawPolygon[1][i], ctx);
+                if(!addedPoints.add(point)){
+                    ++duplicatePoints;
+                }
+                builder.pointXY(rawPolygon[0][i], rawPolygon[1][i]);
+            }
+
+            if(duplicatePoints<2){
+                resultShape = builder.build();
+            } else {
+                if(fallbackShape == null){
+                    throw new IllegalArgumentException("Circle: "+circle.toString()+" cannot be converted to another shape " +
+                        "following the specified error distance. The Polygon conversion logic produces "+duplicatePoints+" points " +
+                        "which is most likely related to either small radius or increased math complexity for Polygon creation.");
+                }
+                resultShape = fallbackShape;
+            }
+        } catch (RuntimeException e){
+            if(fallbackShape == null){
+                if(e instanceof IllegalArgumentException){
+                    throw e;
+                }
+                throw new IllegalArgumentException("Circle: "+circle.toString()+" cannot be converted to another shape " +
+                    "following the specified error distance. Reason: "+e.getMessage(), e);
+            }
+            resultShape = fallbackShape;
+        }
+
+        return Geoshape.geoshape(resultShape);
+    }
+
+    private Shape fallbackShape(double errorDistanceMeters, double radiusMeters, boolean boundingBoxFallback,
+                                Point center, Rectangle boundingBox){
+        if(errorDistanceMeters >= radiusMeters){
+            return center;
+        } else if(boundingBoxFallback){
+            return boundingBox;
+        }
+        return null;
+    }
+}

--- a/janusgraph-mixed-index-utils/src/main/java/org/janusgraph/diskstorage/mixed/utils/processor/FixedErrorDistanceCircleProcessor.java
+++ b/janusgraph-mixed-index-utils/src/main/java/org/janusgraph/diskstorage/mixed/utils/processor/FixedErrorDistanceCircleProcessor.java
@@ -1,0 +1,42 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.mixed.utils.processor;
+
+import org.janusgraph.core.attribute.Geoshape;
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.diskstorage.mixed.utils.MixedIndexUtilsConfigOptions;
+
+/**
+ * Circle processor implementing the same logic as ElasticSearch Server side
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-circle-processor.html">Circle Processor</a>
+ * but on the JanusGraph side. <br>
+ * Error distance can be specified using {@link  MixedIndexUtilsConfigOptions#BKD_FIXED_CIRCLE_PROCESSOR_ERROR_DISTANCE} configuration.
+ */
+public class FixedErrorDistanceCircleProcessor extends ErrorDistanceCircleProcessor {
+
+    public static final String SHORTHAND = "fixedErrorDistance";
+
+    private final double errorDistanceMeters;
+
+    public FixedErrorDistanceCircleProcessor(Configuration config) {
+        super(config.get(MixedIndexUtilsConfigOptions.BKD_FIXED_CIRCLE_PROCESSOR_BOUNDING_BOX_FALLBACK));
+        this.errorDistanceMeters = config.get(MixedIndexUtilsConfigOptions.BKD_FIXED_CIRCLE_PROCESSOR_ERROR_DISTANCE);
+    }
+
+    @Override
+    double getErrorDistanceMeters(Geoshape circle) {
+        return errorDistanceMeters;
+    }
+}

--- a/janusgraph-mixed-index-utils/src/main/java/org/janusgraph/diskstorage/mixed/utils/processor/NoTransformCircleProcessor.java
+++ b/janusgraph-mixed-index-utils/src/main/java/org/janusgraph/diskstorage/mixed/utils/processor/NoTransformCircleProcessor.java
@@ -1,0 +1,35 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.mixed.utils.processor;
+
+import org.janusgraph.core.attribute.Geoshape;
+
+/**
+ * Circle processor which isn't transforming circle into Polygon, but instead keep the circle shape unchanged.
+ * This implementation may be useful in situations when the user wants to control circle transformation logic on the
+ * mixed index server side. <br>
+ * For example, using
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-circle-processor.html">ElasticSearch Circle Processor</a>
+ * or any custom plugin.
+ */
+public class NoTransformCircleProcessor implements CircleProcessor {
+
+    public static final String SHORTHAND = "noTransformation";
+
+    @Override
+    public Geoshape process(Geoshape circle) {
+        return circle;
+    }
+}

--- a/janusgraph-mixed-index-utils/src/test/java/org/janusgraph/diskstorage/mixed/utils/CircleUtilsTest.java
+++ b/janusgraph-mixed-index-utils/src/test/java/org/janusgraph/diskstorage/mixed/utils/CircleUtilsTest.java
@@ -1,0 +1,137 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.mixed.utils;
+
+import org.apache.lucene.util.SloppyMath;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.hamcrest.Matchers.closeTo;
+
+/**
+ * This test class implementation is mostly take from
+ * <a href="https://github.com/elastic/elasticsearch/blob/8.6/libs/geo/src/test/java/org/elasticsearch/geometry/utils/CircleUtilsTests.java">CircleUtilsTests.java</a>
+ */
+public class CircleUtilsTest {
+
+    @Test
+    public void testCreateRegularGeoShapePolygon() {
+        double lat = ThreadLocalRandom.current().nextDouble(-89, 89);
+        double lon = ThreadLocalRandom.current().nextDouble(-179, 179);
+        double radius = ThreadLocalRandom.current().nextDouble(10, 10000);
+        doRegularGeoShapePolygon(lat, lon, radius);
+    }
+
+    @Test
+    public void testCircleContainsNorthPole() {
+        Exception exception = Assertions.assertThrows(Exception.class, () -> {
+            doRegularGeoShapePolygon(90, 179, 100);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("contains the north pole"));
+    }
+
+    @Test
+    public void testCircleContainsSouthPole() {
+        Exception exception = Assertions.assertThrows(Exception.class, () -> {
+            doRegularGeoShapePolygon(-90, 179, 100);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("contains the south pole"));
+    }
+
+    private void doRegularGeoShapePolygon(double lat, double lon, double radius) {
+        int numSides = ThreadLocalRandom.current().nextInt(4, 1000);
+        double[][] polygon = CircleUtils.createRegularGeoShapePolygon(lat, lon, radius, numSides);
+        int numPoints = polygon[0].length;
+
+        // check there are numSides edges
+        Assertions.assertEquals(numSides + 1, numPoints);
+
+        // check that all the points are about a radius away from the center
+        for (int i = 0; i < numPoints; i++) {
+            double actualDistance = SloppyMath.haversinMeters(lat, lon, polygon[1][i], polygon[0][i]);
+            Assertions.assertTrue(closeTo(radius, 0.1).matches(actualDistance));
+        }
+    }
+
+    @Test
+    public void testCreateRegularShapePolygon() {
+        double x = ThreadLocalRandom.current().nextDouble(-20, 20);
+        double y = ThreadLocalRandom.current().nextDouble(-20, 20);
+        double radius = ThreadLocalRandom.current().nextDouble(10, 10000);
+        int numSides = ThreadLocalRandom.current().nextInt(4, 1000);
+        double[][] polygon = CircleUtils.createRegularShapePolygon(x,y,radius, numSides);
+        int numPoints = polygon[0].length;
+
+        // check there are numSides edges
+        Assertions.assertEquals(numSides + 1, numPoints);
+
+        // check that all the points are about a radius away from the center
+        for (int i = 0; i < numPoints; i++) {
+            double deltaX = x - polygon[0][i];
+            double deltaY = y - polygon[1][i];
+            double distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+            Assertions.assertTrue(closeTo(radius, 0.0001).matches(distance));
+        }
+    }
+
+    @Test
+    public void testCircleToPolygonNumSides() {
+        // 0.01, 6371000
+        double randomErrorDistanceMeters = ThreadLocalRandom.current().nextDouble(0.01, 6371000);
+        double[] errorDistancesMeters = new double[] {
+            0.0000001,
+            0.0001,
+            0.001,
+            0.01,
+            0.02,
+            0.03,
+            0.1,
+            0.2,
+            1,
+            1.1,
+            1.2,
+            2,
+            2.5,
+            3,
+            3.7,
+            10,
+            100,
+            1000,
+            10000,
+            100000,
+            1000000,
+            5000000.12345,
+            6370999.999,
+            6371000,
+            randomErrorDistanceMeters };
+
+        for (double errorDistanceMeters : errorDistancesMeters) {
+            // radius is same as error distance
+            Assertions.assertEquals(4, CircleUtils.circleToPolygonNumSides(errorDistanceMeters, errorDistanceMeters));
+            // radius is much smaller than error distance
+            Assertions.assertEquals(4, CircleUtils.circleToPolygonNumSides(0, errorDistanceMeters));
+            // radius is much larger than error distance
+            double errorDistanceForPow = errorDistanceMeters;
+            if (errorDistanceForPow < 1.12d) {
+                errorDistanceForPow = 1.12;
+            }
+            Assertions.assertEquals(1000, CircleUtils.circleToPolygonNumSides(Math.pow(errorDistanceForPow, 100), errorDistanceForPow));
+            // radius is 5 times longer than error distance
+            Assertions.assertEquals(10, CircleUtils.circleToPolygonNumSides(5 * errorDistanceMeters, errorDistanceMeters));
+        }
+    }
+}

--- a/janusgraph-mixed-index-utils/src/test/java/org/janusgraph/diskstorage/mixed/utils/processor/DynamicErrorDistanceCircleProcessorTest.java
+++ b/janusgraph-mixed-index-utils/src/test/java/org/janusgraph/diskstorage/mixed/utils/processor/DynamicErrorDistanceCircleProcessorTest.java
@@ -1,0 +1,69 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.mixed.utils.processor;
+
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.diskstorage.mixed.utils.MixedIndexUtilsConfigOptions;
+import org.mockito.Mockito;
+
+public class DynamicErrorDistanceCircleProcessorTest extends ErrorDistanceCircleProcessorTest {
+
+    public DynamicErrorDistanceCircleProcessorTest() {
+        super(processorWithBoundingBoxFallbackAndNormalErrorDistance(),
+            processorWithoutBoundingBoxFallbackAndNormalErrorDistance(),
+            processorWithBoundingBoxFallbackAndSmallErrorDistance(),
+            processorWithoutBoundingBoxFallbackAndSmallErrorDistance());
+    }
+
+    private static DynamicErrorDistanceCircleProcessor processorWithBoundingBoxFallbackAndNormalErrorDistance(){
+        Configuration config = Mockito.mock(Configuration.class);
+        Mockito.when(config.get(MixedIndexUtilsConfigOptions.BKD_DYNAMIC_CIRCLE_PROCESSOR_MULTIPLIER))
+            .thenReturn(2d);
+        Mockito.when(config.get(MixedIndexUtilsConfigOptions.BKD_DYNAMIC_CIRCLE_PROCESSOR_BOUNDING_BOX_FALLBACK))
+            .thenReturn(true);
+
+        return new DynamicErrorDistanceCircleProcessor(config);
+    }
+
+    private static DynamicErrorDistanceCircleProcessor processorWithoutBoundingBoxFallbackAndNormalErrorDistance(){
+        Configuration config = Mockito.mock(Configuration.class);
+        Mockito.when(config.get(MixedIndexUtilsConfigOptions.BKD_DYNAMIC_CIRCLE_PROCESSOR_MULTIPLIER))
+            .thenReturn(2d);
+        Mockito.when(config.get(MixedIndexUtilsConfigOptions.BKD_DYNAMIC_CIRCLE_PROCESSOR_BOUNDING_BOX_FALLBACK))
+            .thenReturn(false);
+
+        return new DynamicErrorDistanceCircleProcessor(config);
+    }
+
+    private static DynamicErrorDistanceCircleProcessor processorWithBoundingBoxFallbackAndSmallErrorDistance(){
+        Configuration config = Mockito.mock(Configuration.class);
+        Mockito.when(config.get(MixedIndexUtilsConfigOptions.BKD_DYNAMIC_CIRCLE_PROCESSOR_MULTIPLIER))
+            .thenReturn(0.0000001d);
+        Mockito.when(config.get(MixedIndexUtilsConfigOptions.BKD_DYNAMIC_CIRCLE_PROCESSOR_BOUNDING_BOX_FALLBACK))
+            .thenReturn(true);
+
+        return new DynamicErrorDistanceCircleProcessor(config);
+    }
+
+    private static DynamicErrorDistanceCircleProcessor processorWithoutBoundingBoxFallbackAndSmallErrorDistance(){
+        Configuration config = Mockito.mock(Configuration.class);
+        Mockito.when(config.get(MixedIndexUtilsConfigOptions.BKD_DYNAMIC_CIRCLE_PROCESSOR_MULTIPLIER))
+            .thenReturn(0.0000001d);
+        Mockito.when(config.get(MixedIndexUtilsConfigOptions.BKD_DYNAMIC_CIRCLE_PROCESSOR_BOUNDING_BOX_FALLBACK))
+            .thenReturn(false);
+
+        return new DynamicErrorDistanceCircleProcessor(config);
+    }
+}

--- a/janusgraph-mixed-index-utils/src/test/java/org/janusgraph/diskstorage/mixed/utils/processor/ErrorDistanceCircleProcessorTest.java
+++ b/janusgraph-mixed-index-utils/src/test/java/org/janusgraph/diskstorage/mixed/utils/processor/ErrorDistanceCircleProcessorTest.java
@@ -1,0 +1,148 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.mixed.utils.processor;
+
+import org.janusgraph.core.attribute.Geoshape;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+public abstract class ErrorDistanceCircleProcessorTest {
+
+    protected final ErrorDistanceCircleProcessor processorWithBoundingBoxFallbackAndNormalErrorDistance;
+    protected final ErrorDistanceCircleProcessor processorWithoutBoundingBoxFallbackAndNormalErrorDistance;
+    protected final ErrorDistanceCircleProcessor processorWithBoundingBoxFallbackAndSmallErrorDistance;
+    protected final ErrorDistanceCircleProcessor processorWithoutBoundingBoxFallbackAndSmallErrorDistance;
+
+    public ErrorDistanceCircleProcessorTest(ErrorDistanceCircleProcessor processorWithBoundingBoxFallbackAndNormalErrorDistance,
+                                            ErrorDistanceCircleProcessor processorWithoutBoundingBoxFallbackAndNormalErrorDistance,
+                                            ErrorDistanceCircleProcessor processorWithBoundingBoxFallbackAndSmallErrorDistance,
+                                            ErrorDistanceCircleProcessor processorWithoutBoundingBoxFallbackAndSmallErrorDistance) {
+        this.processorWithBoundingBoxFallbackAndNormalErrorDistance = processorWithBoundingBoxFallbackAndNormalErrorDistance;
+        this.processorWithoutBoundingBoxFallbackAndNormalErrorDistance = processorWithoutBoundingBoxFallbackAndNormalErrorDistance;
+        this.processorWithBoundingBoxFallbackAndSmallErrorDistance = processorWithBoundingBoxFallbackAndSmallErrorDistance;
+        this.processorWithoutBoundingBoxFallbackAndSmallErrorDistance = processorWithoutBoundingBoxFallbackAndSmallErrorDistance;
+    }
+
+    @Test
+    public void testRegularCircleToPolygon() {
+
+        for(Double radiusKM : Arrays.asList(
+            0.008993203677616636d,
+            0.01d,
+            0.02d,
+            0.03d,
+            0.1d,
+            0.2d,
+            1d,
+            1.1d,
+            1.2d,
+            2d,
+            2.5d,
+            3d,
+            3.7d,
+            10d,
+            100d,
+            1000d,
+            3000d)){
+            Geoshape circle = Geoshape.circle(0.0, 0.0, radiusKM);
+            Geoshape polygon = processorWithoutBoundingBoxFallbackAndNormalErrorDistance.process(circle);
+            Assertions.assertEquals(Geoshape.Type.POLYGON, polygon.getType());
+            polygon = processorWithoutBoundingBoxFallbackAndSmallErrorDistance.process(circle);
+            Assertions.assertEquals(Geoshape.Type.POLYGON, polygon.getType());
+        }
+    }
+
+    @Test
+    public void testCircleWithPoles() {
+
+        Geoshape northPoleCircle = Geoshape.circle(90, 0, 13330);
+        Geoshape southPoleCircle = Geoshape.circle(-90, 0, 13330);
+
+        Geoshape boxFromNorthPoleCircle = processorWithBoundingBoxFallbackAndNormalErrorDistance.process(northPoleCircle);
+        Assertions.assertEquals(Geoshape.Type.BOX, boxFromNorthPoleCircle.getType());
+        Assertions.assertEquals(northPoleCircle.getShape().getBoundingBox(), boxFromNorthPoleCircle.getShape());
+
+        RuntimeException northPoleException = Assertions.assertThrows(RuntimeException.class, () ->
+            processorWithoutBoundingBoxFallbackAndNormalErrorDistance.process(northPoleCircle));
+        Assertions.assertTrue(northPoleException.getMessage().contains("contains the north pole"));
+
+        Geoshape boxFromSouthPoleCircle = processorWithBoundingBoxFallbackAndNormalErrorDistance.process(southPoleCircle);
+        Assertions.assertEquals(Geoshape.Type.BOX, boxFromSouthPoleCircle.getType());
+        Assertions.assertEquals(southPoleCircle.getShape().getBoundingBox(), boxFromSouthPoleCircle.getShape());
+
+        RuntimeException southPoleException = Assertions.assertThrows(RuntimeException.class, () ->
+            processorWithoutBoundingBoxFallbackAndNormalErrorDistance.process(southPoleCircle));
+        Assertions.assertTrue(southPoleException.getMessage().contains("contains the south pole"));
+    }
+
+    @Test
+    public void testWholePlanetShape() {
+
+        Geoshape wholeEarthCircle = Geoshape.circle(89.9, 179.7, 20100);
+        Geoshape maxRadiusCircleEarthCircle = Geoshape.circle(89.9, 179.7, Integer.MAX_VALUE);
+
+        Geoshape wholePlanetBoundingBox = processorWithBoundingBoxFallbackAndNormalErrorDistance.process(wholeEarthCircle);
+        Assertions.assertEquals(Geoshape.Type.BOX, wholePlanetBoundingBox.getType());
+        Assertions.assertEquals(wholeEarthCircle.getShape().getBoundingBox(), wholePlanetBoundingBox.getShape());
+
+        wholePlanetBoundingBox = processorWithBoundingBoxFallbackAndNormalErrorDistance.process(maxRadiusCircleEarthCircle);
+        Assertions.assertEquals(Geoshape.Type.BOX, wholePlanetBoundingBox.getType());
+        Assertions.assertEquals(maxRadiusCircleEarthCircle.getShape().getBoundingBox(), wholePlanetBoundingBox.getShape());
+
+        wholePlanetBoundingBox = processorWithoutBoundingBoxFallbackAndNormalErrorDistance.process(wholeEarthCircle);
+        Assertions.assertEquals(Geoshape.Type.BOX, wholePlanetBoundingBox.getType());
+        Assertions.assertEquals(wholeEarthCircle.getShape().getBoundingBox(), wholePlanetBoundingBox.getShape());
+
+        wholePlanetBoundingBox = processorWithoutBoundingBoxFallbackAndNormalErrorDistance.process(maxRadiusCircleEarthCircle);
+        Assertions.assertEquals(Geoshape.Type.BOX, wholePlanetBoundingBox.getType());
+        Assertions.assertEquals(maxRadiusCircleEarthCircle.getShape().getBoundingBox(), wholePlanetBoundingBox.getShape());
+    }
+
+    @Test
+    public void testSmallRadiusCircle() {
+
+        // Circle with hard to calculate radius which is in bound of error distance can be represented as Point
+        Geoshape smallRadiusCircle = Geoshape.circle(-48.0, 0.0, 0.000008993203677616636);
+        Geoshape point = processorWithBoundingBoxFallbackAndNormalErrorDistance.process(smallRadiusCircle);
+        Assertions.assertEquals(Geoshape.Type.POINT, point.getType());
+        Assertions.assertEquals(smallRadiusCircle.getShape().getCenter(), point.getShape());
+
+        Geoshape boundingBox = processorWithBoundingBoxFallbackAndSmallErrorDistance.process(smallRadiusCircle);
+        Assertions.assertEquals(Geoshape.Type.BOX, boundingBox.getType());
+        Assertions.assertEquals(smallRadiusCircle.getShape().getBoundingBox(), boundingBox.getShape());
+
+        IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () ->
+            processorWithoutBoundingBoxFallbackAndSmallErrorDistance.process(smallRadiusCircle));
+
+        Assertions.assertTrue(exception.getMessage().contains("cannot be converted to another shape"));
+    }
+
+    @Test
+    public void testOnlyCircleShapeAccepted() {
+
+        Geoshape box = Geoshape.box(-48.0, 0.0, 10, 10);
+        IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class,
+            () -> processorWithBoundingBoxFallbackAndNormalErrorDistance.process(box));
+
+        Assertions.assertTrue(exception.getMessage().contains("Cannot process non-circle shape"));
+
+        exception = Assertions.assertThrows(IllegalArgumentException.class,
+            () -> processorWithoutBoundingBoxFallbackAndNormalErrorDistance.process(box));
+
+        Assertions.assertTrue(exception.getMessage().contains("Cannot process non-circle shape"));
+    }
+}

--- a/janusgraph-mixed-index-utils/src/test/java/org/janusgraph/diskstorage/mixed/utils/processor/FixedErrorDistanceCircleProcessorTest.java
+++ b/janusgraph-mixed-index-utils/src/test/java/org/janusgraph/diskstorage/mixed/utils/processor/FixedErrorDistanceCircleProcessorTest.java
@@ -1,0 +1,69 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.mixed.utils.processor;
+
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.diskstorage.mixed.utils.MixedIndexUtilsConfigOptions;
+import org.mockito.Mockito;
+
+public class FixedErrorDistanceCircleProcessorTest extends ErrorDistanceCircleProcessorTest {
+
+    public FixedErrorDistanceCircleProcessorTest() {
+        super(processorWithBoundingBoxFallbackAndNormalErrorDistance(),
+            processorWithoutBoundingBoxFallbackAndNormalErrorDistance(),
+            processorWithBoundingBoxFallbackAndSmallErrorDistance(),
+            processorWithoutBoundingBoxFallbackAndSmallErrorDistance());
+    }
+
+    private static FixedErrorDistanceCircleProcessor processorWithBoundingBoxFallbackAndNormalErrorDistance(){
+        Configuration config = Mockito.mock(Configuration.class);
+        Mockito.when(config.get(MixedIndexUtilsConfigOptions.BKD_FIXED_CIRCLE_PROCESSOR_ERROR_DISTANCE))
+            .thenReturn(10d);
+        Mockito.when(config.get(MixedIndexUtilsConfigOptions.BKD_FIXED_CIRCLE_PROCESSOR_BOUNDING_BOX_FALLBACK))
+            .thenReturn(true);
+
+        return new FixedErrorDistanceCircleProcessor(config);
+    }
+
+    private static FixedErrorDistanceCircleProcessor processorWithoutBoundingBoxFallbackAndNormalErrorDistance(){
+        Configuration config = Mockito.mock(Configuration.class);
+        Mockito.when(config.get(MixedIndexUtilsConfigOptions.BKD_FIXED_CIRCLE_PROCESSOR_ERROR_DISTANCE))
+            .thenReturn(10d);
+        Mockito.when(config.get(MixedIndexUtilsConfigOptions.BKD_FIXED_CIRCLE_PROCESSOR_BOUNDING_BOX_FALLBACK))
+            .thenReturn(false);
+
+        return new FixedErrorDistanceCircleProcessor(config);
+    }
+
+    private static FixedErrorDistanceCircleProcessor processorWithBoundingBoxFallbackAndSmallErrorDistance(){
+        Configuration config = Mockito.mock(Configuration.class);
+        Mockito.when(config.get(MixedIndexUtilsConfigOptions.BKD_FIXED_CIRCLE_PROCESSOR_ERROR_DISTANCE))
+            .thenReturn(0.0000001d);
+        Mockito.when(config.get(MixedIndexUtilsConfigOptions.BKD_FIXED_CIRCLE_PROCESSOR_BOUNDING_BOX_FALLBACK))
+            .thenReturn(true);
+
+        return new FixedErrorDistanceCircleProcessor(config);
+    }
+
+    private static FixedErrorDistanceCircleProcessor processorWithoutBoundingBoxFallbackAndSmallErrorDistance(){
+        Configuration config = Mockito.mock(Configuration.class);
+        Mockito.when(config.get(MixedIndexUtilsConfigOptions.BKD_FIXED_CIRCLE_PROCESSOR_ERROR_DISTANCE))
+            .thenReturn(0.0000001d);
+        Mockito.when(config.get(MixedIndexUtilsConfigOptions.BKD_FIXED_CIRCLE_PROCESSOR_BOUNDING_BOX_FALLBACK))
+            .thenReturn(false);
+
+        return new FixedErrorDistanceCircleProcessor(config);
+    }
+}

--- a/janusgraph-mixed-index-utils/src/test/java/org/janusgraph/diskstorage/mixed/utils/processor/NoTransformCircleProcessorTest.java
+++ b/janusgraph-mixed-index-utils/src/test/java/org/janusgraph/diskstorage/mixed/utils/processor/NoTransformCircleProcessorTest.java
@@ -1,0 +1,31 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.mixed.utils.processor;
+
+import org.janusgraph.core.attribute.Geoshape;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class NoTransformCircleProcessorTest {
+
+    @Test
+    public void testNotTransformed(){
+        NoTransformCircleProcessor noTransformCircleProcessor = new NoTransformCircleProcessor();
+        Geoshape circle = Geoshape.circle(50, 50, 50);
+        Geoshape result = noTransformCircleProcessor.process(circle);
+        Assertions.assertEquals(circle, result);
+    }
+
+}

--- a/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrIndexTest.java
+++ b/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrIndexTest.java
@@ -208,4 +208,9 @@ public abstract class SolrIndexTest extends IndexProviderTest {
         assertEquals("test1", result[0]);
         assertEquals("test2", result[1]);
     }
+
+    @Override
+    public Mapping preferredGeoShapeMapping() {
+        return Mapping.PREFIX_TREE;
+    }
 }

--- a/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrJanusGraphIndexTest.java
+++ b/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrJanusGraphIndexTest.java
@@ -87,4 +87,8 @@ public abstract class SolrJanusGraphIndexTest extends JanusGraphIndexTest {
         super.testIndexReplay();
     }
 
+    @Override
+    public boolean supportsGeoShapePrefixTreeMapping() {
+        return true;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -75,9 +75,7 @@
         <jackson2.version>2.14.1</jackson2.version>
         <lucene-solr.version>8.11.2</lucene-solr.version>
         <!-- When this version updated please also update sha512 -->
-        <elasticsearch.version>7.17.5</elasticsearch.version>
-        <!-- https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.17.5-linux-x86_64.tar.gz.sha512 -->
-        <elasticsearch.version.sha512>98791c40f7ce1ba2a463fddb0986bb6ab9f94ab6479d79f96cd9b772e5208a04c7552c56e9fea484248d2ff1dd46fa25ed7066a41160fb22eb1b8dc837448ccf</elasticsearch.version.sha512>
+        <elasticsearch.version>8.6.0</elasticsearch.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <zookeeper.version>3.8.0</zookeeper.version>
@@ -143,6 +141,7 @@
         <module>janusgraph-doc</module>
         <module>janusgraph-solr</module>
         <module>janusgraph-examples</module>
+        <module>janusgraph-mixed-index-utils</module>
     </modules>
     <repositories>
         <repository>


### PR DESCRIPTION
- Added ElasticSearch 8.6.0 High Rest Client support
- Fixed ElasticSearch 7.17.8 version for janusgraph-full distribution because ElasticSearch 8 doesn't support Java 8 or Java 11 (see discussion here: #3467)
- Added BKD index mapping support for ElasticSearch (see [more info here](https://www.elastic.co/blog/bkd-backed-geo-shapes-in-elasticsearch-precision-efficiency-speed))
- Added BKD Circle Processor implementations to allow converting Circle to another shape when such mapping is used
- Moved BKD Circle Processors to general module `janusgraph-mixed-index-utils`, so that it could be reused by Lucene or Solr when BKD Geoshape mapping is added to those index backends. Currently 3 general circle processors are added and a possibility to provide custom circle processor for advanced use cases. 

Fixes #3015

Prehistory.
Initially I moved ElasticSearch internal Circle processor to public `elasticsearch-geo` library to reuse it JanusGraph (here is the PR: https://github.com/elastic/elasticsearch/pull/88088). That said, after a small investigation the next was found:
- `elasticsearch-geo` requires Java 17 to be used, but we use Java 8 in JanusGraph.
- The Circle Processor implementation ElasticSearch has right now has problems with small radius circles, circles touching north or south poles, slow `haversinMeters` is used instead of fast `haversinMeters` which is provided in `org.apache.lucene.util.SloppyMath`.
- `CircleUtils` in ElasticSearch uses internal ES Geometry implementation classes which prevents us from reusing that logic for Solr or Lucene in the future if we decide to add BKD support to Solr or Lucene.

Thus, the decision was made to copy math under main `CircleUtils` provided by ElasticSearch to a similar class `CircleUtils` provided by JanusGraph but make it more general and with `haversinMeters` usage. Reference to those classes are made in JavaDoc.
As such, the pros we gain are the next:
- We are not bound to ElasticSearch Geometry data structures which gives us ability to reuse this logic for Lucene and Solr without introducing `elasticsearch-geo` dependency there.
- We can use this logic for Java 8 (the version we are using right now)
- We have small performance improvement due to `org.apache.lucene.util.SloppyMath.haversinMeters` usage.

ElasticSearch Circle processor doc for reference: https://github.com/elastic/elasticsearch/blob/main/docs/reference/ingest/processors/circle.asciidoc

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
