### PR TITLE
Fix snakeyaml NoSuchMethodError in remote console

### DIFF
--- a/janusgraph-dist/src/test/expect/remote-console.expect.vm
+++ b/janusgraph-dist/src/test/expect/remote-console.expect.vm
@@ -36,4 +36,6 @@ send ":> graph.tx().commit()\r"
 send ":> graph.traversal().V().count()\r"
 expect "1"
 expect gremlin>
+send ":> graph.close()\r"
+expect gremlin>
 exit 0

--- a/janusgraph-dist/src/test/expect/remote-console.expect.vm
+++ b/janusgraph-dist/src/test/expect/remote-console.expect.vm
@@ -1,0 +1,39 @@
+#!/usr/bin/env expect
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+set timeout 30
+
+spawn bin/gremlin.sh
+expect_after {
+    timeout {
+        # Default timeout handler
+        exit 1
+    }
+}
+expect gremlin>
+send ":remote connect tinkerpop.server conf/remote.yaml\r"
+send ":> graph.traversal().V().drop().iterate()\r"
+send ":> graph.traversal().V().count()\r"
+expect "0"
+expect gremlin>
+send ":> graph.traversal().addV().next()\r"
+send ":> graph.traversal().V().count()\r"
+expect "1"
+expect gremlin>
+send ":> graph.tx().commit()\r"
+send ":> graph.traversal().V().count()\r"
+expect "1"
+expect gremlin>
+exit 0

--- a/janusgraph-dist/src/test/expect/remote-console.expect.vm
+++ b/janusgraph-dist/src/test/expect/remote-console.expect.vm
@@ -36,6 +36,4 @@ send ":> graph.tx().commit()\r"
 send ":> graph.traversal().V().count()\r"
 expect "1"
 expect gremlin>
-send ":> graph.close()\r"
-expect gremlin>
 exit 0

--- a/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/AbstractJanusGraphAssemblyIT.java
+++ b/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/AbstractJanusGraphAssemblyIT.java
@@ -156,7 +156,7 @@ public abstract class AbstractJanusGraphAssemblyIT extends JanusGraphAssemblyBas
         runTraversalAgainstServer(createGraphBinaryMessageSerializerV1());
 
         // test use Gremlin console
-        unzipAndRunExpect("remote-console.expect.vm", Collections.emptyMap(), false, false);
+        parseTemplateAndRunExpect("remote-console.expect.vm", Collections.emptyMap(), full, debug);
 
         parseTemplateAndRunExpect("janusgraph-server-sh.after.expect.vm", contextVars, full, debug);
     }

--- a/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/AbstractJanusGraphAssemblyIT.java
+++ b/janusgraph-dist/src/test/java/org/janusgraph/pkgtest/AbstractJanusGraphAssemblyIT.java
@@ -129,7 +129,8 @@ public abstract class AbstractJanusGraphAssemblyIT extends JanusGraphAssemblyBas
         assertNotEquals(0, vertices.size());
     }
 
-    protected void runTraversalAgainstServer(MessageSerializer serializer) {
+    protected void runTraversalAgainstServer(MessageSerializer serializer) throws Exception {
+        // test use Cluster class in Java
         Cluster cluster = Cluster.build("localhost")
             .port(8182)
             .serializer(serializer)
@@ -153,6 +154,9 @@ public abstract class AbstractJanusGraphAssemblyIT extends JanusGraphAssemblyBas
 
         runTraversalAgainstServer(createGraphSONMessageSerializer());
         runTraversalAgainstServer(createGraphBinaryMessageSerializerV1());
+
+        // test use Gremlin console
+        unzipAndRunExpect("remote-console.expect.vm", Collections.emptyMap(), false, false);
 
         parseTemplateAndRunExpect("janusgraph-server-sh.after.expect.vm", contextVars, full, debug);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -747,7 +747,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>2.0</version>
+                <version>1.32</version>
             </dependency>
             <dependency>
                 <groupId>net.oneandone.reflections8</groupId>


### PR DESCRIPTION
When connecting to a remote gremlin server from gremlin console, a NoSuchMethodError is thrown. This commit fixes this bug and adds an integration test to verify correctness.

Fixes #3763

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
