### PR TITLE
[v0.6] Bump jackson2.version from 2.14.0 to 2.14.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <!-- align with org.apache.hbase:hbase -->
         <jackson1.version>1.9.13</jackson1.version>
         <!-- align with org.apache.spark:spark-core_2.12 -->
-        <jackson2.version>2.14.0</jackson2.version>
+        <jackson2.version>2.14.1</jackson2.version>
         <lucene-solr.version>8.11.0</lucene-solr.version>
         <!-- When this version updated please also update sha512 -->
         <elasticsearch.version>7.14.0</elasticsearch.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump jackson2.version from 2.14.0 to 2.14.1](https://github.com/JanusGraph/janusgraph/pull/3383)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)