### PR TITLE
installation.md: Remove ARM warning

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -61,10 +61,6 @@ gremlin> :remote connect tinkerpop.server conf/remote.yaml
     To forward every command to the remote server, use the `:remote console` command.
     Further documentation can be found in the [TinkerPop reference docs](https://tinkerpop.apache.org/docs/{{ tinkerpop_version }}/reference/#console-remote-console)
 
-!!! info
-    Due to a known [issue](https://github.com/JanusGraph/janusgraph-docker/issues/123), `gremlin.sh` won't work in ARM
-    containers.
-
 ### Running Gremlin Console on Bare-metal
 
 We can also run the Gremlin Console on our bare-metal machine. To make the server able to communicate with the gremlin


### PR DESCRIPTION
As janusgraph-docker#123 is resolved since 1.0.0-rc2 release, we can remove the ARM machine warning from the installation guide.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
