### PR TITLE
Apply Dependabot config also for security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,6 @@ version: 2
 updates:
 - package-ecosystem: maven
   directory: "/"
-  target-branch: "master"
   schedule:
     interval: daily
     time: "11:00"
@@ -10,10 +9,11 @@ updates:
   labels:
     - "backport"
     - "backport/v0.6"
+    - "dependencies"
+    - "java"
 
 - package-ecosystem: github-actions
   directory: "/"
-  target-branch: "master"
   schedule:
     interval: daily
     time: "11:00"
@@ -21,3 +21,4 @@ updates:
   labels:
     - "backport"
     - "backport/v0.6"
+    - "dependencies"


### PR DESCRIPTION
Otherwise we won't get backports for security updates which is bad.

Dependabot only uses the config for security updates if no target-branch is configured:

> target-branch
> [...]
> When you use this option, the settings for this package manager will no longer affect any pull requests raised for security updates.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#target-branch

The reason is probably that security updates should always be applied directly to the main branch to ensure that the warnings are only resolved if the updates are applied to the main branch. Since we have already configured `master` as the `target-branch` we can also remove the option as that is also the default. This will hopefully let Dependabot use this config also for security updates.

I've also added the default Dependabot labels back as I think that they make it easier to find Dependabot PRs.

Note that our `open-pull-requests-limit` will be ignored for security updates as they always have their own limit as described here: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
