### PR TITLE
[v0.6] Document textContainsPhrase (#3907)

### DIFF
--- a/docs/index-backend/text-search.md
+++ b/docs/index-backend/text-search.md
@@ -59,6 +59,7 @@ Full-text search is case-insensitive.
 -   `textContainsFuzzy`: is true if (at least) one word inside the text
     string is similar to the query String (based on Levenshtein edit
     distance)
+-   `textContainsPhrase`: is true if the text string does contain the sequence of words in the query string
 
 ```groovy
 import static org.janusgraph.core.attribute.Text.*
@@ -66,6 +67,7 @@ g.V().has('booksummary', textContains('unicorns'))
 g.V().has('booksummary', textContainsPrefix('uni'))
 g.V().has('booksummary', textContainsRegex('.*corn.*'))
 g.V().has('booksummary', textContainsFuzzy('unicorn'))
+g.V().has('booksummary', textContainsPhrase('unicorn horn'))
 ```
 
 The Elasticsearch backend extends this functionality and includes support for negations


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Document textContainsPhrase (#3907)](https://github.com/JanusGraph/janusgraph/pull/3907)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)