### PR TITLE
Fix backport of: Mark more tests as flaky

### DIFF
--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/BerkeleyElasticsearchTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/BerkeleyElasticsearchTest.java
@@ -14,7 +14,6 @@
 
 package org.janusgraph.diskstorage.es;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.janusgraph.core.JanusGraph;
 import org.janusgraph.core.JanusGraphFactory;
 import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
@@ -25,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.File;
-import java.util.concurrent.ExecutionException;
 
 import static org.janusgraph.BerkeleyStorageSetup.getBerkeleyJEConfiguration;
 
@@ -41,13 +39,6 @@ public class BerkeleyElasticsearchTest extends ElasticsearchJanusGraphIndexTest 
         return getBerkeleyJEConfiguration();
     }
 
-    // flaky test: https://github.com/JanusGraph/janusgraph/issues/3960
-    @RepeatedIfExceptionsTest(repeats = 3)
-    @Override
-    public void indexShouldNotExistAfterDeletion() throws Exception {
-        super.indexShouldNotExistAfterDeletion();
-    }
-
     /**
      * Test {@link org.janusgraph.example.GraphOfTheGodsFactory#create(String)}.
      */
@@ -60,19 +51,5 @@ public class BerkeleyElasticsearchTest extends ElasticsearchJanusGraphIndexTest 
         GraphOfTheGodsFactory.load(gotg);
         JanusGraphIndexTest.assertGraphOfTheGods(gotg);
         gotg.close();
-    }
-
-    // flaky test: https://github.com/JanusGraph/janusgraph/issues/3651
-    @RepeatedIfExceptionsTest(repeats = 3)
-    @Override
-    public void testDisableAndDiscardManuallyAndDropEnabledIndex() throws Exception {
-        super.testDisableAndDiscardManuallyAndDropEnabledIndex();
-    }
-
-    // flaky test: https://github.com/JanusGraph/janusgraph/issues/3931
-    @RepeatedIfExceptionsTest(repeats = 3)
-    @Override
-    public void testDiscardAndDropRegisteredIndex() throws ExecutionException, InterruptedException {
-        super.testDiscardAndDropRegisteredIndex();
     }
 }


### PR DESCRIPTION
Looks like the backport went wrong here as it included 3 tests which aren't present at all on `v0.6`. This currently breaks the build on `v0.6`. Not sure why the checks still passed for the backporting PR: #3982
