### PR TITLE
[v0.6] Bump graalvm-nativeimage.version from 22.3.1 to 22.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <protoc.version>3.15.3</protoc.version>
         <gson.version>2.10.1</gson.version>
         <jmh.version>1.21</jmh.version>
-        <graalvm-nativeimage.version>22.3.1</graalvm-nativeimage.version>
+        <graalvm-nativeimage.version>22.3.2</graalvm-nativeimage.version>
     </properties>
     <modules>
         <module>janusgraph-grpc</module>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump graalvm-nativeimage.version from 22.3.1 to 22.3.2](https://github.com/JanusGraph/janusgraph/pull/3722)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)