### PR TITLE
[v0.6] Bump netty-handler from 4.1.93.Final to 4.1.94.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <zookeeper.version>3.8.1</zookeeper.version>
-        <netty4.version>4.1.93.Final</netty4.version>
+        <netty4.version>4.1.94.Final</netty4.version>
         <jna.version>5.13.0</jna.version>
         <gmavenplus.version>1.12.1</gmavenplus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump netty-handler from 4.1.93.Final to 4.1.94.Final](https://github.com/JanusGraph/janusgraph/pull/3845)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)