### PR TITLE
[v0.6] Merge pull request #4063 from JanusGraph/dependabot/maven/org.jacoco-org.jacoco.ant-0.8.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -514,7 +514,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.10</version>
+                    <version>0.8.11</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -976,7 +976,7 @@
             <dependency>
                 <groupId>org.jacoco</groupId>
                 <artifactId>org.jacoco.ant</artifactId>
-                <version>0.8.10</version>
+                <version>0.8.11</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
@@ -1529,7 +1529,7 @@
                             <dependency>
                                 <groupId>org.jacoco</groupId>
                                 <artifactId>org.jacoco.ant</artifactId>
-                                <version>0.8.10</version>
+                                <version>0.8.11</version>
                             </dependency>
                         </dependencies>
                     </plugin>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Merge pull request #4063 from JanusGraph/dependabot/maven/org.jacoco-org.jacoco.ant-0.8.11](https://github.com/JanusGraph/janusgraph/pull/4063)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)