### PR TITLE
Add possibility to execute multiple slice queries together to KeyColumnValueStore [cql-tests] [tp-tests]

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -314,6 +314,20 @@ mandatory and cannot be disabled. The default ExecutorService core pool size is 
 the default value is considered to be optimal unless users want to artificially limit parallelism of CQL results deserialization 
 jobs.
 
+##### A new multi-query method added into `KeyColumnValueStore` (affects storage adapters implementations only)
+
+A new method `Map<SliceQuery, Map<StaticBuffer, EntryList>> getMultiSlices(MultiKeysQueryGroups<StaticBuffer, SliceQuery> multiKeysQueryGroups, StoreTransaction txh)` 
+is added into `KeyColumnValueStore` which is now preferred for multi-queries (batch queries) with multiple slice queries.  
+In case a multi-query executes more than one Slice query per multi-query execution then those Slice queries will be 
+grouped per same key sets and the new `getMultiSlices` query will be executed with groups of different `SliceQuery` for the same sets of keys.  
+
+Notice, if the storage doesn't have multiQuery feature enabled - the method won't be used. Hence, it's not necessary to implement it.  
+
+In case storage backend has multiQuery feature enabled, then it is highly recommended to overwrite the default (non-optimized) implementation 
+and optimize this method execution to execute all the slice queries for all the requested keys in the shortest time possible 
+(for example, by using asynchronous programming, slice queries grouping, multi-threaded execution, or any other technique which 
+is efficient for the respective storage adapter).  
+
 ##### Removal of deprecated classes/methods/functionalities
 
 ###### Methods

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphBaseTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphBaseTest.java
@@ -616,7 +616,7 @@ public abstract class JanusGraphBaseTest implements JanusGraphBaseStoreFeaturesT
         int subQueryCounter = 0;
         for (SimpleQueryProfiler subProfiler : profiler) {
             assertNotNull(subProfiler);
-            if (subProfiler.getGroupName().equals(QueryProfiler.OPTIMIZATION)) continue;
+            if (subProfiler.getGroupName().equals(QueryProfiler.OPTIMIZATION) || Boolean.TRUE.equals(subProfiler.getAnnotation(QueryProfiler.MULTI_SLICES_ANNOTATION))) continue;
             if (subQuerySpecs.length == 2) { //0=>fitted, 1=>ordered
                 assertEquals(subQuerySpecs[0], subProfiler.getAnnotation(QueryProfiler.FITTED_ANNOTATION));
                 assertEquals(subQuerySpecs[1], subProfiler.getAnnotation(QueryProfiler.ORDERED_ANNOTATION));

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -197,7 +197,6 @@ import java.util.stream.Stream;
 
 import static org.apache.tinkerpop.gremlin.process.traversal.Order.asc;
 import static org.apache.tinkerpop.gremlin.process.traversal.Order.desc;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.has;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.hasNot;
 import static org.apache.tinkerpop.gremlin.structure.Direction.BOTH;
 import static org.apache.tinkerpop.gremlin.structure.Direction.IN;
@@ -5817,8 +5816,8 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
             option(PROPERTY_PREFETCHING), false,
             option(HAS_STEP_BATCH_MODE), MultiQueryHasStepStrategyMode.REQUIRED_PROPERTIES_ONLY.getConfigName());
         // `foo` and `fooBar` properties are prefetched separately
-        assertEquals(6, countBackendQueriesOfSize(barrierSize, profile.getMetrics()));
-        assertEquals(2, countBackendQueriesOfSize(numV - 3 * barrierSize, profile.getMetrics()));
+        assertEquals(3, countBackendQueriesOfSize(barrierSize * 2, profile.getMetrics()));
+        assertEquals(1, countBackendQueriesOfSize((numV - 3 * barrierSize) * 2, profile.getMetrics()));
 
         // test batching for 3 `has()` steps of required properties only
         profile = testLimitedBatch(() -> graph.traversal().V(cs).barrier(barrierSize).has("foo", "bar").has("fooBar", "Bar").has("barFoo", "Foo"),
@@ -5826,8 +5825,8 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
             option(PROPERTY_PREFETCHING), false,
             option(HAS_STEP_BATCH_MODE), MultiQueryHasStepStrategyMode.REQUIRED_PROPERTIES_ONLY.getConfigName());
         // `foo`, `fooBar`, and `barFoo` properties are prefetched separately
-        assertEquals(9, countBackendQueriesOfSize(barrierSize, profile.getMetrics()));
-        assertEquals(3, countBackendQueriesOfSize(numV - 3 * barrierSize, profile.getMetrics()));
+        assertEquals(3, countBackendQueriesOfSize(barrierSize * 3, profile.getMetrics()));
+        assertEquals(1, countBackendQueriesOfSize((numV - 3 * barrierSize) * 3, profile.getMetrics()));
 
         // test `has()` step `REQUIRED_AND_NEXT_PROPERTIES` mode with not following any properties steps
         profile = testLimitedBatch(() -> graph.traversal().V(cs).barrier(barrierSize).has("foo", "bar").has("fooBar", "Bar"),
@@ -5835,8 +5834,8 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
             option(PROPERTY_PREFETCHING), false,
             option(HAS_STEP_BATCH_MODE), MultiQueryHasStepStrategyMode.REQUIRED_AND_NEXT_PROPERTIES.getConfigName());
         // `foo` and `fooBar` properties are prefetched separately
-        assertEquals(6, countBackendQueriesOfSize(barrierSize, profile.getMetrics()));
-        assertEquals(2, countBackendQueriesOfSize(numV - 3 * barrierSize, profile.getMetrics()));
+        assertEquals(3, countBackendQueriesOfSize(barrierSize * 2, profile.getMetrics()));
+        assertEquals(1, countBackendQueriesOfSize((numV - 3 * barrierSize) * 2, profile.getMetrics()));
 
         // test `has()` step `REQUIRED_AND_NEXT_PROPERTIES` mode with following valueMap step
         profile = testLimitedBatch(() -> graph.traversal().V(cs).barrier(barrierSize).has("foo", "bar").has("fooBar", "Bar").valueMap("barFoo"),
@@ -5844,8 +5843,8 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
             option(PROPERTY_PREFETCHING), false,
             option(HAS_STEP_BATCH_MODE), MultiQueryHasStepStrategyMode.REQUIRED_AND_NEXT_PROPERTIES.getConfigName());
         // `foo`, `fooBar`, and `barFoo` properties are prefetched separately
-        assertEquals(9, countBackendQueriesOfSize(barrierSize, profile.getMetrics()));
-        assertEquals(3, countBackendQueriesOfSize(numV - 3 * barrierSize, profile.getMetrics()));
+        assertEquals(3, countBackendQueriesOfSize(barrierSize * 3, profile.getMetrics()));
+        assertEquals(1, countBackendQueriesOfSize((numV - 3 * barrierSize) * 3, profile.getMetrics()));
 
         // test `has()` step `REQUIRED_AND_NEXT_PROPERTIES` mode with following properties step
         profile = testLimitedBatch(() -> graph.traversal().V(cs).barrier(barrierSize).has("foo", "bar").has("fooBar", "Bar").properties("barFoo"),
@@ -5853,8 +5852,8 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
             option(PROPERTY_PREFETCHING), false,
             option(HAS_STEP_BATCH_MODE), MultiQueryHasStepStrategyMode.REQUIRED_AND_NEXT_PROPERTIES.getConfigName());
         // `foo`, `fooBar`, and `barFoo` properties are prefetched separately
-        assertEquals(9, countBackendQueriesOfSize(barrierSize, profile.getMetrics()));
-        assertEquals(3, countBackendQueriesOfSize(numV - 3 * barrierSize, profile.getMetrics()));
+        assertEquals(3, countBackendQueriesOfSize(barrierSize * 3, profile.getMetrics()));
+        assertEquals(1, countBackendQueriesOfSize((numV - 3 * barrierSize) * 3, profile.getMetrics()));
 
         // test `has()` step `REQUIRED_AND_NEXT_PROPERTIES` mode with following values step
         profile = testLimitedBatch(() -> graph.traversal().V(cs).barrier(barrierSize).has("foo", "bar").has("fooBar", "Bar").values("barFoo"),
@@ -5862,8 +5861,8 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
             option(PROPERTY_PREFETCHING), false,
             option(HAS_STEP_BATCH_MODE), MultiQueryHasStepStrategyMode.REQUIRED_AND_NEXT_PROPERTIES.getConfigName());
         // `foo`, `fooBar`, and `barFoo` properties are prefetched separately
-        assertEquals(9, countBackendQueriesOfSize(barrierSize, profile.getMetrics()));
-        assertEquals(3, countBackendQueriesOfSize(numV - 3 * barrierSize, profile.getMetrics()));
+        assertEquals(3, countBackendQueriesOfSize(barrierSize * 3, profile.getMetrics()));
+        assertEquals(1, countBackendQueriesOfSize((numV - 3 * barrierSize) * 3, profile.getMetrics()));
 
         // test `has()` step `REQUIRED_AND_NEXT_PROPERTIES` mode with following elementMap step
         profile = testLimitedBatch(() -> graph.traversal().V(cs).barrier(barrierSize).has("foo", "bar").has("fooBar", "Bar").elementMap("barFoo"),
@@ -5871,8 +5870,8 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
             option(PROPERTY_PREFETCHING), false,
             option(HAS_STEP_BATCH_MODE), MultiQueryHasStepStrategyMode.REQUIRED_AND_NEXT_PROPERTIES.getConfigName());
         // `foo`, `fooBar`, and `barFoo` properties are prefetched separately
-        assertEquals(9, countBackendQueriesOfSize(barrierSize, profile.getMetrics()));
-        assertEquals(3, countBackendQueriesOfSize(numV - 3 * barrierSize, profile.getMetrics()));
+        assertEquals(3, countBackendQueriesOfSize(barrierSize * 3, profile.getMetrics()));
+        assertEquals(1, countBackendQueriesOfSize((numV - 3 * barrierSize) * 3, profile.getMetrics()));
 
         // test `has()` step `REQUIRED_AND_NEXT_PROPERTIES` mode with following valueMap step (all properties)
         profile = testLimitedBatch(() -> graph.traversal().V(cs).barrier(barrierSize).has("foo", "bar").has("fooBar", "Bar").valueMap(),
@@ -5974,8 +5973,8 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
             option(PROPERTY_PREFETCHING), false,
             option(HAS_STEP_BATCH_MODE), MultiQueryHasStepStrategyMode.REQUIRED_AND_NEXT_PROPERTIES_OR_ALL.getConfigName());
         // `foo`, `fooBar`, and `barFoo` properties are prefetched separately
-        assertEquals(9, countBackendQueriesOfSize(barrierSize, profile.getMetrics()));
-        assertEquals(3, countBackendQueriesOfSize(numV - 3 * barrierSize, profile.getMetrics()));
+        assertEquals(3, countBackendQueriesOfSize(barrierSize * 3, profile.getMetrics()));
+        assertEquals(1, countBackendQueriesOfSize((numV - 3 * barrierSize) * 3, profile.getMetrics()));
 
         // test `has()` step `REQUIRED_AND_NEXT_PROPERTIES_OR_ALL` mode with not following values step
         profile = testLimitedBatch(() -> graph.traversal().V(cs).barrier(barrierSize).has("foo", "bar").has("fooBar", "Bar")
@@ -6091,6 +6090,70 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         // test batching for `out()` inside `or()` limited with second filter not being executed due to first filter is true
         profile = testLimitedBatch(() -> graph.traversal().V(bs).barrier(barrierSize).or(__.out("knows").count().is(P.gte(0)), __.inE("knows").count().is(P.gte(0))).limit(limit));
         assertEquals((int) Math.ceil((double) Math.min(bs.length, limit) / barrierSize), countOptimizationQueries(profile.getMetrics()));
+    }
+
+    @Test
+    public void testMultiSliceDBCachedRequests(){
+        clopen(option(DB_CACHE), false);
+        mgmt.makeVertexLabel("testVertex").make();
+        finishSchema();
+        int numV = 100;
+        JanusGraphVertex a = graph.addVertex();
+        JanusGraphVertex[] bs = new JanusGraphVertex[numV];
+        JanusGraphVertex[] cs = new JanusGraphVertex[numV];
+        for (int i = 0; i < numV; ++i) {
+            bs[i] = graph.addVertex();
+            cs[i] = graph.addVertex("testVertex");
+            cs[i].property("foo", "bar");
+            cs[i].property("fooBar", "Bar");
+            cs[i].property("barFoo", "Foo");
+            a.addEdge("knows", bs[i]);
+            bs[i].addEdge("knows", cs[i]);
+        }
+
+        clopen(option(USE_MULTIQUERY), true, option(LIMITED_BATCH), true,
+            option(DB_CACHE), true, option(DB_CACHE_TIME), 1000000L,
+            option(HAS_STEP_BATCH_MODE), MultiQueryHasStepStrategyMode.REQUIRED_PROPERTIES_ONLY.getConfigName(),
+            option(PROPERTIES_BATCH_MODE), MultiQueryPropertiesStrategyMode.REQUIRED_PROPERTIES_ONLY.getConfigName());
+        assertEquals(numV, graph.traversal().V(cs).values("foo").toList().size());
+        graph.tx().rollback();
+        assertEquals(numV, graph.traversal().V(cs).values("foo").toList().size());
+        graph.tx().rollback();
+        assertEquals(numV * 2, graph.traversal().V(cs).values("foo", "fooBar").toList().size());
+        graph.tx().rollback();
+        assertEquals(numV * 2, graph.traversal().V(cs).values("foo", "fooBar").toList().size());
+        graph.tx().rollback();
+        assertEquals(numV * 3, graph.traversal().V(cs).values("foo", "barFoo", "fooBar").toList().size());
+        graph.tx().rollback();
+        assertEquals(numV * 3, graph.traversal().V(cs).values("foo", "barFoo", "fooBar").toList().size());
+
+        clopen(option(USE_MULTIQUERY), true, option(LIMITED_BATCH), true,
+            option(DB_CACHE), true, option(DB_CACHE_TIME), 1000000L,
+            option(HAS_STEP_BATCH_MODE), MultiQueryHasStepStrategyMode.REQUIRED_PROPERTIES_ONLY.getConfigName(),
+            option(PROPERTIES_BATCH_MODE), MultiQueryPropertiesStrategyMode.REQUIRED_PROPERTIES_ONLY.getConfigName());
+        assertEquals(numV, graph.traversal().V(cs).values("foo").toList().size());
+        graph.tx().rollback();
+        assertEquals(numV * 3, graph.traversal().V(cs).values("foo", "barFoo", "fooBar").toList().size());
+        graph.tx().rollback();
+
+        clopen(option(USE_MULTIQUERY), true, option(LIMITED_BATCH), true,
+            option(DB_CACHE), true, option(DB_CACHE_TIME), 1000000L,
+            option(HAS_STEP_BATCH_MODE), MultiQueryHasStepStrategyMode.REQUIRED_PROPERTIES_ONLY.getConfigName(),
+            option(PROPERTIES_BATCH_MODE), MultiQueryPropertiesStrategyMode.REQUIRED_PROPERTIES_ONLY.getConfigName());
+        assertEquals(3, graph.traversal().V(cs[1], cs[5], cs[10]).values("foo").toList().size());
+        graph.tx().rollback();
+        assertEquals(3, graph.traversal().V(cs[1], cs[7], cs[10]).values("foo").toList().size());
+        graph.tx().rollback();
+        assertEquals(6, graph.traversal().V(cs[1], cs[6], cs[8]).values("foo", "fooBar").toList().size());
+        graph.tx().rollback();
+        assertEquals(6, graph.traversal().V(cs[1], cs[7], cs[10]).values("foo", "fooBar").toList().size());
+        graph.tx().rollback();
+        assertEquals(9, graph.traversal().V(cs[1], cs[5], cs[10]).values("foo", "barFoo", "fooBar").toList().size());
+        graph.tx().rollback();
+        assertEquals(numV * 3, graph.traversal().V(cs).values("foo", "barFoo", "fooBar").toList().size());
+        graph.tx().rollback();
+        assertEquals(numV * 2, graph.traversal().V(cs).values("foo", "fooBar").toList().size());
+        assertEquals(numV * 3, graph.traversal().V().values("foo", "barFoo", "fooBar").toList().size());
     }
 
     private TraversalMetrics testLimitedBatch(Supplier<GraphTraversal<?, ?>> traversal, Object... settings){
@@ -7791,7 +7854,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         }};
         mMultiLabels.getAnnotations().remove("percentDur");
         assertEquals(annotations, mMultiLabels.getAnnotations());
-        assertEquals(3, mMultiLabels.getNested().size());
+        assertEquals(4, mMultiLabels.getNested().size());
         Metrics friendMetrics = (Metrics) mMultiLabels.getNested().toArray()[1];
         assertEquals("OR-query", friendMetrics.getName());
         // FIXME: assertTrue(friendMetrics.getDuration(TimeUnit.MICROSECONDS) > 0);
@@ -7810,6 +7873,14 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
             put("query", "friend-no-index:SliceQuery[0x7180,0x7181)"); // no vertex-centric index found
         }};
         assertEquals(annotations, friendNoIndexMetrics.getAnnotations());
+        Metrics backendQueryMetrics = (Metrics) mMultiLabels.getNested().toArray()[3];
+        assertEquals("backend-query", backendQueryMetrics.getName());
+        Map<String, Object> annotatnions = backendQueryMetrics.getAnnotations();
+        assertEquals(3, annotatnions.size());
+        assertEquals("true", annotatnions.get("multiSlices"));
+        assertEquals(2, annotatnions.get("queriesAmount"));
+        assertTrue(annotatnions.get("queries").equals("[2069:byTime:SliceQuery[0xB0E0FF7FFFFF9B,0xB0E0FF7FFFFF9C), friend-no-index:SliceQuery[0x7180,0x7181)]") ||
+            annotatnions.get("queries").equals("[friend-no-index:SliceQuery[0x7180,0x7181), 2069:byTime:SliceQuery[0xB0E0FF7FFFFF9B,0xB0E0FF7FFFFF9C)]"));
     }
 
     @Test

--- a/janusgraph-benchmark/src/main/java/org/janusgraph/CQLMultiQueryMultiSlicesBenchmark.java
+++ b/janusgraph-benchmark/src/main/java/org/janusgraph/CQLMultiQueryMultiSlicesBenchmark.java
@@ -1,0 +1,188 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph;
+
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.JanusGraphFactory;
+import org.janusgraph.core.JanusGraphTransaction;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.diskstorage.BackendException;
+import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
+import org.janusgraph.diskstorage.configuration.WriteConfiguration;
+import org.janusgraph.diskstorage.cql.CQLConfigOptions;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.janusgraph.graphdb.tinkerpop.optimize.strategy.MultiQueryPropertiesStrategyMode;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Fork(1)
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class CQLMultiQueryMultiSlicesBenchmark {
+    @Param({"5000", "50000"})
+    int verticesAmount;
+
+    JanusGraph graph;
+
+    public WriteConfiguration getConfiguration() {
+        ModifiableConfiguration config = GraphDatabaseConfiguration.buildGraphConfiguration();
+        config.set(GraphDatabaseConfiguration.STORAGE_BACKEND,"cql");
+        config.set(CQLConfigOptions.LOCAL_DATACENTER, "dc1");
+        config.set(GraphDatabaseConfiguration.USE_MULTIQUERY, true);
+        config.set(GraphDatabaseConfiguration.PROPERTIES_BATCH_MODE, MultiQueryPropertiesStrategyMode.REQUIRED_PROPERTIES_ONLY.getConfigName());
+        config.set(GraphDatabaseConfiguration.PROPERTY_PREFETCHING, false);
+        return config.getConfiguration();
+    }
+
+    @Setup
+    public void setUp() throws Exception {
+        graph = JanusGraphFactory.open(getConfiguration());
+        int propertiesAmount = 10;
+
+        JanusGraphManagement mgmt = graph.openManagement();
+        PropertyKey name = mgmt.makePropertyKey("name").dataType(String.class).make();
+
+        for(int i=0;i<propertiesAmount;i++){
+            mgmt.makePropertyKey("prop"+i).dataType(String.class).make();
+        }
+
+        mgmt.buildIndex("nameIndex", Vertex.class).addKey(name).buildCompositeIndex();
+
+        mgmt.commit();
+
+        for (int i = 0; i < verticesAmount; i++) {
+            Vertex vertex = graph.addVertex("name", "testVertex");
+            for(int j=0;j<propertiesAmount;j++){
+                vertex.property("prop"+j,
+                    "SomeTestPropertyValue "+j+" 0123456789 ABCDEFG");
+            }
+        }
+
+        graph.tx().commit();
+    }
+
+    @TearDown
+    public void tearDown() throws BackendException {
+        JanusGraphFactory.drop(graph);
+    }
+
+    @Benchmark
+    public List<? extends Object> getValuesMultiplePropertiesWithAllMultiQuerySlicesUnderMaxRequestsPerConnection() {
+        JanusGraphTransaction tx = graph.buildTransaction()
+            .start();
+        List<? extends Object> result = toVerticesTraversal(tx)
+            .barrier(CQLConfigOptions.MAX_REQUESTS_PER_CONNECTION.getDefaultValue() / 10 - 2)
+            .values("prop0", "prop1", "prop2", "prop3", "prop4", "prop5", "prop6", "prop7", "prop8", "prop9")
+            .toList();
+        tx.rollback();
+        return result;
+    }
+
+    @Benchmark
+    public List<? extends Object> getValuesMultiplePropertiesWithUnlimitedBatch() {
+        JanusGraphTransaction tx = graph.buildTransaction()
+            .start();
+        List<? extends Object> result = toVerticesTraversal(tx)
+            .barrier(Integer.MAX_VALUE)
+            .values("prop0", "prop1", "prop2", "prop3", "prop4", "prop5", "prop6", "prop7", "prop8", "prop9")
+            .toList();
+        tx.rollback();
+        return result;
+    }
+
+    @Benchmark
+    public List<? extends Object> getValuesMultiplePropertiesWithSmallBatch() {
+        JanusGraphTransaction tx = graph.buildTransaction()
+            .start();
+        List<? extends Object> result = toVerticesTraversal(tx)
+            .barrier(10)
+            .values("prop0", "prop1", "prop2", "prop3", "prop4", "prop5", "prop6", "prop7", "prop8", "prop9")
+            .toList();
+        tx.rollback();
+        return result;
+    }
+
+    @Benchmark
+    public List<? extends Object> getValuesThreePropertiesWithAllMultiQuerySlicesUnderMaxRequestsPerConnection() {
+        JanusGraphTransaction tx = graph.buildTransaction()
+            .start();
+        List<? extends Object> result = toVerticesTraversal(tx)
+            .barrier(100)
+            .values("prop1", "prop3", "prop8")
+            .toList();
+        tx.rollback();
+        return result;
+    }
+
+    @Benchmark
+    public List<? extends Object> getValuesAllPropertiesWithAllMultiQuerySlicesUnderMaxRequestsPerConnection() {
+        JanusGraphTransaction tx = graph.buildTransaction()
+            .start();
+        List<? extends Object> result = toVerticesTraversal(tx)
+            .barrier(CQLConfigOptions.MAX_REQUESTS_PER_CONNECTION.getDefaultValue() / 10 - 2)
+            .values()
+            .toList();
+        tx.rollback();
+        return result;
+    }
+
+    @Benchmark
+    public List<? extends Object> getValuesAllPropertiesWithUnlimitedBatch() {
+        JanusGraphTransaction tx = graph.buildTransaction()
+            .start();
+        List<? extends Object> result = toVerticesTraversal(tx)
+            .barrier(Integer.MAX_VALUE)
+            .values()
+            .toList();
+        tx.rollback();
+        return result;
+    }
+
+    @Benchmark
+    public List<? extends Object> vertexCentricPropertiesFetching() {
+        JanusGraphTransaction tx = graph.buildTransaction()
+            .start();
+        List<? extends Vertex> vertices = toVerticesTraversal(tx)
+            .toList();
+        List<Object> result = new ArrayList<>(vertices.size() * 10);
+        for(Vertex vertex : vertices){
+            vertex.properties("prop0", "prop1", "prop2", "prop3", "prop4", "prop5", "prop6", "prop7", "prop8", "prop9")
+                .forEachRemaining(property -> result.add(property.value()));
+        }
+        tx.rollback();
+        return result;
+    }
+
+    private GraphTraversal<Vertex, Vertex> toVerticesTraversal(JanusGraphTransaction tx){
+        return tx.traversal().V()
+            .has("name", "testVertex");
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KCVSProxy.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KCVSProxy.java
@@ -86,4 +86,9 @@ public class KCVSProxy implements KeyColumnValueStore {
     public Map<StaticBuffer,EntryList> getSlice(List<StaticBuffer> keys, SliceQuery query, StoreTransaction txh) throws BackendException {
         return store.getSlice(keys, query, unwrapTx(txh));
     }
+
+    @Override
+    public Map<SliceQuery, Map<StaticBuffer, EntryList>> getMultiSlices(MultiKeysQueryGroups<StaticBuffer, SliceQuery> multiKeysQueryGroups, StoreTransaction txh) throws BackendException {
+        return store.getMultiSlices(multiKeysQueryGroups, unwrapTx(txh));
+    }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KCVSUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KCVSUtil.java
@@ -22,6 +22,7 @@ import org.janusgraph.diskstorage.util.BufferUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -106,7 +107,7 @@ public class KCVSUtil {
     }
 
 
-    public static Map<StaticBuffer,EntryList> emptyResults(List<StaticBuffer> keys) {
+    public static Map<StaticBuffer,EntryList> emptyResults(Collection<StaticBuffer> keys) {
         final Map<StaticBuffer,EntryList> result = new HashMap<>(keys.size());
         for (StaticBuffer key : keys) {
             result.put(key,EntryList.EMPTY_LIST);

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KeyMultiQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KeyMultiQuery.java
@@ -1,0 +1,56 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.keycolumnvalue;
+
+import com.google.common.collect.Iterables;
+import org.janusgraph.graphdb.query.Query;
+
+import java.util.List;
+
+/**
+ * Represents a list of queries which should be performed for a specified key.
+ *
+ * @param <K> key
+ */
+public class KeyMultiQuery<K> {
+
+    private final K key;
+
+    private final List<SliceQuery> columnQueries;
+
+    private final List<SliceQuery> columnSliceQueries;
+
+    public KeyMultiQuery(K key, List<SliceQuery> columnQueries, List<SliceQuery> columnSliceQueries) {
+        this.key = key;
+        this.columnQueries = columnQueries;
+        this.columnSliceQueries = columnSliceQueries;
+    }
+
+    public K getKey() {
+        return key;
+    }
+
+    public List<SliceQuery> getColumnQueries() {
+        return columnQueries;
+    }
+
+    public List<SliceQuery> getColumnSliceQueries() {
+        return columnSliceQueries;
+    }
+
+    public Iterable<Query> getAllQueries() {
+        return Iterables.concat(columnQueries, columnSliceQueries);
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KeyRangeQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KeyRangeQuery.java
@@ -80,8 +80,7 @@ public class KeyRangeQuery extends SliceQuery {
     @Override
     public boolean equals(Object other) {
         if (this==other) return true;
-        else if (other==null) return false;
-        else if (!getClass().isInstance(other)) return false;
+        if (!(other instanceof KeyRangeQuery)) return false;
         KeyRangeQuery oth = (KeyRangeQuery)other;
         return keyStart.equals(oth.keyStart) && keyEnd.equals(oth.keyEnd) && super.equals(oth);
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KeySliceQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KeySliceQuery.java
@@ -66,8 +66,7 @@ public class KeySliceQuery extends SliceQuery {
     @Override
     public boolean equals(Object other) {
         if (this==other) return true;
-        else if (other==null) return false;
-        else if (!getClass().isInstance(other)) return false;
+        if (!(other instanceof KeySliceQuery)) return false;
         KeySliceQuery oth = (KeySliceQuery)other;
         return key.equals(oth.key) && super.equals(oth);
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KeysQueriesGroup.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/KeysQueriesGroup.java
@@ -1,0 +1,43 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.keycolumnvalue;
+
+import org.janusgraph.graphdb.query.Query;
+
+import java.util.List;
+
+public class KeysQueriesGroup<K, Q extends Query> {
+
+    private final List<K> keysGroup;
+
+    private List<Q> queries;
+
+    public KeysQueriesGroup(List<K> keysGroup, List<Q> queries) {
+        this.keysGroup = keysGroup;
+        this.queries = queries;
+    }
+
+    public List<K> getKeysGroup() {
+        return keysGroup;
+    }
+
+    public List<Q> getQueries() {
+        return queries;
+    }
+
+    public void setQueries(List<Q> queries) {
+        this.queries = queries;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/MultiKeyMultiQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/MultiKeyMultiQuery.java
@@ -1,0 +1,35 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.keycolumnvalue;
+
+import java.util.List;
+
+/**
+ * Represents a list of keys and a list of queries for each of the key which should be performed for a specified key.
+ *
+ * @param <K> key
+ */
+public class MultiKeyMultiQuery<K> {
+
+    private final List<KeyMultiQuery<K>> keyMultiQueries;
+
+    public MultiKeyMultiQuery(List<KeyMultiQuery<K>> keyMultiQueries) {
+        this.keyMultiQueries = keyMultiQueries;
+    }
+
+    public List<KeyMultiQuery<K>> getKeyMultiQueries() {
+        return keyMultiQueries;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/MultiKeysQueryGroups.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/MultiKeysQueryGroups.java
@@ -1,0 +1,43 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.keycolumnvalue;
+
+import org.janusgraph.graphdb.query.Query;
+
+import java.util.List;
+
+public class MultiKeysQueryGroups<K, Q extends Query> {
+
+    private List<KeysQueriesGroup<K, Q>> queryGroups;
+
+    private final MultiQueriesByKeysGroupsContext<K> multiQueryContext;
+
+    public MultiKeysQueryGroups(List<KeysQueriesGroup<K, Q>> queryGroups, MultiQueriesByKeysGroupsContext<K> multiQueryContext) {
+        this.queryGroups = queryGroups;
+        this.multiQueryContext = multiQueryContext;
+    }
+
+    public List<KeysQueriesGroup<K, Q>> getQueryGroups() {
+        return queryGroups;
+    }
+
+    public MultiQueriesByKeysGroupsContext<K> getMultiQueryContext() {
+        return multiQueryContext;
+    }
+
+    public void setQueryGroups(List<KeysQueriesGroup<K, Q>> queryGroups) {
+        this.queryGroups = queryGroups;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/MultiQueriesByKeysGroupsContext.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/MultiQueriesByKeysGroupsContext.java
@@ -1,0 +1,77 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.keycolumnvalue;
+
+import org.janusgraph.graphdb.util.MultiSliceQueriesGroupingUtil;
+
+import java.util.List;
+
+public class MultiQueriesByKeysGroupsContext<K> {
+
+    /**
+     * This is a list of all unique keys which could be used in this multi-query.
+     * It doesn't mean that all these keys should be performed for each query.
+     * This array should be considered to be a mata-data which may be useful for queries grouping and should not
+     * be considered that all these keys should be requested.
+     */
+    private final K[] allKeysArr;
+
+    /**
+     * This is the tree where each left node represents a missing key from `allKeysArr` and each right node represents a selected
+     * key from `allKeysArr`. The first child node represents the key with index 0 from `allKeysArr`,
+     * while the leaf nodes are always represent a query with the index `allKeysArr.length-1`.
+     * Moreover, each leaf node is of type {@code MultiSliceQueriesGroupingUtil.DataTreeNode<KeysQueriesGroup<K>>} ,
+     * where `K` is of key type.
+     * Each leaf node represents a separate group where all queries are unique.
+     */
+    private final MultiSliceQueriesGroupingUtil.TreeNode groupingRootTreeNode;
+
+    /**
+     * All parent nodes which has at least one child node which is a leaf node with data.
+     */
+    private final List<MultiSliceQueriesGroupingUtil.TreeNode> allLeafParents;
+
+    private final int totalAmountOfQueries;
+
+    public MultiQueriesByKeysGroupsContext(K[] allKeysArr, MultiQueriesByKeysGroupsContext<?> cloneContext) {
+        this.allKeysArr = allKeysArr;
+        this.groupingRootTreeNode = cloneContext.getGroupingRootTreeNode();
+        this.totalAmountOfQueries = cloneContext.totalAmountOfQueries;
+        this.allLeafParents = cloneContext.getAllLeafParents();
+    }
+
+    public MultiQueriesByKeysGroupsContext(K[] allKeysArr, MultiSliceQueriesGroupingUtil.TreeNode groupingRootTreeNode, int totalAmountOfQueries, List<MultiSliceQueriesGroupingUtil.TreeNode> allLeafParents) {
+        this.allKeysArr = allKeysArr;
+        this.groupingRootTreeNode = groupingRootTreeNode;
+        this.totalAmountOfQueries = totalAmountOfQueries;
+        this.allLeafParents = allLeafParents;
+    }
+
+    public K[] getAllKeysArr() {
+        return allKeysArr;
+    }
+
+    public MultiSliceQueriesGroupingUtil.TreeNode getGroupingRootTreeNode() {
+        return groupingRootTreeNode;
+    }
+
+    public int getTotalAmountOfQueries() {
+        return totalAmountOfQueries;
+    }
+
+    public List<MultiSliceQueriesGroupingUtil.TreeNode> getAllLeafParents() {
+        return allLeafParents;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/SliceQuery.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/SliceQuery.java
@@ -88,8 +88,9 @@ public class SliceQuery extends BaseQuery implements BackendQuery<SliceQuery> {
         if (this == other)
             return true;
 
-        if (other == null && !getClass().isInstance(other))
+        if(!(other instanceof SliceQuery)){
             return false;
+        }
 
         SliceQuery oth = (SliceQuery) other;
         return sliceStart.equals(oth.sliceStart)

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/StoreFeatures.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/StoreFeatures.java
@@ -18,6 +18,8 @@ import org.janusgraph.diskstorage.configuration.Configuration;
 import org.janusgraph.diskstorage.keycolumnvalue.scan.ScanJob;
 import org.janusgraph.diskstorage.util.time.TimestampProviders;
 
+import java.util.List;
+
 /**
  * Describes features supported by a storage backend.
  *
@@ -56,7 +58,7 @@ public interface StoreFeatures {
     /**
      * Whether this storage backend supports query operations on multiple keys
      * via
-     * {@link KeyColumnValueStore#getSlice(java.util.List, SliceQuery, StoreTransaction)}
+     * {@link KeyColumnValueStore#getSlice(List, SliceQuery, StoreTransaction)} and {@link KeyColumnValueStore#getMultiSlices(MultiKeysQueryGroups, StoreTransaction)}
      */
     boolean hasMultiQuery();
 

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/cache/KCVSCache.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/cache/KCVSCache.java
@@ -21,6 +21,7 @@ import org.janusgraph.diskstorage.StaticBuffer;
 import org.janusgraph.diskstorage.keycolumnvalue.KCVSProxy;
 import org.janusgraph.diskstorage.keycolumnvalue.KeyColumnValueStore;
 import org.janusgraph.diskstorage.keycolumnvalue.KeySliceQuery;
+import org.janusgraph.diskstorage.keycolumnvalue.MultiKeysQueryGroups;
 import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
 import org.janusgraph.diskstorage.keycolumnvalue.StoreTransaction;
 import org.janusgraph.diskstorage.util.CacheMetricsAction;
@@ -85,4 +86,7 @@ public abstract class KCVSCache extends KCVSProxy {
         return store.getSlice(keys,query,unwrapTx(txh));
     }
 
+    public Map<SliceQuery, Map<StaticBuffer, EntryList>> getMultiSlicesNoCache(MultiKeysQueryGroups<StaticBuffer, SliceQuery> multiSliceQueriesWithKeys, StoreTransaction txh) throws BackendException {
+        return store.getMultiSlices(multiSliceQueriesWithKeys, unwrapTx(txh));
+    }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/CompletableFutureUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/CompletableFutureUtil.java
@@ -60,12 +60,34 @@ public class CompletableFutureUtil {
         }
     }
 
+    //
     public static <K,V> Map<K,V> unwrap(Map<K,CompletableFuture<V>> futureMap) throws Throwable{
         Map<K, V> resultMap = new HashMap<>(futureMap.size());
         Throwable firstException = null;
         for(Map.Entry<K, CompletableFuture<V>> entry : futureMap.entrySet()){
             try{
                 resultMap.put(entry.getKey(), entry.getValue().get());
+            } catch (Throwable throwable){
+                if(firstException == null){
+                    firstException = throwable;
+                } else {
+                    firstException.addSuppressed(throwable);
+                }
+            }
+        }
+
+        if(firstException != null){
+            throw firstException;
+        }
+        return resultMap;
+    }
+
+    public static <K,V,R> Map<K,Map<V, R>> unwrapMapOfMaps(Map<K, Map<V, CompletableFuture<R>>> futureMap) throws Throwable{
+        Map<K, Map<V, R>> resultMap = new HashMap<>(futureMap.size());
+        Throwable firstException = null;
+        for(Map.Entry<K, Map<V, CompletableFuture<R>>> entry : futureMap.entrySet()){
+            try{
+                resultMap.put(entry.getKey(), unwrap(entry.getValue()));
             } catch (Throwable throwable){
                 if(firstException == null){
                     firstException = throwable;

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/MetricInstrumentedStore.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/MetricInstrumentedStore.java
@@ -26,6 +26,7 @@ import org.janusgraph.diskstorage.keycolumnvalue.KeyIterator;
 import org.janusgraph.diskstorage.keycolumnvalue.KeyRangeQuery;
 import org.janusgraph.diskstorage.keycolumnvalue.KeySliceQuery;
 import org.janusgraph.diskstorage.keycolumnvalue.KeySlicesIterator;
+import org.janusgraph.diskstorage.keycolumnvalue.MultiKeysQueryGroups;
 import org.janusgraph.diskstorage.keycolumnvalue.MultiSlicesQuery;
 import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
 import org.janusgraph.diskstorage.keycolumnvalue.StoreTransaction;
@@ -123,6 +124,20 @@ public class MetricInstrumentedStore implements KeyColumnValueStore {
 
             for (final EntryList result : results.values()) {
                 recordSliceMetrics(txh, result);
+            }
+            return results;
+        });
+    }
+
+    @Override
+    public Map<SliceQuery, Map<StaticBuffer, EntryList>> getMultiSlices(MultiKeysQueryGroups<StaticBuffer, SliceQuery> multiKeysQueryGroups, StoreTransaction txh) throws BackendException {
+        return runWithMetrics(txh, metricsStoreName, M_GET_SLICE, () -> {
+            final Map<SliceQuery, Map<StaticBuffer, EntryList>> results = backend.getMultiSlices(multiKeysQueryGroups, txh);
+
+            for (final Map<StaticBuffer, EntryList> queryResults : results.values()) {
+                for (final EntryList result : queryResults.values()) {
+                    recordSliceMetrics(txh, result);
+                }
             }
             return results;
         });

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/BackendQueryHolder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/BackendQueryHolder.java
@@ -18,6 +18,8 @@ import com.google.common.base.Preconditions;
 import org.janusgraph.graphdb.query.profile.ProfileObservable;
 import org.janusgraph.graphdb.query.profile.QueryProfiler;
 
+import java.util.Objects;
+
 /**
  * Holds a {@link BackendQuery} and captures additional information that pertains to its execution and to be used by a
  * {@link QueryExecutor}:
@@ -80,5 +82,22 @@ public class BackendQueryHolder<E extends BackendQuery<E>> implements ProfileObs
         profiler.setAnnotation(QueryProfiler.ORDERED_ANNOTATION,isSorted);
         profiler.setAnnotation(QueryProfiler.QUERY_ANNOTATION,backendQuery);
         if (backendQuery instanceof ProfileObservable) ((ProfileObservable)backendQuery).observeWith(profiler);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(backendQuery, isFitted, isFitted);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if(!(other instanceof BackendQueryHolder)){
+            return false;
+        }
+        BackendQueryHolder oth = (BackendQueryHolder) other;
+        return isFitted == oth.isFitted && isSorted == oth.isSorted && Objects.equals(backendQuery, oth.backendQuery);
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/QueryProfiler.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/QueryProfiler.java
@@ -14,10 +14,12 @@
 
 package org.janusgraph.graphdb.query.profile;
 
+import org.janusgraph.diskstorage.keycolumnvalue.MultiKeysQueryGroups;
 import org.janusgraph.graphdb.query.Query;
 import org.janusgraph.graphdb.query.graph.JointIndexQuery.Subquery;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -39,6 +41,10 @@ public interface QueryProfiler {
     String QUERY_ANNOTATION = "query";
     String FULLSCAN_ANNOTATION = "fullscan";
     String INDEX_ANNOTATION = "index";
+    String QUERIES_ANNOTATION = "queries";
+    String QUERIES_AMOUNT_ANNOTATION = "queriesAmount";
+    String MULTI_SLICES_ANNOTATION = "multiSlices";
+    String QUERY_LIMITS_ANNOTATION = "limitsPerQuery";
 
     /* ==================================================================================
                                        GROUP NAMES
@@ -115,6 +121,38 @@ public interface QueryProfiler {
             }
         } else {
             resultSize = result.size();
+        }
+        sub.setResultSize(resultSize);
+        return result;
+    }
+
+    static<Q extends Query, R extends Collection> Map<Q, Map<Object, R>> profile(QueryProfiler profiler, MultiKeysQueryGroups<Object, Q> multiSliceQueries, boolean multiQuery, Function<MultiKeysQueryGroups<Object, Q>, Map<Q, Map<Object, R>>> queryExecutor) {
+        return profile(BACKEND_QUERY,profiler,multiSliceQueries,multiQuery,queryExecutor);
+    }
+
+    static<Q extends Query, R extends Collection> Map<Q, Map<Object, R>> profile(String groupName, QueryProfiler profiler, MultiKeysQueryGroups<Object, Q> multiSliceQueries, boolean multiQuery, Function<MultiKeysQueryGroups<Object, Q>, Map<Q, Map<Object, R>>> queryExecutor) {
+        final QueryProfiler sub = profiler.addNested(groupName);
+        QueryProfilerUtil.setMultiSliceQueryAnnotations(sub, multiSliceQueries);
+        sub.startTimer();
+        final Map<Q, Map<Object, R>> result = queryExecutor.apply(multiSliceQueries);
+        sub.stopTimer();
+        long resultSize = 0;
+        if (multiQuery && profiler!=QueryProfiler.NO_OP) {
+            //The result set is a collection of collections, but don't do this computation if profiling is disabled
+            for(Map<Object, R> resultsPerSlice : result.values()){
+                for (R resultsPerVertex : resultsPerSlice.values()) {
+                    for(Object r : resultsPerVertex){
+                        if (r instanceof Collection) resultSize+=((Collection)r).size();
+                        else resultSize++;
+                    }
+                }
+            }
+        } else {
+            for(Map<Object, R> resultsPerSlice : result.values()){
+                for (R resultsPerVertex : resultsPerSlice.values()) {
+                    resultSize += resultsPerVertex.size();
+                }
+            }
         }
         sub.setResultSize(resultSize);
         return result;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/QueryProfilerUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/profile/QueryProfilerUtil.java
@@ -1,0 +1,61 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.query.profile;
+
+import org.janusgraph.diskstorage.keycolumnvalue.KeysQueriesGroup;
+import org.janusgraph.diskstorage.keycolumnvalue.MultiKeysQueryGroups;
+import org.janusgraph.graphdb.query.Query;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class QueryProfilerUtil {
+
+    private QueryProfilerUtil(){}
+
+    public static <Q extends Query> void setMultiSliceQueryAnnotations(QueryProfiler profiler, MultiKeysQueryGroups<Object, Q> multiSliceQueries){
+        if(profiler == QueryProfiler.NO_OP){
+            return;
+        }
+        profiler.setAnnotation(QueryProfiler.MULTI_SLICES_ANNOTATION, true);
+        List<Q> allQueries = new ArrayList<>();
+        ArrayList<Integer> allLimits = null;
+        boolean hasLimit = false;
+        int queriesCount = 0;
+        for(KeysQueriesGroup<Object, Q> groupedQueries : multiSliceQueries.getQueryGroups()){
+            for(Q query : groupedQueries.getQueries()){
+                allQueries.add(query);
+                if(hasLimit){
+                    allLimits.add(query.hasLimit() ? query.getLimit() : -1);
+                } else if(query.hasLimit()){
+                    hasLimit = true;
+                    allLimits = new ArrayList<>();
+                    allLimits.ensureCapacity(queriesCount+1);
+                    for(int i=0;i<queriesCount;i++){
+                        allLimits.add(-1);
+                    }
+                    allLimits.add(query.getLimit());
+                }
+                ++queriesCount;
+            }
+        }
+        profiler.setAnnotation(QueryProfiler.QUERIES_ANNOTATION, allQueries);
+        profiler.setAnnotation(QueryProfiler.QUERIES_AMOUNT_ANNOTATION, queriesCount);
+        if(hasLimit){
+            profiler.setAnnotation(QueryProfiler.QUERY_LIMITS_ANNOTATION,allLimits);
+        }
+    }
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/MultiSliceQueriesGroupingUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/MultiSliceQueriesGroupingUtil.java
@@ -1,0 +1,327 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.util;
+
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.commons.lang3.tuple.Pair;
+import org.janusgraph.diskstorage.keycolumnvalue.KeysQueriesGroup;
+import org.janusgraph.diskstorage.keycolumnvalue.MultiKeysQueryGroups;
+import org.janusgraph.diskstorage.keycolumnvalue.MultiQueriesByKeysGroupsContext;
+import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
+import org.janusgraph.graphdb.internal.InternalVertex;
+import org.janusgraph.graphdb.query.BackendQueryHolder;
+import org.janusgraph.graphdb.vertices.CacheVertex;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility class which helps to group necessary queries to matched vertices for the following multi-query execution.
+ */
+public class MultiSliceQueriesGroupingUtil {
+
+    private static final MultiKeysQueryGroups<Object, SliceQuery> EMPTY_QUERY = new MultiKeysQueryGroups<>(Collections.emptyList(),
+        new MultiQueriesByKeysGroupsContext<>(new Object[0], new TreeNode(), 0, Collections.emptyList()));
+
+    /**
+     * Moves queries `updatedQueryGroup` to either existing leaf nodes or generates new leaf nodes for the necessary key sets.
+     *
+     * @param updatedQueryGroup Query groups to which a query should be moved.
+     * @param allVertices All vertices
+     * @param groupingRootTreeNode Root tree node which represents chains where each left node represents a missing key
+     *                             from `allVertices` array, and each right node represents existing key from `allVertices`
+     *                             array.
+     * @param remainingQueryGroups Remaining groups where queries from `updatedQueryGroup` should be added. Notice, if
+     *                             a new leaf node is added into `groupingRootTreeNode` then a new group is added to
+     *                             `remainingQueryGroups`.
+     */
+    public static <K> void moveQueriesToNewLeafNode(List<Pair<SliceQuery, List<K>>> updatedQueryGroup,
+                                                    K[] allVertices,
+                                                    TreeNode groupingRootTreeNode,
+                                                    List<KeysQueriesGroup<K, SliceQuery>> remainingQueryGroups){
+
+        for(Pair<SliceQuery, List<K>> keyNewQueriesGroup : updatedQueryGroup){
+            boolean newChainGenerated = false;
+            TreeNode previousNode = groupingRootTreeNode;
+            TreeNode currentNode = groupingRootTreeNode;
+            boolean rightNode = false;
+            Iterator<K> usedKeyIt = keyNewQueriesGroup.getValue().iterator();
+            for(int keyIndex = 0; keyIndex < allVertices.length; keyIndex++){
+
+                K usedKey = usedKeyIt.hasNext() ? usedKeyIt.next() : null;
+
+                while (keyIndex < allVertices.length && usedKey != allVertices[keyIndex]){
+                    rightNode = false;
+                    if(currentNode.left == null){
+                        currentNode.left = new TreeNode();
+                        newChainGenerated = true;
+                    }
+                    previousNode = currentNode;
+                    currentNode = currentNode.left;
+                    ++keyIndex;
+                }
+
+                if(keyIndex == allVertices.length){
+                    break;
+                }
+
+                rightNode = true;
+                if(currentNode.right == null){
+                    currentNode.right = new TreeNode();
+                    newChainGenerated = true;
+                }
+                previousNode = currentNode;
+                currentNode = currentNode.right;
+            }
+
+            DataTreeNode<KeysQueriesGroup<K, SliceQuery>> chainLeafNode;
+            if(newChainGenerated){
+                KeysQueriesGroup<K, SliceQuery> data = new KeysQueriesGroup<>(keyNewQueriesGroup.getValue(), new ArrayList<>());
+                chainLeafNode = new DataTreeNode<>(data);
+                if(rightNode){
+                    previousNode.right = chainLeafNode;
+                } else {
+                    previousNode.left = chainLeafNode;
+                }
+                remainingQueryGroups.add(data);
+            } else {
+                chainLeafNode = (DataTreeNode<KeysQueriesGroup<K, SliceQuery>>) currentNode;
+            }
+            chainLeafNode.data.getQueries().add(keyNewQueriesGroup.getKey());
+        }
+    }
+
+    /**
+     * Replaces child leaf nodes which have data {@code KeysQueriesGroup<C>} with new leaf nodes which have keys replaces
+     * by `oldToNewKeysMap`. The resulting data of child nodes will be {@code KeysQueriesGroup<N>}.
+     *
+     * @param allLeafParents parent nodes
+     * @param oldToNewKeysMap map to replace old type keys with new type keys
+     * @param <C> current key type
+     * @param <N> new key type
+     */
+    public static <C,N> void replaceCurrentLeafNodeWithUpdatedTypeLeafNodes(List<TreeNode> allLeafParents, Map<C, N> oldToNewKeysMap){
+        for(TreeNode node : allLeafParents){
+            if(node.left instanceof DataTreeNode){
+                node.left = generateConvertedLeafNode((DataTreeNode<KeysQueriesGroup<C, SliceQuery>>) node.left, oldToNewKeysMap);
+            }
+            if(node.right instanceof DataTreeNode){
+                node.right = generateConvertedLeafNode((DataTreeNode<KeysQueriesGroup<C, SliceQuery>>) node.right, oldToNewKeysMap);
+            }
+        }
+    }
+
+    private static <C,N> DataTreeNode<KeysQueriesGroup<N, SliceQuery>> generateConvertedLeafNode(DataTreeNode<KeysQueriesGroup<C, SliceQuery>> currentLeafNode, Map<C, N> oldToNewKeysMap){
+        KeysQueriesGroup<C, SliceQuery> data = currentLeafNode.data;
+        List<N> keysGroup = new ArrayList<>(data.getKeysGroup().size());
+        for(C currentKey : data.getKeysGroup()){
+            keysGroup.add(oldToNewKeysMap.get(currentKey));
+        }
+        KeysQueriesGroup<N, SliceQuery> newData = new KeysQueriesGroup<>(keysGroup, data.getQueries());
+        return new DataTreeNode<>(newData);
+    }
+
+    /**
+     * Queries grouping algorithm for the same sets of keys (vertices).
+     * <br>
+     * This algorithm uses a binary prefix tree to find a group with the same vertices (same vertices Set).
+     * All and only the leaf nodes store the final computed data (queries used for this leaf node + vertices used for this leaf nodes).
+     * Each leaf node represents a group of queries which always have the same vertices.
+     * Time complexity is always O(N+M), where N is the vertices amount and M is the queries amount.
+     * Space complexity in most cases is O(N+M), or O(N*M) in the worst case.
+     *
+     * @param vertices all vertices.
+     * @param queries all queries which should be executed for all vertices.
+     * @return Generated grouped multi-query representation.
+     */
+    public static MultiKeysQueryGroups<Object, SliceQuery> toMultiKeysQueryGroups(final Collection<InternalVertex> vertices, final List<BackendQueryHolder<SliceQuery>> queries){
+        if(queries.isEmpty()){
+            return EMPTY_QUERY;
+        }
+        MutableInt verticesMutableSize = new MutableInt();
+        InternalVertex[] cacheableVertices = filterNonCacheableVertices(vertices, verticesMutableSize);
+        final int verticesSize = verticesMutableSize.intValue();
+        Object[] vertexIds = toIds(cacheableVertices, verticesSize);
+        if(verticesSize == 0){
+            return EMPTY_QUERY;
+        }
+        List<KeysQueriesGroup<Object, SliceQuery>> result = new ArrayList<>();
+        TreeNode root = new TreeNode();
+        boolean[] useVertex = new boolean[verticesSize];
+        List<TreeNode> allLeafParents = new ArrayList<>();
+        for(BackendQueryHolder<SliceQuery> queryHolder : queries){
+            final SliceQuery query = queryHolder.getBackendQuery();
+            TreeNode currentNode = root;
+            int usedVertices = 0;
+            for(int i=0; i<verticesSize; i++){
+                if (cacheableVertices[i].hasLoadedRelations(query)){
+                    useVertex[i] = false;
+                    if(currentNode.left == null){
+                        currentNode = generateNewChainAndReturnLeafNode(true, currentNode, cacheableVertices,
+                            useVertex, i, usedVertices, verticesSize, query, result, allLeafParents);
+                        break;
+                    } else {
+                        currentNode = currentNode.left;
+                    }
+                } else {
+                    useVertex[i] = true;
+                    ++usedVertices;
+                    if(currentNode.right == null){
+                        currentNode = generateNewChainAndReturnLeafNode(false, currentNode, cacheableVertices,
+                            useVertex, i, usedVertices, verticesSize, query, result, allLeafParents);
+                        break;
+                    } else {
+                        currentNode = currentNode.right;
+                    }
+                }
+            }
+            ((DataTreeNode<KeysQueriesGroup<Object, SliceQuery>>) currentNode).data.getQueries().add(query);
+        }
+        return new MultiKeysQueryGroups<>(result, new MultiQueriesByKeysGroupsContext<>(vertexIds, root, queries.size(), allLeafParents));
+    }
+
+    private static InternalVertex[] filterNonCacheableVertices(Collection<InternalVertex> vertices, MutableInt verticesMutableSize){
+        InternalVertex[] cacheableVertices = new InternalVertex[vertices.size()];
+        int i = 0;
+        for(InternalVertex v : vertices){
+            if(!v.isNew() && v.hasId() && (v instanceof CacheVertex)){
+                cacheableVertices[i++] = v;
+            }
+        }
+        verticesMutableSize.setValue(i);
+        return cacheableVertices;
+    }
+
+    private static Object[] toPartiallyFilledVertexIds(InternalVertex[] cacheableVertices, boolean[] useVertex, int fillUpToIndex, int totalVerticesSize){
+        Object[] vertexIds = new Object[totalVerticesSize];
+        for(int i=0, j=0; i<=fillUpToIndex; i++){
+            if(useVertex[i]){
+                vertexIds[j++] = cacheableVertices[i].id();
+            }
+        }
+        return vertexIds;
+    }
+
+    private static Object[] toIds(InternalVertex[] cacheableVertices, int totalVerticesSize){
+        Object[] vertexIds = new Object[totalVerticesSize];
+        for(int i=0; i<totalVerticesSize; i++){
+            vertexIds[i] = cacheableVertices[i].id();
+        }
+        return vertexIds;
+    }
+
+    private static TreeNode generateNewChainAndReturnLeafNode(boolean childNodeHasLoadedRelations, TreeNode currentNode, InternalVertex[] cacheableVertices,
+                                                              boolean[] useVertex, int currentIndex, int usedVertices, int totalVerticesSize,
+                                                              SliceQuery query, List<KeysQueriesGroup<Object, SliceQuery>> result,
+                                                              List<TreeNode> allLeafParents){
+        TreeNode previousNode = currentNode;
+        currentNode = new TreeNode();
+        assignChild(previousNode, currentNode, childNodeHasLoadedRelations);
+        Object[] queryVertexIds = toPartiallyFilledVertexIds(cacheableVertices, useVertex, currentIndex, totalVerticesSize);
+        ChainCreationResult newChain = generateNewNodesChain(
+            cacheableVertices, queryVertexIds, previousNode, currentNode, currentIndex, usedVertices, totalVerticesSize, childNodeHasLoadedRelations, query);
+        previousNode = newChain.latestParent;
+        usedVertices = newChain.usedVerticesCount;
+        if(usedVertices != totalVerticesSize){
+            if(usedVertices == 0){
+                queryVertexIds = new Object[0];
+            } else {
+                Object[] trimmedQueryVertexIds = new Object[usedVertices];
+                System.arraycopy(queryVertexIds, 0, trimmedQueryVertexIds, 0, usedVertices);
+                queryVertexIds = trimmedQueryVertexIds;
+            }
+        }
+
+        KeysQueriesGroup<Object, SliceQuery> data = new KeysQueriesGroup<>(Arrays.asList(queryVertexIds), new ArrayList<>());
+        currentNode = new DataTreeNode<>(data);
+        assignChild(previousNode, currentNode, newChain.lastVertexHasLoadedRelations);
+        if(previousNode.left == null || previousNode.right == null){
+            allLeafParents.add(previousNode);
+        }
+        if(usedVertices > 0){
+            result.add(data);
+        }
+        return currentNode;
+    }
+
+    private static void assignChild(TreeNode parent, TreeNode child, boolean childNodeHasLoadedRelations){
+        if(childNodeHasLoadedRelations){
+            parent.left = child;
+        } else {
+            parent.right = child;
+        }
+    }
+
+    private static ChainCreationResult generateNewNodesChain(InternalVertex[] cacheableVertices,
+                                                             Object[] queryVertexIds,
+                                                             TreeNode previousNode,
+                                                             TreeNode currentNode,
+                                                             int currentIndex,
+                                                             int usedVertices,
+                                                             int totalVerticesSize,
+                                                             boolean lastChildHasLoadedRelations,
+                                                             SliceQuery currentQuery){
+        boolean hasLoadedRelations = lastChildHasLoadedRelations;
+        while (++currentIndex < totalVerticesSize){
+            previousNode = currentNode;
+            hasLoadedRelations = cacheableVertices[currentIndex].hasLoadedRelations(currentQuery);
+            if(hasLoadedRelations){
+                currentNode.left = new TreeNode();
+                currentNode = currentNode.left;
+            } else {
+                currentNode.right = new TreeNode();
+                currentNode = currentNode.right;
+                queryVertexIds[usedVertices++] = cacheableVertices[currentIndex].id();
+            }
+        }
+        return new ChainCreationResult(previousNode, hasLoadedRelations, usedVertices);
+    }
+
+    public static class TreeNode {
+        public TreeNode left;
+        public TreeNode right;
+        public TreeNode() {
+        }
+        public TreeNode(TreeNode left, TreeNode right) {
+            this.left = left;
+            this.right = right;
+        }
+    }
+
+    public static class DataTreeNode<Q> extends TreeNode{
+        public final Q data;
+        public DataTreeNode(Q data) {
+            this.data = data;
+        }
+    }
+
+    private static class ChainCreationResult{
+        // parent before the leaf node
+        public final TreeNode latestParent;
+        public final boolean lastVertexHasLoadedRelations;
+        public final int usedVerticesCount;
+
+        private ChainCreationResult(TreeNode latestParent, boolean lastVertexHasLoadedRelations, int usedVerticesCount) {
+            this.latestParent = latestParent;
+            this.lastVertexHasLoadedRelations = lastVertexHasLoadedRelations;
+            this.usedVerticesCount = usedVerticesCount;
+        }
+    }
+}

--- a/janusgraph-core/src/test/java/org/janusgraph/graphdb/util/MultiSliceQueriesGroupingUtilTest.java
+++ b/janusgraph-core/src/test/java/org/janusgraph/graphdb/util/MultiSliceQueriesGroupingUtilTest.java
@@ -1,0 +1,754 @@
+// Copyright 2023 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.util;
+
+import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.apache.commons.lang3.tuple.Pair;
+import org.janusgraph.diskstorage.keycolumnvalue.KeysQueriesGroup;
+import org.janusgraph.diskstorage.keycolumnvalue.MultiKeysQueryGroups;
+import org.janusgraph.diskstorage.keycolumnvalue.MultiQueriesByKeysGroupsContext;
+import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
+import org.janusgraph.graphdb.internal.InternalVertex;
+import org.janusgraph.graphdb.query.BackendQueryHolder;
+import org.janusgraph.graphdb.vertices.CacheVertex;
+import org.janusgraph.graphdb.vertices.StandardVertex;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.janusgraph.graphdb.util.MultiSliceQueriesGroupingUtil.DataTreeNode;
+import static org.janusgraph.graphdb.util.MultiSliceQueriesGroupingUtil.TreeNode;
+import static org.janusgraph.graphdb.util.MultiSliceQueriesGroupingUtil.moveQueriesToNewLeafNode;
+import static org.janusgraph.graphdb.util.MultiSliceQueriesGroupingUtil.replaceCurrentLeafNodeWithUpdatedTypeLeafNodes;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class MultiSliceQueriesGroupingUtilTest {
+
+    private static final AtomicLong VERTEX_ID = new AtomicLong(1);
+
+    ///// Grouping testing
+
+    @Test
+    public void testGroupingNoVertices() {
+
+        MultiKeysQueryGroups<Object, SliceQuery> result = MultiSliceQueriesGroupingUtil.toMultiKeysQueryGroups(Collections.emptyList(),
+            Collections.singletonList(new BackendQueryHolder<>(mock(SliceQuery.class), false, false)));
+
+        assertEquals(0, result.getQueryGroups().size());
+        assertEquals(0, result.getMultiQueryContext().getAllKeysArr().length);
+        assertEquals(0, result.getMultiQueryContext().getTotalAmountOfQueries());
+        assertEquals(0, result.getMultiQueryContext().getAllLeafParents().size());
+        assertContextIsValid(result.getMultiQueryContext());
+    }
+
+    @Test
+    public void testGroupingNoQueries() {
+        MultiKeysQueryGroups<Object, SliceQuery> result = MultiSliceQueriesGroupingUtil.toMultiKeysQueryGroups(
+            Collections.singletonList(alwaysUseVertex()),
+            Collections.emptyList());
+
+        assertEquals(0, result.getQueryGroups().size());
+        assertEquals(0, result.getMultiQueryContext().getAllKeysArr().length);
+        assertEquals(0, result.getMultiQueryContext().getTotalAmountOfQueries());
+        assertEquals(0, result.getMultiQueryContext().getAllLeafParents().size());
+        assertContextIsValid(result.getMultiQueryContext());
+
+        result = MultiSliceQueriesGroupingUtil.toMultiKeysQueryGroups(
+            Collections.emptyList(),
+            Collections.emptyList());
+
+        assertEquals(0, result.getQueryGroups().size());
+        assertEquals(0, result.getMultiQueryContext().getAllKeysArr().length);
+        assertEquals(0, result.getMultiQueryContext().getTotalAmountOfQueries());
+        assertEquals(0, result.getMultiQueryContext().getAllLeafParents().size());
+        assertContextIsValid(result.getMultiQueryContext());
+    }
+
+    @Test
+    public void testGroupingNonCacheableVertices() {
+        MultiKeysQueryGroups<Object, SliceQuery> result = MultiSliceQueriesGroupingUtil.toMultiKeysQueryGroups(
+            Collections.singletonList(nonCacheVertex()),
+            Collections.singletonList(new BackendQueryHolder<>(mock(SliceQuery.class), false, false)));
+        assertEquals(0, result.getQueryGroups().size());
+        assertEquals(0, result.getMultiQueryContext().getAllKeysArr().length);
+        assertEquals(0, result.getMultiQueryContext().getTotalAmountOfQueries());
+        assertEquals(0, result.getMultiQueryContext().getAllLeafParents().size());
+        assertContextIsValid(result.getMultiQueryContext());
+
+        result = MultiSliceQueriesGroupingUtil.toMultiKeysQueryGroups(
+            Arrays.asList(nonCacheVertex(), alwaysUseVertex(), nonCacheVertex()),
+            Collections.singletonList(new BackendQueryHolder<>(mock(SliceQuery.class), false, false)));
+        assertEquals(1, result.getQueryGroups().size());
+        assertEquals(1, result.getQueryGroups().get(0).getQueries().size());
+        assertEquals(1, result.getQueryGroups().get(0).getKeysGroup().size());
+        assertEquals(1, result.getMultiQueryContext().getAllKeysArr().length);
+        assertEquals(1, result.getMultiQueryContext().getTotalAmountOfQueries());
+        assertEquals(1, result.getMultiQueryContext().getAllLeafParents().size());
+        assertContextIsValid(result.getMultiQueryContext());
+    }
+
+    @Test
+    public void testGroupingAlwaysSkipVertex() {
+        MultiKeysQueryGroups<Object, SliceQuery> result = MultiSliceQueriesGroupingUtil.toMultiKeysQueryGroups(
+            Collections.singletonList(alwaysSkipVertex()),
+            Collections.singletonList(new BackendQueryHolder<>(mock(SliceQuery.class), false, false)));
+        assertEquals(0, result.getQueryGroups().size());
+        assertEquals(1, result.getMultiQueryContext().getAllKeysArr().length);
+        assertEquals(1, result.getMultiQueryContext().getTotalAmountOfQueries());
+        assertEquals(1, result.getMultiQueryContext().getAllLeafParents().size());
+        assertContextIsValid(result.getMultiQueryContext());
+
+        result = MultiSliceQueriesGroupingUtil.toMultiKeysQueryGroups(
+            Arrays.asList(alwaysSkipVertex(), alwaysUseVertex(), nonCacheVertex()),
+            Collections.singletonList(new BackendQueryHolder<>(mock(SliceQuery.class), false, false)));
+        assertEquals(1, result.getQueryGroups().size());
+        assertEquals(1, result.getQueryGroups().get(0).getQueries().size());
+        assertEquals(1, result.getQueryGroups().get(0).getKeysGroup().size());
+        assertEquals(2, result.getMultiQueryContext().getAllKeysArr().length);
+        assertEquals(1, result.getMultiQueryContext().getTotalAmountOfQueries());
+        assertEquals(1, result.getMultiQueryContext().getAllLeafParents().size());
+        assertContextIsValid(result.getMultiQueryContext());
+    }
+
+    @Test
+    public void testGroupingByQueries() {
+
+        ArrayList<BackendQueryHolder<SliceQuery>> queries = new ArrayList<>();
+        for (int i=0; i<10; i++){
+            queries.add(new BackendQueryHolder<>(mock(SliceQuery.class), false, false));
+        }
+
+        ArrayList<InternalVertex> alwaysUseVertices = new ArrayList<>();
+        for(int i=0;i<10;i++){
+            alwaysUseVertices.add(alwaysUseVertex());
+        }
+        InternalVertex vertex1Query1 = vertex(queries.get(1).getBackendQuery());
+
+        InternalVertex vertex1Query2 = vertex(queries.get(2).getBackendQuery(), queries.get(3).getBackendQuery());
+        InternalVertex vertex2Query2 = vertex(queries.get(2).getBackendQuery(), queries.get(3).getBackendQuery());
+        InternalVertex vertex3Query2 = vertex(queries.get(2).getBackendQuery(), queries.get(3).getBackendQuery());
+
+        InternalVertex vertex1Query5_9 = vertex(queries.get(5).getBackendQuery(), queries.get(9).getBackendQuery());
+        InternalVertex vertex1Query8 = vertex(queries.get(8).getBackendQuery());
+
+        InternalVertex vertex1Query7 = vertex(queries.get(7).getBackendQuery());
+        InternalVertex vertex2Query7 = vertex(queries.get(7).getBackendQuery());
+
+        InternalVertex vertex1Query1_2_4_7 = vertex(queries.get(1).getBackendQuery(), queries.get(2).getBackendQuery(),
+            queries.get(3).getBackendQuery(), queries.get(7).getBackendQuery());
+        InternalVertex vertex2Query1_2_4_7 = vertex(queries.get(1).getBackendQuery(), queries.get(2).getBackendQuery(),
+            queries.get(3).getBackendQuery(), queries.get(7).getBackendQuery());
+
+        ArrayList<InternalVertex> allVertices = new ArrayList<>();
+        allVertices.addAll(alwaysUseVertices);
+        allVertices.add(alwaysSkipVertex());
+        allVertices.add(alwaysSkipVertex());
+        allVertices.add(alwaysSkipVertex());
+        allVertices.add(vertex1Query1);
+        allVertices.add(vertex1Query2);
+        allVertices.add(vertex2Query2);
+        allVertices.add(vertex3Query2);
+        allVertices.add(vertex1Query5_9);
+        allVertices.add(vertex1Query8);
+        allVertices.add(vertex1Query7);
+        allVertices.add(vertex2Query7);
+        allVertices.add(vertex1Query1_2_4_7);
+        allVertices.add(vertex2Query1_2_4_7);
+
+        MultiKeysQueryGroups<Object, SliceQuery> result = MultiSliceQueriesGroupingUtil.toMultiKeysQueryGroups(
+            allVertices, queries);
+
+        assertEquals(6, result.getQueryGroups().size());
+        assertEquals(alwaysUseVertices.size()+13, result.getMultiQueryContext().getAllKeysArr().length);
+        assertEquals(queries.size(), result.getMultiQueryContext().getTotalAmountOfQueries());
+        assertEquals(6, result.getMultiQueryContext().getAllLeafParents().size());
+        assertContextIsValid(result.getMultiQueryContext());
+        assertGroupedByUniqueQueriesAndVertexSets(result);
+
+        Map<SliceQuery, Integer> queryVerticesSizes = new HashMap<>();
+        for(Integer queryNumber : Arrays.asList(0, 4, 6)){
+            queryVerticesSizes.put(queries.get(queryNumber).getBackendQuery(), alwaysUseVertices.size());
+        }
+        queryVerticesSizes.put(queries.get(1).getBackendQuery(), alwaysUseVertices.size() + 3);
+        queryVerticesSizes.put(queries.get(2).getBackendQuery(), alwaysUseVertices.size() + 5);
+        queryVerticesSizes.put(queries.get(3).getBackendQuery(), alwaysUseVertices.size() + 5);
+        queryVerticesSizes.put(queries.get(5).getBackendQuery(), alwaysUseVertices.size() + 1);
+        queryVerticesSizes.put(queries.get(7).getBackendQuery(), alwaysUseVertices.size() + 4);
+        queryVerticesSizes.put(queries.get(8).getBackendQuery(), alwaysUseVertices.size() + 1);
+        queryVerticesSizes.put(queries.get(9).getBackendQuery(), alwaysUseVertices.size() + 1);
+
+        assertQueriesVertexSizes(result, queryVerticesSizes);
+
+        result.getQueryGroups().forEach(group -> {
+            if(group.getQueries().contains(queries.get(0).getBackendQuery())){
+                assertEquals(3, group.getQueries().size());
+                assertTrue(group.getQueries().contains(queries.get(4).getBackendQuery()));
+                assertTrue(group.getQueries().contains(queries.get(6).getBackendQuery()));
+            }
+            if(group.getQueries().contains(queries.get(1).getBackendQuery())){
+                assertEquals(1, group.getQueries().size());
+            }
+            if(group.getQueries().contains(queries.get(2).getBackendQuery())){
+                assertEquals(2, group.getQueries().size());
+                assertTrue(group.getQueries().contains(queries.get(3).getBackendQuery()));
+            }
+            if(group.getQueries().contains(queries.get(5).getBackendQuery())){
+                assertEquals(2, group.getQueries().size());
+                assertTrue(group.getQueries().contains(queries.get(9).getBackendQuery()));
+            }
+            if(group.getQueries().contains(queries.get(7).getBackendQuery())){
+                assertEquals(1, group.getQueries().size());
+            }
+            if(group.getQueries().contains(queries.get(8).getBackendQuery())){
+                assertEquals(1, group.getQueries().size());
+            }
+        });
+    }
+
+    @Test
+    public void testGroupingByQueriesTwoElementsDifference() {
+        // this module doesn't have JUnit platform, thus, we are not using @ParametrizedTest here.
+        testGroupingByQueriesTwoElementsDifference(true);
+        testGroupingByQueriesTwoElementsDifference(false);
+    }
+
+    private void testGroupingByQueriesTwoElementsDifference(boolean useFirst){
+        ArrayList<BackendQueryHolder<SliceQuery>> queries = new ArrayList<>();
+        queries.add(new BackendQueryHolder<>(mock(SliceQuery.class), false, false));
+        queries.add(new BackendQueryHolder<>(mock(SliceQuery.class), false, false));
+
+        ArrayList<InternalVertex> allVertices = new ArrayList<>();
+        InternalVertex vertex1 = null;
+        InternalVertex vertex2 = null;
+
+        if(useFirst){
+            vertex1 = vertex(queries.get(0).getBackendQuery());
+            vertex2 = vertex(queries.get(1).getBackendQuery());
+            allVertices.add(vertex1);
+            allVertices.add(vertex2);
+        }
+        for(int i=0;i<10;i++){
+            allVertices.add(alwaysUseVertex());
+        }
+        if(!useFirst){
+            vertex1 = vertex(queries.get(0).getBackendQuery());
+            vertex2 = vertex(queries.get(1).getBackendQuery());
+            allVertices.add(vertex1);
+            allVertices.add(vertex2);
+        }
+
+        MultiKeysQueryGroups<Object, SliceQuery> result = MultiSliceQueriesGroupingUtil.toMultiKeysQueryGroups(
+            allVertices, queries);
+
+        assertEquals(2, result.getQueryGroups().size());
+        assertEquals(allVertices.size(), result.getMultiQueryContext().getAllKeysArr().length);
+        assertEquals(queries.size(), result.getMultiQueryContext().getTotalAmountOfQueries());
+        assertEquals(2, result.getMultiQueryContext().getAllLeafParents().size());
+        assertContextIsValid(result.getMultiQueryContext());
+        assertGroupedByUniqueQueriesAndVertexSets(result);
+
+        Map<SliceQuery, Integer> queryVerticesSizes = new HashMap<>();
+        queryVerticesSizes.put(queries.get(0).getBackendQuery(), allVertices.size() - 1);
+        queryVerticesSizes.put(queries.get(1).getBackendQuery(), allVertices.size() - 1);
+        assertQueriesVertexSizes(result, queryVerticesSizes);
+
+        for(KeysQueriesGroup<Object, SliceQuery> group : result.getQueryGroups()){
+            if(group.getQueries().contains(queries.get(0).getBackendQuery())){
+                assertEquals(1, group.getQueries().size());
+                assertTrue(group.getKeysGroup().contains(vertex1.id()));
+                assertFalse(group.getKeysGroup().contains(vertex2.id()));
+            }
+            if(group.getQueries().contains(queries.get(1).getBackendQuery())){
+                assertEquals(1, group.getQueries().size());
+                assertTrue(group.getKeysGroup().contains(vertex2.id()));
+                assertFalse(group.getKeysGroup().contains(vertex1.id()));
+            }
+        }
+    }
+
+    @Test
+    public void testGroupingByQueriesLastOneElementDifference(){
+        ArrayList<BackendQueryHolder<SliceQuery>> queries = new ArrayList<>();
+        queries.add(new BackendQueryHolder<>(mock(SliceQuery.class), false, false));
+        queries.add(new BackendQueryHolder<>(mock(SliceQuery.class), false, false));
+
+        ArrayList<InternalVertex> allVertices = new ArrayList<>();
+
+        for(int i=0;i<10;i++){
+            allVertices.add(alwaysUseVertex());
+        }
+        InternalVertex vertex1 = vertex(queries.get(0).getBackendQuery());
+        allVertices.add(vertex1);
+
+        MultiKeysQueryGroups<Object, SliceQuery> result = MultiSliceQueriesGroupingUtil.toMultiKeysQueryGroups(
+            allVertices, queries);
+
+        assertEquals(2, result.getQueryGroups().size());
+        assertEquals(allVertices.size(), result.getMultiQueryContext().getAllKeysArr().length);
+        assertEquals(queries.size(), result.getMultiQueryContext().getTotalAmountOfQueries());
+        assertEquals(1, result.getMultiQueryContext().getAllLeafParents().size());
+        assertContextIsValid(result.getMultiQueryContext());
+        assertGroupedByUniqueQueriesAndVertexSets(result);
+
+        Map<SliceQuery, Integer> queryVerticesSizes = new HashMap<>();
+        queryVerticesSizes.put(queries.get(0).getBackendQuery(), allVertices.size());
+        queryVerticesSizes.put(queries.get(1).getBackendQuery(), allVertices.size() - 1);
+        assertQueriesVertexSizes(result, queryVerticesSizes);
+
+        for(KeysQueriesGroup<Object, SliceQuery> group : result.getQueryGroups()){
+            if(group.getQueries().contains(queries.get(0).getBackendQuery())){
+                assertEquals(1, group.getQueries().size());
+                assertTrue(group.getKeysGroup().contains(vertex1.id()));
+                assertEquals(allVertices.size(), group.getKeysGroup().size());
+            }
+            if(group.getQueries().contains(queries.get(1).getBackendQuery())){
+                assertEquals(1, group.getQueries().size());
+                assertFalse(group.getKeysGroup().contains(vertex1.id()));
+                assertEquals(allVertices.size()-1, group.getKeysGroup().size());
+            }
+        }
+    }
+
+    @Test
+    public void testGroupingVertexMultipleQueries() {
+        MultiKeysQueryGroups<Object, SliceQuery> result = MultiSliceQueriesGroupingUtil.toMultiKeysQueryGroups(
+            Collections.singletonList(alwaysUseVertex()),
+            Arrays.asList(new BackendQueryHolder<>(mock(SliceQuery.class), false, false),
+                new BackendQueryHolder<>(mock(SliceQuery.class), false, false),
+                new BackendQueryHolder<>(mock(SliceQuery.class), false, false)));
+        assertEquals(1, result.getQueryGroups().size());
+        assertEquals(3, result.getQueryGroups().get(0).getQueries().size());
+        assertEquals(1, result.getQueryGroups().get(0).getKeysGroup().size());
+        assertEquals(1, result.getMultiQueryContext().getAllKeysArr().length);
+        assertEquals(3, result.getMultiQueryContext().getTotalAmountOfQueries());
+        assertEquals(1, result.getMultiQueryContext().getAllLeafParents().size());
+        assertContextIsValid(result.getMultiQueryContext());
+    }
+
+    ///// Nodes replacement testing
+
+    @Test
+    public void testReplaceCurrentLeafNodeWithUpdatedTypeLeafNodesEmptyList() {
+        List<TreeNode> allLeafParents = Collections.emptyList();
+        Map<Object, Object> oldToNewKeysMap = new HashMap<>();
+        MultiSliceQueriesGroupingUtil.replaceCurrentLeafNodeWithUpdatedTypeLeafNodes(allLeafParents, oldToNewKeysMap);
+        assertTrue(allLeafParents.isEmpty());
+        assertTrue(oldToNewKeysMap.isEmpty());
+    }
+
+    @Test
+    public void testReplaceCurrentLeafNodeWithUpdatedTypeLeafNodeBothChildrenDataTreeNode() {
+        // Create leaf nodes with both children being instances of DataTreeNode
+        DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>> leftChild = new DataTreeNode<>(new KeysQueriesGroup<>(Collections.singletonList(1), Collections.emptyList()));
+        DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>> rightChild = new DataTreeNode<>(new KeysQueriesGroup<>(Collections.singletonList(2), Collections.emptyList()));
+        TreeNode parentNode = new TreeNode(leftChild, rightChild);
+        List<TreeNode> allLeafParents = Collections.singletonList(parentNode);
+
+        // Create a mapping from Integer to String
+        Map<Integer, String> oldToNewKeysMap = new HashMap<>();
+        oldToNewKeysMap.put(1, "one");
+        oldToNewKeysMap.put(2, "two");
+
+        replaceCurrentLeafNodeWithUpdatedTypeLeafNodes(allLeafParents, oldToNewKeysMap);
+
+        // Verify that both children are replaced with updated type leaf nodes
+        assertTrue(parentNode.left instanceof DataTreeNode);
+        assertTrue(parentNode.right instanceof DataTreeNode);
+        assertEquals("one", ((DataTreeNode<KeysQueriesGroup>) parentNode.left).data.getKeysGroup().get(0));
+        assertEquals("two", ((DataTreeNode<KeysQueriesGroup>) parentNode.right).data.getKeysGroup().get(0));
+    }
+
+    @Test
+    public void testReplaceCurrentLeafNodeWithUpdatedTypeLeafNodesOnlyLeftChildDataTreeNode() {
+        // Create a leaf node with only the left child being an instance of DataTreeNode
+        DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>> leftChild = new DataTreeNode<>(new KeysQueriesGroup<>(Collections.singletonList(1), Collections.emptyList()));
+        TreeNode parentNode = new TreeNode(leftChild, new TreeNode());
+        List<TreeNode> allLeafParents = Collections.singletonList(parentNode);
+
+        // Create a mapping from Integer to String
+        Map<Integer, String> oldToNewKeysMap = new HashMap<>();
+        oldToNewKeysMap.put(1, "one");
+
+        replaceCurrentLeafNodeWithUpdatedTypeLeafNodes(allLeafParents, oldToNewKeysMap);
+
+        // Verify that only the left child is replaced with an updated type leaf node
+        assertTrue(parentNode.left instanceof DataTreeNode);
+        assertFalse(parentNode.right instanceof DataTreeNode);
+        assertEquals("one", ((DataTreeNode<KeysQueriesGroup>) parentNode.left).data.getKeysGroup().get(0));
+    }
+
+    @Test
+    public void testReplaceCurrentLeafNodeWithUpdatedTypeLeafNodesOnlyRightChildDataTreeNode() {
+        // Create a leaf node with only the right child being an instance of DataTreeNode
+        TreeNode parentNode = new TreeNode(new TreeNode(), new DataTreeNode<>(new KeysQueriesGroup<>(Collections.singletonList(2), Collections.emptyList())));
+        List<TreeNode> allLeafParents = Collections.singletonList(parentNode);
+
+        // Create a mapping from Integer to String
+        Map<Integer, String> oldToNewKeysMap = new HashMap<>();
+        oldToNewKeysMap.put(2, "two");
+
+        replaceCurrentLeafNodeWithUpdatedTypeLeafNodes(allLeafParents, oldToNewKeysMap);
+
+        // Verify that only the right child is replaced with an updated type leaf node
+        assertFalse(parentNode.left instanceof DataTreeNode);
+        assertTrue(parentNode.right instanceof DataTreeNode);
+        assertEquals("two", ((DataTreeNode<KeysQueriesGroup>) parentNode.right).data.getKeysGroup().get(0));
+    }
+
+    @Test
+    public void testReplaceCurrentLeafNodeWithUpdatedTypeLeafNodesNoDataTreeNodeChildren() {
+        // Create leaf nodes with both children not being instances of DataTreeNode
+        TreeNode parentNode = new TreeNode(new TreeNode(), new TreeNode());
+        List<TreeNode> allLeafParents = Collections.singletonList(parentNode);
+
+        // Create a mapping from Integer to String
+        Map<Integer, String> oldToNewKeysMap = new HashMap<>();
+        oldToNewKeysMap.put(1, "one");
+        oldToNewKeysMap.put(2, "two");
+
+        replaceCurrentLeafNodeWithUpdatedTypeLeafNodes(allLeafParents, oldToNewKeysMap);
+
+        // Verify that no modifications occur
+        assertFalse(parentNode.left instanceof DataTreeNode);
+        assertFalse(parentNode.right instanceof DataTreeNode);
+    }
+
+    @Test
+    public void testReplaceCurrentLeafNodeWithUpdatedTypeLeafNodesEmptyMap() {
+        // Create leaf nodes with both children being instances of DataTreeNode
+        DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>> leftChild = new DataTreeNode<>(new KeysQueriesGroup<>(Collections.singletonList(1), Collections.emptyList()));
+        DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>> rightChild = new DataTreeNode<>(new KeysQueriesGroup<>(Collections.singletonList(2), Collections.emptyList()));
+        TreeNode parentNode = new TreeNode(leftChild, rightChild);
+        List<TreeNode> allLeafParents = Collections.singletonList(parentNode);
+
+        // Empty mapping
+        Map<Integer, String> oldToNewKeysMap = Collections.emptyMap();
+
+        replaceCurrentLeafNodeWithUpdatedTypeLeafNodes(allLeafParents, oldToNewKeysMap);
+
+        // Verify that no modifications occur
+        assertTrue(parentNode.left instanceof DataTreeNode);
+        assertTrue(parentNode.right instanceof DataTreeNode);
+        assertNull(((DataTreeNode<KeysQueriesGroup>) parentNode.left).data.getKeysGroup().get(0));
+        assertNull(((DataTreeNode<KeysQueriesGroup>) parentNode.right).data.getKeysGroup().get(0));
+    }
+
+    @Test
+    public void testReplaceCurrentLeafNodeWithUpdatedTypeLeafNodesKeysNotPresentInData() {
+        // Create leaf nodes with both children being instances of DataTreeNode
+        DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>> leftChild = new DataTreeNode<>(new KeysQueriesGroup<>(Collections.singletonList(1), Collections.emptyList()));
+        DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>> rightChild = new DataTreeNode<>(new KeysQueriesGroup<>(Collections.singletonList(2), Collections.emptyList()));
+        TreeNode parentNode = new TreeNode(leftChild, rightChild);
+        List<TreeNode> allLeafParents = Collections.singletonList(parentNode);
+
+        // Create a mapping from Integer to String
+        Map<Integer, String> oldToNewKeysMap = new HashMap<>();
+        oldToNewKeysMap.put(3, "three");
+
+        replaceCurrentLeafNodeWithUpdatedTypeLeafNodes(allLeafParents, oldToNewKeysMap);
+
+        // Verify that no modifications occur
+        assertTrue(parentNode.left instanceof DataTreeNode);
+        assertTrue(parentNode.right instanceof DataTreeNode);
+        assertNull(((DataTreeNode<KeysQueriesGroup>) parentNode.left).data.getKeysGroup().get(0));
+        assertNull(((DataTreeNode<KeysQueriesGroup>) parentNode.right).data.getKeysGroup().get(0));
+    }
+
+    @Test
+    public void testReplaceCurrentLeafNodeWithUpdatedTypeLeafNodesValidMapping() {
+        // Create leaf nodes with both children being instances of DataTreeNode
+        DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>> leftChild = new DataTreeNode<>(new KeysQueriesGroup<>(Collections.singletonList(1), Collections.emptyList()));
+        DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>> rightChild = new DataTreeNode<>(new KeysQueriesGroup<>(Collections.singletonList(2), Collections.emptyList()));
+        TreeNode parentNode = new TreeNode(leftChild, rightChild);
+        List<TreeNode> allLeafParents = Collections.singletonList(parentNode);
+
+        // Create a mapping from Integer to String
+        Map<Integer, String> oldToNewKeysMap = new HashMap<>();
+        oldToNewKeysMap.put(1, "one");
+        oldToNewKeysMap.put(2, "two");
+
+        replaceCurrentLeafNodeWithUpdatedTypeLeafNodes(allLeafParents, oldToNewKeysMap);
+
+        // Verify that both children are replaced with updated type leaf nodes
+        assertTrue(parentNode.left instanceof DataTreeNode);
+        assertTrue(parentNode.right instanceof DataTreeNode);
+        assertEquals("one", ((DataTreeNode<KeysQueriesGroup>) parentNode.left).data.getKeysGroup().get(0));
+        assertEquals("two", ((DataTreeNode<KeysQueriesGroup>) parentNode.right).data.getKeysGroup().get(0));
+    }
+
+    // Queries movement testing
+
+    @Test
+    public void testMoveQueriesToNewLeafNodeEmptyUpdatedQueryGroup() {
+        List<Pair<SliceQuery, List<Integer>>> updatedQueryGroup = Collections.emptyList();
+        Integer[] allVertices = {1, 2, 3};
+        TreeNode groupingRootTreeNode = new TreeNode(null, new TreeNode());
+        List<KeysQueriesGroup<Integer, SliceQuery>> remainingQueryGroups = new ArrayList<>();
+
+        moveQueriesToNewLeafNode(updatedQueryGroup, allVertices, groupingRootTreeNode, remainingQueryGroups);
+
+        assertNull(groupingRootTreeNode.left);
+        assertNull(groupingRootTreeNode.right.right);
+        assertNull(groupingRootTreeNode.right.left);
+        assertTrue(remainingQueryGroups.isEmpty());
+    }
+
+    @Test
+    public void testMoveQueriesToNewLeafNodeMatchingVertices() {
+        // Create leaf nodes with matching vertices
+        TreeNode leftChild = new TreeNode();
+        TreeNode rightChild = new TreeNode();
+        TreeNode groupingRootTreeNode = new TreeNode(leftChild, rightChild);
+        List<Pair<SliceQuery, List<Integer>>> updatedQueryGroup = new ArrayList<>();
+        updatedQueryGroup.add(Pair.of(mock(SliceQuery.class), Arrays.asList(1, 2)));
+        updatedQueryGroup.add(Pair.of(mock(SliceQuery.class), Collections.singletonList(3)));
+        Integer[] allVertices = {1, 2, 3};
+        List<KeysQueriesGroup<Integer, SliceQuery>> remainingQueryGroups = new ArrayList<>();
+
+       moveQueriesToNewLeafNode(updatedQueryGroup, allVertices, groupingRootTreeNode, remainingQueryGroups);
+
+        // Verify that the queries are added to the corresponding leaf nodes
+        assertEquals(1, ((DataTreeNode<KeysQueriesGroup>) leftChild.left.right).data.getQueries().size());
+        assertEquals(1, ((DataTreeNode<KeysQueriesGroup>) rightChild.right.left).data.getQueries().size());
+        assertEquals(2, remainingQueryGroups.size());
+    }
+
+    @Test
+    public void testMoveQueriesToNewLeafNodeNewChainNodes() {
+        // Create a leaf node without matching vertices
+        List<Pair<SliceQuery, List<Integer>>> updatedQueryGroup = new ArrayList<>();
+        updatedQueryGroup.add(Pair.of(mock(SliceQuery.class), Collections.singletonList(1)));
+        updatedQueryGroup.add(Pair.of(mock(SliceQuery.class), Collections.singletonList(2)));
+        updatedQueryGroup.add(Pair.of(mock(SliceQuery.class), Collections.singletonList(3)));
+        updatedQueryGroup.add(Pair.of(mock(SliceQuery.class), Arrays.asList(1,2,3)));
+
+        Integer[] allVertices = {1, 2, 3};
+        List<KeysQueriesGroup<Integer, SliceQuery>> remainingQueryGroups = new ArrayList<>();
+        KeysQueriesGroup<Integer, SliceQuery> existingQueryData = new KeysQueriesGroup<>(Arrays.asList(allVertices), new ArrayList<>());
+        remainingQueryGroups.add(existingQueryData);
+        TreeNode root = new TreeNode(null, new TreeNode(null, new TreeNode(null, new DataTreeNode<>(existingQueryData))));
+
+       moveQueriesToNewLeafNode(updatedQueryGroup, allVertices, root, remainingQueryGroups);
+
+        // Verify that new chain nodes are generated and queries are added to the corresponding leaf nodes
+        assertEquals(3, ((DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>>) root.right.right.right).data.getKeysGroup().size());
+        assertTrue(((DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>>) root.right.right.right).data.getKeysGroup().containsAll(Arrays.asList(allVertices)));
+        assertEquals(1, ((DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>>) root.right.right.right).data.getQueries().size());
+        assertEquals(updatedQueryGroup.get(3).getKey(), ((DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>>) root.right.right.right).data.getQueries().iterator().next());
+        assertEquals(existingQueryData, ((DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>>) root.right.right.right).data);
+
+        assertEquals(1, ((DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>>) root.right.left.left).data.getQueries().size());
+        assertEquals(1, ((DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>>) root.left.right.left).data.getQueries().size());
+        assertEquals(1, ((DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>>) root.left.left.right).data.getQueries().size());
+        assertEquals(updatedQueryGroup.get(0).getKey(), ((DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>>) root.right.left.left).data.getQueries().iterator().next());
+        assertEquals(updatedQueryGroup.get(1).getKey(), ((DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>>) root.left.right.left).data.getQueries().iterator().next());
+        assertEquals(updatedQueryGroup.get(2).getKey(), ((DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>>) root.left.left.right).data.getQueries().iterator().next());
+        assertNull(root.right.right.left);
+        assertNull(root.right.left.right);
+        assertNull(root.left.right.right);
+        assertNull(root.left.left.left);
+
+        assertEquals(4, remainingQueryGroups.size());
+        assertTrue(remainingQueryGroups.containsAll(Arrays.asList(
+            ((DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>>) root.right.right.right).data,
+            ((DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>>) root.right.left.left).data,
+            ((DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>>) root.left.right.left).data,
+            ((DataTreeNode<KeysQueriesGroup<Integer, SliceQuery>>) root.left.left.right).data
+        )));
+    }
+
+    @Test
+    public void testMoveQueriesToNewLeafNodeEmptyRemainingQueryGroups() {
+        TreeNode leaf1 = new TreeNode();
+        TreeNode leaf2 = new TreeNode();
+        TreeNode groupingRootTreeNode = new TreeNode(leaf1, leaf2);
+        List<Pair<SliceQuery, List<Integer>>> updatedQueryGroup = new ArrayList<>();
+        updatedQueryGroup.add(Pair.of(mock(SliceQuery.class), Arrays.asList(1, 2)));
+        Integer[] allVertices = {1, 2, 3};
+        List<KeysQueriesGroup<Integer, SliceQuery>> remainingQueryGroups = new ArrayList<>();
+
+        moveQueriesToNewLeafNode(updatedQueryGroup, allVertices, groupingRootTreeNode, remainingQueryGroups);
+
+        assertEquals(1, remainingQueryGroups.size());
+    }
+
+    @Test
+    public void testMoveQueriesToNewLeafNodeNonEmptyRemainingQueryGroups() {
+        List<Pair<SliceQuery, List<Integer>>> updatedQueryGroup = new ArrayList<>();
+        updatedQueryGroup.add(Pair.of(mock(SliceQuery.class), Collections.singletonList(1)));
+        Integer[] allVertices = {1};
+        List<KeysQueriesGroup<Integer, SliceQuery>> remainingQueryGroups = new ArrayList<>();
+        remainingQueryGroups.add(new KeysQueriesGroup<>(Collections.emptyList(), Collections.emptyList()));
+        TreeNode groupingRootTreeNode = new TreeNode(new DataTreeNode<>(remainingQueryGroups.get(0)), null);
+
+        moveQueriesToNewLeafNode(updatedQueryGroup, allVertices, groupingRootTreeNode, remainingQueryGroups);
+
+        assertEquals(2, remainingQueryGroups.size());
+        assertEquals(1, remainingQueryGroups.get(1).getKeysGroup().size());
+        assertTrue(remainingQueryGroups.get(1).getKeysGroup().contains(1));
+        assertEquals(1, remainingQueryGroups.get(1).getQueries().size());
+        assertTrue(remainingQueryGroups.get(1).getQueries().contains(updatedQueryGroup.get(0).getKey()));
+    }
+
+    private void assertContextIsValid(MultiQueriesByKeysGroupsContext<Object> context){
+        assertTrue(context.getAllLeafParents().size() <= context.getTotalAmountOfQueries());
+
+        Object[] keys = context.getAllKeysArr();
+        Set<Object> keysSet = new HashSet<>(Arrays.asList(keys));
+        assertEquals(keysSet.size(), keys.length);
+
+        Set<Integer> allLeafDepths = new HashSet<>(1);
+        addAllLeafDepths(context.getGroupingRootTreeNode(), 0, allLeafDepths);
+        if(keysSet.isEmpty()){
+            assertTrue(allLeafDepths.isEmpty());
+        } else {
+            assertEquals(1, allLeafDepths.size());
+            Integer calculatedTreeDepth = allLeafDepths.iterator().next();
+            assertEquals(keys.length, calculatedTreeDepth);
+        }
+
+        List<DataTreeNode> calculatedLeafNodes = new ArrayList<>();
+        addAllLeafNodes(context.getGroupingRootTreeNode(), calculatedLeafNodes);
+        assertTrue(calculatedLeafNodes.size() >= context.getAllLeafParents().size());
+
+        for(DataTreeNode leafNode : calculatedLeafNodes){
+            boolean childOfLeafParents = false;
+            for(TreeNode parentNode : context.getAllLeafParents()){
+                if(parentNode.left == leafNode || parentNode.right == leafNode){
+                    assertFalse(childOfLeafParents, "This child node was already a child of another parent. " +
+                        "Each parent should have unique children nodes.");
+                    childOfLeafParents = true;
+                }
+            }
+            assertTrue(childOfLeafParents, "Calculated leaf node is not a child of any of the context's leaf parent nodes.");
+        }
+    }
+
+    private void addAllLeafDepths(TreeNode node, int currentDepth, Set<Integer> depths){
+        if(node == null){
+            return;
+        }
+        if(node instanceof DataTreeNode){
+            assertNull(node.left);
+            assertNull(node.right);
+            depths.add(currentDepth);
+            return;
+        }
+        addAllLeafDepths(node.left, currentDepth+1, depths);
+        addAllLeafDepths(node.right, currentDepth+1, depths);
+    }
+
+    private void addAllLeafNodes(TreeNode node, List<DataTreeNode> leafNodes){
+        if(node == null){
+            return;
+        }
+        if(node instanceof DataTreeNode){
+            assertNull(node.left);
+            assertNull(node.right);
+            leafNodes.add((DataTreeNode) node);
+            return;
+        }
+        addAllLeafNodes(node.left, leafNodes);
+        addAllLeafNodes(node.right, leafNodes);
+    }
+
+    private StandardVertex nonCacheVertex(){
+        return mock(StandardVertex.class);
+    }
+
+    private CacheVertex vertex(SliceQuery ... queriesWithHasLoadedRelations){
+        return mockVertex(CacheVertex.class, queriesWithHasLoadedRelations);
+    }
+
+    private CacheVertex alwaysSkipVertex(){
+        return mockVertex(CacheVertex.class, true);
+    }
+
+    private CacheVertex alwaysUseVertex(){
+        return mockVertex(CacheVertex.class, false);
+    }
+
+    private <T extends InternalVertex> T mockVertex(Class<T> type, boolean hasLoadedRelations){
+        T vertex = mock(type);
+        doReturn(hasLoadedRelations).when(vertex).hasLoadedRelations(any());
+        doReturn(false).when(vertex).isNew();
+        doReturn(true).when(vertex).hasId();
+        doReturn(VERTEX_ID.incrementAndGet()).when(vertex).id();
+        doReturn(hasLoadedRelations).when(vertex).hasLoadedRelations(any());
+        return vertex;
+    }
+
+    private <T extends InternalVertex> T mockVertex(Class<T> type, SliceQuery ... queriesWithHasLoadedRelations){
+        T vertex = mock(type);
+        doReturn(false).when(vertex).isNew();
+        doReturn(true).when(vertex).hasId();
+        doReturn(VERTEX_ID.incrementAndGet()).when(vertex).id();
+        Set<SliceQuery> falseQueries = new HashSet<>(Arrays.asList(queriesWithHasLoadedRelations));
+        doAnswer(invocationOnMock -> {
+            return !falseQueries.contains(invocationOnMock.getArgument(0));
+        }).when(vertex).hasLoadedRelations(any());
+        return vertex;
+    }
+
+
+    private void assertQueriesVertexSizes(MultiKeysQueryGroups<Object, SliceQuery> result, Map<SliceQuery, Integer> queryVerticesSizes){
+        result.getQueryGroups().forEach(group -> group.getQueries().forEach(query -> assertEquals(queryVerticesSizes.get(query), group.getKeysGroup().size())));
+    }
+
+    private void assertGroupedByUniqueQueriesAndVertexSets(MultiKeysQueryGroups<Object, SliceQuery> result){
+
+        // Check all slice queries are unique across all collections
+        result.getQueryGroups().forEach(group -> {
+            group.getQueries().forEach(query -> {
+                MutableBoolean duplicate = new MutableBoolean(false);
+                result.getQueryGroups().forEach(group2 -> {
+                    group2.getQueries().forEach(query2 -> {
+                        if(query == query2){
+                            assertFalse(duplicate.booleanValue());
+                            duplicate.setTrue();
+                        }
+                    });
+                });
+            });
+        });
+
+        // Check all vertex sets are unique across all pairs
+        result.getQueryGroups().forEach(group -> {
+            MutableBoolean duplicate = new MutableBoolean(false);
+            result.getQueryGroups().forEach(group2 -> {
+                if(group.getKeysGroup().size() == group2.getKeysGroup().size() && group.getKeysGroup().containsAll(group2.getKeysGroup())){
+                    assertFalse(duplicate.booleanValue());
+                    duplicate.setTrue();
+                }
+            });
+        });
+    }
+
+}

--- a/janusgraph-inmemory/src/test/java/org/janusgraph/graphdb/inmemory/InMemoryGraphTest.java
+++ b/janusgraph-inmemory/src/test/java/org/janusgraph/graphdb/inmemory/InMemoryGraphTest.java
@@ -64,6 +64,9 @@ public class InMemoryGraphTest extends JanusGraphTest {
     public void testLimitBatchSizeForMultiQuery() {}
 
     @Override @Test @Disabled
+    public void testMultiSliceDBCachedRequests(){}
+
+    @Override @Test @Disabled
     public void testMaskableGraphConfig() {}
 
     @Override @Test @Disabled

--- a/janusgraph-test/src/main/java/org/janusgraph/diskstorage/cache/KCVSCacheTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/diskstorage/cache/KCVSCacheTest.java
@@ -25,6 +25,7 @@ import org.janusgraph.diskstorage.keycolumnvalue.KeyIterator;
 import org.janusgraph.diskstorage.keycolumnvalue.KeyRangeQuery;
 import org.janusgraph.diskstorage.keycolumnvalue.KeySliceQuery;
 import org.janusgraph.diskstorage.keycolumnvalue.KeySlicesIterator;
+import org.janusgraph.diskstorage.keycolumnvalue.MultiKeysQueryGroups;
 import org.janusgraph.diskstorage.keycolumnvalue.MultiSlicesQuery;
 import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
 import org.janusgraph.diskstorage.keycolumnvalue.StoreTransaction;
@@ -208,6 +209,12 @@ public abstract class KCVSCacheTest {
         public Map<StaticBuffer, EntryList> getSlice(List<StaticBuffer> keys, SliceQuery query, StoreTransaction txh) throws BackendException {
             getSliceCounter.incrementAndGet();
             return store.getSlice(keys,query,txh);
+        }
+
+        @Override
+        public Map<SliceQuery, Map<StaticBuffer, EntryList>> getMultiSlices(MultiKeysQueryGroups<StaticBuffer, SliceQuery> multiKeysQueryGroups, StoreTransaction txh) throws BackendException {
+            multiKeysQueryGroups.getQueryGroups().forEach(group -> getSliceCounter.addAndGet(group.getQueries().size()));
+            return store.getMultiSlices(multiKeysQueryGroups,txh);
         }
 
         @Override


### PR DESCRIPTION
**What this PR does**:
- Adds possibility to execute groups of same key sets slice queries together
- Implement parallel execution of all provided Slice queries to CQL storage backend
- Adds a basic implementation (i.e. current non-optimized implementation) to any other storage backend which doesn't have optimized implementation right now

**Detailed explanation**:
As for now when JanusGraph performs multi-query it executes slice queries for multiple vertices one by one.
I.e. assuming multi-query is enabled `g.V(v1,v2,v3,v4,v5).values("prop1", "prop2", "prop3")` this step fetches `prop1` for all provided vertices (`v1`, `v2`, `v3`, `v4`, `v5`), awaits for the result, then sends another slice query to fetch `prop2` for the same set of vertices, then awaits for the result again and sends the last slice query to fetch `prop3` for the provided set of vertices.
This behavior currently exists in `master` branch as well as in the PR #3803 for `required_properties_only` mode. However, #3803 PR adds another mode `all_properties` which fetches all vertex properties in a single slice query which is usually much faster. The downside of `all_properties` mode is that it fetches all properties of the vertex and not only requested properties.

This PR will change the way we execute multi-queries and instead of processing all slice queries one by one - we send all the necessary slice queries as well as all the necessary keys (vertices) to the storage implementation. Now the storage implementation is going to decide how those queries should be executed. 
First obvious CQL optimization I did - execute all those slice queries in parallel. Thus, for CQL storage backend we will not wait for the previous property to be fetched anymore. Instead, we will fetch all properties in parallel which should significantly speedup properties fetching for cases when several specific properties are requested and the user uses `required_properties_only` mode.
However, I'm adding this optimization to CQL storage implementation only as for now. All other storage backends won't see any difference (i.e. if you use HBase then the properties fetching using `required_properties_only` mode will be the same as currently in `master` - non-optimized / blocking). We can improve other storage backends later as well.

There are 2 breaking changes expected:
1. `KeyColumnValueStore` adds a new method which storage backend implementations (adapters) will need to implement. However, I'm adding the utility method (`KeyColumnValueStoreUtil.getMultiSliceNonOptimized`) which can be used to have the same implementation as it's currently on `master` branch (i.e. non-optimized version of the method). This should help any storage adapter developers to quickly implement this method in case they are not interested in multi-slice optimizations.
2. As all multi-query slice queries are executed together now, we can't profile individual slice queries. Thus, for multi-slice queries profiling is now grouped for all slice queries instead of individual slice queries.

Fixes #3824
Related to #3816

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
