### PR TITLE
[v0.6] Re-tag images after release mark ready

### DIFF
--- a/.github/workflows/ci-backend-cql-dummy.yml
+++ b/.github/workflows/ci-backend-cql-dummy.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci-backend-cql.yml
+++ b/.github/workflows/ci-backend-cql.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   build-all:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -55,7 +55,7 @@ jobs:
       - run: mvn verify --projects janusgraph-all -Pjanusgraph-cache ${{ env.VERIFY_MAVEN_OPTS }}
 
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build-all
     strategy:
       fail-fast: false
@@ -154,7 +154,7 @@ jobs:
           name: codecov-cql-${{ matrix.name }}
 
   full-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: "github.event_name == 'push' && contains(github.event.head_commit.message, '[cql-tests]') || github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[cql-tests]')"
     needs: build-all
     strategy:

--- a/.github/workflows/ci-backend-hbase-dummy.yml
+++ b/.github/workflows/ci-backend-hbase-dummy.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci-backend-hbase.yml
+++ b/.github/workflows/ci-backend-hbase.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   build-all:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -55,7 +55,7 @@ jobs:
       - run: mvn verify --projects janusgraph-all -Pjanusgraph-cache ${{ env.VERIFY_MAVEN_OPTS }}
 
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build-all
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-core-dummy.yml
+++ b/.github/workflows/ci-core-dummy.yml
@@ -26,12 +26,12 @@ on:
 
 jobs:
   build-all:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - run: 'echo "No build required"'
 
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   build-all:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -54,7 +54,7 @@ jobs:
       - run: mvn verify --projects janusgraph-all -Pjanusgraph-cache ${{ env.VERIFY_MAVEN_OPTS }}
 
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build-all
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   build-all:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -42,7 +42,7 @@ jobs:
       - run: mvn verify --projects janusgraph-all -Pjanusgraph-cache ${{ env.VERIFY_MAVEN_OPTS }}
 
   build-doc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build-all
     steps:
       - uses: actions/checkout@v3
@@ -67,7 +67,7 @@ jobs:
           path: site
 
   deploy-doc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.ref == 'refs/heads/master'
     needs: build-doc
     steps: 

--- a/.github/workflows/ci-index-es-dummy.yml
+++ b/.github/workflows/ci-index-es-dummy.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci-index-es.yml
+++ b/.github/workflows/ci-index-es.yml
@@ -39,7 +39,7 @@ env:
 
 jobs:
   build-all:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -56,7 +56,7 @@ jobs:
       - run: mvn verify --projects janusgraph-all -Pjanusgraph-cache ${{ env.VERIFY_MAVEN_OPTS }}
 
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build-all
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-index-solr-dummy.yml
+++ b/.github/workflows/ci-index-solr-dummy.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci-index-solr.yml
+++ b/.github/workflows/ci-index-solr.yml
@@ -39,7 +39,7 @@ env:
 
 jobs:
   build-all:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -56,7 +56,7 @@ jobs:
       - run: mvn verify --projects janusgraph-all -Pjanusgraph-cache ${{ env.VERIFY_MAVEN_OPTS }}
 
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build-all
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-java-11.yml
+++ b/.github/workflows/ci-java-11.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   build-all:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3

--- a/.github/workflows/ci-publish-commit.yml
+++ b/.github/workflows/ci-publish-commit.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   commit-publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci-publish-official.yml
+++ b/.github/workflows/ci-publish-official.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   build-all:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/ci-release-dummy.yml
+++ b/.github/workflows/ci-release-dummy.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   dist-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   build-all:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -58,7 +58,7 @@ jobs:
       - run: mvn verify --projects janusgraph-all -Pjanusgraph-cache ${{ env.VERIFY_MAVEN_OPTS }}
 
   dist-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build-all
     strategy:
       fail-fast: false
@@ -89,7 +89,7 @@ jobs:
           path: janusgraph-dist/target/janusgraph-*.zip
 
   tp-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: "github.event_name == 'push' && contains(github.event.head_commit.message, '[tp-tests]') || github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[tp-tests]') || github.event_name == 'schedule'"
     needs: build-all
     strategy:

--- a/.github/workflows/docker-release-tags.yml
+++ b/.github/workflows/docker-release-tags.yml
@@ -1,0 +1,74 @@
+# Copyright 2023 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Apply docker tags to the official JanusGraph release
+
+on:
+  release:
+    types: [released,edited]
+
+env:
+  LATEST_RELEASE: 0.6
+
+jobs:
+  tagging:
+    runs-on: ubuntu-22.04
+    if: "!contains(github.event.release.tag_name, '-') && !github.event.release.prerelease"
+    steps:
+      - name: EXTRACT VERSION
+        run: |
+          MINOR_VERSION=$(echo "${{ github.event.release.tag_name }}" | grep -Eo '[0-9]+\.[0-9]+' | head -1)
+          PATCH_VERSION=$(echo "${{ github.event.release.tag_name }}" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          REVISION="$(git rev-parse --short HEAD)"
+          echo "MINOR_VERSION=${MINOR_VERSION}" >> $GITHUB_ENV
+          echo "PATCH_VERSION=${PATCH_VERSION}" >> $GITHUB_ENV
+          echo "REVISION=${REVISION}" >> $GITHUB_ENV
+      - name: Run minor tag for ghcr.io
+        uses: shrink/actions-docker-registry-tag@v3
+        with:
+          registry: ghcr.io
+          repository: janusgraph/janusgraph
+          target: ${{ env.PATCH_VERSION }}-${{ env.REVISION }}
+          tags: |
+            ${{ env.PATCH_VERSION }}
+            ${{ env.MINOR_VERSION }}
+      - name: Run minor tag for docker.io
+        uses: shrink/actions-docker-registry-tag@v3
+        with:
+          registry: index.docker.io
+          repository: janusgraph/janusgraph
+          target: ${{ env.PATCH_VERSION }}-${{ env.REVISION }}
+          token: ${{ secrets.DOCKERHUB_TOKEN }}
+          tags: |
+            ${{ env.PATCH_VERSION }}
+            ${{ env.MINOR_VERSION }}
+      - name: Run latest tag for ghcr.io
+        if: "env.MINOR_VERSION == '${{ env.LATEST_RELEASE }}'"
+        uses: shrink/actions-docker-registry-tag@v3
+        with:
+          registry: ghcr.io
+          repository: janusgraph/janusgraph
+          target: ${{ env.PATCH_VERSION }}-${{ env.REVISION }}
+          tags: |
+            latest
+      - name: Run latest tag for docker.io
+        if: "env.MINOR_VERSION == '${{ env.LATEST_RELEASE }}'"
+        uses: shrink/actions-docker-registry-tag@v3
+        with:
+          registry: index.docker.io
+          repository: janusgraph/janusgraph
+          target: ${{ env.PATCH_VERSION }}-${{ env.REVISION }}
+          token: ${{ secrets.DOCKERHUB_TOKEN }}
+          tags: |
+            latest

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -158,6 +158,8 @@ Any outstanding pull requests that will need to be re-targeted at future milesto
 
 Before any artifacts can be generated and vote can be made the version number will need to be updated in the pom.xml files.
 
+Make sure the latest support release version in `.github/workflows/docker-release.yml` is correct.
+
 #### Update configuration reference documentation
 
 ```Shell

--- a/janusgraph-dist/docker/Dockerfile
+++ b/janusgraph-dist/docker/Dockerfile
@@ -86,13 +86,13 @@ CMD [ "janusgraph" ]
 ARG CREATED=test
 ARG REVISION=test
 
-LABEL org.opencontainers.image.title="JanusGraph Docker Image" \
-      org.opencontainers.image.description="Official JanusGraph Docker image" \
-      org.opencontainers.image.url="https://janusgraph.org/" \
-      org.opencontainers.image.documentation="https://docs.janusgraph.org/v1.0/" \
-      org.opencontainers.image.revision="${REVISION}" \
-      org.opencontainers.image.source="https://github.com/JanusGraph/janusgraph-docker/" \
-      org.opencontainers.image.vendor="JanusGraph" \
-      org.opencontainers.image.version="${JANUS_VERSION}" \
-      org.opencontainers.image.created="${CREATED}" \
-      org.opencontainers.image.license="Apache-2.0"
+LABEL org.opencontainers.image.title="JanusGraph Docker Image"
+LABEL org.opencontainers.image.description="Official JanusGraph Docker image"
+LABEL org.opencontainers.image.url="https://janusgraph.org/"
+LABEL org.opencontainers.image.documentation="https://docs.janusgraph.org/v1.0/"
+LABEL org.opencontainers.image.revision="${REVISION}"
+LABEL org.opencontainers.image.source="https://github.com/JanusGraph/janusgraph-docker/"
+LABEL org.opencontainers.image.vendor="JanusGraph"
+LABEL org.opencontainers.image.version="${JANUS_VERSION}"
+LABEL org.opencontainers.image.created="${CREATED}"
+LABEL org.opencontainers.image.license="Apache-2.0"

--- a/janusgraph-dist/docker/build-and-push-image.sh
+++ b/janusgraph-dist/docker/build-and-push-image.sh
@@ -58,18 +58,14 @@ fi
 if [[ $MULTI_PLATFORM == "true" ]]; then
     ARGS="${ARGS} --platform ${PLATFORMS}"
 fi
-if [[ $LATEST == "true" ]] && [[ $TAG_SUFFIX == "" ]]; then
-    TAGS+=('latest')
-fi
-if [[ $JANUS_VERSION == *-* ]]; then
-    echo "no full release"
+if [[ $JANUS_VERSION == *"${REVISION}"* ]]; then
+    TAGS+=("${JANUS_VERSION}${TAG_SUFFIX}")
 else
-    MINOR_VERSION=$(echo "${JANUS_VERSION}" | grep -Eo '[0-9]+\.[0-9]+' | head -1)
-    echo "full release ${MINOR_VERSION}"
-    TAGS+=("${MINOR_VERSION}${TAG_SUFFIX}")
+    TAGS+=("${JANUS_VERSION}-${REVISION}${TAG_SUFFIX}")
+    if [[ $PUSH == "no-push" ]]; then
+        TAGS+=("${JANUS_VERSION}${TAG_SUFFIX}")
+    fi
 fi
-TAGS+=("${JANUS_VERSION}${TAG_SUFFIX}")
-TAGS+=("${JANUS_VERSION}-${REVISION}${TAG_SUFFIX}")
 for BUILD_ARG in "${BUILD_ARGS[@]}"
 do
     ARGS="${ARGS} --build-arg ${BUILD_ARG}"

--- a/janusgraph-dist/pom.xml
+++ b/janusgraph-dist/pom.xml
@@ -801,7 +801,6 @@
                         </executions>
                     </plugin>
 
-
                     <!-- gpg must follow assembly.
                          Both plugins run in the package phase, so only <plugin> ordering
                          ensures that signing happens after assembly file generation.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Re-tag images after release mark ready](https://github.com/JanusGraph/janusgraph/pull/3842)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)