### PR TITLE
[v0.6] Bump nimbus-jose-jwt from 9.8.1 to 9.25.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1176,7 +1176,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
-                <version>8.2.1</version>
+                <version>9.25.6</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump nimbus-jose-jwt from 9.8.1 to 9.25.6](https://github.com/JanusGraph/janusgraph/pull/3289)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)