### PR TITLE
Use graph name for ES indices if index name is not configured

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -117,6 +117,16 @@ an older version will not be able to read a Geoshape created by a client that is
 versa.
 Users who do not use GraphBinary yet or who are not using Geoshapes are not affected by this change.
 
+##### ConfiguredGraphFactory now creates separate indices per graph in Elasticsearch
+
+If the ConfiguredGraphFactory is used together with Elasticsearch as the index backend, then the same Elasticsearch
+index is used for all graphs (if the same index names were used across different graphs).
+Now it is possible to let JanusGraph create the index names dynamically by using the `graph.graphname` if no `index.name`
+is provided in the template configuration. This is exactly like it was already the case for the CQL keyspace name for
+example.
+
+Users who don't want to use this feature can simply continue providing the `index.name` in the template configuration.
+
 ##### Removal of deprecated classes/methods/functionalities
 
 ###### Methods

--- a/docs/operations/configured-graph-factory.md
+++ b/docs/operations/configured-graph-factory.md
@@ -367,11 +367,11 @@ the property `graph.graphname`, then these graphs will be stored in the
 JanusGraphManager and thus bound in your gremlin script executions as
 `graph1` and `graph2`, respectively.
 
-### Important
+### Automatic Separation of Graphs in Backends
 
 For convenience, if your configuration used to open a graph specifies
 `graph.graphname`, but does not specify the backend’s storage directory,
-tablename, or keyspacename, then the relevant parameter will
+table name, keyspace name, or index name, then the relevant parameter will
 automatically be set to the value of `graph.graphname`. However, if you
 supply one of those parameters, that value will always take precedence.
 And if you supply neither, they default to the configuration option’s

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/converter/ReadConfigurationConverter.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/configuration/converter/ReadConfigurationConverter.java
@@ -15,8 +15,12 @@
 package org.janusgraph.diskstorage.configuration.converter;
 
 import org.apache.commons.configuration2.BaseConfiguration;
+import org.apache.commons.configuration2.MapConfiguration;
 import org.janusgraph.diskstorage.configuration.ReadConfiguration;
 import org.janusgraph.util.system.ConfigurationUtil;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Converter from {@link ReadConfiguration} into {@link BaseConfiguration}
@@ -34,7 +38,7 @@ public class ReadConfigurationConverter {
         return configurationConverter;
     }
 
-    public BaseConfiguration convert(ReadConfiguration readConfiguration) {
+    public BaseConfiguration convertToBaseConfiguration(ReadConfiguration readConfiguration) {
         BaseConfiguration result = ConfigurationUtil.createBaseConfiguration();
         for (String k : readConfiguration.getKeys("")) {
             result.setProperty(k, readConfiguration.get(k, Object.class));
@@ -42,4 +46,11 @@ public class ReadConfigurationConverter {
         return result;
     }
 
+    public MapConfiguration convertToMapConfiguration(ReadConfiguration readConfiguration) {
+        Map<String, Object> map = new HashMap<>();
+        for (String k : readConfiguration.getKeys("")) {
+            map.put(k, readConfiguration.get(k, Object.class));
+        }
+        return new MapConfiguration(map);
+    }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -1450,7 +1450,7 @@ public class GraphDatabaseConfiguration {
     }
 
     public org.apache.commons.configuration2.Configuration getConfigurationAtOpen() {
-        return ReadConfigurationConverter.getInstance().convert(configurationAtOpen);
+        return ReadConfigurationConverter.getInstance().convertToBaseConfiguration(configurationAtOpen);
     }
 
     private void preLoadConfiguration() {

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
@@ -303,8 +303,9 @@ public class CQLStoreManager extends DistributedStoreManager implements KeyColum
     }
 
     public static String determineKeyspaceName(Configuration config) {
-        if ((!config.has(KEYSPACE) && (config.has(GRAPH_NAME)))) return config.get(GRAPH_NAME);
-        return config.get(KEYSPACE);
+        return !config.has(KEYSPACE) && config.has(GRAPH_NAME)
+            ? config.get(GRAPH_NAME)
+            : config.get(KEYSPACE);
     }
 
     @Override

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
@@ -95,6 +95,7 @@ import static org.janusgraph.diskstorage.es.ElasticSearchConstants.ES_GEO_COORDS
 import static org.janusgraph.diskstorage.es.ElasticSearchConstants.ES_LANG_KEY;
 import static org.janusgraph.diskstorage.es.ElasticSearchConstants.ES_SCRIPT_KEY;
 import static org.janusgraph.diskstorage.es.ElasticSearchConstants.ES_TYPE_KEY;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.GRAPH_NAME;
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.INDEX_MAX_RESULT_SET_SIZE;
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.INDEX_NAME;
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.INDEX_NS;
@@ -365,7 +366,7 @@ public class ElasticSearchIndex implements IndexProvider {
 
     public ElasticSearchIndex(Configuration config) throws BackendException {
 
-        indexName = config.get(INDEX_NAME);
+        indexName = determineIndexName(config);
         parameterizedAdditionScriptId = generateScriptId("add");
         parameterizedDeletionScriptId = generateScriptId("del");
         useAllField = config.get(USE_ALL_FIELD);
@@ -389,6 +390,12 @@ public class ElasticSearchIndex implements IndexProvider {
         setupMaxOpenScrollContextsIfNeeded(config);
 
         setupStoredScripts();
+    }
+
+    public static String determineIndexName(Configuration config) {
+        return !config.has(INDEX_NAME) && config.has(GRAPH_NAME)
+            ? config.get(GRAPH_NAME)
+            : config.get(INDEX_NAME);
     }
 
     private void checkClusterHealth(String healthCheck) throws BackendException {

--- a/janusgraph-es/src/test/java/org/janusgraph/core/es/ElasticsearchConfiguredGraphFactoryTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/core/es/ElasticsearchConfiguredGraphFactoryTest.java
@@ -1,0 +1,106 @@
+// Copyright 2022 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.es;
+
+import org.apache.commons.configuration2.MapConfiguration;
+import org.apache.http.HttpHost;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.janusgraph.core.AbstractConfiguredGraphFactoryTest;
+import org.janusgraph.core.ConfiguredGraphFactory;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
+import org.janusgraph.diskstorage.configuration.WriteConfiguration;
+import org.janusgraph.diskstorage.configuration.converter.ReadConfigurationConverter;
+import org.janusgraph.diskstorage.es.JanusGraphElasticsearchContainer;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.janusgraph.graphdb.database.StandardJanusGraph;
+import org.janusgraph.util.system.ConfigurationUtil;
+import org.janusgraph.util.system.IOUtils;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Map;
+
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.GRAPH_NAME;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.STORAGE_BACKEND;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@Testcontainers
+public class ElasticsearchConfiguredGraphFactoryTest extends AbstractConfiguredGraphFactoryTest {
+
+    private String indexBackendName = "search";
+    @Container
+    public static final JanusGraphElasticsearchContainer esContainer = new JanusGraphElasticsearchContainer();
+
+    protected MapConfiguration getManagementConfig() {
+        final ModifiableConfiguration config = GraphDatabaseConfiguration.buildGraphConfiguration();
+        config.set(STORAGE_BACKEND, "inmemory");
+        WriteConfiguration writeConf = esContainer.setConfiguration(config, indexBackendName).getConfiguration();
+        return ReadConfigurationConverter.getInstance().convertToMapConfiguration(writeConf);
+    }
+
+    protected MapConfiguration getTemplateConfig() {
+        return getManagementConfig();
+    }
+
+    protected MapConfiguration getGraphConfig() {
+        final Map<String, Object> map = getTemplateConfig().getMap();
+        map.put(GRAPH_NAME.toStringWithoutRoot(), "graph1");
+        return ConfigurationUtil.loadMapConfiguration(map);
+    }
+
+    private boolean indexExists(String name) throws IOException {
+        CloseableHttpClient httpClient = HttpClients.createDefault();
+        HttpHost host = new HttpHost(InetAddress.getByName(esContainer.getHostname()), esContainer.getPort());
+        final CloseableHttpResponse response = httpClient.execute(host, new HttpHead(name));
+        final boolean exists = response.getStatusLine().getStatusCode() == 200;
+        IOUtils.closeQuietly(response);
+        return exists;
+    }
+
+    @Test
+    public void indexNameShouldContainGraphName() throws Exception {
+        final MapConfiguration graphConfig = getGraphConfig();
+        final String graphName = graphConfig.getString(GRAPH_NAME.toStringWithoutRoot());
+
+        try {
+            ConfiguredGraphFactory.createConfiguration(graphConfig);
+
+            final StandardJanusGraph graph = (StandardJanusGraph) ConfiguredGraphFactory.open(graphName);
+            assertNotNull(graph);
+
+            String graphIndexName = "verticesByName";
+            JanusGraphManagement mgmt = graph.openManagement();
+            PropertyKey key = mgmt.makePropertyKey("name").dataType(String.class).make();
+            mgmt.buildIndex(graphIndexName, Vertex.class).addKey(key).buildMixedIndex(indexBackendName);
+            mgmt.commit();
+
+            String expectedIndexName = graphName + "_" + graphIndexName.toLowerCase();
+            assertTrue(indexExists(expectedIndexName));
+        } finally {
+            ConfiguredGraphFactory.removeConfiguration(graphName);
+            ConfiguredGraphFactory.close(graphName);
+        }
+    }
+}

--- a/janusgraph-test/src/test/java/org/janusgraph/diskstorage/configuration/converter/ReadConfigurationConverterTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/diskstorage/configuration/converter/ReadConfigurationConverterTest.java
@@ -57,7 +57,7 @@ public class ReadConfigurationConverterTest {
             return configurationProperties.get(key);
         });
 
-        BaseConfiguration baseConfiguration = readConfigurationConverter.convert(readConfiguration);
+        BaseConfiguration baseConfiguration = readConfigurationConverter.convertToBaseConfiguration(readConfiguration);
 
         Iterator<String> keyIterator = baseConfiguration.getKeys();
         int propertiesAmount = 0;


### PR DESCRIPTION
Fix #3338

The elasticsearch backend now uses the graph name by default if no index name is configured. This is relevant for users of `ConfiguredGraphFactory` who use template configurations and want to assign index names automatically upon graph creation.

Co-authored-by: Florian Hockmann <fh@florian-hockmann.de>