### PR TITLE
Use And Or steps multi-query for children MultiQueriable Steps

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/testutil/JanusGraphAssert.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/testutil/JanusGraphAssert.java
@@ -201,4 +201,28 @@ public class JanusGraphAssert {
         }
         return null;
     }
+
+    /**
+     * Checks that the amount of steps of given type is equal to the provided amount.
+     */
+    public static void assertStepExists(Traversal traversal, Class<? extends Step> expectedStepType, int stepsCount) {
+
+        String traversalString = traversal.toString();
+
+        int lastStepIndex = traversalString.indexOf(expectedStepType.getSimpleName());
+
+        if(stepsCount <= 0){
+            assertEquals(-1, lastStepIndex);
+        }
+
+       int stepsFound = 0;
+
+        while (lastStepIndex != -1){
+            ++stepsFound;
+            lastStepIndex = traversalString.indexOf(expectedStepType.getSimpleName(), lastStepIndex+1);
+        }
+
+        assertEquals(stepsCount, stepsFound);
+    }
+
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphTraversalUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphTraversalUtil.java
@@ -15,6 +15,7 @@
 package org.janusgraph.graphdb.tinkerpop.optimize;
 
 import org.apache.tinkerpop.gremlin.process.traversal.step.PathProcessor;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.ConnectiveStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.NoOpBarrierStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.ProfileStep;
@@ -65,7 +66,7 @@ public class JanusGraphTraversalUtil {
      * using them to initialise a JanusGraphVertexStep if it's the first step of any child traversal.
      */
     private static final List<Class<? extends TraversalParent>> MULTIQUERY_COMPATIBLE_PARENTS =
-            Arrays.asList(BranchStep.class, OptionalStep.class, RepeatStep.class, TraversalFilterStep.class);
+            Arrays.asList(BranchStep.class, OptionalStep.class, RepeatStep.class, TraversalFilterStep.class, ConnectiveStep.class);
 
     public static StandardJanusGraph getJanusGraph(final Traversal.Admin<?, ?> traversal) {
         Optional<Graph> optionalGraph = traversal.getGraph();

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphStepStrategyTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/tinkerpop/optimize/JanusGraphStepStrategyTest.java
@@ -338,15 +338,18 @@ public class JanusGraphStepStrategyTest {
             // There are 'sideEffect' and 'as' steps preceding the JanusGraphVertexStep
             arguments(g.V().choose(has("weight", 0),__.as("true").sideEffect(i -> {}).inE("knows"),__.as("false").sideEffect(i -> {}).inE("knows")),
                 g_V().is(MQ_STEP).barrier().choose(has("weight", 0),__.as("true").sideEffect(i -> {}).inE("knows"),__.as("false").sideEffect(i -> {}).inE("knows")), otherStrategies),
-            // 'local' is not MultiQueryCompatible (at the moment)
-            arguments(g.V().and(__.inE("knows"), __.inE("knows")),
-                g_V().and(__.is(MQ_STEP).barrier().inE("knows"), __.is(MQ_STEP).barrier().inE("knows")), otherStrategies),
             // `JanusGraphMultiQueryStep` should be used for filter step when at least one child is registered as a client of `JanusGraphMultiQueryStep`.
             arguments(g.V().where(__.out("knows").count().is(P.gte(5))),
                 g_V().is(MQ_STEP).barrier().where(__.out("knows").count().is(P.gte(5))), otherStrategies),
             // `JanusGraphMultiQueryStep` should not be used for filter step when none of children is registered as a client of `JanusGraphMultiQueryStep`.
             arguments(g.V().where(__.count().is(P.gte(5))),
                 g_V().where(__.count().is(P.gte(5))), otherStrategies),
+            // Needs one JanusGraphMultiQueryStep before executing `and` step with `MultiQueriable` steps
+            arguments(g.V().and(__.inE("knows"), __.inE("knows")),
+                g_V().is(MQ_STEP).barrier().and(__.inE("knows"), __.inE("knows")), otherStrategies),
+            // Needs one JanusGraphMultiQueryStep before executing `or` step with `MultiQueriable` steps
+            arguments(g.V().or(__.inE("knows"), __.inE("knows")),
+                g_V().is(MQ_STEP).barrier().or(__.inE("knows"), __.inE("knows")), otherStrategies),
         });
     }
 }


### PR DESCRIPTION
This is a single line code change. All other code changes are for tests.

The PR is ready for review, but I think it makes sense to merge it after #3743 because this PR adds `And` and `Or` steps as compatible parent steps for `MultiQueriable` optimization which may be influenced by problems discussed in #3737 .

Fixes #3735

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
