### PR TITLE
[v0.6] Fix Index Providers limit on aggregated count

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphIndexTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphIndexTest.java
@@ -3348,4 +3348,51 @@ public abstract class JanusGraphIndexTest extends JanusGraphBaseTest {
         // Check that Gremlin query doesn't return a stale edge and doesn't skip edges after a stale one
         assertEquals(1, tx.traversal().E().has(namePropKeyStr, nameValue).toList().size());
     }
+
+    @Test
+    public void testMixedIndexAggregatedCountReturnsCorrectResult() {
+        clopen();
+        String namePropKeyStr = "name";
+        String indexName = "mixed";
+        PropertyKey nameProp = mgmt.makePropertyKey(namePropKeyStr).dataType(String.class).cardinality(Cardinality.SINGLE).make();
+        mgmt.buildIndex(indexName, Vertex.class).addKey(nameProp, getStringMapping()).buildMixedIndex(INDEX);
+        finishSchema();
+        String nameValue = "NameTestValue";
+        int addedVerticesAmount = 10;
+
+        for(int i=0; i<addedVerticesAmount; i++){
+            tx.traversal().addV().property(namePropKeyStr, nameValue).iterate();
+        }
+
+        tx.commit();
+
+        long countWithoutOptimization = graph.traversal().withoutStrategies(JanusGraphMixedIndexCountStrategy.class)
+            .V().has(namePropKeyStr, nameValue).count().next();
+
+        assertEquals(addedVerticesAmount, countWithoutOptimization);
+
+        long countWithOptimization = graph.traversal().V().has(namePropKeyStr, nameValue).count().next();
+
+        assertEquals(addedVerticesAmount, countWithOptimization);
+
+        for(int i=0; i<addedVerticesAmount; i++){
+            assertEquals(
+                i,
+                graph.traversal().V().has(namePropKeyStr, nameValue).limit(i).count().next()
+            );
+        }
+
+        for(Long limit : Arrays.asList(
+            (long)addedVerticesAmount,
+            (long) (addedVerticesAmount+1),
+            (long) (addedVerticesAmount+2),
+            (long) (addedVerticesAmount*2),
+            Long.MAX_VALUE,
+            -1L)){
+            assertEquals(
+                addedVerticesAmount,
+                graph.traversal().V().has(namePropKeyStr, nameValue).limit(limit).count().next()
+            );
+        }
+    }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/QueryUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/QueryUtil.java
@@ -403,6 +403,9 @@ public class QueryUtil {
         return results;
     }
 
+    public static long applyQueryLimitAfterCount(long count, Query query){
+        return Math.max(0L, (query.hasLimit()) ? Math.min(count, query.getLimit()) : count);
+    }
 
     public interface IndexCall<R> {
 

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
@@ -55,6 +55,7 @@ import org.janusgraph.diskstorage.util.DefaultTransaction;
 import org.janusgraph.graphdb.configuration.PreInitializeConfigOptions;
 import org.janusgraph.graphdb.database.serialize.AttributeUtils;
 import org.janusgraph.graphdb.query.JanusGraphPredicate;
+import org.janusgraph.graphdb.query.QueryUtil;
 import org.janusgraph.graphdb.query.condition.And;
 import org.janusgraph.graphdb.query.condition.Condition;
 import org.janusgraph.graphdb.query.condition.Not;
@@ -1296,9 +1297,10 @@ public class ElasticSearchIndex implements IndexProvider {
         final Map<String,Object> esQuery = getFilter(query.getCondition(), information.get(query.getStore()));
         sr.setQuery(compat.prepareQuery(esQuery));
         try {
-            return client.countTotal(
+            long total = client.countTotal(
                 getIndexStoreName(query.getStore()),
                 compat.createRequestBody(sr, null));
+            return QueryUtil.applyQueryLimitAfterCount(total, query);
         } catch (final IOException | UncheckedIOException e) {
             throw new PermanentBackendException(e);
         }

--- a/janusgraph-lucene/src/main/java/org/janusgraph/diskstorage/lucene/LuceneIndex.java
+++ b/janusgraph-lucene/src/main/java/org/janusgraph/diskstorage/lucene/LuceneIndex.java
@@ -95,6 +95,7 @@ import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
 import org.janusgraph.graphdb.database.serialize.AttributeUtils;
 import org.janusgraph.graphdb.internal.Order;
 import org.janusgraph.graphdb.query.JanusGraphPredicate;
+import org.janusgraph.graphdb.query.QueryUtil;
 import org.janusgraph.graphdb.query.condition.And;
 import org.janusgraph.graphdb.query.condition.Condition;
 import org.janusgraph.graphdb.query.condition.Not;
@@ -947,7 +948,7 @@ public class LuceneIndex implements IndexProvider {
             // We ignore offset and limit for totals
             final TopDocs docs = searcher.search(q, 1);
             log.debug("Executed query [{}] in {} ms", q, System.currentTimeMillis() - time);
-            return docs.totalHits.value;
+            return QueryUtil.applyQueryLimitAfterCount(docs.totalHits.value, query);
         } catch (final IOException e) {
             throw new TemporaryBackendException("Could not execute Lucene query", e);
         }

--- a/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
+++ b/janusgraph-solr/src/main/java/org/janusgraph/diskstorage/solr/SolrIndex.java
@@ -82,6 +82,7 @@ import org.janusgraph.graphdb.configuration.PreInitializeConfigOptions;
 import org.janusgraph.graphdb.database.serialize.AttributeUtils;
 import org.janusgraph.graphdb.internal.Order;
 import org.janusgraph.graphdb.query.JanusGraphPredicate;
+import org.janusgraph.graphdb.query.QueryUtil;
 import org.janusgraph.graphdb.query.condition.And;
 import org.janusgraph.graphdb.query.condition.Condition;
 import org.janusgraph.graphdb.query.condition.Not;
@@ -712,7 +713,7 @@ public class SolrIndex implements IndexProvider {
             solrQuery.addFilterQuery(queryFilter);
             final QueryResponse response = solrClient.query(collection, solrQuery);
             logger.debug("Executed query [{}] in {} ms", query.toString(), response.getElapsedTime());
-            return response.getResults().getNumFound();
+            return QueryUtil.applyQueryLimitAfterCount(response.getResults().getNumFound(), query);
         } catch (final IOException e) {
             logger.error("Query did not complete : ", e);
             throw new PermanentBackendException(e);


### PR DESCRIPTION
Applies limit to count in case it exists in the query. Due to count taking place in aggregation logic it's easier to fix it for each index provider.

Fixes #3199

Replaces #3452

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
