### PR TITLE
CQLStoreFeature updated - AWSKeyspace supports cell level TTL

### DIFF
--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/builder/CQLStoreFeaturesBuilder.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/builder/CQLStoreFeaturesBuilder.java
@@ -80,7 +80,6 @@ public class CQLStoreFeaturesBuilder {
         }
         switch (partitioner) {
             case "DefaultPartitioner": // Amazon managed KeySpace uses com.amazonaws.cassandra.DefaultPartitioner
-
                 fb.timestamps(false);
             case "RandomPartitioner":
             case "Murmur3Partitioner": {

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/builder/CQLStoreFeaturesBuilder.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/builder/CQLStoreFeaturesBuilder.java
@@ -80,7 +80,7 @@ public class CQLStoreFeaturesBuilder {
         }
         switch (partitioner) {
             case "DefaultPartitioner": // Amazon managed KeySpace uses com.amazonaws.cassandra.DefaultPartitioner
-                fb.timestamps(false).cellTTL(false);
+                fb.timestamps(false);
             case "RandomPartitioner":
             case "Murmur3Partitioner": {
                 fb.keyOrdered(false).orderedScan(false).unorderedScan(true);

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/builder/CQLStoreFeaturesBuilder.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/builder/CQLStoreFeaturesBuilder.java
@@ -80,6 +80,7 @@ public class CQLStoreFeaturesBuilder {
         }
         switch (partitioner) {
             case "DefaultPartitioner": // Amazon managed KeySpace uses com.amazonaws.cassandra.DefaultPartitioner
+
                 fb.timestamps(false);
             case "RandomPartitioner":
             case "Murmur3Partitioner": {


### PR DESCRIPTION
AWSKeyspace now supports TTL. So updating the feature builder accordingly

Fixes: https://github.com/JanusGraph/janusgraph/issues/3325
