### PR TITLE
[v0.6] Update commons-compress to 1.24.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1051,7 +1051,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
+                <version>1.24.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Update commons-compress to 1.24.0](https://github.com/JanusGraph/janusgraph/pull/4027)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)