### PR TITLE
[v0.6] Bump codecov/codecov-action from 1 to 3

### DIFF
--- a/.github/workflows/ci-backend-cql.yml
+++ b/.github/workflows/ci-backend-cql.yml
@@ -147,7 +147,7 @@ jobs:
         with:
           name: jacoco-reports
           path: target/jacoco-combined.exec
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
           name: codecov-cql-${{ matrix.name }}
 

--- a/.github/workflows/ci-backend-hbase.yml
+++ b/.github/workflows/ci-backend-hbase.yml
@@ -100,6 +100,6 @@ jobs:
         with:
           name: jacoco-reports
           path: target/jacoco-combined.exec
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
           name: codecov-hbase-${{ matrix.name }}

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -85,6 +85,6 @@ jobs:
         with:
           name: jacoco-reports
           path: target/jacoco-combined.exec
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
           name: codecov-core-${{ matrix.module }}

--- a/.github/workflows/ci-index-es.yml
+++ b/.github/workflows/ci-index-es.yml
@@ -89,6 +89,6 @@ jobs:
         with:
           name: jacoco-reports
           path: target/jacoco-combined.exec
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
           name: codecov-index-${{ matrix.name }}

--- a/.github/workflows/ci-index-solr.yml
+++ b/.github/workflows/ci-index-solr.yml
@@ -86,6 +86,6 @@ jobs:
         with:
           name: jacoco-reports
           path: target/jacoco-combined.exec
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
           name: codecov-index-${{ matrix.name }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump codecov/codecov-action from 1 to 3](https://github.com/JanusGraph/janusgraph/pull/3284)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)