### PR TITLE
[v0.6] Bump com.google.errorprone:error_prone_annotations from 2.21.1 to 2.22.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -904,7 +904,7 @@
             <dependency>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_annotations</artifactId>
-                <version>2.21.1</version>
+                <version>2.22.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump com.google.errorprone:error_prone_annotations from 2.21.1 to 2.22.0](https://github.com/JanusGraph/janusgraph/pull/4009)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)