### PR TITLE
[v0.6] Bump avro from 1.11.0 to 1.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -742,7 +742,7 @@
             <dependency>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro</artifactId>
-                <version>1.10.1</version>
+                <version>1.11.1</version>
             </dependency>
             <dependency>
                 <artifactId>jboss-logging</artifactId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump avro from 1.11.0 to 1.11.1](https://github.com/JanusGraph/janusgraph/pull/3387)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)