### PR TITLE
[v0.6] Bump maven-dependency-plugin from 3.3.0 to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -481,7 +481,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump maven-dependency-plugin from 3.3.0 to 3.5.0](https://github.com/JanusGraph/janusgraph/pull/3546)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)