### PR TITLE
[v0.6] Mark more tests as flaky

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -35,10 +35,14 @@ All of JanusGraph's tests are written for JUnit.  JanusGraph's JUnit tests are a
 
 ### Marking tests as flaky
 
-If a test should be marked as flaky add following annotation to the test and open an issue.
+If a test should be marked as flaky, then first [open an issue](https://github.com/JanusGraph/janusgraph/issues/new?assignees=&labels=testing%2Fflaky&projects=&template=flaky-test.md)
+where you can add information about the flaky test that could be helpful later to others to understand why the test is
+marked as flaky and hopefully for fixing it.
+Afterwards, add the annotation to the test and link to the issue you just created:
 
 ```java
-@RepeatedIfExceptionsTest(repeats = 4, minSuccess = 2)
+// flaky test: https://github.com/JanusGraph/janusgraph/issues/[ISSUE_NUMBER]
+@RepeatedIfExceptionsTest(repeats = 3)
 public void testFlakyFailsSometimes(){}
 ```
 
@@ -128,7 +132,7 @@ mvn clean install -pl janusgraph-es -Delasticsearch.docker.version=6.0.0 -Delast
 
 **Note** Running CQL tests require Docker.
 
-CQL tests are executed using [testcontainers-java](https://www.testcontainers.org/). 
+CQL tests are executed using [testcontainers-java](https://www.testcontainers.org/).
 CQL tests can be executed against a Cassandra 3 using the profile `cassandra3`, or a Scylla 3 using the profile `scylladb`.
 
 ```bash
@@ -172,10 +176,10 @@ System properties to configure HBase test executions:
 
 ### TinkerPop tests
 
-The CQL backend is tested with TinkerPop tests using following command. 
+The CQL backend is tested with TinkerPop tests using following command.
 
-**Note: Profiles are not supported during running TinkerPop tests. 
-If you do not want to use the default config, you can set `cassandra.docker.image`, 
+**Note: Profiles are not supported during running TinkerPop tests.
+If you do not want to use the default config, you can set `cassandra.docker.image`,
 `cassandra.docker.version`, or `cassandra.docker.partitioner`.**
 
 ```bash
@@ -185,6 +189,6 @@ mvn clean install -Dtest.skip.tp=false -DskipTests=true -pl janusgraph-cql \
 
 ### Create new configuration files for new Versions of Cassandra
 
-The file `janusgraph-cql/src/test/resources/docker/docker-compose.yml` can be used to generate new configuration files. 
-Therefore, you have to start a Cassandra instance using `docker-compose up`. 
+The file `janusgraph-cql/src/test/resources/docker/docker-compose.yml` can be used to generate new configuration files.
+Therefore, you have to start a Cassandra instance using `docker-compose up`.
 Afterward, you can extract the configuration which is located in the following file `/etc/cassandra/cassandra.yaml`.

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/diskstorage/indexing/IndexProviderTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/diskstorage/indexing/IndexProviderTest.java
@@ -842,7 +842,8 @@ public abstract class IndexProviderTest {
         assertTrue(results.contains("restore-doc1"));
     }
 
-    @RepeatedIfExceptionsTest(repeats = 4, minSuccess = 2)
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/1091
+    @RepeatedIfExceptionsTest(repeats = 3)
     public void testTTL() throws Exception {
         if (!index.getFeatures().supportsDocumentTTL())
             return;

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/diskstorage/log/LogTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/diskstorage/log/LogTest.java
@@ -99,7 +99,8 @@ public abstract class LogTest {
         simpleSendReceive(2000,1);
     }
 
-    @RepeatedIfExceptionsTest(repeats = 4, minSuccess = 2)
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/1445
+    @RepeatedIfExceptionsTest(repeats = 3)
     @Tag(LogTest.requiresOrderPreserving)
     public void testMultipleReadersOnSingleLogSerial() throws Exception {
         sendReceive(4, 2000, 5, true, TIMEOUT_MS);

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphIndexTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphIndexTest.java
@@ -2144,7 +2144,8 @@ public abstract class JanusGraphIndexTest extends JanusGraphBaseTest {
         assertEquals(4, recoveryStats[1]); //all 4 index transaction had provoked errors in the indexing backend
     }
 
-    @Test
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/2272
+    @RepeatedIfExceptionsTest(repeats = 3)
     public void testIndexUpdatesWithoutReindex() throws InterruptedException, ExecutionException {
         final Object[] settings = new Object[]{option(LOG_SEND_DELAY, MANAGEMENT_LOG), Duration.ofMillis(0),
                 option(KCVSLog.LOG_READ_LAG_TIME, MANAGEMENT_LOG), Duration.ofMillis(50),
@@ -3149,7 +3150,8 @@ public abstract class JanusGraphIndexTest extends JanusGraphBaseTest {
 
     }
 
-    @RepeatedIfExceptionsTest(repeats = 4, minSuccess = 2)
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/3976
+    @RepeatedIfExceptionsTest(repeats = 3)
     public void shouldUpdateIndexFieldsAfterIndexModification() throws InterruptedException, ExecutionException {
         clopen(option(FORCE_INDEX_USAGE), true, option(LOG_READ_INTERVAL, MANAGEMENT_LOG), Duration.ofMillis(5000));
         String key1 = "testKey1";

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphOperationCountingTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphOperationCountingTest.java
@@ -20,6 +20,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -127,7 +128,8 @@ public abstract class JanusGraphOperationCountingTest extends JanusGraphBaseTest
         }
     }
 
-    @Test
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/1459
+    @RepeatedIfExceptionsTest(repeats = 3)
     public void testIdCounts() {
         makeVertexIndexedUniqueKey("uid", Integer.class);
         mgmt.setConsistency(mgmt.getGraphIndex("uid"), ConsistencyModifier.LOCK);

--- a/janusgraph-berkeleyje/src/test/java/org/janusgraph/graphdb/berkeleyje/BerkeleyOperationCountingTest.java
+++ b/janusgraph-berkeleyje/src/test/java/org/janusgraph/graphdb/berkeleyje/BerkeleyOperationCountingTest.java
@@ -14,7 +14,6 @@
 
 package org.janusgraph.graphdb.berkeleyje;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.janusgraph.BerkeleyStorageSetup;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
 import org.janusgraph.graphdb.JanusGraphOperationCountingTest;
@@ -25,12 +24,6 @@ public class BerkeleyOperationCountingTest extends JanusGraphOperationCountingTe
     @Override
     public WriteConfiguration getBaseConfiguration() {
         return BerkeleyStorageSetup.getBerkeleyJEGraphConfiguration();
-    }
-
-    @Override
-    @RepeatedIfExceptionsTest(repeats = 4, minSuccess = 2)
-    public void testIdCounts() {
-        super.testIdCounts();
     }
 
     @AfterEach

--- a/janusgraph-cql/src/test/java/org/janusgraph/core/cql/CQLConfiguredGraphFactoryTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/core/cql/CQLConfiguredGraphFactoryTest.java
@@ -109,7 +109,8 @@ public class CQLConfiguredGraphFactoryTest extends AbstractConfiguredGraphFactor
         }
     }
 
-    @Test
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/3393
+    @RepeatedIfExceptionsTest(repeats = 3)
     public void dropGraphShouldRemoveGraphKeyspace() throws Exception {
         final MapConfiguration graphConfig = getGraphConfig();
         final String graphName = graphConfig.getString(GRAPH_NAME.toStringWithoutRoot());
@@ -132,10 +133,18 @@ public class CQLConfiguredGraphFactoryTest extends AbstractConfiguredGraphFactor
         }
     }
 
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/3096
     @RepeatedIfExceptionsTest(repeats = 3)
     @Override
     public void updateConfigurationShouldRemoveGraphFromCache() throws Exception {
         super.updateConfigurationShouldRemoveGraphFromCache();
+    }
+
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/3959
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void dropShouldCleanUpTraversalSourceAndBindings() throws Exception {
+        super.dropShouldCleanUpTraversalSourceAndBindings();
     }
 }
 

--- a/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLGraphCacheTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLGraphCacheTest.java
@@ -14,12 +14,15 @@
 
 package org.janusgraph.graphdb.cql;
 
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.janusgraph.JanusGraphCassandraContainer;
 import org.janusgraph.StorageSetup;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
 import org.janusgraph.graphdb.JanusGraphTest;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.concurrent.ExecutionException;
 
 @Testcontainers
 public class CQLGraphCacheTest extends JanusGraphTest {
@@ -30,5 +33,61 @@ public class CQLGraphCacheTest extends JanusGraphTest {
     @Override
     public WriteConfiguration getConfiguration() {
         return StorageSetup.addPermanentCache(cqlContainer.getConfiguration(getClass().getSimpleName()));
+    }
+
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/1498
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void testIndexUpdatesWithReindexAndRemove() throws InterruptedException, ExecutionException {
+        super.testIndexUpdatesWithReindexAndRemove();
+    }
+
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/1457
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void simpleLogTest() throws InterruptedException {
+        super.simpleLogTest();
+    }
+
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/1457
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void simpleLogTestWithFailure() throws InterruptedException {
+        super.simpleLogTestWithFailure();
+    }
+
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/1497
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void testEdgeTTLTiming() throws Exception {
+        super.testEdgeTTLTiming();
+    }
+
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/1462
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void testEdgeTTLWithTransactions() throws Exception {
+        super.testEdgeTTLWithTransactions();
+    }
+
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/1464
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void testVertexTTLWithCompositeIndex() throws Exception {
+        super.testVertexTTLWithCompositeIndex();
+    }
+
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/1465
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void testVertexTTLImplicitKey() throws Exception {
+        super.testVertexTTLImplicitKey();
+    }
+
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/3142
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void testReindexingForEdgeIndex() throws ExecutionException, InterruptedException {
+        super.testReindexingForEdgeIndex();
     }
 }

--- a/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLGraphTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLGraphTest.java
@@ -65,12 +65,42 @@ public class CQLGraphTest extends JanusGraphTest {
         assertTrue(features.hasCellTTL());
     }
 
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/1457
     @RepeatedIfExceptionsTest(repeats = 3)
     @Override
     public void simpleLogTest() throws InterruptedException{
         super.simpleLogTest();
     }
 
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/1457
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void simpleLogTestWithFailure() throws InterruptedException {
+        super.simpleLogTestWithFailure();
+    }
+
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/1497
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void testEdgeTTLTiming() throws Exception {
+        super.testEdgeTTLTiming();
+    }
+
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/1464
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void testVertexTTLWithCompositeIndex() throws Exception {
+        super.testVertexTTLWithCompositeIndex();
+    }
+
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/1465
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void testVertexTTLImplicitKey() throws Exception {
+        super.testVertexTTLImplicitKey();
+    }
+
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/3142
     @RepeatedIfExceptionsTest(repeats = 3)
     @Override
     public void testReindexingForEdgeIndex() throws ExecutionException, InterruptedException {

--- a/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLOLAPTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLOLAPTest.java
@@ -14,6 +14,7 @@
 
 package org.janusgraph.graphdb.cql;
 
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.janusgraph.JanusGraphCassandraContainer;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
 import org.janusgraph.olap.OLAPTest;
@@ -28,5 +29,12 @@ public class CQLOLAPTest extends OLAPTest {
     @Override
     public WriteConfiguration getConfiguration() {
         return cqlContainer.getConfiguration(getClass().getSimpleName()).getConfiguration();
+    }
+
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/3392
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void testShortestDistance() throws Exception {
+        super.testShortestDistance();
     }
 }

--- a/janusgraph-cql/src/test/java/org/janusgraph/hadoop/CQLIndexManagementIT.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/hadoop/CQLIndexManagementIT.java
@@ -33,6 +33,7 @@ public class CQLIndexManagementIT extends AbstractIndexManagementIT {
         return cql.getConfiguration(getClass().getSimpleName().toLowerCase()).getConfiguration();
     }
 
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/3132
     @RepeatedIfExceptionsTest(repeats = 3)
     @Override
     public void testRepairRelationIndex() throws ExecutionException, InterruptedException, BackendException {

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/BerkeleyElasticsearchTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/BerkeleyElasticsearchTest.java
@@ -41,6 +41,13 @@ public class BerkeleyElasticsearchTest extends ElasticsearchJanusGraphIndexTest 
         return getBerkeleyJEConfiguration();
     }
 
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/3960
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void indexShouldNotExistAfterDeletion() throws Exception {
+        super.indexShouldNotExistAfterDeletion();
+    }
+
     /**
      * Test {@link org.janusgraph.example.GraphOfTheGodsFactory#create(String)}.
      */
@@ -55,9 +62,17 @@ public class BerkeleyElasticsearchTest extends ElasticsearchJanusGraphIndexTest 
         gotg.close();
     }
 
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/3651
     @RepeatedIfExceptionsTest(repeats = 3)
     @Override
-    public void testIndexUpdatesWithoutReindex() throws InterruptedException, ExecutionException {
-        super.testIndexUpdatesWithoutReindex();
+    public void testDisableAndDiscardManuallyAndDropEnabledIndex() throws Exception {
+        super.testDisableAndDiscardManuallyAndDropEnabledIndex();
+    }
+
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/3931
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void testDiscardAndDropRegisteredIndex() throws ExecutionException, InterruptedException {
+        super.testDiscardAndDropRegisteredIndex();
     }
 }

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/CQLElasticsearchTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/CQLElasticsearchTest.java
@@ -14,14 +14,11 @@
 
 package org.janusgraph.diskstorage.es;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.janusgraph.JanusGraphCassandraContainer;
 import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.junit.jupiter.api.Disabled;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-
-import java.util.concurrent.ExecutionException;
 
 @Testcontainers
 public class CQLElasticsearchTest extends ElasticsearchJanusGraphIndexTest {
@@ -37,10 +34,4 @@ public class CQLElasticsearchTest extends ElasticsearchJanusGraphIndexTest {
     @Override
     @Disabled("CQL seems to not clear storage correctly")
     public void testClearStorage() {}
-
-    @RepeatedIfExceptionsTest(repeats = 3)
-    @Override
-    public void testIndexUpdatesWithoutReindex() throws InterruptedException, ExecutionException {
-        super.testIndexUpdatesWithoutReindex();
-    }
 }

--- a/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/CQLSolrTest.java
+++ b/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/CQLSolrTest.java
@@ -14,6 +14,7 @@
 
 package org.janusgraph.diskstorage.solr;
 
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.janusgraph.JanusGraphCassandraContainer;
 import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.testcontainers.junit.jupiter.Container;
@@ -35,4 +36,10 @@ public class CQLSolrTest extends SolrJanusGraphIndexTest {
         return false;
     }
 
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/3356
+    @RepeatedIfExceptionsTest(repeats = 3)
+    @Override
+    public void testSetIndexing() {
+        super.testSetIndexing();
+    }
 }

--- a/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrJanusGraphIndexTest.java
+++ b/janusgraph-solr/src/test/java/org/janusgraph/diskstorage/solr/SolrJanusGraphIndexTest.java
@@ -81,6 +81,7 @@ public abstract class SolrJanusGraphIndexTest extends JanusGraphIndexTest {
         super.testClearStorage();
     }
 
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/2271
     @Override
     @RepeatedIfExceptionsTest(repeats = 10, suspend = 1000L)
     public void testIndexReplay() throws Exception {

--- a/janusgraph-test/src/test/java/org/janusgraph/diskstorage/cache/ExpirationCacheTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/diskstorage/cache/ExpirationCacheTest.java
@@ -26,7 +26,6 @@ import org.janusgraph.diskstorage.keycolumnvalue.cache.CacheTransaction;
 import org.janusgraph.diskstorage.keycolumnvalue.cache.ExpirationKCVSCache;
 import org.janusgraph.diskstorage.keycolumnvalue.cache.KCVSCache;
 import org.janusgraph.diskstorage.util.BufferUtil;
-import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -53,8 +52,8 @@ public class ExpirationCacheTest extends KCVSCacheTest {
         return new ExpirationKCVSCache(store,METRICS_STRING,expirationTime.toMillis(),graceWait.toMillis(),CACHE_SIZE);
     }
 
-
-    @Test
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/2934
+    @RepeatedIfExceptionsTest(repeats = 3)
     public void testExpiration() throws Exception {
         testExpiration(Duration.ofMillis(200));
         testExpiration(Duration.ofSeconds(4));
@@ -98,6 +97,7 @@ public class ExpirationCacheTest extends KCVSCacheTest {
         verifyResults(key, keys, query, 4);
     }
 
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/3352
     @RepeatedIfExceptionsTest(repeats = 3)
     public void testGracePeriod() throws Exception {
         testGracePeriod(Duration.ofMillis(200));

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/vertices/StandardVertexTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/vertices/StandardVertexTest.java
@@ -59,7 +59,9 @@ public class StandardVertexTest {
         standardVertex = spy(new StandardVertex(tx, 1, (byte) 1));
     }
 
-    @RepeatedIfExceptionsTest(repeats = 3, minSuccess = 1)
+    // This test is flaky simply because it tests a possible deadlock
+    // https://github.com/JanusGraph/janusgraph/pull/1486
+    @RepeatedIfExceptionsTest(repeats = 3)
     public void shouldNotStuckInDeadlockWhenTheVerticeAndItsRelationIsDeletedInParallel()
         throws InterruptedException, TimeoutException, ExecutionException {
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Mark more tests as flaky](https://github.com/JanusGraph/janusgraph/pull/3961)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)