### PR TITLE
Update commons-compress to 1.24.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1056,7 +1056,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
+                <version>1.24.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
This fixes a dependency convergence errors with testcontainers which for some reason only occurs on `v0.6` and prevents backporting the latest testcontainers update (see #4026):

```sh
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for org.apache.commons:commons-compress:1.23.0 paths to dependency are:
+-org.janusgraph:janusgraph-driver:0.6.4-SNAPSHOT
  +-org.testcontainers:testcontainers:1.19.1
    +-org.apache.commons:commons-compress:1.23.0 (managed) <-- org.apache.commons:commons-compress:1.24.0
]
```

I'm not sure though why Dependabot hasn't created a PR for this update yet. Its latest log shows that it checked for an update:

```
updater | 2023/10/04 11:12:32 INFO <job_730481777> No update possible for org.apache.commons:commons-compress 1.23.0
```
