### PR TITLE
[v0.6] Bump mockito.version from 4.8.1 to 4.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <tinkerpop.version>3.5.4</tinkerpop.version>
         <junit-platform.version>1.9.1</junit-platform.version>
         <junit.version>5.9.1</junit.version>
-        <mockito.version>4.8.1</mockito.version>
+        <mockito.version>4.10.0</mockito.version>
         <jamm.version>0.3.0</jamm.version>
         <metrics.version>4.1.33</metrics.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump mockito.version from 4.8.1 to 4.10.0](https://github.com/JanusGraph/janusgraph/pull/3424)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)