### PR TITLE
[v0.6] Bump snappy-java from 1.1.7.6 to 1.1.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1161,7 +1161,7 @@
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.7.6</version>
+                <version>1.1.9.1</version>
             </dependency>
             <dependency>
                 <groupId>javax.activation</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump snappy-java from 1.1.8.4 to 1.1.9.1](https://github.com/JanusGraph/janusgraph/pull/3535)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)