### PR TITLE
[v0.6] Bump jacoco-maven-plugin from 0.8.6 to 0.8.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -512,7 +512,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.6</version>
+                    <version>0.8.8</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump jacoco-maven-plugin from 0.8.7 to 0.8.8](https://github.com/JanusGraph/janusgraph/pull/3482)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)