### PR TITLE
Add possibility to remove stale mixed index entries for given vertices or edges

### DIFF
--- a/docs/advanced-topics/stale-index.md
+++ b/docs/advanced-topics/stale-index.md
@@ -18,13 +18,13 @@ As for now there is the utility tool which may be used to fix permanent stale in
 to fix permanent stale index entries. 
 
 `StaleIndexRecordUtil.forceRemoveVertexFromGraphIndex` can be used to force remove an index record for any vertex from 
-a graph index. Right now the limitations of this method is that it can be used with Composite indices only.  
+a graph index.   
 An example of using this method is below:
 ```java
 // Let's say we want to remove non-existent vertex from a stale index. 
 // We will assume the next constraints: 
 // Vertex id is: `12345`
-// Composite index name is: `nameAgeIndex`
+// Index name is: `nameAgeIndex`
 // There are two indexed properties: `name` and `age`
 // Value of the name property is: `HelloWorld`
 // Value of the age property is: `123`
@@ -41,7 +41,7 @@ StaleIndexRecordUtil.forceRemoveVertexFromGraphIndex(
     12345L, // vertex id of the index record to be removed
     indexRecordPropertyValues, // index record property values
     graph,
-    "nameAgeIndex" // composite index name for which to remove the index record
+    "nameAgeIndex" // graph index name for which to remove the index record
 );
 ```
-For more in-depth information about usage of this tool see JavaDoc for `StaleIndexRecordUtil`.
+For more in-depth information about usage of this tool as well as explanations of additional methods of this tool see JavaDoc for `StaleIndexRecordUtil`.


### PR DESCRIPTION
Continuation of #3022

Related to #1099

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
