### PR TITLE
[v0.6] Bump grpc.version from 1.57.1 to 1.57.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <testcontainers.version>1.18.3</testcontainers.version>
         <easymock.version>5.1.0</easymock.version>
         <protobuf.version>3.22.3</protobuf.version>
-        <grpc.version>1.57.1</grpc.version>
+        <grpc.version>1.57.2</grpc.version>
         <protoc.version>3.15.3</protoc.version>
         <gson.version>2.10.1</gson.version>
         <jmh.version>1.21</jmh.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump grpc.version from 1.57.1 to 1.57.2](https://github.com/JanusGraph/janusgraph/pull/3926)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)