### PR TITLE
Increase wait time for slow ConfigurationManagementGraphServerTest

### DIFF
--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/ConfigurationManagementGraphServerTest.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/ConfigurationManagementGraphServerTest.java
@@ -73,7 +73,7 @@ public class ConfigurationManagementGraphServerTest extends AbstractGremlinServe
             "org.janusgraph.util.system.ConfigurationUtil.loadMapConfiguration(map));" +
             "org.janusgraph.core.ConfiguredGraphFactory.create(\"newGraph\")");
 
-        Thread.sleep(1000,0);
+        Thread.sleep(3000,0);
 
         //assert newGraph is indeed bound
         assertEquals(0, client.submit("newGraph.vertices().size()").all().get().get(0).getInt());


### PR DESCRIPTION
The test has been failing quite often lately, probably simply because it didn't wait long enough for the new graph to be created, at least for slow hardware like we have with GH Actions.

I executed the test at least 10 times with this change in GH Actions and it didn't fail a single time so I guess that this increased timeout is enough.

Fixes #3849

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
