### PR TITLE
[v0.6] Bump error_prone_annotations from 2.14.0 to 2.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -904,7 +904,7 @@
             <dependency>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_annotations</artifactId>
-                <version>2.10.0</version>
+                <version>2.16</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump error_prone_annotations from 2.14.0 to 2.16](https://github.com/JanusGraph/janusgraph/pull/3347)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)