### PR TITLE
[v0.6] Bump junit.version from 5.9.1 to 5.9.2 | Also bump junit-platform to 1.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <titan.compatible-versions>1.0.0,1.1.0-SNAPSHOT</titan.compatible-versions>
         <tinkerpop.version>3.5.4</tinkerpop.version>
         <junit-platform.version>1.9.1</junit-platform.version>
-        <junit.version>5.9.1</junit.version>
+        <junit.version>5.9.2</junit.version>
         <mockito.version>4.10.0</mockito.version>
         <jamm.version>0.3.0</jamm.version>
         <metrics.version>4.1.33</metrics.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <titan.compatible-versions>1.0.0,1.1.0-SNAPSHOT</titan.compatible-versions>
         <tinkerpop.version>3.5.4</tinkerpop.version>
-        <junit-platform.version>1.9.1</junit-platform.version>
+        <junit-platform.version>1.9.2</junit-platform.version>
         <junit.version>5.9.2</junit.version>
         <mockito.version>4.10.0</mockito.version>
         <jamm.version>0.3.0</jamm.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump junit.version from 5.9.1 to 5.9.2](https://github.com/JanusGraph/janusgraph/pull/3461)
 - [Also bump junit-platform to 1.9.2](https://github.com/JanusGraph/janusgraph/pull/3461)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)