### PR TITLE
[v0.6] Bump maven-enforcer-plugin from 3.0.0 to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M3</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>enforce-dependency-convergence</id>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump maven-enforcer-plugin from 3.0.0 to 3.1.0](https://github.com/JanusGraph/janusgraph/pull/3462)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)