### PR TITLE
Document new backporting strategy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,15 +87,7 @@ $ git config user.email "my-email@example.com"
 
 ## Create a new branch
 
-First, you need to decide which release branch (e.g., `master`, `v0.2`) to
-create the feature branch from. If you intend to add a new feature, then
-`master` is the right branch. Bug fixes however should also be applied to
-other releases, so you should create your feature branch from the release
-branch with the lowest version number that is still active (e.g., `v0.2`).
-When in doubt, ask on [janusgraph-dev](https://lists.lfaidata.foundation/g/janusgraph-dev).
-Changes to all release branches will also be merged into `master`.
-
-Do not develop on the release branch: feature branches are intended to be
+Do not develop on a release branch like `master`: feature branches are intended to be
 light-weight and deleted after being merged to upstream, but you should not
 delete your release branch, so don't use it for development.
 
@@ -107,9 +99,9 @@ $ git pull --ff-only upstream master
 $ git checkout -b my-new-feature
 ```
 
-> NOTE: This listing assumes that you create the feature branch from `master`.
-> Replace `master` by the name of the release branch (e.g., `v0.2`) if you want
-> to create the branch from that release branch instead.
+JanusGraph uses a backporting strategy to ensure that changes can be applied to all release branches that are still
+maintained.
+This means that a feature branch should always be created from `master`.
 
 ## Develop and test your changes
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -83,7 +83,7 @@ include:
 
 - Documentation typo or small documentation addition
 - Addition of a new test case
-- Merging approved fixes into an upstream branch
+- Backporting approved changes into other release branches
 
 Any commit that is made following CTR shall include the fact that it is
 a CTR in the commit comments. Community members who wish to review CTRs
@@ -92,27 +92,53 @@ list so that they will see CTRs as they come through. If another
 committer responds with a -1, the commit should be rolled back and the
 formal RTC process should be followed.
 
+### Enable Automatic Backporting
+
+Before merging the pull request, it should be decided whether the contribution should be backported to other release
+branches.
+This should be the case for most non-breaking changes.
+If the change applies to something that is not present at all on other still supported release branches, like updating
+a dependency that was only introduced on `master` or code that was added / heavily modified on `master`, then
+backporting cannot work or would require too much effort.
+Otherwise, the appropriate labels for backporting (for example `backport/v0.6` for the branch `v0.6`) should be added
+before the pull requests gets merged as that allows the backporting action to automatically handle the backporting.
+
 ### Merging of Pull Requests
 
 A pull request is ready to be merged when it has been approved (see
-[Review-Then-Commit (RTC)](#review-then-commit)). It can either be
-merged manually with `git` commands or through the GitHub UI with the
-*Merge pull request* button. If the pull request targets a release
-branch that is upstream of other release branches (e.g., `v0.2` is
-upstream of `master`), then it is important to make sure that the change
-also lands in the downstream release branches. This is the
-responsibility of the committer who merges the pull request. Therefore,
-merge the pull request first into its target branch and then merge that
-branch (e.g., `v0.2`) into the next downstream branch (e.g., `v0.3`), and
-so on until you merge the last release branch into `master`. Afterwards
-push all release branches, ideally with an atomic commit:
+[Review-Then-Commit (RTC)](#review-then-commit-rtc)).
+It can either be merged manually with `git` commands or through the GitHub UI.
+
+For pull requests that should be backported (see [Enable Automatic Backporting](#enable-automatic-backporting)), the
+backporting action should create a pull request to backport the changes to other release branches after the pull
+request has been merged.
+The committer who merges the pull request should ensure that this automatic backporting succeeds.
+It may fail in case of merge conflicts.
+In that case the backporting needs to be [performed manually](#manual-backporting).
+
+### Manual Backporting
+
+The [Backport CLI tool](https://github.com/sqren/backport) can be used to manually backport a pull request.
+This can be necessary if the automatic backporting of a pull request fails.
+After installing the CLI tool, you also need to configure it with a GitHub access token.
+This is explained in the README.md of the Backport CLI tool.
+
+You can then use the tool to backport a pull request #xyz:
 
 ```bash
-git push --atomic origin master v0.3 v0.2
+ backport --pr xyz
 ```
 
-This approach keeps merge conflicts to a minimum when a release branch
-is merged into a downstream release branch.
+This will checkout the repository, apply the change from the pull request to the appropriate release branch
+(like `v0.6`), and then ask you to resolve any merge conflicts.
+After the merge conflicts are resolved, it will create a pull request that backports the changes.
+Note that such a backporting pull request can usually be merged via [CTR](#commit-then-review-ctr) after all
+automatic checks have been executed.
+If non-trivial changes were necessary to resolve merge conflicts, then waiting for a review before merging the
+pull request may still make sense.
+
+It is of course also possible to use cherry-picking to apply the commits manually to a different release branch instead
+of using this CLI tool.
 
 ## Release Policy
 


### PR DESCRIPTION
Fixes #3404

Unfortunately, adding the backport labels is a manual process right now that we have to do as committers because:

* Labels cannot be added already by a pull request template: https://github.com/community/community/discussions/12815
* Contributors cannot add them themselves as they lack the required permissions to add labels.

We can however look into adding some action that automatically adds labels to all PRs: https://github.com/actions/labeler Then we would only have to remove the label again on PRs that should not be backported (as that should be fewer than the PRs that we want to backport).

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
