### PR TITLE
[v0.6] fix structur failure

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,8 +59,9 @@ plugins:
 theme:
   language: 'en'
   name: 'material'
-  feature:
-    tabs: false
+  features:
+    - navigation.footer
+    - navigation.tabs
   palette:
     primary: 'green'
     accent: 'teal'
@@ -74,14 +75,23 @@ extra_css:
 
 extra:
   social:
-    - type: github-alt
+    - icon: fontawesome/brands/github
       link: https://github.com/janusgraph
-    - type: twitter
+    - icon: fontawesome/brands/discord
+      link: https://discord.gg/5n4fjv4QAf
+    - icon: fontawesome/brands/x-twitter
       link: https://twitter.com/janusgraph
-    - type: envelope
+    - icon: fontawesome/brands/linkedin
+      link: https://www.linkedin.com/company/janusgraph
+    - icon: fontawesome/solid/envelope
       link: https://lists.lfaidata.foundation/g/janusgraph-users
-    - type: envelope
+    - icon: fontawesome/solid/envelope
       link: https://lists.lfaidata.foundation/g/janusgraph-dev
+  latest_version: 0.6.4
+  snapshot_version: 0.6.5-SNAPSHOT
+  tinkerpop_version: 3.5.7
+  hadoop2_version: 2.8.5
+  jamm_version: 0.3.0
 
 markdown_extensions:
   - pymdownx.superfences
@@ -166,10 +176,3 @@ nav:
   - Common Questions: common-questions.md
   - Development: development.md
   - Changelog: changelog.md
-
-extra:
-  latest_version: 0.6.4
-  snapshot_version: 0.6.5-SNAPSHOT
-  tinkerpop_version: 3.5.7
-  hadoop2_version: 2.8.5
-  jamm_version: 0.3.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [fix structur failure](https://github.com/JanusGraph/janusgraph/pull/4104)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)