### PR TITLE
[v0.6] Bump actions/checkout from 2 to 3

### DIFF
--- a/.github/workflows/ci-backend-cql.yml
+++ b/.github/workflows/ci-backend-cql.yml
@@ -40,7 +40,7 @@ jobs:
   build-all:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -129,7 +129,7 @@ jobs:
             name: scylladb-core
             java: 8
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - uses: actions/cache@v2
@@ -178,7 +178,7 @@ jobs:
           - module: cql
             args: "-Pcassandra3-murmur-client-auth -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository

--- a/.github/workflows/ci-backend-hbase.yml
+++ b/.github/workflows/ci-backend-hbase.yml
@@ -40,7 +40,7 @@ jobs:
   build-all:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -82,7 +82,7 @@ jobs:
             args: "-Dtest=\"**/hadoop/*\""
             name: hbase2-hadoop
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - uses: actions/cache@v2

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -39,7 +39,7 @@ jobs:
   build-all:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -67,7 +67,7 @@ jobs:
           - module: berkeleyje
           - module: lucene
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - uses: actions/cache@v2

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -27,7 +27,7 @@ jobs:
   build-all:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: build-all
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -69,7 +69,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     needs: build-doc
     steps: 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/ci-index-es.yml
+++ b/.github/workflows/ci-index-es.yml
@@ -41,7 +41,7 @@ jobs:
   build-all:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -71,7 +71,7 @@ jobs:
             args: "-Pelasticsearch60"
             name: es60
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - uses: actions/cache@v2

--- a/.github/workflows/ci-index-solr.yml
+++ b/.github/workflows/ci-index-solr.yml
@@ -41,7 +41,7 @@ jobs:
   build-all:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -68,7 +68,7 @@ jobs:
             args: "-Psolr8"
             name: solr8
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - uses: actions/cache@v2

--- a/.github/workflows/ci-java-11.yml
+++ b/.github/workflows/ci-java-11.yml
@@ -39,7 +39,7 @@ jobs:
   build-all:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -56,7 +56,7 @@ jobs:
     needs: build-all
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -23,7 +23,7 @@ jobs:
   build-all:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -43,7 +43,7 @@ jobs:
   build-all:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -68,7 +68,7 @@ jobs:
           - args: "-Pjava-11"
             java: 11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -108,7 +108,7 @@ jobs:
             install-args: "-Dhbase.profile -Phbase2"
             args: "-Dtest.skip.tp=false -DskipTests=true"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository

--- a/.github/workflows/lint-proto.yml
+++ b/.github/workflows/lint-proto.yml
@@ -29,7 +29,7 @@ jobs:
     name: buf check lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ory/build-buf-action@v0
         with:
           bufVersion: v0.31.1


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump actions/checkout from 2 to 3](https://github.com/JanusGraph/janusgraph/pull/3286)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)