### PR TITLE
[v0.6] Bump protobuf-java from 3.21.6 to 3.21.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,8 +111,8 @@
         <cassandra-driver.version>4.14.1</cassandra-driver.version>
         <scylladb.version>4.4.0</scylladb.version>
         <testcontainers.version>1.17.3</testcontainers.version>
-        <easymock.version>4.2</easymock.version>
-        <protobuf.version>3.21.6</protobuf.version>
+        <easymock.version>4.3</easymock.version>
+        <protobuf.version>3.21.7</protobuf.version>
         <grpc.version>1.47.0</grpc.version>
         <protoc.version>3.15.3</protoc.version>
         <gson.version>2.9.1</gson.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump protobuf-java from 3.21.6 to 3.21.7](https://github.com/JanusGraph/janusgraph/pull/3239)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)