### PR TITLE
[v0.6] Bump netty4.version from 4.1.85.Final to 4.1.86.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <zookeeper.version>3.8.0</zookeeper.version>
-        <netty4.version>4.1.85.Final</netty4.version>
+        <netty4.version>4.1.86.Final</netty4.version>
         <jna.version>5.7.0</jna.version>
         <gmavenplus.version>1.12.1</gmavenplus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump netty4.version from 4.1.85.Final to 4.1.86.Final](https://github.com/JanusGraph/janusgraph/pull/3411)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)