### PR TITLE
[v0.6] Bump org.xerial.snappy:snappy-java from 1.1.10.3 to 1.1.10.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1162,7 +1162,7 @@
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.10.3</version>
+                <version>1.1.10.5</version>
             </dependency>
             <dependency>
                 <groupId>javax.activation</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump org.xerial.snappy:snappy-java from 1.1.10.3 to 1.1.10.5](https://github.com/JanusGraph/janusgraph/pull/4006)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)