### PR TITLE
Trigger Actions for Backport PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,12 +16,6 @@ on:
   pull_request_target:
     types: ["labeled", "closed"]
 
-permissions:
-  actions: write
-  pull-requests: write
-  contents: write
-  repository-projects: write
-
 jobs:
   backport:
     name: Backport PR
@@ -37,14 +31,14 @@ jobs:
       - name: Backport Action
         uses: sqren/backport-github-action@v8.9.7
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.ACCESS_TOKEN }}
           auto_backport_label_prefix: backport/
           add_original_reviewers: true
 
       - name: Info log
         if: ${{ success() }}
         run: cat ~/.backport/backport.info.log
-        
+
       - name: Debug log
         if: ${{ failure() }}
-        run: cat ~/.backport/backport.debug.log   
+        run: cat ~/.backport/backport.debug.log


### PR DESCRIPTION
We need to use a PAT (personal access token) instead of the default `GITHUB_TOKEN` as that doesn't trigger any workflow runs by design:

> When you use the repository's GITHUB_TOKEN to perform tasks, events
> triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch
> and repository_dispatch, will not create a new workflow run. This
> prevents you from accidentally creating recursive workflow runs.

Source: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

The PAT used here is from our new bot: https://github.com/janusgraph-automations So that should become the author of backporting PRs from now on.

This fixes #3635

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
