### PR TITLE
[v0.6] Bump exec-maven-plugin from 3.0.0 to 3.1.0 | Require Maven 3.2.5

### DIFF
--- a/janusgraph-examples/pom.xml
+++ b/janusgraph-examples/pom.xml
@@ -34,7 +34,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -495,7 +495,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>0.6.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <prerequisites>
-        <maven>3.0.0</maven>
+        <maven>3.2.5</maven>
     </prerequisites>
     <name>JanusGraph: Distributed Graph Database</name>
     <url>https://janusgraph.org</url>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump exec-maven-plugin from 3.0.0 to 3.1.0](https://github.com/JanusGraph/janusgraph/pull/3311)
 - [Require Maven 3.2.5](https://github.com/JanusGraph/janusgraph/pull/3311)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)