### PR TITLE
Document textContainsPhrase

### DIFF
--- a/docs/index-backend/text-search.md
+++ b/docs/index-backend/text-search.md
@@ -59,6 +59,7 @@ Full-text search is case-insensitive.
 -   `textContainsFuzzy`: is true if (at least) one word inside the text
     string is similar to the query String (based on Levenshtein edit
     distance)
+- `textContainsPhrase`:  is true if the text string does contain the sequence of words in the query string
 
 ```groovy
 import static org.janusgraph.core.attribute.Text.*

--- a/docs/index-backend/text-search.md
+++ b/docs/index-backend/text-search.md
@@ -59,7 +59,7 @@ Full-text search is case-insensitive.
 -   `textContainsFuzzy`: is true if (at least) one word inside the text
     string is similar to the query String (based on Levenshtein edit
     distance)
-- `textContainsPhrase`:  is true if the text string does contain the sequence of words in the query string
+-   `textContainsPhrase`: is true if the text string does contain the sequence of words in the query string
 
 ```groovy
 import static org.janusgraph.core.attribute.Text.*
@@ -67,6 +67,7 @@ g.V().has('booksummary', textContains('unicorns'))
 g.V().has('booksummary', textContainsPrefix('uni'))
 g.V().has('booksummary', textContainsRegex('.*corn.*'))
 g.V().has('booksummary', textContainsFuzzy('unicorn'))
+g.V().has('booksummary', textContainsPhrase('unicorn horn'))
 ```
 
 The Elasticsearch backend extends this functionality and includes support for negations


### PR DESCRIPTION
-----

Prompted from a conversation on [Discord](https://discord.com/channels/981533699378135051/981533699378135054/1137300643300786186). @li-boxuan suggested spinning up a PR for it.

It appears `textContainsPhrase` was not documented for full-text search predicates, but its negation was documented.

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
