### PR TITLE
Fix Index Providers limited count

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/QueryUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/QueryUtil.java
@@ -403,6 +403,9 @@ public class QueryUtil {
         return results;
     }
 
+    public static long applyQueryLimitAfterCount(long count, Query query){
+        return Math.max(0L, (query.hasLimit()) ? Math.min(count, query.getLimit()) : count);
+    }
 
     public interface IndexCall<R> {
 

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
@@ -57,6 +57,7 @@ import org.janusgraph.diskstorage.util.DefaultTransaction;
 import org.janusgraph.graphdb.configuration.PreInitializeConfigOptions;
 import org.janusgraph.graphdb.database.serialize.AttributeUtils;
 import org.janusgraph.graphdb.query.JanusGraphPredicate;
+import org.janusgraph.graphdb.query.QueryUtil;
 import org.janusgraph.graphdb.query.condition.And;
 import org.janusgraph.graphdb.query.condition.Condition;
 import org.janusgraph.graphdb.query.condition.Not;
@@ -1327,7 +1328,7 @@ public class ElasticSearchIndex implements IndexProvider {
             final String indexName = getIndexStoreName(query.getStore());
             final Map<String,Object> requestData = compat.createRequestBody(sr, null);
             switch (aggregation.getType()) {
-                case COUNT: return client.countTotal(indexName, requestData);
+                case COUNT: return QueryUtil.applyQueryLimitAfterCount(client.countTotal(indexName, requestData), query);
                 case MIN: return client.min(indexName, requestData, aggregation.getFieldName(), aggregation.getDataType());
                 case MAX: return client.max(indexName, requestData, aggregation.getFieldName(), aggregation.getDataType());
                 case AVG: return client.avg(indexName, requestData, aggregation.getFieldName());

--- a/janusgraph-lucene/src/main/java/org/janusgraph/diskstorage/lucene/LuceneIndex.java
+++ b/janusgraph-lucene/src/main/java/org/janusgraph/diskstorage/lucene/LuceneIndex.java
@@ -96,6 +96,7 @@ import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
 import org.janusgraph.graphdb.database.serialize.AttributeUtils;
 import org.janusgraph.graphdb.internal.Order;
 import org.janusgraph.graphdb.query.JanusGraphPredicate;
+import org.janusgraph.graphdb.query.QueryUtil;
 import org.janusgraph.graphdb.query.condition.And;
 import org.janusgraph.graphdb.query.condition.Condition;
 import org.janusgraph.graphdb.query.condition.Not;
@@ -946,7 +947,7 @@ public class LuceneIndex implements IndexProvider {
             Query q = searchParams.getQuery();
 
             switch (aggregation.getType()) {
-                case COUNT: return executeCount(searcher, q);
+                case COUNT: return QueryUtil.applyQueryLimitAfterCount(executeCount(searcher, q), query);
                 case MIN: return executeMin(searcher, q, aggregation.getFieldName(), aggregation.getDataType());
                 case MAX: return executeMax(searcher, q, aggregation.getFieldName(), aggregation.getDataType());
                 case AVG: return executeAvg(searcher, q, aggregation.getFieldName());

--- a/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
+++ b/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
@@ -83,6 +83,7 @@ import org.janusgraph.graphdb.configuration.PreInitializeConfigOptions;
 import org.janusgraph.graphdb.database.serialize.AttributeUtils;
 import org.janusgraph.graphdb.internal.Order;
 import org.janusgraph.graphdb.query.JanusGraphPredicate;
+import org.janusgraph.graphdb.query.QueryUtil;
 import org.janusgraph.graphdb.query.condition.And;
 import org.janusgraph.graphdb.query.condition.Condition;
 import org.janusgraph.graphdb.query.condition.Not;
@@ -741,7 +742,7 @@ public class SolrIndex implements IndexProvider {
     private long executeCount(IndexQuery query, String collection, SolrQuery solrQuery) throws IOException, SolrServerException {
         final QueryResponse response = solrClient.query(collection, solrQuery);
         logger.debug("Executed query [{}] in {} ms", query, response.getElapsedTime());
-        return response.getResults().getNumFound();
+        return QueryUtil.applyQueryLimitAfterCount(response.getResults().getNumFound(), query);
     }
 
     private Number adaptNumberType(Number value, Class<? extends Number> expectedType) {


### PR DESCRIPTION
Applies limit to count in case it exists in the query. Due to count taking place in aggregation logic it's easier to fix it for each index provider.

Fixes #3199

Replacement for #3452

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
