### PR TITLE
[v0.6] Move Janusgraph docker into main repo

### DIFF
--- a/.github/workflows/ci-publish-commit.yml
+++ b/.github/workflows/ci-publish-commit.yml
@@ -39,14 +39,25 @@ jobs:
           distribution: 'zulu'
           java-version: '8.0.312+7'
           java-package: jdk
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Remove version SNAPSHOT suffix if exists
         run:  mvn versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
       - name: Set JanusGraph version environment variable
         run: |
           export JG_VER="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$(date '+%Y%m%d-%H%M%S').$(git rev-parse --short HEAD)"
           export JG_DESCRIPTION="Janusgraph commit release. Commit $(git rev-parse HEAD). Branch $(git rev-parse --abbrev-ref HEAD). Version $JG_VER."
+          export MULTI_PLATFORM="true"
           echo "JG_VER=${JG_VER}" >> $GITHUB_ENV
           echo "JG_DESCRIPTION=${JG_DESCRIPTION}" >> $GITHUB_ENV
+          echo "MULTI_PLATFORM=${MULTI_PLATFORM}" >> $GITHUB_ENV
       - name: Configure GPG Key
         run: |
           echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --import

--- a/.github/workflows/ci-publish-official.yml
+++ b/.github/workflows/ci-publish-official.yml
@@ -29,6 +29,15 @@ jobs:
           distribution: 'zulu'
           java-version: '8.0.312+7'
           java-package: jdk
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -43,11 +52,13 @@ jobs:
           export JG_DIST_NAME="janusgraph-${JG_VER}"
           export JG_FULL_DIST_NAME="janusgraph-full-${JG_VER}"
           export JG_DOC_DIST_NAME="${JG_DIST_NAME}-doc"
+          export MULTI_PLATFORM="true"
           echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
           echo "JG_VER=${JG_VER}" >> $GITHUB_ENV
           echo "JG_DIST_NAME=${JG_DIST_NAME}" >> $GITHUB_ENV
           echo "JG_FULL_DIST_NAME=${JG_FULL_DIST_NAME}" >> $GITHUB_ENV
           echo "JG_DOC_DIST_NAME=${JG_DOC_DIST_NAME}" >> $GITHUB_ENV
+          echo "MULTI_PLATFORM=${MULTI_PLATFORM}" >> $GITHUB_ENV
       - name: Configure GPG Key
         run: |
           echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --import

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -39,46 +39,9 @@ For more details information, please see [here](janusgraph-dist/README.md#buildi
 
 ## Building Docker Image for JanusGraph Server
 
-In order to build Docker image for JanusGraph Server, a
-distribution archive is needed. If you wish to build an image from source
-refer to `To build the distribution archive` section to build the distribution
-archive first. You can also use an [official release](https://github.com/JanusGraph/janusgraph/releases) to avoid building.
-To do so check out the release tag you wish to build, example: `git checkout v0.2.0`. Then create target
-directory that houses the distribution zip with `mkdir janusgraph-dist/target`.
-The [downloaded release](https://github.com/JanusGraph/janusgraph/releases)
-is then placed in the recently created target directory. Note that if the
-tag is not found you can run `git fetch --all --tags --prune` and then rerun the checkout command.
-
-Once the distribution is in place use the following command
-to build and run Docker images with JanusGraph Server, configured
-to run the BerkeleyJE backend and Elasticsearch (requires [Docker Compose](https://docs.docker.com/compose/)):
-
-```bash
-mvn docker:build -Pjanusgraph-docker -pl janusgraph-dist
-docker-compose -f janusgraph-dist/docker-compose.yml up
+We moved the docker build back into the main repo, see `janusgraph-dist/docker`. You can use the default command to build the distribution archive to also build the docker images.
 ```
-
-If you are building the Docker image behind a proxy please set an environment variable for either http_proxy or https_proxy accordingly.
-
-Note the above `docker-compose` call launches containers in the foreground and is convenient for monitoring logs but add "-d" to instead run in the background.
-
-To connect to the server in the same container on the console:
-
-```bash
-docker exec -i -t janusgraph /var/janusgraph/bin/gremlin.sh
-```
-
-Then you can interact with the graph on the console through the `:remote` interface:
-
-```groovy
-gremlin> :remote connect tinkerpop.server conf/remote.yaml
-==>Configured localhost/127.0.0.1:8182
-gremlin> :remote console
-==>All scripts will now be sent to Gremlin Server - [localhost/127.0.0.1:8182] - type ':remote console' to return to local mode
-gremlin> GraphOfTheGodsFactory.load(graph)
-==>null
-gremlin> g = graph.traversal()
-==>graphtraversalsource[standardjanusgraph[berkeleyje:db/berkeley], standard]
+mvn clean install -Pjanusgraph-release -Dgpg.skip=true -DskipTests=true
 ```
 
 ## Building on Eclipse IDE

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ distributed across a multi-machine cluster. JanusGraph is a transactional databa
 can support thousands of concurrent users, complex traversals, and analytic graph queries.
 
 [![Downloads][downloads-shield]][downloads-link]
+[![Docker pulls][docker-pulls-img]][docker-hub-url]
 [![Maven][maven-shield]][maven-link]
 [![Javadoc][javadoc-shield]][javadoc-link]
 [![GitHub Workflow Status][actions-shield]][actions-link]
@@ -33,6 +34,8 @@ can support thousands of concurrent users, complex traversals, and analytic grap
 [codecov-link]:https://codecov.io/gh/JanusGraph/janusgraph
 [coverity-shield]: https://img.shields.io/coverity/scan/janusgraph-janusgraph.svg
 [coverity-link]: https://scan.coverity.com/projects/janusgraph-janusgraph
+[docker-pulls-img]: https://img.shields.io/docker/pulls/janusgraph/janusgraph.svg
+[docker-hub-url]: https://hub.docker.com/r/janusgraph/janusgraph
 
 ## Learn More
 

--- a/docs/operations/container.md
+++ b/docs/operations/container.md
@@ -1,0 +1,308 @@
+# JanusGraph Container
+
+!!! note
+    even though the examples below and in the Docker Compose config
+    files (`*.yml`) use the `latest` image, when running a service in production,
+    be sure to specify a specific numeric version to
+    [avoid](https://medium.com/@mccode/the-misunderstood-docker-tag-latest-af3babfd6375)
+    [unexpected](https://github.com/hadolint/hadolint/wiki/DL3007)
+    [behavior changes](https://vsupalov.com/docker-latest-tag/)
+    due to `latest` pointing to a new release version, see our [Docker tagging Policy](#docker-tagging-policy).
+
+## Usage
+
+### Start a JanusGraph Server instance
+
+The default configuration uses the [Oracle Berkeley DB Java Edition](../storage-backend/bdb.md) storage backend
+and the [Apache Lucene](../index-backend/lucene.md) indexing backend:
+
+```bash
+docker run --rm --name janusgraph-default docker.io/janusgraph/janusgraph:latest
+```
+
+### Connecting with Gremlin Console
+
+Start a JanusGraph container and connect to the `janusgraph` server remotely
+using Gremlin Console:
+
+```bash
+$ docker run --rm --link janusgraph-default:janusgraph -e GREMLIN_REMOTE_HOSTS=janusgraph \
+    -it docker.io/janusgraph/janusgraph:latest ./bin/gremlin.sh
+
+         \,,,/
+         (o o)
+-----oOOo-(3)-oOOo-----
+plugin activated: janusgraph.imports
+plugin activated: tinkerpop.server
+plugin activated: tinkerpop.utilities
+plugin activated: tinkerpop.hadoop
+plugin activated: tinkerpop.spark
+plugin activated: tinkerpop.tinkergraph
+gremlin> :remote connect tinkerpop.server conf/remote.yaml
+==>Configured janusgraph/172.17.0.2:8182
+gremlin> :> g.addV('person').property('name', 'chris')
+==>v[4160]
+gremlin> :> g.V().values('name')
+==>chris
+```
+
+### Using Docker Compose
+
+Start a JanusGraph Server instance using [`docker-compose.yml`](https://github.com/JanusGraph/janusgraph/tree/master/janusgraph-dist/docker/examples/docker-compose.yml):
+
+```bash
+docker-compose -f docker-compose.yml up
+```
+
+Start a JanusGraph container running Gremlin Console in the same network using
+[`docker-compose.yml`](https://github.com/JanusGraph/janusgraph/tree/master/janusgraph-dist/docker/examples/docker-compose.yml):
+
+```bash
+docker-compose -f docker-compose.yml run --rm \
+    -e GREMLIN_REMOTE_HOSTS=janusgraph janusgraph ./bin/gremlin.sh
+```
+
+### Initialization
+
+When the container is started it will execute files with the extension
+`.groovy` that are found in `/docker-entrypoint-initdb.d` with the
+Gremlin Console.
+These scripts are only executed after the JanusGraph Server instance was
+started.
+So, they can [connect to it](../interactions/connecting/index.md) and execute Gremlin traversals.
+
+For example, to add a vertex to the graph, create a file
+`/docker-entrypoint-initdb.d/add-vertex.groovy` with the following content:
+
+```groovy
+g = traversal().withRemote('conf/remote-graph.properties')
+g.addV('demigod').property('name', 'hercules').iterate()
+```
+
+### Generate Config
+
+JanusGraph-Docker has a single utility method. This method writes the JanusGraph Configuration and show the config afterward.
+
+```bash
+docker run --rm -it docker.io/janusgraph/janusgraph:latest janusgraph show-config
+```
+
+**Default config locations are `/etc/opt/janusgraph/janusgraph.properties` and `/etc/opt/janusgraph/janusgraph-server.yaml`.**
+
+## Configuration
+
+The JanusGraph image provides multiple methods for configuration, including using environment
+variables to set options and using bind-mounted configuration.
+
+### Docker environment variables
+
+The environment variables supported by the JanusGraph image are summarized below.
+
+| Variable | Description | Default |
+| ---- | ---- | ---- |
+| `JANUS_PROPS_TEMPLATE` | JanusGraph properties file template (see [below](#properties-template)). |`berkeleyje-lucene` |
+| `janusgraph.*` | Any JanusGraph configuration option to override in the template properties file, specified with an outer `janusgraph` namespace (e.g., `janusgraph.storage.hostname`). See [JanusGraph Configuration](../configs/configuration-reference.md) for available options. | no default value | 
+| `gremlinserver.*` | Any Gremlin Server configuration option to override in the default configuration (YAML) file, specified with an outer `gremlinserver` namespace (e.g., `gremlinserver.threadPoolWorker`). You can set or update nested options using additional dots (e.g., `gremlinserver.graphs.graph`). See [Gremlin Server Configuration][GS_CONFIG] for available options. See [Gremlin Server Environment Variable Syntax](#Gremlin-Server-Environment-Variable-Syntax) section below for help editing gremlin server configuration using environment variables. | no default value` | 
+| `JANUS_SERVER_TIMEOUT` | Timeout (seconds) used when waiting for Gremlin Server before executing initialization scripts. | `30` |
+| `JANUS_STORAGE_TIMEOUT` | Timeout (seconds) used when waiting for the storage backend before starting Gremlin Server. | `60` |
+| `GREMLIN_REMOTE_HOSTS` | Optional hostname for external Gremlin Server instance. Enables a container running Gremlin Console to connect to a remote server using `conf/remote.yaml` (or `remote-objects.yaml`). | no default value | 
+| `JANUS_INITDB_DIR` | Defines the location of the initialization scripts.  | `/docker-entrypoint-initdb.d` |
+
+#### Properties template
+
+The `JANUS_PROPS_TEMPLATE` environment variable is used to define the base JanusGraph
+properties file. Values in the template properties file are used unless an alternate value
+for a given property is provided in the environment. The common usage will be to specify
+a template for the general environment (e.g., `cassandra-es`) and then provide additional
+individual configuration to override/extend the template. The available templates depend
+on the JanusGraph version (see [`conf/janusgraph*.properties`][JG_TEMPLATES]).
+
+| `JANUS_PROPS_TEMPLATE` | Supported Versions |
+| ----- | ----- |
+| `berkeleyje` | all |
+| `berkeleyje-es` | all |
+| `berkeleyje-lucene` (default) | all |
+| `cassandra-es` | <=0.5.3 |
+| `cql-es` | >=0.2.1 |
+| `cql` | >=0.5.3 |
+| `inmemory` | >=0.5.3 |
+
+##### Example: Berkeleyje-Lucene
+
+Start a JanusGraph instance using the default `berkeleyje-lucene` template with custom
+storage and server settings:
+
+```bash
+docker run --name janusgraph-default \
+    -e janusgraph.storage.berkeleyje.cache-percentage=80 \
+    -e gremlinserver.threadPoolWorker=2 \
+    docker.io/janusgraph/janusgraph:latest
+```
+
+Inspect the configuration:
+
+```bash
+$ docker exec janusgraph-default sh -c 'cat /etc/opt/janusgraph/janusgraph.properties | grep ^[a-z]'
+gremlin.graph=org.janusgraph.core.JanusGraphFactory
+storage.backend=berkeleyje
+storage.directory=/var/lib/janusgraph/data
+index.search.backend=lucene
+storage.berkeleyje.cache-percentage=80
+index.search.directory=/var/lib/janusgraph/index
+
+$ docker exec janusgraph-default grep threadPoolWorker /etc/opt/janusgraph/janusgraph-server.yaml
+threadPoolWorker: 2
+```
+
+##### Example: Cassandra-ES with Docker Compose
+
+Start a JanusGraph instance with Cassandra and Elasticsearch using the `cql-es`
+template through [`docker-compose-cql-es.yml`](https://github.com/JanusGraph/janusgraph/tree/master/janusgraph-dist/docker/examples/docker-compose-cql-es.yml):
+
+```bash
+docker-compose -f docker-compose-cql-es.yml up
+```
+
+Inspect the configuration using
+[`docker-compose-cql-es.yml`](https://github.com/JanusGraph/janusgraph/tree/master/janusgraph-dist/docker/examples/docker-compose-cql-es.yml):
+
+```bash
+$ docker-compose -f docker-compose-cql-es.yml exec \
+      janusgraph sh -c 'cat /etc/opt/janusgraph/janusgraph.properties | grep ^[a-z]'
+gremlin.graph=org.janusgraph.core.JanusGraphFactory
+storage.backend=cql
+storage.hostname=jce-cassandra
+cache.db-cache = true
+cache.db-cache-clean-wait = 20
+cache.db-cache-time = 180000
+cache.db-cache-size = 0.25
+index.search.backend=elasticsearch
+index.search.hostname=jce-elastic
+index.search.elasticsearch.client-only=true
+storage.directory=/var/lib/janusgraph/data
+index.search.directory=/var/lib/janusgraph/index
+```
+
+#### Gremlin Server Environment Variable Syntax
+
+Environment Variables that start with the prefix `gremlinserver.` or `gremlinserver%d.` are used
+to edit the base janusgraph-server.yaml file. The text after the prefix in the environment variable
+name should follow a specific syntax. This syntax is implemented using the [yq][YQ_GITHUB] write and
+delete commands and the [yq documentation][YQ_DOC] can be used as a reference for this syntax.
+Secondly, the value of the environment variable will be used to set the value of the key specified
+in the environment variable name.
+
+Let's take a look at a few examples:
+
+##### Nested Properties
+
+For example, say we want to add a configuration property `graphs.ConfigurationMangementGraph`
+with the value `conf/JanusGraph-configurationmanagement.properties`:
+
+```text
+$ docker run --rm -it -e gremlinserver.graphs.ConfigurationManagementGraph=\
+conf/JanusGraph-configurationmanagement.properties docker.io/janusgraph/janusgraph:latest janusgraph show-config
+...
+graphs:
+  graph: conf/janusgraph-cql-es-server.properties
+  ConfigurationManagementGraph: conf/JanusGraph-configurationmanagement.properties
+scriptEngines:
+...
+```
+
+##### Delete a component
+
+To delete a component append %d to the 'gremlinserver.' prefix before the closing dot and then
+select the component following the prefix. Don't forget the trailing '='. For example to delete the
+graphs.graph configuration property we can do the following:
+
+```text
+$ docker run --rm -it -e gremlinserver%d.graphs.graph= docker.io/janusgraph/janusgraph:latest janusgraph show-config
+...
+channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
+graphs: {}
+scriptEngines:
+...
+```
+
+##### Append item and alternate indexing syntax
+
+This example shows how to append an item to a list. This can be done by adding "[+]" at the end of
+the environment variable name. This example also shows how to use square bracket syntax as an
+alternative to the dot syntax. This alternate syntax is useful if one of the keys in the property
+path contains special characters as we see in the example below.
+
+```text
+$ docker run --rm -it -e gremlinserver.scriptEngines.gremlin-groovy\
+.plugins["org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin"]\
+.files[+]=/scripts/another-script.groovy docker.io/janusgraph/janusgraph:latest janusgraph show-config
+...
+scriptEngines:
+  gremlin-groovy:
+    plugins:
+      org.janusgraph.graphdb.tinkerpop.plugin.JanusGraphGremlinPlugin: {}
+      org.apache.tinkerpop.gremlin.server.jsr223.GremlinServerGremlinPlugin: {}
+      org.apache.tinkerpop.gremlin.tinkergraph.jsr223.TinkerGraphGremlinPlugin: {}
+      org.apache.tinkerpop.gremlin.jsr223.ImportGremlinPlugin:
+        classImports:
+        - java.lang.Math
+        methodImports:
+        - java.lang.Math#*
+      org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin:
+        files:
+        - scripts/empty-sample.groovy
+        - /scripts/another-script.groovy
+...
+```
+
+### Mounted Configuration
+
+By default, the container stores both the `janusgraph.properties` and `janusgraph-server.yaml` files
+in the `JANUS_CONFIG_DIR` directory which maps to `/etc/opt/janusgraph`. When the container
+starts, it updates those files using the environment variable values. If you have a specific
+configuration and do not wish to use environment variables to configure JanusGraph, you can
+mount a directory containing your own version of those configuration files into the container
+through a bind mount, e.g., `-v /local/path/on/host:/etc/opt/janusgraph:ro`. You'll need to bind
+the files as read-only, however, if you do not wish to have the environment variables override the
+values in that file.
+
+#### Example with mounted configuration
+
+Start a JanusGraph instance with mounted configuration using
+[`docker-compose-mount.yml`](https://github.com/JanusGraph/janusgraph/tree/master/janusgraph-dist/docker/examples/docker-compose-mount.yml):
+
+```bash
+$ docker-compose -f docker-compose-mount.yml up
+janusgraph-mount | chown: changing ownership of '/etc/opt/janusgraph/janusgraph.properties': Read-only file system
+...
+```
+
+## Default user JanusGraph
+
+> **Note:** The default user of the image changed for all version beginning with the newest image version of 0.5.3.
+
+The user is created with uid 999 and gid 999 and user's a home dir is `/var/lib/janusgraph`. 
+
+Following folder are created with these user rights:
+* `/var/lib/janusgraph`
+* `/etc/opt/janusgraph`
+* `/opt/janusgraph`
+* `/docker-entrypoint-initdb.d`
+
+## Image Tagging Policy
+
+Here's the policy we follow for tagging our container images:
+
+| Tag            | Support level | Docker base image      |
+|:--------------|:-------------|------------------------|
+| latest         | <ul><li>latest JanusGraph release</li><li>no breaking changes guarantees</li></ul> | eclipse-temurin:11-jre |
+| x.x            | <ul><li>newest patch-level version of JanusGraph</li><li>expect breaking changes</li></ul> | eclipse-temurin:8-jre  |
+| x.x.x          | <ul><li>defined JanusGraph version</li><li>breaking changes are only in this repo</li></ul> | eclipse-temurin:8-jre  |
+| x.x.x-revision | <ul><li>defined JanusGraph version</li><li>defined commit in JanusGraph repo</li></ul> | eclipse-temurin:8-jre  |
+
+
+[JG]: https://janusgraph.org/
+[JG_TEMPLATES]: https://github.com/search?q=org:JanusGraph+repo:janusgraph+filename:janusgraph.properties%20path:janusgraph-dist/src/assembly/static/conf/gremlin-server
+[GS_CONFIG]: http://tinkerpop.apache.org/docs/current/reference/#_configuring_2
+[YQ_GITHUB]: https://github.com/mikefarah/yq
+[YQ_DOC]: https://mikefarah.gitbook.io/yq

--- a/janusgraph-dist/README.md
+++ b/janusgraph-dist/README.md
@@ -2,14 +2,13 @@
 
 ## Building zip archives
 
-Run `mvn clean install -Pjanusgraph-release -Dgpg.skip=true
--DskipTests=true`.  This command can be run from either the root of
-the JanusGraph repository (the parent of the janusgraph-dist directory) or the
-janusgraph-dist directory.  Running from the root of the repository is
-recommended.  Running from janusgraph-dist requires that JanusGraph's jars be
-available on either Sonatype, Maven Central, or your local Maven
-repository (~/.m2/repository/) depending on whether you're building a
-SNAPSHOT or a release tag.
+Run `mvn clean install -Pjanusgraph-release -Dgpg.skip=true -DskipTests=true -Pjava-11`.  
+This command can be run from either the root of the JanusGraph repository 
+(the parent of the janusgraph-dist directory) or the janusgraph-dist directory.
+Running from the root of the repository is recommended.  Running from 
+janusgraph-dist requires that JanusGraph's jars be available on either 
+Sonatype, Maven Central, or your local Maven repository (~/.m2/repository/)
+depending on whether you're building a SNAPSHOT or a release tag.
 
 This command writes one archive:
 

--- a/janusgraph-dist/docker/.dockerignore
+++ b/janusgraph-dist/docker/.dockerignore
@@ -1,0 +1,15 @@
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+examples/

--- a/janusgraph-dist/docker/Dockerfile
+++ b/janusgraph-dist/docker/Dockerfile
@@ -1,0 +1,98 @@
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASE_IMAGE=eclipse-temurin:11-jre
+
+FROM debian:buster-slim as builder
+
+ARG TARGETARCH
+ARG JANUS_VERSION=1.0.0-SNAPSHOT
+ARG BUILD_PATH=janusgraph-java-11-1.0.0-SNAPSHOT
+ARG YQ_VERSION=3.4.1
+
+ENV JANUS_VERSION=${JANUS_VERSION} \
+    JANUS_HOME=/opt/janusgraph
+
+WORKDIR /opt
+
+COPY target/${BUILD_PATH}.zip /opt/${BUILD_PATH}.zip
+
+RUN apt update -y && apt install -y gpg unzip curl && \
+    curl -fSL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${TARGETARCH} -o yq && \
+    unzip ${BUILD_PATH}.zip && \
+    mv ${BUILD_PATH} /opt/janusgraph && \
+    rm -rf ${JANUS_HOME}/elasticsearch && \
+    rm -rf ${JANUS_HOME}/javadocs && \
+    rm -rf ${JANUS_HOME}/log && \
+    rm -rf ${JANUS_HOME}/examples && \
+    rm -rf ${JANUS_HOME}/conf/janusgraph-*.properties && \
+    mv ${JANUS_HOME}/conf/gremlin-server/gremlin-server.yaml ${JANUS_HOME}/conf/janusgraph-server.yaml && \
+    rm -rf ${JANUS_HOME}/conf/gremlin-server
+
+COPY docker/conf/ ${JANUS_HOME}/conf/
+COPY docker/scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
+
+FROM ${BASE_IMAGE}
+ARG JANUS_VERSION=1.0.0-SNAPSHOT
+
+ENV JANUS_VERSION=${JANUS_VERSION} \
+    JANUS_HOME=/opt/janusgraph \
+    JANUS_CONFIG_DIR=/etc/opt/janusgraph \
+    JANUS_DATA_DIR=/var/lib/janusgraph \
+    JANUS_SERVER_TIMEOUT=30 \
+    JANUS_STORAGE_TIMEOUT=60 \
+    JANUS_PROPS_TEMPLATE=berkeleyje-lucene \
+    JANUS_INITDB_DIR=/docker-entrypoint-initdb.d \
+    gremlinserver.graphs.graph=/etc/opt/janusgraph/janusgraph.properties \
+    gremlinserver.threadPoolWorker=1 \
+    gremlinserver.gremlinPool=8
+
+RUN groupadd -r janusgraph --gid=999 && \
+    useradd -r -g janusgraph --uid=999 -d ${JANUS_DATA_DIR} janusgraph && \
+    apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends krb5-user && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/janusgraph/ /opt/janusgraph/
+COPY --from=builder /opt/yq /usr/bin/yq
+COPY docker/docker-entrypoint.sh /usr/local/bin/
+COPY docker/load-initdb.sh /usr/local/bin/
+
+RUN chmod 755 /usr/local/bin/docker-entrypoint.sh && \
+    chmod 755 /usr/local/bin/load-initdb.sh && \
+    chmod 755 /usr/bin/yq && \
+    mkdir -p ${JANUS_INITDB_DIR} ${JANUS_CONFIG_DIR} ${JANUS_DATA_DIR} && \
+    chown -R janusgraph:janusgraph ${JANUS_HOME} ${JANUS_INITDB_DIR} ${JANUS_CONFIG_DIR} ${JANUS_DATA_DIR}
+
+EXPOSE 8182
+
+WORKDIR ${JANUS_HOME}
+USER janusgraph
+
+ENTRYPOINT [ "docker-entrypoint.sh" ]
+CMD [ "janusgraph" ]
+
+ARG CREATED=test
+ARG REVISION=test
+
+LABEL org.opencontainers.image.title="JanusGraph Docker Image" \
+      org.opencontainers.image.description="Official JanusGraph Docker image" \
+      org.opencontainers.image.url="https://janusgraph.org/" \
+      org.opencontainers.image.documentation="https://docs.janusgraph.org/v1.0/" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.source="https://github.com/JanusGraph/janusgraph-docker/" \
+      org.opencontainers.image.vendor="JanusGraph" \
+      org.opencontainers.image.version="${JANUS_VERSION}" \
+      org.opencontainers.image.created="${CREATED}" \
+      org.opencontainers.image.license="Apache-2.0"

--- a/janusgraph-dist/docker/build-and-push-image.sh
+++ b/janusgraph-dist/docker/build-and-push-image.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+if [ "$#" -gt "4" ]; then
+  echo "usage: build-and-push-image.sh version base-image build-path tag-suffix [push]"
+  exit 1
+fi
+
+JANUS_VERSION=$1
+BASE_IMAGE=$2
+BUILD_PATH=$3
+TAG_SUFFIX=$4
+PUSH="${5:-false}"
+
+REVISION="$(git rev-parse --short HEAD)"
+CREATED="$(date -u +”%Y-%m-%dT%H:%M:%SZ”)"
+IMAGE_NAME="docker.io/janusgraph/janusgraph"
+PLATFORMS="linux/amd64,linux/arm64"
+
+echo "REVISION: ${REVISION}"
+echo "CREATED: ${CREATED}"
+echo "IMAGE_NAME: ${IMAGE_NAME}"
+echo "JANUS_VERSION: ${JANUS_VERSION}"
+echo "BASE_IMAGE: ${BASE_IMAGE}"
+echo "BUILD_PATH: ${BUILD_PATH}"
+echo "TAG_SUFFIX: ${TAG_SUFFIX}"
+
+# enable buildkit
+export DOCKER_BUILDKIT=1
+
+ARGS=""
+if [[ $PUSH == "push" ]]; then
+    ARGS="${ARGS} --push"
+fi
+if [[ $MULTI_PLATFORM == "true" ]]; then
+    ARGS="${ARGS} --platform ${PLATFORMS}"
+fi
+if [[ $LATEST == "true" ]] && [[ $TAG_SUFFIX == "" ]]; then
+    ARGS="${ARGS} -t ${IMAGE_NAME}:latest"
+fi
+ARGS="${ARGS} -t ${IMAGE_NAME}:${JANUS_VERSION}${TAG_SUFFIX} -t ${IMAGE_NAME}:${JANUS_VERSION}${TAG_SUFFIX}-${REVISION}"
+
+# build and push the multi-arch image
+# unfortunately, when building a multi-arch image, we have to push it right after building it,
+# rather than save locally and then push it. see https://github.com/docker/buildx/issues/166
+docker buildx build -f "docker/Dockerfile" --build-arg JANUS_VERSION="$JANUS_VERSION" --build-arg REVISION="$REVISION" --build-arg CREATED="$CREATED" --build-arg BUILD_PATH="$BUILD_PATH" --build-arg BASE_IMAGE="$BASE_IMAGE" ${ARGS} .

--- a/janusgraph-dist/docker/conf/janusgraph-berkeleyje-es-server.properties
+++ b/janusgraph-dist/docker/conf/janusgraph-berkeleyje-es-server.properties
@@ -1,0 +1,65 @@
+#
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# JanusGraph configuration sample: BerkeleyDB JE and Elasticsearch
+
+gremlin.graph = org.janusgraph.core.JanusGraphFactory
+
+# The primary persistence provider used by JanusGraph.  This is required.  It
+# should be set one of JanusGraph's built-in shorthand names for its standard
+# storage backends or to the full package and classname of a custom/third-party
+# StoreManager implementation.
+#
+# Default:    (no default value)
+# Data Type:  String
+# Mutability: LOCAL
+storage.backend = berkeleyje
+
+# Storage directory for those storage backends that require local storage.
+#
+# Default:    (no default value)
+# Data Type:  String
+# Mutability: LOCAL
+storage.directory = /var/lib/janusgraph/data
+
+# The indexing backend used to extend and optimize JanusGraph's query
+# functionality. This setting is optional.  JanusGraph can use multiple
+# heterogeneous index backends.  Hence, this option can appear more than
+# once, so long as the user-defined name between "index" and "backend" is
+# unique among appearances.Similar to the storage backend, this should be
+# set to one of JanusGraph's built-in shorthand names for its standard index
+# backends (shorthands: lucene, elasticsearch, es, solr) or to the full
+# package and classname of a custom/third-party IndexProvider
+# implementation.
+#
+# Default:    elasticsearch
+# Data Type:  String
+# Mutability: GLOBAL_OFFLINE
+#
+# Settings with mutability GLOBAL_OFFLINE are centrally managed in JanusGraph's
+# storage backend.  After starting the database for the first time, this
+# file's copy of this setting is ignored.  Use JanusGraph's Management System
+# to read or modify this value after bootstrapping.
+index.search.backend = elasticsearch
+
+# The hostname or comma-separated list of hostnames of index backend
+# servers.  This is only applicable to some index backends, such as
+# elasticsearch and solr.
+#
+# Default:    127.0.0.1
+# Data Type:  class java.lang.String[]
+# Mutability: MASKABLE
+index.search.hostname = elasticsearch
+

--- a/janusgraph-dist/docker/conf/janusgraph-berkeleyje-lucene-server.properties
+++ b/janusgraph-dist/docker/conf/janusgraph-berkeleyje-lucene-server.properties
@@ -1,0 +1,62 @@
+#
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# JanusGraph configuration sample: BerkeleyDB JE and Apache Lucene
+
+gremlin.graph = org.janusgraph.core.JanusGraphFactory
+
+# The primary persistence provider used by JanusGraph.  This is required.  It
+# should be set one of JanusGraph's built-in shorthand names for its standard
+# storage backends or to the full package and classname of a custom/third-party
+# StoreManager implementation.
+#
+# Default:    (no default value)
+# Data Type:  String
+# Mutability: LOCAL
+storage.backend = berkeleyje
+
+# Storage directory for those storage backends that require local storage.
+#
+# Default:    (no default value)
+# Data Type:  String
+# Mutability: LOCAL
+storage.directory = /var/lib/janusgraph/data
+
+# The indexing backend used to extend and optimize JanusGraph's query
+# functionality. This setting is optional.  JanusGraph can use multiple
+# heterogeneous index backends.  Hence, this option can appear more than
+# once, so long as the user-defined name between "index" and "backend" is
+# unique among appearances.Similar to the storage backend, this should be
+# set to one of JanusGraph's built-in shorthand names for its standard
+# index backends (shorthands: lucene, elasticsearch, es, solr) or to the
+# full package and classname of a custom/third-party IndexProvider
+# implementation.
+#
+# Default:    elasticsearch
+# Data Type:  String
+# Mutability: GLOBAL_OFFLINE
+#
+# Settings with mutability GLOBAL_OFFLINE are centrally managed in
+# JanusGraph's storage backend.  After starting the database for the first
+# time, this file's copy of this setting is ignored.  Use JanusGraph's
+# Management System to read or modify this value after bootstrapping.
+index.search.backend = lucene
+
+# Directory to store index data locally
+#
+# Default:    (no default value)
+# Data Type:  String
+# Mutability: MASKABLE
+index.search.directory = /var/lib/janusgraph/index

--- a/janusgraph-dist/docker/conf/janusgraph-berkeleyje-server.properties
+++ b/janusgraph-dist/docker/conf/janusgraph-berkeleyje-server.properties
@@ -1,0 +1,35 @@
+#
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# JanusGraph configuration sample: BerkeleyDB JE
+
+gremlin.graph = org.janusgraph.core.JanusGraphFactory
+
+# The primary persistence provider used by JanusGraph.  This is required.  It
+# should be set one of JanusGraph's built-in shorthand names for its standard
+# storage backends or to the full package and classname of a custom/third-party
+# StoreManager implementation.
+#
+# Default:    (no default value)
+# Data Type:  String
+# Mutability: LOCAL
+storage.backend = berkeleyje
+
+# Storage directory for those storage backends that require local storage.
+#
+# Default:    (no default value)
+# Data Type:  String
+# Mutability: LOCAL
+storage.directory = /var/lib/janusgraph/data

--- a/janusgraph-dist/docker/conf/janusgraph-cql-es-server.properties
+++ b/janusgraph-dist/docker/conf/janusgraph-cql-es-server.properties
@@ -1,0 +1,138 @@
+#
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+gremlin.graph = org.janusgraph.core.JanusGraphFactory
+
+# JanusGraph configuration sample: Cassandra & Elasticsearch over sockets
+#
+# This file connects to Cassandra and Elasticsearch services running
+# on localhost over the CQL API and the Elasticsearch native
+# "Transport" API on their respective default ports.  The Cassandra
+# and Elasticsearch services must already be running before starting
+# JanusGraph with this file.
+
+# The primary persistence provider used by JanusGraph.  This is required.  It
+# should be set one of JanusGraph's built-in shorthand names for its standard
+# storage backends or to the full package and classname of a custom/third-party
+# StoreManager implementation.
+#
+# Default:    (no default value)
+# Data Type:  String
+# Mutability: LOCAL
+storage.backend = cql
+
+# The hostname or comma-separated list of hostnames of storage backend
+# servers.  This is only applicable to some storage backends, such as
+# cassandra and hbase.
+#
+# Default:    127.0.0.1
+# Data Type:  class java.lang.String[]
+# Mutability: LOCAL
+storage.hostname = cassandra
+
+# The name of JanusGraph's keyspace.  It will be created if it does not
+# exist.
+#
+# Default:    janusgraph
+# Data Type:  String
+# Mutability: LOCAL
+storage.cql.keyspace = janusgraph
+
+# Whether to enable JanusGraph's database-level cache, which is shared across
+# all transactions. Enabling this option speeds up traversals by holding
+# hot graph elements in memory, but also increases the likelihood of
+# reading stale data.  Disabling it forces each transaction to
+# independently fetch graph elements from storage before reading/writing
+# them.
+#
+# Default:    false
+# Data Type:  Boolean
+# Mutability: MASKABLE
+cache.db-cache = true
+
+# How long, in milliseconds, database-level cache will keep entries after
+# flushing them.  This option is only useful on distributed storage
+# backends that are capable of acknowledging writes without necessarily
+# making them immediately visible.
+#
+# Default:    50
+# Data Type:  Integer
+# Mutability: GLOBAL_OFFLINE
+#
+# Settings with mutability GLOBAL_OFFLINE are centrally managed in JanusGraph's
+# storage backend.  After starting the database for the first time, this
+# file's copy of this setting is ignored.  Use JanusGraph's Management System
+# to read or modify this value after bootstrapping.
+cache.db-cache-clean-wait = 20
+
+# Default expiration time, in milliseconds, for entries in the
+# database-level cache. Entries are evicted when they reach this age even
+# if the cache has room to spare. Set to 0 to disable expiration (cache
+# entries live forever or until memory pressure triggers eviction when set
+# to 0).
+#
+# Default:    10000
+# Data Type:  Long
+# Mutability: GLOBAL_OFFLINE
+#
+# Settings with mutability GLOBAL_OFFLINE are centrally managed in JanusGraph's
+# storage backend.  After starting the database for the first time, this
+# file's copy of this setting is ignored.  Use JanusGraph's Management System
+# to read or modify this value after bootstrapping.
+cache.db-cache-time = 180000
+
+# Size of JanusGraph's database level cache.  Values between 0 and 1 are
+# interpreted as a percentage of VM heap, while larger values are
+# interpreted as an absolute size in bytes.
+#
+# Default:    0.3
+# Data Type:  Double
+# Mutability: MASKABLE
+cache.db-cache-size = 0.25
+
+# The indexing backend used to extend and optimize JanusGraph's query
+# functionality. This setting is optional.  JanusGraph can use multiple
+# heterogeneous index backends.  Hence, this option can appear more than
+# once, so long as the user-defined name between "index" and "backend" is
+# unique among appearances.Similar to the storage backend, this should be
+# set to one of JanusGraph's built-in shorthand names for its standard index
+# backends (shorthands: lucene, elasticsearch, es, solr) or to the full
+# package and classname of a custom/third-party IndexProvider
+# implementation.
+#
+# Default:    elasticsearch
+# Data Type:  String
+# Mutability: GLOBAL_OFFLINE
+#
+# Settings with mutability GLOBAL_OFFLINE are centrally managed in JanusGraph's
+# storage backend.  After starting the database for the first time, this
+# file's copy of this setting is ignored.  Use JanusGraph's Management System
+# to read or modify this value after bootstrapping.
+index.search.backend = elasticsearch
+
+# The hostname or comma-separated list of hostnames of index backend
+# servers.  This is only applicable to some index backends, such as
+# elasticsearch and solr.
+#
+# Default:    127.0.0.1
+# Data Type:  class java.lang.String[]
+# Mutability: MASKABLE
+index.search.hostname = elasticsearch
+
+# Or start ES inside the JanusGraph JVM
+#index.search.backend=elasticsearch
+#index.search.directory=db/es
+#index.search.elasticsearch.client-only=false
+#index.search.elasticsearch.local-mode=true

--- a/janusgraph-dist/docker/conf/janusgraph-cql-server.properties
+++ b/janusgraph-dist/docker/conf/janusgraph-cql-server.properties
@@ -1,0 +1,103 @@
+#
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+gremlin.graph = org.janusgraph.core.JanusGraphFactory
+
+# JanusGraph configuration sample: Cassandra & Elasticsearch over sockets
+#
+# This file connects to Cassandra and Elasticsearch services running
+# on localhost over the CQL API and the Elasticsearch native
+# "Transport" API on their respective default ports.  The Cassandra
+# and Elasticsearch services must already be running before starting
+# JanusGraph with this file.
+
+# The primary persistence provider used by JanusGraph.  This is required.  It
+# should be set one of JanusGraph's built-in shorthand names for its standard
+# storage backends or to the full package and classname of a custom/third-party
+# StoreManager implementation.
+#
+# Default:    (no default value)
+# Data Type:  String
+# Mutability: LOCAL
+storage.backend = cql
+
+# The hostname or comma-separated list of hostnames of storage backend
+# servers.  This is only applicable to some storage backends, such as
+# cassandra and hbase.
+#
+# Default:    127.0.0.1
+# Data Type:  class java.lang.String[]
+# Mutability: LOCAL
+storage.hostname = cassandra
+
+# The name of JanusGraph's keyspace.  It will be created if it does not
+# exist.
+#
+# Default:    janusgraph
+# Data Type:  String
+# Mutability: LOCAL
+storage.cql.keyspace = janusgraph
+
+# Whether to enable JanusGraph's database-level cache, which is shared across
+# all transactions. Enabling this option speeds up traversals by holding
+# hot graph elements in memory, but also increases the likelihood of
+# reading stale data.  Disabling it forces each transaction to
+# independently fetch graph elements from storage before reading/writing
+# them.
+#
+# Default:    false
+# Data Type:  Boolean
+# Mutability: MASKABLE
+cache.db-cache = true
+
+# How long, in milliseconds, database-level cache will keep entries after
+# flushing them.  This option is only useful on distributed storage
+# backends that are capable of acknowledging writes without necessarily
+# making them immediately visible.
+#
+# Default:    50
+# Data Type:  Integer
+# Mutability: GLOBAL_OFFLINE
+#
+# Settings with mutability GLOBAL_OFFLINE are centrally managed in JanusGraph's
+# storage backend.  After starting the database for the first time, this
+# file's copy of this setting is ignored.  Use JanusGraph's Management System
+# to read or modify this value after bootstrapping.
+cache.db-cache-clean-wait = 20
+
+# Default expiration time, in milliseconds, for entries in the
+# database-level cache. Entries are evicted when they reach this age even
+# if the cache has room to spare. Set to 0 to disable expiration (cache
+# entries live forever or until memory pressure triggers eviction when set
+# to 0).
+#
+# Default:    10000
+# Data Type:  Long
+# Mutability: GLOBAL_OFFLINE
+#
+# Settings with mutability GLOBAL_OFFLINE are centrally managed in JanusGraph's
+# storage backend.  After starting the database for the first time, this
+# file's copy of this setting is ignored.  Use JanusGraph's Management System
+# to read or modify this value after bootstrapping.
+cache.db-cache-time = 180000
+
+# Size of JanusGraph's database level cache.  Values between 0 and 1 are
+# interpreted as a percentage of VM heap, while larger values are
+# interpreted as an absolute size in bytes.
+#
+# Default:    0.3
+# Data Type:  Double
+# Mutability: MASKABLE
+cache.db-cache-size = 0.25

--- a/janusgraph-dist/docker/conf/janusgraph-inmemory-server.properties
+++ b/janusgraph-dist/docker/conf/janusgraph-inmemory-server.properties
@@ -1,0 +1,89 @@
+#
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# JanusGraph configuration sample: in-memory
+#
+# This file connects to an in-memory storage backend
+
+# The implementation of graph factory that will be used by gremlin server
+#
+# Default:    org.janusgraph.core.JanusGraphFactory
+# Data Type:  String
+# Mutability: LOCAL
+gremlin.graph = org.janusgraph.core.JanusGraphFactory
+
+# The primary persistence provider used by JanusGraph.  This is required.
+# It should be set one of JanusGraph's built-in shorthand names for its
+# standard storage backends (shorthands: berkeleyje, cassandrathrift,
+# cassandra, astyanax, embeddedcassandra, cql, hbase, inmemory) or to the
+# full package and classname of a custom/third-party StoreManager
+# implementation.
+#
+# Default:    (no default value)
+# Data Type:  String
+# Mutability: LOCAL
+storage.backend = inmemory
+
+# Whether to enable JanusGraph's database-level cache, which is shared across
+# all transactions. Enabling this option speeds up traversals by holding
+# hot graph elements in memory, but also increases the likelihood of
+# reading stale data.  Disabling it forces each transaction to
+# independently fetch graph elements from storage before reading/writing
+# them.
+#
+# Default:    false
+# Data Type:  Boolean
+# Mutability: MASKABLE
+cache.db-cache = true
+
+# How long, in milliseconds, database-level cache will keep entries after
+# flushing them.  This option is only useful on distributed storage
+# backends that are capable of acknowledging writes without necessarily
+# making them immediately visible.
+#
+# Default:    50
+# Data Type:  Integer
+# Mutability: GLOBAL_OFFLINE
+#
+# Settings with mutability GLOBAL_OFFLINE are centrally managed in JanusGraph's
+# storage backend.  After starting the database for the first time, this
+# file's copy of this setting is ignored.  Use JanusGraph's Management System
+# to read or modify this value after bootstrapping.
+cache.db-cache-clean-wait = 20
+
+# Default expiration time, in milliseconds, for entries in the
+# database-level cache. Entries are evicted when they reach this age even
+# if the cache has room to spare. Set to 0 to disable expiration (cache
+# entries live forever or until memory pressure triggers eviction when set
+# to 0).
+#
+# Default:    10000
+# Data Type:  Long
+# Mutability: GLOBAL_OFFLINE
+#
+# Settings with mutability GLOBAL_OFFLINE are centrally managed in JanusGraph's
+# storage backend.  After starting the database for the first time, this
+# file's copy of this setting is ignored.  Use JanusGraph's Management System
+# to read or modify this value after bootstrapping.
+cache.db-cache-time = 180000
+
+# Size of JanusGraph's database level cache.  Values between 0 and 1 are
+# interpreted as a percentage of VM heap, while larger values are
+# interpreted as an absolute size in bytes.
+#
+# Default:    0.3
+# Data Type:  Double
+# Mutability: MASKABLE
+cache.db-cache-size = 0.25

--- a/janusgraph-dist/docker/docker-entrypoint.sh
+++ b/janusgraph-dist/docker/docker-entrypoint.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+JANUS_PROPS="${JANUS_CONFIG_DIR}/janusgraph.properties"
+JANUSGRAPH_SERVER_YAML="${JANUS_CONFIG_DIR}/janusgraph-server.yaml"
+
+# running as root; step down to run as janusgraph user
+if [ "$1" == 'janusgraph' ] && [ "$(id -u)" == "0" ]; then
+  mkdir -p ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
+  chown -R janusgraph:janusgraph ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
+  chmod 700 ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
+
+  exec chroot --skip-chdir --userspec janusgraph:janusgraph / "${BASH_SOURCE}" "$@"
+fi
+
+# running as non root user
+if [ "$1" == 'janusgraph' ]; then
+  # setup config directory
+  mkdir -p ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
+  cp conf/janusgraph-${JANUS_PROPS_TEMPLATE}-server.properties ${JANUS_PROPS}
+  cp conf/janusgraph-server.yaml ${JANUSGRAPH_SERVER_YAML}
+  chown -R "$(id -u):$(id -g)" ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
+  chmod 700 ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
+  chmod -R 600 ${JANUS_CONFIG_DIR}/*
+
+  # apply configuration from environment
+  while IFS=' ' read -r envvar_key envvar_val; do
+    if [[ "${envvar_key}" =~ janusgraph\. ]] && [[ ! -z ${envvar_val} ]]; then
+      # strip namespace and use properties file delimiter for janusgraph properties
+      envvar_key=${envvar_key#"janusgraph."}
+      # Add new or update existing field in configuration file
+      if grep -q -E "^\s*${envvar_key}\s*=\.*" ${JANUS_PROPS}; then
+        sed -ri "s#^(\s*${envvar_key}\s*=).*#\\1${envvar_val}#" ${JANUS_PROPS}
+      else
+        echo "${envvar_key}=${envvar_val}" >> ${JANUS_PROPS}
+      fi
+    elif [[ "${envvar_key}" =~ gremlinserver(%d)?[.]{1}(.+) ]]; then
+      # Check for edit mode %d after prefix
+      if [[ ${BASH_REMATCH[1]} == "%d" ]]; then edit_mode="d"; else edit_mode="w"; fi
+      # strip namespace from env variable and get value
+      envvar_key=${BASH_REMATCH[2]}
+      if [[ edit_mode == "d" ]]; then envvar_val=""; fi
+      # add new or update existing field in configuration file
+      yq ${edit_mode} -P -i ${JANUSGRAPH_SERVER_YAML} ${envvar_key} ${envvar_val}
+    else
+      continue
+    fi
+  done < <(env | sort -r | awk -F= '{ st = index($0, "="); print $1 " " substr($0, st+1) }')
+
+  if [ "$2" == 'show-config' ]; then
+    echo "# contents of ${JANUS_PROPS}"
+    cat "$JANUS_PROPS"
+    echo "---------------------------------------"
+    echo "# contents of ${JANUSGRAPH_SERVER_YAML}"
+    cat "$JANUSGRAPH_SERVER_YAML"
+    exit 0
+  else
+    # wait for storage
+    if ! [ -z "${JANUS_STORAGE_TIMEOUT:-}" ]; then
+      F="$(mktemp --suffix .groovy)"
+      echo "graph = JanusGraphFactory.open('${JANUS_PROPS}')" > $F
+      timeout "${JANUS_STORAGE_TIMEOUT}s" bash -c \
+        "until bin/gremlin.sh -e $F > /dev/null 2>&1; do echo \"waiting for storage...\"; sleep 5; done"
+      rm -f "$F"
+    fi
+
+    /usr/local/bin/load-initdb.sh &
+
+    exec ${JANUS_HOME}/bin/janusgraph-server.sh ${JANUSGRAPH_SERVER_YAML}
+  fi
+fi
+
+# override hosts for remote connections with Gremlin Console
+if ! [ -z "${GREMLIN_REMOTE_HOSTS:-}" ]; then
+  sed -i "s/hosts\s*:.*/hosts: [$GREMLIN_REMOTE_HOSTS]/" ${JANUS_HOME}/conf/remote.yaml
+  sed -i "s/hosts\s*:.*/hosts: [$GREMLIN_REMOTE_HOSTS]/" ${JANUS_HOME}/conf/remote-objects.yaml
+fi
+
+exec "$@"

--- a/janusgraph-dist/docker/examples/docker-compose-cql-es.yml
+++ b/janusgraph-dist/docker/examples/docker-compose-cql-es.yml
@@ -1,0 +1,63 @@
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3"
+
+services:
+  janusgraph:
+    image: docker.io/janusgraph/janusgraph:latest
+    container_name: jce-janusgraph
+    environment:
+      JANUS_PROPS_TEMPLATE: cql-es
+      janusgraph.storage.hostname: jce-cassandra
+      janusgraph.index.search.hostname: jce-elastic
+    ports:
+      - "8182:8182"
+    networks:
+      - jce-network
+    healthcheck:
+      test: ["CMD", "bin/gremlin.sh", "-e", "scripts/remote-connect.groovy"]
+      interval: 10s
+      timeout: 30s
+      retries: 3
+
+  cassandra:
+    image: cassandra:3
+    container_name: jce-cassandra
+    ports:
+      - "9042:9042"
+      - "9160:9160"
+    networks:
+      - jce-network
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.6.0
+    container_name: jce-elastic
+    environment:
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "http.host=0.0.0.0"
+      - "network.host=0.0.0.0"
+      - "transport.host=127.0.0.1"
+      - "cluster.name=docker-cluster"
+      - "xpack.security.enabled=false"
+      - "discovery.zen.minimum_master_nodes=1"
+    ports:
+      - "9200:9200"
+    networks:
+      - jce-network
+
+networks:
+  jce-network:
+volumes:
+  janusgraph-default-data:

--- a/janusgraph-dist/docker/examples/docker-compose-mount.yml
+++ b/janusgraph-dist/docker/examples/docker-compose-mount.yml
@@ -1,0 +1,31 @@
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3"
+
+services:
+  janusgraph:
+    image: docker.io/janusgraph/janusgraph:latest
+    container_name: janusgraph-mount
+    ports:
+      - "8182:8182"
+    volumes:
+      # Named volume mounts. The data mount is only used when BerkeleyDB is used for storage.
+      - "janusgraph-mount-data:/var/lib/janusgraph"
+      # bind mounts for configs; use read only so not overridden by environment variables
+      - "./example-config:/etc/opt/janusgraph/:ro"
+
+# use a named volume to maintain database data between restarts
+volumes:
+  janusgraph-mount-data:

--- a/janusgraph-dist/docker/examples/docker-compose.yml
+++ b/janusgraph-dist/docker/examples/docker-compose.yml
@@ -1,0 +1,28 @@
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3"
+
+services:
+  janusgraph:
+    image: docker.io/janusgraph/janusgraph:latest
+    container_name: janusgraph-default
+    ports:
+      - "8182:8182"
+    # The mounted volume only makes sense if JanusGraph is being run with the BerekeleyDB storage.
+    volumes:
+      - "janusgraph-default-data:/var/lib/janusgraph"
+
+volumes:
+  janusgraph-default-data:

--- a/janusgraph-dist/docker/load-initdb.sh
+++ b/janusgraph-dist/docker/load-initdb.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# exit early if directory is empty
+if ! [ "$(ls -A ${JANUS_INITDB_DIR})" ]; then
+  exit 0
+fi
+
+# wait for JanusGraph Server
+if ! [ -z "${JANUS_SERVER_TIMEOUT:-}" ]; then
+  timeout "${JANUS_SERVER_TIMEOUT}s" bash -c \
+  "until true &>/dev/null </dev/tcp/127.0.0.1/8182; do echo \"waiting for JanusGraph Server...\"; sleep 5; done"
+fi
+
+for f in ${JANUS_INITDB_DIR}/*; do
+  case "$f" in
+    *.groovy) echo "$0: running $f"; ${JANUS_HOME}/bin/gremlin.sh -e "$f"; echo ;;
+    *)        echo "$0: ignoring $f" ;;
+  esac
+  echo
+done

--- a/janusgraph-dist/docker/scripts/remote-connect.groovy
+++ b/janusgraph-dist/docker/scripts/remote-connect.groovy
@@ -1,0 +1,17 @@
+//
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+:remote connect tinkerpop.server conf/remote.yaml
+:> g

--- a/janusgraph-dist/docker/test-image.sh
+++ b/janusgraph-dist/docker/test-image.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+IMAGE=$1
+
+if [ -z "${IMAGE:-}" ]; then
+  echo "usage: test-image.sh image-name"
+  exit 1
+fi
+
+echo "Testing ${IMAGE}..."
+
+ID=$(docker run --rm -d \
+  --health-cmd='./bin/gremlin.sh -e scripts/remote-connect.groovy' \
+  --health-interval=10s \
+  --health-retries=5 \
+  --health-start-period=10s \
+  ${IMAGE})
+
+for i in $(seq 1 10); do
+  res=$(docker ps --filter "id=$ID" --filter "health=healthy" -q)
+  if [ -z "${res:-}" ]; then
+    status=1
+    sleep 10
+    continue
+  fi
+  status=0
+  break
+done
+
+if [ -z "${res:-}" ]; then
+  echo "Timeout waiting for health check:"
+  res=$(docker inspect --format "{{json .State.Health }}" $ID)
+  # pretty print last output with jq if available
+  echo $res | jq --raw-output '.[-1].Output' || echo $res
+fi
+
+docker stop $ID
+
+exit $status

--- a/janusgraph-dist/pom.xml
+++ b/janusgraph-dist/pom.xml
@@ -26,6 +26,8 @@
 
         <packname.standard>janusgraph-${project.version}</packname.standard>
         <packname.full>janusgraph-full-${project.version}</packname.full>
+        <docker.baseimage>eclipse-temurin:11-jre</docker.baseimage>
+        <docker.tag-suffix></docker.tag-suffix>
 
         <!-- Variables for integration testing on release-candidate archive files -->
         <test.expect.dir>${project.build.directory}/test-classes</test.expect.dir>
@@ -280,7 +282,7 @@
                             <arguments>
                                 <!-- Classpath -->
                                 <argument>-classpath</argument>
-                                <classpath />
+                                <classpath/>
                                 <!-- Main Classname -->
                                 <mainClass>org.janusgraph.util.system.ConfigurationFileFilter</mainClass>
                                 <!-- Input directory (processed recursively) -->
@@ -457,6 +459,9 @@
                 <test.zipfile.path>${project.build.directory}/${packname.standard}.zip</test.zipfile.path>
                 <test.excluded.groups>FULL_TESTS</test.excluded.groups>
                 <build.full>none</build.full>
+                <packname.full>janusgraph-java-11-full-${project.version}</packname.full>
+                <docker.baseimage>eclipse-temurin:11-jre</docker.baseimage>
+                <docker.tag-suffix>-java-11</docker.tag-suffix>
             </properties>
         </profile>
         <profile>
@@ -473,35 +478,35 @@
 
             <build>
                 <plugins>
-                        <plugin>
-                            <artifactId>maven-jar-plugin</artifactId>
-                            <executions>
-                                <execution>
-                                    <id>pack-test-jar</id>
-                                    <phase>package</phase>
-                                    <goals>
-                                        <goal>test-jar</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
-                        </plugin>
+                    <plugin>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>pack-test-jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>test-jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
 
-                        <plugin>
-                            <artifactId>maven-compiler-plugin</artifactId>
-                            <executions>
-                                <execution>
-                                    <id>compile-tests</id>
-                                    <phase>test-compile</phase>
-                                    <goals>
-                                        <goal>testCompile</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
-                        </plugin>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>compile-tests</id>
+                                <phase>test-compile</phase>
+                                <goals>
+                                    <goal>testCompile</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
 
-                        <plugin>
-                            <artifactId>maven-resources-plugin</artifactId>
-                            <executions>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
                             <execution>
                                 <id>filter-release-resources</id>
                                 <phase>process-resources</phase>
@@ -522,54 +527,54 @@
                                     </resources>
                                 </configuration>
                             </execution>
-                                <execution>
-                                    <id>filter-expect-scripts</id>
-                                    <phase>process-test-resources</phase>
-                                    <goals>
-                                        <goal>copy-resources</goal>
-                                    </goals>
-                                    <configuration>
-                                        <resources>
-                                            <resource>
-                                                <directory>${top.level.basedir}/janusgraph-dist/src/test/expect</directory>
-                                                <filtering>true</filtering>
-                                            </resource>
-                                        </resources>
-                                        <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
-                                    </configuration>
-                                </execution>
-                                <execution>
-                                    <id>filter-test-resources</id>
-                                    <phase>process-test-resources</phase>
-                                    <goals>
-                                        <goal>copy-resources</goal>
-                                    </goals>
-                                    <configuration>
-                                        <resources>
-                                            <resource>
-                                                <directory>${top.level.basedir}/janusgraph-dist/src/test/resources</directory>
-                                                <filtering>true</filtering>
-                                            </resource>
-                                        </resources>
-                                        <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
-                                    </configuration>
-                                </execution>
-                                <execution>
-                                    <id>copy-test-cfiles</id>
-                                    <phase>process-test-resources</phase>
-                                    <goals>
-                                        <goal>copy-resources</goal>
-                                    </goals>
-                                    <configuration>
-                                        <resources>
-                                            <resource>
-                                                <directory>${assembly.cfilter.out.dir}</directory>
-                                                <filtering>false</filtering>
-                                            </resource>
-                                        </resources>
-                                        <outputDirectory>${project.build.directory}</outputDirectory>
-                                    </configuration>
-                                </execution>
+                            <execution>
+                                <id>filter-expect-scripts</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <resources>
+                                        <resource>
+                                            <directory>${top.level.basedir}/janusgraph-dist/src/test/expect</directory>
+                                            <filtering>true</filtering>
+                                        </resource>
+                                    </resources>
+                                    <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>filter-test-resources</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <resources>
+                                        <resource>
+                                            <directory>${top.level.basedir}/janusgraph-dist/src/test/resources</directory>
+                                            <filtering>true</filtering>
+                                        </resource>
+                                    </resources>
+                                    <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>copy-test-cfiles</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <resources>
+                                        <resource>
+                                            <directory>${assembly.cfilter.out.dir}</directory>
+                                            <filtering>false</filtering>
+                                        </resource>
+                                    </resources>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </configuration>
+                            </execution>
                             <execution>
                                 <id>copy-compat-test-config</id>
                                 <phase>process-resources</phase>
@@ -589,77 +594,77 @@
                                     </resources>
                                 </configuration>
                             </execution>
-                            </executions>
-                        </plugin>
+                        </executions>
+                    </plugin>
 
-                        <plugin>
-                            <artifactId>maven-failsafe-plugin</artifactId>
-                            <configuration>
-                                <forkCount>1</forkCount>
-                                <reuseForks>false</reuseForks>
-                                <testClassesDirectory>${top.level.basedir}/janusgraph-dist/target/test-classes</testClassesDirectory>
-                            </configuration>
-                            <executions>
-                                <execution>
-                                    <id>integration-test</id>
-                                    <phase>integration-test</phase>
-                                    <goals>
-                                        <goal>integration-test</goal>
-                                    </goals>
-                                    <configuration>
-                                        <skip>${skipDefaultDistroIT}</skip>
-                                        <failIfNoTests>false</failIfNoTests>
-                                        <excludedGroups>${test.excluded.groups}</excludedGroups>
-                                        <excludes>
-                                            <exclude>**/*HBase*IT.java</exclude>
-                                            <exclude>**/*CompatIT.java</exclude>
-                                        </excludes>
-                                    </configuration>
-                                </execution>
-                                <execution>
-                                    <id>hbase-integration-test</id>
-                                    <phase>integration-test</phase>
-                                    <goals>
-                                        <goal>integration-test</goal>
-                                    </goals>
-                                    <configuration>
-                                        <argLine>-Dtest.hbase.parentdir=${top.level.basedir}/janusgraph-hbase-parent/</argLine>
-                                        <reportNameSuffix>hbase</reportNameSuffix>
-                                        <failIfNoTests>false</failIfNoTests>
-                                        <includes>
-                                            <include>**/*HBase*IT.java</include>
-                                        </includes>
-                                    </configuration>
-                                </execution>
-                                <!-- Commented until the first 0.9/1.0 release
-                                <execution>
-                                    <id>version-compat-integration-test</id>
-                                    <phase>integration-test</phase>
-                                    <goals>
-                                        <goal>integration-test</goal>
-                                    </goals>
-                                    <configuration>
-                                        <reportNameSuffix>compat</reportNameSuffix>
-                                        <failIfNoTests>false</failIfNoTests>
-                                        <skip>${skipCompatITs}</skip>
-                                        <includes>
-                                            <include>**/*CompatIT.java</include>
-                                        </includes>
-                                    </configuration>
-                                </execution>
-                                -->
-                                <execution>
-                                    <id>verify</id>
-                                    <phase>verify</phase>
-                                    <goals>
-                                        <goal>verify</goal>
-                                    </goals>
-                                    <configuration>
-                                        <failIfNoTests>true</failIfNoTests>
-                                    </configuration>
-                                </execution>
-                            </executions>
-                        </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <forkCount>1</forkCount>
+                            <reuseForks>false</reuseForks>
+                            <testClassesDirectory>${top.level.basedir}/janusgraph-dist/target/test-classes</testClassesDirectory>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipDefaultDistroIT}</skip>
+                                    <failIfNoTests>false</failIfNoTests>
+                                    <excludedGroups>${test.excluded.groups}</excludedGroups>
+                                    <excludes>
+                                        <exclude>**/*HBase*IT.java</exclude>
+                                        <exclude>**/*CompatIT.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>hbase-integration-test</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                                <configuration>
+                                    <argLine>-Dtest.hbase.parentdir=${top.level.basedir}/janusgraph-hbase-parent/</argLine>
+                                    <reportNameSuffix>hbase</reportNameSuffix>
+                                    <failIfNoTests>false</failIfNoTests>
+                                    <includes>
+                                        <include>**/*HBase*IT.java</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                            <!-- Commented until the first 0.9/1.0 release
+                            <execution>
+                                <id>version-compat-integration-test</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                                <configuration>
+                                    <reportNameSuffix>compat</reportNameSuffix>
+                                    <failIfNoTests>false</failIfNoTests>
+                                    <skip>${skipCompatITs}</skip>
+                                    <includes>
+                                        <include>**/*CompatIT.java</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                            -->
+                            <execution>
+                                <id>verify</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <failIfNoTests>true</failIfNoTests>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <artifactId>maven-assembly-plugin</artifactId>
                         <executions>
@@ -732,6 +737,64 @@
                                     <descriptors>
                                         <descriptor>${assembly.descriptor.dir}/javadocs.xml</descriptor>
                                     </descriptors>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>docker-build</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>./docker/build-and-push-image.sh</executable>
+                                    <workingDirectory>${project.basedir}</workingDirectory>
+                                    <arguments>
+                                        <argument>${project.version}</argument>
+                                        <argument>${docker.baseimage}</argument>
+                                        <argument>${packname.standard}</argument>
+                                        <argument>${docker.tag-suffix}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>docker-test</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipTests}</skip>
+                                    <executable>./docker/test-image.sh</executable>
+                                    <workingDirectory>${project.basedir}</workingDirectory>
+                                    <arguments>
+                                        <argument>docker.io/janusgraph/janusgraph:${project.version}${docker.tag-suffix}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>docker-deploy</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>./docker/build-and-push-image.sh</executable>
+                                    <workingDirectory>${project.basedir}</workingDirectory>
+                                    <arguments>
+                                        <argument>${project.version}</argument>
+                                        <argument>${docker.baseimage}</argument>
+                                        <argument>${packname.standard}</argument>
+                                        <argument>${docker.tag-suffix}</argument>
+                                        <argument>push</argument>
+                                    </arguments>
                                 </configuration>
                             </execution>
                         </executions>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,7 @@ nav:
   - Operations:
     - JanusGraph Server: operations/server.md
     - Deployment Scenarios: operations/deployment.md
+    - JanusGraph Container: operations/container.md
     - ConfiguredGraphFactory: operations/configured-graph-factory.md
     - Dynamic Graphs: operations/dynamic-graphs.md
     - Batch Processing: operations/batch-processing.md


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Move Janusgraph docker into main repo](https://github.com/JanusGraph/janusgraph/pull/3782)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)