### PR TITLE
[v0.6] Bump httpcomponents.httpcore.version from 4.4.15 to 4.4.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <slf4j.version>1.7.36</slf4j.version>
         <logback.version>1.2.11</logback.version>
         <httpcomponents.httpclient.version>4.5.13</httpcomponents.httpclient.version>
-        <httpcomponents.httpcore.version>4.4.14</httpcomponents.httpcore.version>
+        <httpcomponents.httpcore.version>4.4.16</httpcomponents.httpcore.version>
         <hadoop2.version>2.8.5</hadoop2.version>
         <hbase1.version>1.6.0</hbase1.version>
         <hbase2.version>2.2.7</hbase2.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump httpcomponents.httpcore.version from 4.4.15 to 4.4.16](https://github.com/JanusGraph/janusgraph/pull/3410)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)