### PR TITLE
[v0.6] Bump gson from 2.9.1 to 2.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <protobuf.version>3.21.12</protobuf.version>
         <grpc.version>1.51.1</grpc.version>
         <protoc.version>3.15.3</protoc.version>
-        <gson.version>2.9.1</gson.version>
+        <gson.version>2.10.1</gson.version>
         <jmh.version>1.21</jmh.version>
         <graalvm-nativeimage.version>22.3.1</graalvm-nativeimage.version>
     </properties>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump gson from 2.9.1 to 2.10.1](https://github.com/JanusGraph/janusgraph/pull/3474)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)