### PR TITLE
[v0.6] Bump maven-jar-plugin from 3.2.2 to 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -443,7 +443,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.0</version>
                     <configuration>
                         <archive>
                             <manifestEntries>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump maven-jar-plugin from 3.2.2 to 3.3.0](https://github.com/JanusGraph/janusgraph/pull/3382)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)