### PR TITLE
[v0.6] Bump avro to 1.11.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <properties>
         <titan.compatible-versions>1.0.0,1.1.0-SNAPSHOT</titan.compatible-versions>
         <tinkerpop.version>3.5.7</tinkerpop.version>
+        <avro.version>1.11.3</avro.version>
         <junit-platform.version>1.10.0</junit-platform.version>
         <junit.version>5.10.0</junit.version>
         <mockito.version>4.11.0</mockito.version>
@@ -743,7 +744,7 @@
             <dependency>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro</artifactId>
-                <version>1.11.1</version>
+                <version>${avro.version}</version>
             </dependency>
             <dependency>
                 <artifactId>jboss-logging</artifactId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Bump avro to 1.11.3](https://github.com/JanusGraph/janusgraph/pull/4024)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)