### PR TITLE
Let required checks pass for doc PRs

### DIFF
--- a/.github/workflows/ci-backend-cql-dummy.yml
+++ b/.github/workflows/ci-backend-cql-dummy.yml
@@ -1,0 +1,198 @@
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI Backend CQL
+
+on:
+  pull_request:
+    paths:
+    - 'docs/**'
+    - '.github/workflows/ci-docs.yml'
+    - '.github/ISSUE_TEMPLATE/**'
+    - 'requirements.txt'
+    - 'docs.Dockerfile'
+    - '*.md'
+
+jobs:
+  tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - module: cql
+            args: "-Pcassandra3-byteordered -Dtest=\"**/diskstorage/cql/*\""
+            name: byteordered-diskstorage
+            java: 8
+          - module: cql
+            args: "-Pcassandra3-murmur -Dtest=\"**/diskstorage/cql/*\""
+            name: murmur-diskstorage
+            java: 8
+          - module: cql
+            args: "-Pcassandra3-byteordered -Dtest=\"**/graphdb/cql/*\""
+            name: byteordered-graphdb
+            java: 8
+          - module: cql
+            args: "-Pcassandra3-murmur -Dtest=\"**/graphdb/cql/*\""
+            name: murmur-graphdb
+            java: 8
+          - module: cql
+            args: "-Pcassandra3-murmur -Dtest=\"**/hadoop/*\""
+            name: murmur-hadoop
+            java: 8
+          - module: cql
+            args: "-Pcassandra3-byteordered -Dtest=\"**/core/cql/*\""
+            name: byteordered-core
+            java: 8
+          - module: cql
+            args: "-Pcassandra3-murmur -Dtest=\"**/core/cql/*\""
+            name: murmur-core
+            java: 8
+          - module: cql
+            args: "-Pcassandra3-murmur-ssl -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
+            name: murmur-ssl
+            java: 8
+          - module: cql
+            args: "-Pcassandra3-murmur-client-auth -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
+            name: murmur-client-auth
+            java: 8
+          - module: cql
+            args: "-Pscylladb -Dtest=\"**/diskstorage/cql/*\""
+            name: scylladb-diskstorage
+            java: 8
+          - module: cql
+            args: "-Pscylladb -Dtest=\"**/graphdb/cql/*\""
+            name: scylladb-graphdb
+            java: 8
+          # FIXME: this takes forever to run
+          # - module: cql
+          #   args: "-Pscylladb -Dtest=\"**/hadoop/*\""
+          #   name: scylladb-hadoop
+          #   java: 8
+          - module: cql
+            args: "-Pscylladb -Dtest=\"**/core/cql/*\""
+            name: scylladb-core
+            java: 8
+          - module: cql
+            args: "-Pcassandra3-byteordered -Dtest=\"**/diskstorage/cql/*\""
+            name: byteordered-diskstorage
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pcassandra3-murmur -Dtest=\"**/diskstorage/cql/*\""
+            name: murmur-diskstorage
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pcassandra3-byteordered -Dtest=\"**/graphdb/cql/*\""
+            name: byteordered-graphdb
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pcassandra3-murmur -Dtest=\"**/graphdb/cql/*\""
+            name: murmur-graphdb
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pcassandra3-murmur -Dtest=\"**/hadoop/*\""
+            name: murmur-hadoop
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pcassandra3-byteordered -Dtest=\"**/core/cql/*\""
+            name: byteordered-core
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pcassandra3-murmur -Dtest=\"**/core/cql/*\""
+            name: murmur-core
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pcassandra3-murmur-ssl -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
+            name: murmur-ssl
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pcassandra3-murmur-client-auth -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
+            name: murmur-client-auth
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pscylladb -Dtest=\"**/diskstorage/cql/*\""
+            name: scylladb-diskstorage
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pscylladb -Dtest=\"**/graphdb/cql/*\""
+            name: scylladb-graphdb
+            install-args: "-Pjava-11"
+            java: 11
+          # FIXME: this takes forever to run
+          # - module: cql
+          #   args: "-Pscylladb -Dtest=\"**/hadoop/*\""
+          #   name: scylladb-hadoop
+          #   install-args: "-Pjava-11"
+          #   java: 11
+          - module: cql
+            args: "-Pscylladb -Dtest=\"**/core/cql/*\""
+            name: scylladb-core
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pcassandra4-byteordered -Dtest=\"**/diskstorage/cql/*\""
+            name: byteordered-diskstorage
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pcassandra4-murmur -Dtest=\"**/diskstorage/cql/*\""
+            name: murmur-diskstorage
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pcassandra4-byteordered -Dtest=\"**/graphdb/cql/*\""
+            name: byteordered-graphdb
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pcassandra4-murmur -Dtest=\"**/graphdb/cql/*\""
+            name: murmur-graphdb
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pcassandra4-murmur -Dtest=\"**/hadoop/*\""
+            name: murmur-hadoop
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pcassandra4-byteordered -Dtest=\"**/core/cql/*\""
+            name: byteordered-core
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pcassandra4-murmur -Dtest=\"**/core/cql/*\""
+            name: murmur-core
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pcassandra4-murmur-ssl -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
+            name: murmur-ssl
+            install-args: "-Pjava-11"
+            java: 11
+          - module: cql
+            args: "-Pcassandra4-murmur-client-auth -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
+            name: murmur-client-auth
+            install-args: "-Pjava-11"
+            java: 11
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/ci-backend-hbase-dummy.yml
+++ b/.github/workflows/ci-backend-hbase-dummy.yml
@@ -1,0 +1,61 @@
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI Backend Hbase
+
+on:
+  pull_request:
+    paths:
+    - 'docs/**'
+    - '.github/workflows/ci-docs.yml'
+    - '.github/ISSUE_TEMPLATE/**'
+    - 'requirements.txt'
+    - 'docs.Dockerfile'
+    - '*.md'
+
+jobs:
+  tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - module: hbase
+            args: "-Dtest=\"**/diskstorage/hbase/*\""
+            name: hbase2-diskstorage
+            java: 8
+          - module: hbase
+            args: "-Dtest=\"**/graphdb/hbase/*\""
+            name: hbase2-graphdb
+            java: 8
+          - module: hbase
+            args: "-Dtest=\"**/hadoop/*\""
+            name: hbase2-hadoop
+            java: 8
+          - module: hbase
+            install-args: "-Pjava-11"
+            args: "-Dtest=\"**/diskstorage/hbase/*\""
+            name: hbase2-diskstorage
+            java: 11
+          - module: hbase
+            install-args: "-Pjava-11"
+            args: "-Dtest=\"**/graphdb/hbase/*\""
+            name: hbase2-graphdb
+            java: 11
+          - module: hbase
+            install-args: "-Pjava-11"
+            args: "-Dtest=\"**/hadoop/*\""
+            name: hbase2-hadoop
+            java: 11
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/ci-core-dummy.yml
+++ b/.github/workflows/ci-core-dummy.yml
@@ -1,0 +1,76 @@
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI Core
+
+on:
+  pull_request:
+    paths:
+    - 'docs/**'
+    - '.github/workflows/ci-docs.yml'
+    - '.github/ISSUE_TEMPLATE/**'
+    - 'requirements.txt'
+    - 'docs.Dockerfile'
+    - '*.md'
+
+jobs:
+  build-all:
+    runs-on: ubuntu-20.04
+    steps:
+      - run: 'echo "No build required"'
+
+  build-java11:
+    runs-on: ubuntu-20.04
+    steps:
+      - run: 'echo "No build required"'
+
+  tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - module: driver
+            java: 8
+          - module: server
+            java: 8
+          - module: test
+            java: 8
+          - module: inmemory
+            args: "-Dtest.skip.tp=false"
+            java: 8
+          - module: berkeleyje
+            java: 8
+          - module: lucene
+            java: 8
+          - module: driver
+            install-args: "-Pjava-11"
+            java: 11
+          - module: server
+            install-args: "-Pjava-11"
+            java: 11
+          - module: test
+            install-args: "-Pjava-11"
+            java: 11
+          - module: inmemory
+            install-args: "-Pjava-11"
+            args: "-Dtest.skip.tp=false"
+            java: 11
+          - module: berkeleyje
+            install-args: "-Pjava-11"
+            java: 11
+          - module: lucene
+            install-args: "-Pjava-11"
+            java: 11
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/ci-index-es-dummy.yml
+++ b/.github/workflows/ci-index-es-dummy.yml
@@ -1,0 +1,61 @@
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI Index ES
+
+on:
+  pull_request:
+    paths:
+    - 'docs/**'
+    - '.github/workflows/ci-docs.yml'
+    - '.github/ISSUE_TEMPLATE/**'
+    - 'requirements.txt'
+    - 'docs.Dockerfile'
+    - '*.md'
+
+jobs:
+  tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - module: es
+            args: "-Pelasticsearch7"
+            name: es7
+            java: 8
+          - module: es
+            args: "-Pelasticsearch6"
+            name: es6
+            java: 8
+          - module: es
+            args: "-Pelasticsearch60"
+            name: es60
+            java: 8
+          - module: es
+            install-args: "-Pjava-11"
+            args: "-Pelasticsearch7"
+            name: es7
+            java: 11
+          - module: es
+            install-args: "-Pjava-11"
+            args: "-Pelasticsearch6"
+            name: es6
+            java: 11
+          - module: es
+            install-args: "-Pjava-11"
+            args: "-Pelasticsearch60"
+            name: es60
+            java: 11
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/ci-index-solr-dummy.yml
+++ b/.github/workflows/ci-index-solr-dummy.yml
@@ -1,0 +1,43 @@
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI Index Solr
+
+on:
+  pull_request:
+    paths:
+    - 'docs/**'
+    - '.github/workflows/ci-docs.yml'
+    - '.github/ISSUE_TEMPLATE/**'
+    - 'requirements.txt'
+    - 'docs.Dockerfile'
+    - '*.md'
+
+jobs:
+  tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - module: solr
+            args: "-Psolr8"
+            name: solr8
+            java: 8
+          - module: solr
+            install-args: "-Pjava-11"
+            args: "-Psolr8"
+            name: solr8
+            java: 11
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/ci-release-dummy.yml
+++ b/.github/workflows/ci-release-dummy.yml
@@ -1,0 +1,38 @@
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI Release
+
+on:
+  pull_request:
+    paths:
+    - 'docs/**'
+    - '.github/workflows/ci-docs.yml'
+    - '.github/ISSUE_TEMPLATE/**'
+    - 'requirements.txt'
+    - 'docs.Dockerfile'
+    - '*.md'
+
+jobs:
+  dist-tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - args: ""
+            java: 8
+          - args: "-Pjava-11"
+            java: 11
+    steps:
+      - run: 'echo "No build required"'


### PR DESCRIPTION
For reference: #3460

We want to use required checks for PRs that prevent merging of PRs if these checks didn't pass. This also makes it possible to use auto-merging.
However, we don't want to build and test PRs that for example only change docs, but such PRs still need to pass the required checks. This forces us to create duplicates of workflows with required checks that are executed only for those PRs (where no code is changed). These duplicate workflows will immediately turn green.
The workflows simply need to have the same name.

This approach is recommended in the GitHub docs:
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks

I simply created duplicates for all workflows that are executed on PRs, even though we don't use most of them for required checks. This allows us to add more checks as required if we want to without having to change the workflows again.
