### PR TITLE
[v0.6] Bump testcontainers.version from 1.18.3 to 1.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <cassandra.version.sha256>bbe772956c841158e3228c3b6c8fc38cece6bceeface695473c59c0573039bf1</cassandra.version.sha256>
         <cassandra-driver.version>4.17.0</cassandra-driver.version>
         <scylladb.version>4.4.0</scylladb.version>
-        <testcontainers.version>1.18.3</testcontainers.version>
+        <testcontainers.version>1.19.0</testcontainers.version>
         <easymock.version>5.1.0</easymock.version>
         <protobuf.version>3.22.3</protobuf.version>
         <grpc.version>1.57.2</grpc.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump testcontainers.version from 1.18.3 to 1.19.0](https://github.com/JanusGraph/janusgraph/pull/3940)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)