### PR TITLE
Use Reload4j as the default logging implementation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -41,6 +41,60 @@ The versions of JanusGraph listed below are outdated and will no longer receive 
 
 ## Release Notes
 
+### Version 0.6.4 (Release Date: ???)
+
+```xml tab='Maven'
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.6.4</version>
+</dependency>
+```
+
+```groovy tab='Gradle'
+compile "org.janusgraph:janusgraph-core:0.6.4"
+```
+
+**Tested Compatibility:**
+
+* Apache Cassandra 3.0.14, 3.11.10
+* Apache HBase 1.6.0, 2.2.7
+* Oracle BerkeleyJE 7.5.11
+* Elasticsearch 6.0.1, 6.6.0, 7.14.0
+* Apache Lucene 8.9.0
+* Apache Solr 7.7.2, 8.11.0
+* Apache TinkerPop 3.5.5
+* Java 1.8
+
+#### Changes
+
+For more information on features and bug fixes in 0.6.4, see the GitHub milestone:
+
+- <https://github.com/JanusGraph/janusgraph/milestone/26?closed=1>
+
+#### Assets
+
+* [JavaDoc](https://javadoc.io/doc/org.janusgraph/janusgraph-core/0.6.4)
+* [GitHub Release](https://github.com/JanusGraph/janusgraph/releases/tag/v0.6.4)
+* [JanusGraph zip](https://github.com/JanusGraph/janusgraph/releases/download/v0.6.4/janusgraph-0.6.4.zip)
+* [JanusGraph zip with embedded Cassandra and ElasticSearch](https://github.com/JanusGraph/janusgraph/releases/download/v0.6.4/janusgraph-full-0.6.4.zip)
+
+#### Upgrade Instructions
+
+##### Default logging library changed to Reload4j
+
+The default logging library used in the pre-packaged distribution has been changed in version 0.6.3 by accident from
+Log4j to Logback.
+While this change meant that some security issues of Log4j were avoided, it was also a breaking change that was not
+intended.
+This resulted in only warnings being logged by default and also that a Log4j config file was ignored.
+To fix this breaking change, we change the default logging library in this release to [Reload4j](https://reload4j.qos.ch/)
+which is completely compatible with Log4j, but fixes the security issues of Log4j.
+This means that Log4j config files will continue to work with this version.
+
+Note that this only applies to JanusGraph 0.6.
+JanusGraph 1.0.0 uses Log4j2 by default.
+
 ### Version 0.6.3 (Release Date: February 18, 2023)
 
 ```xml tab='Maven'

--- a/janusgraph-dist/src/assembly/static/bin/gremlin.sh
+++ b/janusgraph-dist/src/assembly/static/bin/gremlin.sh
@@ -46,14 +46,14 @@ cd -P $BIN/../ext
 EXT=$(pwd)
 # Initialize classpath to $CFG
 CP="$CFG"
-# Add the slf4j-log4j12 binding
-CP="$CP":$(find -L $LIB -name 'slf4j-log4j12*.jar' | sort | tr '\n' ':')
+# Add the slf4j-reload4j binding
+CP="$CP":$(find -L $LIB -name 'slf4j-reload4j*.jar' | sort | tr '\n' ':')
 # Add the jars in $BIN/../lib that start with "janusgraph"
 CP="$CP":$(find -L $LIB -name 'janusgraph*.jar' | sort | tr '\n' ':')
 # Add the remaining jars in $BIN/../lib.
 CP="$CP":$(find -L $LIB -name '*.jar' \
                 \! -name 'janusgraph*' \
-                \! -name 'slf4j-log4j12*.jar' | sort | tr '\n' ':')
+                \! -name 'slf4j-reload4j*.jar' | sort | tr '\n' ':')
 # Add the jars in $BIN/../ext (at any subdirectory depth)
 CP="$CP":$(find -L $EXT -name '*.jar' | sort | tr '\n' ':')
 

--- a/janusgraph-dist/src/assembly/static/bin/janusgraph-server.sh
+++ b/janusgraph-dist/src/assembly/static/bin/janusgraph-server.sh
@@ -129,14 +129,14 @@ JAVA_OPTIONS="$COLLECTED_JAVA_OPTIONS_FILE $JAVA_OPTIONS -javaagent:$JANUSGRAPH_
 if [[ -z "$CP" ]];then
   # Initialize classpath to $JANUSGRAPH_CFG
   CP="${JANUSGRAPH_CONF}"
-  # Add the slf4j-log4j12 binding
-  CP="$CP":$(find -L $JANUSGRAPH_LIB -name 'slf4j-log4j12*.jar' | sort | tr '\n' ':')
+  # Add the slf4j-reload4j binding
+  CP="$CP":$(find -L $JANUSGRAPH_LIB -name 'slf4j-reload4j*.jar' | sort | tr '\n' ':')
   # Add the jars in $JANUSGRAPH_HOME/lib that start with "janusgraph"
   CP="$CP":$(find -L $JANUSGRAPH_LIB -name 'janusgraph*.jar' | sort | tr '\n' ':')
   # Add the remaining jars in $JANUSGRAPH_HOME/lib.
   CP="$CP":$(find -L $JANUSGRAPH_LIB -name '*.jar' \
                   \! -name 'janusgraph*' \
-                  \! -name 'slf4j-log4j12*.jar' | sort | tr '\n' ':')
+                  \! -name 'slf4j-reload4j*.jar' | sort | tr '\n' ':')
   # Add the jars in $BIN/../ext (at any subdirectory depth)
   CP="$CP":$( find -L "$JANUSGRAPH_HOME"/ext -mindepth 1 -maxdepth 1 -type d | \
         sort | sed 's/$/\/plugin\/*/' | tr '\n' ':' )


### PR DESCRIPTION
Log4j isn't available anymore in the lib directory, but Reload4j is. Since Reload4j is a drop-in replacement for Log4j which fixes security issues of Log4j, it makes sense to switch to that. This should provide an elegant, non-breaking way, to avoid the security issues of Log4j.
We only need to do this for `v0.6` as `master` already uses Log4j2.

I verified manually that the expected logs appear again with `bin/janusgraph-server.sh` and that the Log4j config file is used by Reload4j.

Fixes #3681

NOTE: We need to add the changelog entry afterwards also on `master` to get it included in the docs for 1.0.0, too.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
