### PR TITLE
Remove minSuccess arguments from remaining tests

### DIFF
--- a/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLGraphCacheTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLGraphCacheTest.java
@@ -45,7 +45,7 @@ public class CQLGraphCacheTest extends JanusGraphTest {
     }
 
     // flaky test: https://github.com/JanusGraph/janusgraph/issues/1457
-    @ParameterizedRepeatedIfExceptionsTest(repeats = 4, minSuccess = 2)
+    @ParameterizedRepeatedIfExceptionsTest(repeats = 3)
     @ValueSource(booleans = {true, false})
     @Override
     public void simpleLogTest(boolean useStringId) throws InterruptedException {
@@ -53,7 +53,7 @@ public class CQLGraphCacheTest extends JanusGraphTest {
     }
 
     // flaky test: https://github.com/JanusGraph/janusgraph/issues/1457
-    @ParameterizedRepeatedIfExceptionsTest(repeats = 4, minSuccess = 2)
+    @ParameterizedRepeatedIfExceptionsTest(repeats = 3)
     @ValueSource(booleans = {true, false})
     @Override
     public void simpleLogTestWithFailure(boolean useStringId) throws InterruptedException {

--- a/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLGraphTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLGraphTest.java
@@ -229,7 +229,7 @@ public class CQLGraphTest extends JanusGraphTest {
     }
 
     // flaky test: https://github.com/JanusGraph/janusgraph/issues/1457
-    @ParameterizedRepeatedIfExceptionsTest(repeats = 4, minSuccess = 2)
+    @ParameterizedRepeatedIfExceptionsTest(repeats = 3)
     @ValueSource(booleans = {true, false})
     @Override
     public void simpleLogTest(boolean useStringId) throws InterruptedException {
@@ -237,7 +237,7 @@ public class CQLGraphTest extends JanusGraphTest {
     }
 
     // flaky test: https://github.com/JanusGraph/janusgraph/issues/1457
-    @ParameterizedRepeatedIfExceptionsTest(repeats = 4, minSuccess = 2)
+    @ParameterizedRepeatedIfExceptionsTest(repeats = 3)
     @ValueSource(booleans = {true, false})
     @Override
     public void simpleLogTestWithFailure(boolean useStringId) throws InterruptedException {


### PR DESCRIPTION
Follow-up to #3961 where I forgot to remove this argument from these 2 tests because they are using `ParameterizedRepeatedIfExceptionsTest` instead of `RepeatedIfExceptionsTest`.

This could have been a CTR commit, but unfortunately pushing directly to `master` doesn't work any more due to the required checks we have in place (which we need for the auto-merge feature).
