### PR TITLE
Increase timeout for index management operations in tests

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphBaseTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphBaseTest.java
@@ -63,7 +63,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -490,7 +489,6 @@ public abstract class JanusGraphBaseTest implements JanusGraphBaseStoreFeaturesT
         assertTrue(ManagementSystem
             .awaitGraphIndexStatus(graph, indexName)
             .status(SchemaStatus.DISCARDED)
-            .timeout(10, ChronoUnit.SECONDS)
             .call()
             .getSucceeded()
         );

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphIndexTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphIndexTest.java
@@ -2250,14 +2250,13 @@ public abstract class JanusGraphIndexTest extends JanusGraphBaseTest {
         mgmt.updateIndex(mgmt.getGraphIndex("theIndex"), SchemaAction.ENABLE_INDEX);
         assertFalse(ManagementSystem.awaitGraphIndexStatus(graph, "theIndex")
             .status(SchemaStatus.ENABLED)
-            .timeout(10L, ChronoUnit.SECONDS)
             .call()
             .getSucceeded());
         //This call is redundant and just here to make sure it doesn't mess anything up
         mgmt.updateIndex(mgmt.getGraphIndex("theIndex"), SchemaAction.REGISTER_INDEX).get();
         mgmt.commit();
 
-        ManagementSystem.awaitGraphIndexStatus(graph, "theIndex").timeout(10L, ChronoUnit.SECONDS).call();
+        ManagementSystem.awaitGraphIndexStatus(graph, "theIndex").call();
 
         finishSchema();
         mgmt.updateIndex(mgmt.getGraphIndex("theIndex"), SchemaAction.ENABLE_INDEX).get();

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -1708,7 +1708,6 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertTrue(ManagementSystem
             .awaitGraphIndexStatus(graph, indexName)
             .status(SchemaStatus.REGISTERED)
-            .timeout(10, ChronoUnit.SECONDS)
             .call()
             .getSucceeded()
         );
@@ -1828,7 +1827,6 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertTrue(ManagementSystem
             .awaitGraphIndexStatus(graph, name)
             .status(SchemaStatus.DISCARDED)
-            .timeout(10, ChronoUnit.SECONDS)
             .call()
             .getSucceeded()
         );
@@ -2010,7 +2008,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         mgmt.updateIndex(eindex2, SchemaAction.ENABLE_INDEX);
         finishSchema();
         assertTrue(ManagementSystem.awaitRelationIndexStatus(graph, "byTime", "friend").status(SchemaStatus.ENABLED)
-                .timeout(10L, ChronoUnit.SECONDS).call().getSucceeded());
+                .call().getSucceeded());
 
         //Reindex the other two
         pindex2 = mgmt.getRelationIndex(mgmt.getRelationType("sensor"), "byTime");


### PR DESCRIPTION
Some tests have been flaky, probably caused by index management operations exceeding the 10 second limit. By default, a timeout of 60 seconds is enforced, which should be enough for our tests to pass.

Aims to fix #3651 

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
