### PR TITLE
Fix Curl version not found

### DIFF
--- a/janusgraph-hbase/docker/Dockerfile
+++ b/janusgraph-hbase/docker/Dockerfile
@@ -18,7 +18,7 @@ ARG HBASE_VERSION=2.5.0
 ARG HBASE_DIST="http://archive.apache.org/dist/hbase"
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u3
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl
 
 RUN curl -SL ${HBASE_DIST}/${HBASE_VERSION}/hbase-${HBASE_VERSION}-bin.tar.gz | tar -x -z && mv hbase-${HBASE_VERSION} /opt/hbase
 WORKDIR /opt/hbase


### PR DESCRIPTION
HBase tests are currently failing because the test container could not be started as the specified Curl version isn't available any more in the base image.

I don't see much value in pinning the Curl version as it can easily lead to such problems and I guess Curl is stable enough between versions so that our usage won't break.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
