### PR TITLE
[v0.6] Increase wait time for slow test run

### DIFF
--- a/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/ConfigurationManagementGraphServerTest.java
+++ b/janusgraph-server/src/test/java/org/janusgraph/graphdb/tinkerpop/ConfigurationManagementGraphServerTest.java
@@ -73,7 +73,7 @@ public class ConfigurationManagementGraphServerTest extends AbstractGremlinServe
             "org.janusgraph.util.system.ConfigurationUtil.loadMapConfiguration(map));" +
             "org.janusgraph.core.ConfiguredGraphFactory.create(\"newGraph\")");
 
-        Thread.sleep(1000,0);
+        Thread.sleep(3000,0);
 
         //assert newGraph is indeed bound
         assertEquals(0, client.submit("newGraph.vertices().size()").all().get().get(0).getInt());


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Increase wait time for slow test run](https://github.com/JanusGraph/janusgraph/pull/3870)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)