### PR TITLE
[v0.6] Bump cassandra-driver.version from 4.16.0 to 4.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <cassandra.version>3.11.10</cassandra.version>
         <!-- https://downloads.apache.org/cassandra/4.0.3/apache-cassandra-3.11.10-bin.tar.gz.sha256 -->
         <cassandra.version.sha256>bbe772956c841158e3228c3b6c8fc38cece6bceeface695473c59c0573039bf1</cassandra.version.sha256>
-        <cassandra-driver.version>4.16.0</cassandra-driver.version>
+        <cassandra-driver.version>4.17.0</cassandra-driver.version>
         <scylladb.version>4.4.0</scylladb.version>
         <testcontainers.version>1.18.3</testcontainers.version>
         <easymock.version>5.1.0</easymock.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump cassandra-driver.version from 4.16.0 to 4.17.0](https://github.com/JanusGraph/janusgraph/pull/3885)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)