### PR TITLE
[v0.6] Bump org.easymock:easymock from 5.1.0 to 5.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <cassandra-driver.version>4.17.0</cassandra-driver.version>
         <scylladb.version>4.4.0</scylladb.version>
         <testcontainers.version>1.19.0</testcontainers.version>
-        <easymock.version>5.1.0</easymock.version>
+        <easymock.version>5.2.0</easymock.version>
         <protobuf.version>3.22.3</protobuf.version>
         <grpc.version>1.57.2</grpc.version>
         <protoc.version>3.15.3</protoc.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump org.easymock:easymock from 5.1.0 to 5.2.0](https://github.com/JanusGraph/janusgraph/pull/3936)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)