### PR TITLE
[v0.6] Bump com.nimbusds:nimbus-jose-jwt from 9.31 to 9.35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1176,7 +1176,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
-                <version>9.31</version>
+                <version>9.35</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump com.nimbusds:nimbus-jose-jwt from 9.31 to 9.35](https://github.com/JanusGraph/janusgraph/pull/3994)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)