### PR TITLE
Remove unnecessary Guice dependencies [tp-tests]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -560,16 +560,6 @@
                 <version>${tinkerpop.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.inject</groupId>
-                <artifactId>guice</artifactId>
-                <version>5.1.0</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.inject.extensions</groupId>
-                <artifactId>guice-servlet</artifactId>
-                <version>5.1.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.tinkerpop</groupId>
                 <artifactId>hadoop-gremlin</artifactId>
                 <version>${tinkerpop.version}</version>


### PR DESCRIPTION
I am not sure why we needed these dependencies but it seems like we don't need them any more.
They were added as part of an update to a newer TinkerPop version so maybe we needed those entries simply to avoid dependency convergence errors:
https://github.com/JanusGraph/janusgraph/commit/ae07bbdcde56267109b456788b66272cabe40763
