### PR TITLE
[v0.6] Bump actions/setup-python from 2 to 4

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: '8.0.312+7'
           java-package: jdk
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
           architecture: x64


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump actions/setup-python from 2 to 4](https://github.com/JanusGraph/janusgraph/pull/3282)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)