### PR TITLE
[v0.6] Bump commons-text from 1.9 to 1.10.0

### DIFF
--- a/janusgraph-driver/pom.xml
+++ b/janusgraph-driver/pom.xml
@@ -57,14 +57,7 @@
        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.9</version>
-            <exclusions>
-                 <exclusion>
-                      <groupId>org.apache.commons</groupId>
-                      <artifactId>commons-lang3</artifactId>
-                  </exclusion>
-             </exclusions>
-       </dependency>
+        </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1181,7 +1181,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
-                <version>1.9</version>
+                <version>1.10.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump commons-text from 1.9 to 1.10.0](https://github.com/JanusGraph/janusgraph/pull/3261)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)