### PR TITLE
Remove Gitter from docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -8,8 +8,8 @@ labels: "kind/bug/possible"
 Please post all questions and issues on [janusgraph-users](https://lists.lfaidata.foundation/g/janusgraph-users/topics)
 before opening a GitHub issue. Your questions will reach a wider audience there,
 and if we confirm that there is a bug, then you can open a new issue. You could also use
-[GitHub Discussions](https://github.com/JanusGraph/janusgraph/discussions/categories/q-a),
-[Discord](https://discord.gg/5n4fjv4QAf) or [Gitter](https://gitter.im/janusgraph/janusgraph).
+[GitHub Discussions](https://github.com/JanusGraph/janusgraph/discussions/categories/q-a) or
+[Discord](https://discord.gg/5n4fjv4QAf).
 
 Reminder, check your current version and please update to a supported version of JanusGraph, 
 see https://docs.janusgraph.org/changelog/#currently-supported.
@@ -22,7 +22,7 @@ For confirmed bugs, please report:
 - Version: <!-- e.g.: 0.5.0, 0.6.0 -->
 - Storage Backend: <!-- e.g.: cql, hbase, inmemory -->
 - Mixed Index Backend: <!-- e.g.: elasticsearch, none -->
-- Link to discussed bug: <!--GitHub Discussions, Discord, Gitter, Mailing list or StackOverflow-->
+- Link to discussed bug: <!--GitHub Discussions, Discord, Mailing list or StackOverflow-->
 - Expected Behavior:
 - Current Behavior:
 - Steps to Reproduce:

--- a/README.md
+++ b/README.md
@@ -64,11 +64,6 @@ tools:
 
 * Discord for interactive discussions and questions about JanusGraph: [Join the server](https://discord.gg/5n4fjv4QAf)
 
-* Chat rooms on Gitter:
-
-  * [Our main chat room](https://gitter.im/JanusGraph/janusgraph) for all general discussions and questions about JanusGraph
-  * [janusgraph-dev](https://gitter.im/janusgraph/janusgraph-dev) for discussions about the internal implementation of JanusGraph
-
 * Stack Overflow: see the
   [`janusgraph`](https://stackoverflow.com/questions/tagged/janusgraph) tag
 


### PR DESCRIPTION
Users shouldn't start any more with Gitter and instead better go directly to Discord.

Fixes #3819

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
