### PR TITLE
[v0.6] Bump com.googlecode.maven-download-plugin:download-maven-plugin

### DIFF
--- a/janusgraph-dist/pom.xml
+++ b/janusgraph-dist/pom.xml
@@ -200,7 +200,7 @@
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.6.8</version>
+                <version>1.7.1</version>
                 <executions>
                     <execution>
                         <id>get-elasticsearch</id>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump com.googlecode.maven-download-plugin:download-maven-plugin](https://github.com/JanusGraph/janusgraph/pull/3946)

<!--- Backport version: 9.2.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)