### PR TITLE
Remove 2 unused dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1114,16 +1114,6 @@
                 <version>2.1.12</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.ant</groupId>
-                <artifactId>ant</artifactId>
-                <version>1.10.13</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>servlet-api</artifactId>
-                <version>2.5</version>
-            </dependency>
-            <dependency>
                 <groupId>org.elasticsearch.client</groupId>
                 <artifactId>elasticsearch-rest-client</artifactId>
                 <version>${elasticsearch.version}</version>


### PR DESCRIPTION
These dependencies have been added 10 years ago and I can't find any place where they are still used:
https://github.com/JanusGraph/janusgraph/commit/94e75d3fa968c0d2cf890c1883ccbb2f21a391e3
