### PR TITLE
[v0.6] Bump metrics.version from 4.2.12 to 4.2.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <junit.version>5.9.1</junit.version>
         <mockito.version>4.8.1</mockito.version>
         <jamm.version>0.3.0</jamm.version>
-        <metrics.version>4.1.33</metrics.version>
+        <metrics.version>4.2.13</metrics.version>
         <slf4j.version>1.7.36</slf4j.version>
         <logback.version>1.2.11</logback.version>
         <httpcomponents.httpclient.version>4.5.13</httpcomponents.httpclient.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump metrics.version from 4.2.12 to 4.2.13](https://github.com/JanusGraph/janusgraph/pull/3380)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)