### PR TITLE
Reduce redundant operations in MultiVertexCentricQueryBuilder

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
@@ -300,9 +300,8 @@ public abstract class BasicVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q
         return Arrays.asList(tx.getAllRepresentatives(partitionedVertex,restrict2Partitions));
     }
 
-
     protected final boolean isPartitionedVertex(InternalVertex vertex) {
-        return tx.isPartitionedVertex(vertex) && !queryOnlyGivenVertex;
+        return !queryOnlyGivenVertex && tx.isPartitionedVertex(vertex);
     }
 
     protected boolean useSimpleQueryProcessor(BaseVertexCentricQuery query, InternalVertex... vertices) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/VertexCentricQueryBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/VertexCentricQueryBuilder.java
@@ -78,7 +78,7 @@ public class VertexCentricQueryBuilder extends BasicVertexCentricQueryBuilder<Ve
             vertex.query().properties().iterator().hasNext();
         }
 
-        if (isPartitionedVertex(vertex) && !hasQueryOnlyGivenVertex()) { //If it's a preloaded vertex we shouldn't preload data explicitly
+        if (isPartitionedVertex(vertex)) { //If it's a preloaded vertex we shouldn't preload data explicitly
             List<InternalVertex> vertices = allRequiredRepresentatives(vertex);
             profiler.setAnnotation(QueryProfiler.PARTITIONED_VERTEX_ANNOTATION,true);
             profiler.setAnnotation(QueryProfiler.NUMVERTICES_ANNOTATION,vertices.size());

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -1193,14 +1193,14 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
 
     @Override
     public JanusGraphMultiVertexQuery multiQuery(JanusGraphVertex... vertices) {
-        MultiVertexCentricQueryBuilder builder = new MultiVertexCentricQueryBuilder(this);
+        MultiVertexCentricQueryBuilder builder = new MultiVertexCentricQueryBuilder(this, vertices.length);
         for (JanusGraphVertex v : vertices) builder.addVertex(v);
         return builder;
     }
 
     @Override
     public JanusGraphMultiVertexQuery multiQuery(Collection<JanusGraphVertex> vertices) {
-        MultiVertexCentricQueryBuilder builder = new MultiVertexCentricQueryBuilder(this);
+        MultiVertexCentricQueryBuilder builder = new MultiVertexCentricQueryBuilder(this, vertices.size());
         builder.addAllVertices(vertices);
         return builder;
     }


### PR DESCRIPTION
- Do not copy vertices into an array when all vertices are non-paritioned
- Do not add and then remove vertices into / from resolved vertices set. Instead add only resolved vertices into a set
- Use optional initial vertices size estimate for multi-query

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
