### PR TITLE
Fix NO_LIMIT handling for key-value stores

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/keyvalue/KeySelector.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/keyvalue/KeySelector.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.graphdb.query.Query;
 
 /**
  * A {@link KeySelector} utility that can be generated out of a given {@link KVQuery}
@@ -50,7 +51,7 @@ public class KeySelector {
     }
 
     public boolean reachedLimit() {
-        return count >= limit;
+        return Query.NO_LIMIT != limit && count >= limit;
     }
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/LimitAdjustingIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/LimitAdjustingIterator.java
@@ -67,7 +67,7 @@ public abstract class LimitAdjustingIterator<R> implements CloseableIterator<R> 
     @Override
     public boolean hasNext() {
         if (iterator ==null) iterator = getNewIterator(currentLimit);
-        if (count < currentLimit)
+        if (currentLimit == Query.NO_LIMIT || count < currentLimit)
             return iterator.hasNext();
         if (currentLimit>=maxLimit) return false;
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/ResultSetIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/ResultSetIterator.java
@@ -52,7 +52,7 @@ public class ResultSetIterator<R extends JanusGraphElement> implements Closeable
 
     private R nextInternal() {
         R r = null;
-        if (count < limit && iterator.hasNext()) {
+        if ((limit == Query.NO_LIMIT || count < limit) && iterator.hasNext()) {
             r = iterator.next();
         } else {
             close();

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/MultiKeySliceQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/MultiKeySliceQuery.java
@@ -51,7 +51,7 @@ public class MultiKeySliceQuery extends BaseQuery implements BackendQuery<MultiK
             EntryList next =tx.indexQuery(ksq.updateLimit(getLimit()-total));
             result.add(next);
             total+=next.size();
-            if (total>=getLimit()) break;
+            if (total>=getLimit() && hasLimit()) break;
         }
         return result;
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
@@ -383,12 +383,12 @@ public abstract class BasicVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q
                 VertexListInternal merge = null;
 
                 for (InternalVertex rep : representatives) {
-                    if (merge!=null && merge.size()>=baseQuery.getLimit()) break;
+                    if (merge!=null && merge.size()>=baseQuery.getLimit() && baseQuery.hasLimit()) break;
                     VertexList vertexList = executeIndividualVertexIds(rep,baseQuery);
                     if (merge==null) merge = (VertexListInternal)vertexList;
                     else merge.addAll(vertexList);
                 }
-                if (merge != null && merge.size()>baseQuery.getLimit()) {
+                if (merge != null && merge.size()>baseQuery.getLimit() && baseQuery.hasLimit()) {
                     merge = (VertexListInternal)merge.subList(0,baseQuery.getLimit());
                 }
                 return merge;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/MultiDistinctOrderedIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/MultiDistinctOrderedIterator.java
@@ -18,6 +18,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.util.ElementValueComp
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 import org.apache.tinkerpop.gremlin.util.function.MultiComparator;
+import org.janusgraph.graphdb.query.Query;
 import org.janusgraph.graphdb.tinkerpop.optimize.step.HasStepFolder.OrderEntry;
 
 import java.util.ArrayList;
@@ -58,7 +59,7 @@ public class MultiDistinctOrderedIterator<E extends Element> implements Closeabl
 
     @Override
     public boolean hasNext() {
-        if (limit != null && count >= limit) {
+        if (limit != null && limit != Query.NO_LIMIT && count >= limit) {
             return false;
         }
         for (int i = 0; i < iterators.size(); i++) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/MultiDistinctUnorderedIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/MultiDistinctUnorderedIterator.java
@@ -16,6 +16,7 @@ package org.janusgraph.graphdb.util;
 
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
+import org.janusgraph.graphdb.query.Query;
 
 import java.util.HashSet;
 import java.util.Iterator;
@@ -44,7 +45,7 @@ public class MultiDistinctUnorderedIterator<E extends Element> extends Closeable
 
     @Override
     protected E computeNext() {
-        if (count < limit) {
+        if (limit == Query.NO_LIMIT || count < limit) {
             while (iterator.hasNext()) {
                 E elem = iterator.next();
                 if (allElements.add(elem.id())) {


### PR DESCRIPTION
Without fix could not reindex store with more than Integer.MAX_VALUE entries because `KeySelector.limit` is integer

Signed-off-by: Pavel Ershov <owner.mad.epa@gmail.com>
