### PR TITLE
Check connection constraints based on label IDs

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -768,7 +768,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
 
         Collection<Connection> connections = outVertexLabel.mappedConnections();
         for (Connection connection : connections) {
-            if (connection.getIncomingVertexLabel() != inVertexLabel) continue;
+            if (connection.getIncomingVertexLabel().longId() != inVertexLabel.longId()) continue;
             if (connection.getEdgeLabel().equals(edgeLabel.name())) return;
         }
         config.getAutoSchemaMaker().makeConnectionConstraint(edgeLabel, outVertexLabel, inVertexLabel, this);


### PR DESCRIPTION
In #3646, @FlorianHockmann reported a bug that caused JanusGraph to reject valid edges because it was unable to confirm the compliance with the connection constraints. In contrast to our initial assumption, the cache was not root of the issue. In fact, the updated cache behavior only uncovered the actual issue.
When checking the connection constraints, we expect to find a schema edge which points to the corresponding schema vertex of the target vertex. As of now this correspondence is checked with `==`. Therefore the check fails if one of both elements has been evicted from the cache and had to be fetched from the backend while the other one remained in the cache. In this case, both representations are equal but not the same anymore. An easy fix (which I also verified in our production environment) is to reduce the check to only search for matching IDs.

Fixes #3646

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
