### PR TITLE
Let Dependabot update JUnit dependencies together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     interval: daily
     time: "11:00"
   open-pull-requests-limit: 10
+  groups:
+    junit:
+      patterns:
+        - "junit*"
   labels:
     - "backport/v0.6"
     - "dependencies"


### PR DESCRIPTION
junit and junit-platform need to be updated together which is why we always had to manually do the update since Dependabot could only create one PR per dependency.
The new grouping feature should solve this as it lets Dependabot create a single PR for both packages:
https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/