### PR TITLE
[v0.6] Bump test dependencies (JUnit & Mockito)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,9 @@
     <properties>
         <titan.compatible-versions>1.0.0,1.1.0-SNAPSHOT</titan.compatible-versions>
         <tinkerpop.version>3.5.4</tinkerpop.version>
-        <junit-platform.version>1.9.0</junit-platform.version>
-        <junit.version>5.9.0</junit.version>
-        <mockito.version>4.8.0</mockito.version>
+        <junit-platform.version>1.9.1</junit-platform.version>
+        <junit.version>5.9.1</junit.version>
+        <mockito.version>4.8.1</mockito.version>
         <jamm.version>0.3.0</jamm.version>
         <metrics.version>4.1.33</metrics.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump test dependencies (JUnit & Mockito)](https://github.com/JanusGraph/janusgraph/pull/3343)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)