### PR TITLE
Profiler: Display multiKSQ detail

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -159,6 +159,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.opentest4j.AssertionFailedError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -6193,6 +6194,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
 
     @Test
     public void testGraphCentricQueryProfiling() {
+        if (getStoreFeatures().isDistributed() && getStoreFeatures().isKeyOrdered()) return;
         final PropertyKey name = makeKey("name", String.class);
         final PropertyKey weight = makeKey("weight", Integer.class);
         final JanusGraphIndex compositeNameIndex = mgmt.buildIndex("nameIdx", Vertex.class).addKey(name).buildCompositeIndex();
@@ -6223,7 +6225,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
             put("orders", "[]");
             put("isFitted", "true");
             put("isOrdered", "true");
-            put("query", "multiKSQ[1]");
+            put("query", "multiKSQ[1]{KeySliceQuery(0x0689A0626FE2)[0x00,0xFF)}");
             put("index", "nameIdx");
         }};
         assertEquals(nameIdxAnnotations, nested.getAnnotations());
@@ -6263,7 +6265,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
             put("orders", "[]");
             put("isFitted", "true");
             put("isOrdered", "true");
-            put("query", "multiKSQ[1]");
+            put("query", "multiKSQ[1]{KeySliceQuery(0x088901C8)[0x00,0xFF)}");
             put("index", "weightIdx");
         }};
         assertEquals(weightIdxAnnotations, nested.getAnnotations());
@@ -6271,10 +6273,36 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         backendQueryMetrics = (Metrics) nested.getNested().toArray()[0];
         assertTrue(backendQueryMetrics.getDuration(TimeUnit.MICROSECONDS) > 0);
 
+        // satisfied by a single graph-centric query which satisfied by union of two composite index queries
+        newTx();
+        assertEquals(3, tx.traversal().V().or(__.has("name", "bob"), __.has("name", "alex")).count().next());
+        TraversalMetrics metrics = tx.traversal().V().or(__.has("name", "bob"), __.has("name", "alex"))
+            .profile().next();
+        mCompMultiOr = metrics.getMetrics(0);
+        assertEquals("JanusGraphStep([],[name.or(=(bob), =(alex))])", mCompMultiOr.getName());
+        assertTrue(mCompMultiOr.getDuration(TimeUnit.MICROSECONDS) > 0);
+        assertEquals(2, mCompMultiOr.getNested().size());
+        nested = (Metrics) mCompMultiOr.getNested().toArray()[0];
+        assertEquals(QueryProfiler.CONSTRUCT_GRAPH_CENTRIC_QUERY, nested.getName());
+        assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
+        nested = (Metrics) mCompMultiOr.getNested().toArray()[1];
+        assertEquals(QueryProfiler.GRAPH_CENTRIC_QUERY, nested.getName());
+        assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
+        assertEquals("((name = bob OR name = alex))", nested.getAnnotation("condition"));
+        Map<String, String> multiKSQAnnotations = new HashMap() {{
+            put("condition", "((name = bob OR name = alex))");
+            put("orders", "[]");
+            put("isFitted", "true");
+            put("isOrdered", "true");
+            put("query", "multiKSQ[2]{KeySliceQuery(0x0689A0626FE2)[0x00,0xFF),KeySliceQuery(0x0689A0616C65F8)[0x00,0xFF)}");
+            put("index", "nameIdx");
+        }};
+        assertEquals(multiKSQAnnotations, nested.getAnnotations());
+
         // satisfied by a single graph-centric query which satisfied by intersection of two composite index queries
         newTx();
         assertEquals(1, tx.traversal().V().and(__.has("name", "bob"), __.has("weight", 100)).count().next());
-        TraversalMetrics metrics = tx.traversal().V().and(__.has("name", "bob"), __.has("weight", 100))
+        metrics = tx.traversal().V().and(__.has("name", "bob"), __.has("weight", 100))
             .profile().next();
         Metrics mCompMultiAnd = metrics.getMetrics(0);
         assertEquals("JanusGraphStep([],[name.eq(bob), weight.eq(100)])", mCompMultiAnd.getName());
@@ -6288,14 +6316,19 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         assertTrue(nested.getDuration(TimeUnit.MICROSECONDS) > 0);
         assertEquals("(name = bob AND weight = 100)", nested.getAnnotation("condition"));
         assertEquals(2, nested.getNested().size());
-        Metrics deeplyNested = (Metrics) nested.getNested().toArray()[0];
-        assertEquals("AND-query", deeplyNested.getName());
+        Metrics deeplyNested1 = (Metrics) nested.getNested().toArray()[0];
+        assertEquals("AND-query", deeplyNested1.getName());
         // FIXME: assertTrue(deeplyNested.getDuration(TimeUnit.MICROSECONDS) > 0);
-        assertEquals("multiKSQ[1]", deeplyNested.getAnnotation("query"));
-        deeplyNested = (Metrics) nested.getNested().toArray()[1];
-        assertEquals("AND-query", deeplyNested.getName());
+        Metrics deeplyNested2 = (Metrics) nested.getNested().toArray()[1];
+        assertEquals("AND-query", deeplyNested2.getName());
         // FIXME: assertTrue(deeplyNested.getDuration(TimeUnit.MICROSECONDS) > 0);
-        assertEquals("multiKSQ[1]", deeplyNested.getAnnotation("query"));
+        try {
+            assertEquals("multiKSQ[1]{KeySliceQuery(0x088901C8)[0x00,0xFF)}", deeplyNested1.getAnnotation("query"));
+            assertEquals("multiKSQ[1]{KeySliceQuery(0x0689A0626FE2)[0x00,0xFF)}", deeplyNested2.getAnnotation("query"));
+        } catch (AssertionFailedError error) {
+            assertEquals("multiKSQ[1]{KeySliceQuery(0x088901C8)[0x00,0xFF)}", deeplyNested2.getAnnotation("query"));
+            assertEquals("multiKSQ[1]{KeySliceQuery(0x0689A0626FE2)[0x00,0xFF)}", deeplyNested1.getAnnotation("query"));
+        }
 
         // satisfied by one graph-centric query, which satisfied by in-memory filtering after one composite index query
         newTx();
@@ -6317,7 +6350,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
             put("orders", "[]");
             put("isFitted", "false"); // not fitted because prop = 100 requires in-memory filtering
             put("isOrdered", "true");
-            put("query", "multiKSQ[1]");
+            put("query", "multiKSQ[1]{KeySliceQuery(0x0689A0626FE2)[0x00,0xFF)}");
             put("index", "nameIdx");
         }};
         assertEquals(annotations, nested.getAnnotations());
@@ -6366,6 +6399,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
 
     @Test
     public void testGraphCentricQueryProfilingWithLimitAdjusting() throws BackendException {
+        if (getStoreFeatures().isDistributed() && getStoreFeatures().isKeyOrdered()) return;
         Runnable dataLoader = () -> {
             final PropertyKey name = makeKey("name", String.class);
             final JanusGraphIndex compositeNameIndex = mgmt.buildIndex("nameIdx", Vertex.class).addKey(name).buildCompositeIndex();
@@ -6390,14 +6424,14 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
             put("orders", "[]");
             put("isFitted", "true");
             put("isOrdered", "true");
-            put("query", "multiKSQ[1]@100000"); // 100000 is HARD_MAX_LIMIT
+            put("query", "multiKSQ[1]@100000{KeySliceQuery(0x0489A0626FE2)[0x00,0xFF)}"); // 100000 is HARD_MAX_LIMIT
             put("index", "nameIdx");
         }};
         assertEquals(nameIdxAnnotations, nested.getAnnotations());
         List<Metrics> backendQueryMetrics = nested.getNested().stream().map(m -> (Metrics) m).collect(Collectors.toList());
         assertEquals(1, backendQueryMetrics.size());
         Map<String, String> backendAnnotations = new HashMap() {{
-            put("query", "nameIdx:multiKSQ[1]@100000");
+            put("query", "nameIdx:multiKSQ[1]@100000{KeySliceQuery(0x0489A0626FE2)[0x00,0xFF)}");
             put("limit", 100000);
         }};
         assertEquals(backendAnnotations, backendQueryMetrics.get(0).getAnnotations());
@@ -6418,14 +6452,14 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
             put("orders", "[]");
             put("isFitted", "true");
             put("isOrdered", "true");
-            put("query", "multiKSQ[1]");
+            put("query", "multiKSQ[1]{KeySliceQuery(0x0489A0626FE2)[0x00,0xFF)}");
             put("index", "nameIdx");
         }};
         assertEquals(nameIdxAnnotations, nested.getAnnotations());
         backendQueryMetrics = nested.getNested().stream().map(m -> (Metrics) m).collect(Collectors.toList());
         assertEquals(1, backendQueryMetrics.size());
         backendAnnotations = new HashMap() {{
-            put("query", "nameIdx:multiKSQ[1]");
+            put("query", "nameIdx:multiKSQ[1]{KeySliceQuery(0x0489A0626FE2)[0x00,0xFF)}");
         }};
         assertEquals(backendAnnotations, backendQueryMetrics.get(0).getAnnotations());
         assertTrue(backendQueryMetrics.get(0).getDuration(TimeUnit.MICROSECONDS) > 0);
@@ -6453,7 +6487,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
             put("orders", "[]");
             put("isFitted", "true");
             put("isOrdered", "true");
-            put("query", "multiKSQ[1]@4000");
+            put("query", "multiKSQ[1]@4000{KeySliceQuery(0x0489A0626FE2)[0x00,0xFF)}");
             put("index", "nameIdx");
         }};
         assertEquals(nameIdxAnnotations, nested.getAnnotations());
@@ -6464,7 +6498,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         for (Metrics backendQueryMetric : backendQueryMetrics) {
             int queryLimit = limit;
             backendAnnotations = new HashMap() {{
-                put("query", "nameIdx:multiKSQ[1]@" + queryLimit);
+                put("query", "nameIdx:multiKSQ[1]@" + queryLimit + "{KeySliceQuery(0x0489A0626FE2)[0x00,0xFF)}");
                 put("limit", queryLimit);
             }};
             assertEquals(backendAnnotations, backendQueryMetric.getAnnotations());

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/MultiKeySliceQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/graph/MultiKeySliceQuery.java
@@ -75,6 +75,14 @@ public class MultiKeySliceQuery extends BaseQuery implements BackendQuery<MultiK
         StringBuilder builder = new StringBuilder("multiKSQ[");
         builder.append(queries.size()).append("]");
         if (hasLimit()) builder.append("@").append(getLimit());
+        builder.append("{");
+        for (int i = 0; i < queries.size(); i++) {
+            if (i > 0) {
+                builder.append(",");
+            }
+            builder.append(queries.get(i));
+        }
+        builder.append("}");
         return builder.toString();
     }
 

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/query/QueryTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/query/QueryTest.java
@@ -106,22 +106,22 @@ public class QueryTest {
 
         // Single condition, fully met by index prop1_idx. No need to adjust backend query limit.
         assertCount(5, graph.traversal().V().has("prop1", "prop1val").limit(5));
-        assertEquals("multiKSQ[1]@5", getQueryAnnotation(graph.traversal().V().has("prop1", "prop1val").limit(5)
-                .profile().next()));
+        assertEquals("multiKSQ[1]@5{KeySliceQuery(0x0A89A070726F70317661EC)[0x00,0xFF)}",
+            getQueryAnnotation(graph.traversal().V().has("prop1", "prop1val").limit(5).profile().next()));
 
         // Two conditions, fully met by index props_idx. No need to adjust backend query limit.
         assertCount(5, graph.traversal().V().has("prop1", "prop1val").has("prop2", "prop2val").limit(5));
-        assertEquals("multiKSQ[1]@5", getQueryAnnotation(graph.traversal().V().has("prop1", "prop1val").has("prop2", "prop2val").limit(5)
+        assertEquals("multiKSQ[1]@5{KeySliceQuery(0x0C89A070726F70317661ECA070726F70327661EC)[0x00,0xFF)}", getQueryAnnotation(graph.traversal().V().has("prop1", "prop1val").has("prop2", "prop2val").limit(5)
             .profile().next()));
 
         // Two conditions, one of which met by index prop1_idx. Multiply original limit by two for sake of in-memory filtering.
         assertCount(5, graph.traversal().V().has("prop1", "prop1val").has("prop3", "prop3val").limit(5));
-        assertEquals("multiKSQ[1]@10", getQueryAnnotation(graph.traversal().V().has("prop1", "prop1val").has("prop3", "prop3val").limit(5)
+        assertEquals("multiKSQ[1]@10{KeySliceQuery(0x0A89A070726F70317661EC)[0x00,0xFF)}", getQueryAnnotation(graph.traversal().V().has("prop1", "prop1val").has("prop3", "prop3val").limit(5)
             .profile().next()));
 
         // Three conditions, one of which met by index prop1_idx. Multiply original limit by four for sake of in-memory filtering.
         assertCount(5, graph.traversal().V().has("prop1", "prop1val").has("prop3", "prop3val").has("prop4", "prop4val").limit(5));
-        assertEquals("multiKSQ[1]@20", getQueryAnnotation(graph.traversal().V().has("prop1", "prop1val").has("prop3", "prop3val").has("prop4", "prop4val").limit(5)
+        assertEquals("multiKSQ[1]@20{KeySliceQuery(0x0A89A070726F70317661EC)[0x00,0xFF)}", getQueryAnnotation(graph.traversal().V().has("prop1", "prop1val").has("prop3", "prop3val").has("prop4", "prop4val").limit(5)
             .profile().next()));
     }
 


### PR DESCRIPTION
Currently, multiKSQ (multi-key slice query) does not show concrete queries fired in profiling results. This sometimes makes debugging difficult.

This work is inspired by a user question on the Discord channel.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
