### PR TITLE
[v0.6] Bump protobuf.version from 3.22.3 to 3.24.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <scylladb.version>4.4.0</scylladb.version>
         <testcontainers.version>1.18.3</testcontainers.version>
         <easymock.version>5.1.0</easymock.version>
-        <protobuf.version>3.22.3</protobuf.version>
+        <protobuf.version>3.24.2</protobuf.version>
         <grpc.version>1.57.1</grpc.version>
         <protoc.version>3.15.3</protoc.version>
         <gson.version>2.10.1</gson.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump protobuf.version from 3.23.4 to 3.24.2](https://github.com/JanusGraph/janusgraph/pull/3927)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)