### PR TITLE
[v0.6] Update ci-publish Java to 8.0.372+7

### DIFF
--- a/.github/workflows/ci-publish-commit.yml
+++ b/.github/workflows/ci-publish-commit.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '8.0.312+7'
+          java-version: '8.0.372+7'
           java-package: jdk
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/ci-publish-official.yml
+++ b/.github/workflows/ci-publish-official.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '8.0.312+7'
+          java-version: '8.0.372+7'
           java-package: jdk
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Update ci-publish Java to 8.0.372+7](https://github.com/JanusGraph/janusgraph/pull/3866)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)