### PR TITLE
[v0.6] mark flaky tests

### DIFF
--- a/janusgraph-cql/src/test/java/org/janusgraph/core/cql/CQLConfiguredGraphFactoryTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/core/cql/CQLConfiguredGraphFactoryTest.java
@@ -15,6 +15,7 @@
 package org.janusgraph.core.cql;
 
 import com.datastax.driver.core.Session;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.commons.configuration2.MapConfiguration;
 import org.janusgraph.JanusGraphCassandraContainer;
 import org.janusgraph.core.AbstractConfiguredGraphFactoryTest;
@@ -129,6 +130,12 @@ public class CQLConfiguredGraphFactoryTest extends AbstractConfiguredGraphFactor
             ConfiguredGraphFactory.removeConfiguration(graphName);
             ConfiguredGraphFactory.close(graphName);
         }
+    }
+
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void updateConfigurationShouldRemoveGraphFromCache() throws Exception {
+        super.updateConfigurationShouldRemoveGraphFromCache();
     }
 }
 

--- a/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLGraphTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLGraphTest.java
@@ -37,6 +37,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.Arrays;
 import java.util.Random;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.ATOMIC_BATCH_MUTATE;
@@ -68,6 +69,12 @@ public class CQLGraphTest extends JanusGraphTest {
     @Override
     public void simpleLogTest() throws InterruptedException{
         super.simpleLogTest();
+    }
+
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void testReindexingForEdgeIndex() throws ExecutionException, InterruptedException {
+        super.testReindexingForEdgeIndex();
     }
 
     protected static Stream<Arguments> generateConsistencyConfigs() {

--- a/janusgraph-cql/src/test/java/org/janusgraph/hadoop/CQLIndexManagementIT.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/hadoop/CQLIndexManagementIT.java
@@ -14,10 +14,14 @@
 
 package org.janusgraph.hadoop;
 
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.janusgraph.JanusGraphCassandraContainer;
+import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.concurrent.ExecutionException;
 
 @Testcontainers
 public class CQLIndexManagementIT extends AbstractIndexManagementIT {
@@ -27,5 +31,11 @@ public class CQLIndexManagementIT extends AbstractIndexManagementIT {
     @Override
     public WriteConfiguration getConfiguration() {
         return cql.getConfiguration(getClass().getSimpleName().toLowerCase()).getConfiguration();
+    }
+
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void testRepairRelationIndex() throws ExecutionException, InterruptedException, BackendException {
+        super.testRepairRelationIndex();
     }
 }

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/CQLElasticsearchTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/CQLElasticsearchTest.java
@@ -14,11 +14,14 @@
 
 package org.janusgraph.diskstorage.es;
 
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.janusgraph.JanusGraphCassandraContainer;
 import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.junit.jupiter.api.Disabled;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.concurrent.ExecutionException;
 
 @Testcontainers
 public class CQLElasticsearchTest extends ElasticsearchJanusGraphIndexTest {
@@ -34,4 +37,10 @@ public class CQLElasticsearchTest extends ElasticsearchJanusGraphIndexTest {
     @Override
     @Disabled("CQL seems to not clear storage correctly")
     public void testClearStorage() {}
+
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void testIndexUpdatesWithoutReindex() throws InterruptedException, ExecutionException {
+        super.testIndexUpdatesWithoutReindex();
+    }
 }

--- a/janusgraph-test/src/test/java/org/janusgraph/diskstorage/cache/ExpirationCacheTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/diskstorage/cache/ExpirationCacheTest.java
@@ -15,6 +15,7 @@
 package org.janusgraph.diskstorage.cache;
 
 import com.google.common.collect.Lists;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.janusgraph.diskstorage.EntryList;
 import org.janusgraph.diskstorage.StaticBuffer;
 import org.janusgraph.diskstorage.keycolumnvalue.KeyColumnValueStore;
@@ -97,7 +98,7 @@ public class ExpirationCacheTest extends KCVSCacheTest {
         verifyResults(key, keys, query, 4);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = 3)
     public void testGracePeriod() throws Exception {
         testGracePeriod(Duration.ofMillis(200));
         testGracePeriod(Duration.ZERO);


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [mark flaky tests](https://github.com/JanusGraph/janusgraph/pull/3319)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)