### PR TITLE
[v0.6] Bump snakeyaml from 1.32 to 1.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -712,7 +712,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>1.32</version>
+                <version>1.33</version>
             </dependency>
             <dependency>
                 <groupId>net.oneandone.reflections8</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump snakeyaml from 1.32 to 1.33](https://github.com/JanusGraph/janusgraph/pull/3453)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)