### PR TITLE
[v0.6] Bump jna from 5.7.0 to 5.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <commons.collections.version>3.2.2</commons.collections.version>
         <zookeeper.version>3.8.1</zookeeper.version>
         <netty4.version>4.1.87.Final</netty4.version>
-        <jna.version>5.7.0</jna.version>
+        <jna.version>5.13.0</jna.version>
         <gmavenplus.version>1.12.1</gmavenplus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump jna from 5.12.1 to 5.13.0](https://github.com/JanusGraph/janusgraph/pull/3518)

This actually bumps jna from 5.7.0 to 5.13.0 as `v0.6` was a lot behind here. Let's see whether the builds work for this.

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)