### PR TITLE
[v0.6] Bump build-helper-maven-plugin from 3.3.0 to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -490,7 +490,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump build-helper-maven-plugin from 3.3.0 to 3.4.0](https://github.com/JanusGraph/janusgraph/pull/3834)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)