### PR TITLE
[v0.6] Remove dangling netty dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -922,11 +922,6 @@
                 <artifactId>netty</artifactId>
                 <version>3.2.10.Final</version>
             </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty</artifactId>
-                <version>3.10.6.Final</version>
-            </dependency>
 
             <!-- Spatial4j -->
             <dependency>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Remove dangling netty dependency management](https://github.com/JanusGraph/janusgraph/pull/4023)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)