### PR TITLE
[v0.6] Bump maven-surefire-plugin from 3.0.0-M8 to 3.0.0-M9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.0.0-M9</version>
                     <configuration>
                         <argLine>${default.test.jvm.opts}</argLine>
                         <runOrder>alphabetical</runOrder>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump maven-surefire-plugin from 3.0.0-M8 to 3.0.0-M9](https://github.com/JanusGraph/janusgraph/pull/3602)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)