### PR TITLE
Amazon Keyspace: Add hint on full-scan

### DIFF
--- a/docs/storage-backend/cassandra.md
+++ b/docs/storage-backend/cassandra.md
@@ -250,7 +250,7 @@ as per this [doc](https://docs.datastax.com/en/astra/docs/manage-application-tok
 To learn more about different configuration options of DataStax driver, please refer to the DataStax driver configuration
 [documentation](https://docs.datastax.com/en/developer/java-driver/latest/manual/core/configuration/).
 
-## Deploying on Amazon Keyspaces (Experimental)
+## Deploying on Amazon Keyspaces
 
 > Amazon Keyspaces (for Apache Cassandra) is a scalable, highly available, and managed
 > Apache Cassandra–compatible database service. Amazon Keyspaces is serverless, so you
@@ -343,6 +343,13 @@ storage.cql.ssl.truststore.password=<your-trust-store-password>
 # Thus, the below config must be turned off
 graph.assign-timestamp=false
 
+# We strongly recommend you to turn on this config. It will
+# prohibit all full-scan attempts. This is because Amazon keyspace
+# diverges from Apache Cassandra and might result in incomplete
+# results when a full-scan is executed. See issue #3390 for more
+# details
+query.force-index=true
+
 # Amazon Keyspaces only supports LOCAL QUORUM consistency
 storage.cql.only-use-local-consistency-for-system-operations=true
 storage.cql.read-consistency-level=LOCAL_QUORUM
@@ -352,10 +359,12 @@ log.tx.key-consistent=true
 
 # Amazon Keyspaces does not have metadata available to clients
 # Thus, we need to tell JanusGraph that metadata are disabled,
-# and provide a hint of which partitioner AWS is using.
+# and provide a hint of which partitioner AWS is using. Valid
+# partitioner-names are: Murmur3Partitioner, RandomPartitioner,
+# and DefaultPartitioner
 storage.cql.metadata-schema-enabled=false
 storage.cql.metadata-token-map-enabled=false
-storage.cql.partitioner-name=DefaultPartitioner
+storage.cql.partitioner-name=Murmur3Partitioner
 ```
 
 Now you should be able to open the graph via gremlin console


### PR DESCRIPTION
This commit improves the doc for Amazon Keyspace usage, including:
1. Add hint on the potential problem of doing full-scan
2. Include a list of all available partition names
3. Change default partitioner to the current Amazon default one

Closes #3391

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
