### PR TITLE
[v0.4] fix update mkdocs

### DIFF
--- a/docs.Dockerfile
+++ b/docs.Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.8
+FROM python:3.12
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin
 

--- a/docs/advanced-topics/hadoop.md
+++ b/docs/advanced-topics/hadoop.md
@@ -36,7 +36,7 @@ computations of various OLAP queries may be persisted on the Hadoop file
 system.
 
 For configuring a single node Hadoop cluster, please refer to official
-[Apache Hadoop Docs](https://hadoop.apache.org/docs/r{{hadoop2_version }}/hadoop-project-dist/hadoop-common/SingleCluster.html)
+[Apache Hadoop Docs](https://hadoop.apache.org/docs/r{{ hadoop2_version }}/hadoop-project-dist/hadoop-common/SingleCluster.html)
 
 Once you have a Hadoop cluster up and running, we will need to specify
 the Hadoop configuration files in the `CLASSPATH`. The below document

--- a/docs/basics/configuration-reference.md
+++ b/docs/basics/configuration-reference.md
@@ -62,6 +62,7 @@ configuration
 log.user.send-batch-size = 100
 ```
 
-Configuration Namespaces and Options
-------------------------------------
-{!basics/janusgraph-cfg.md!}
+## Configuration Namespaces and Options
+{%
+    include "basics/janusgraph-cfg.md"
+%}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,19 +28,21 @@ use the latest versions of the software.
 
 ### Version 0.4.1 (Release Date: January 14, 2020)
 
-=== "Maven"
-    ```xml
-    <dependency>
-        <groupId>org.janusgraph</groupId>
-        <artifactId>janusgraph-core</artifactId>
-        <version>0.4.1</version>
-    </dependency>
-    ```
+/// tab | Maven
+```xml
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.4.1</version>
+</dependency>
+```
+///
 
-=== "Gradle"
-    ```groovy
-    compile "org.janusgraph:janusgraph-core:0.4.1"
-    ```
+/// tab | Gradle
+```groovy
+compile "org.janusgraph:janusgraph-core:0.4.1"
+```
+///
 
 **Tested Compatibility:**
 
@@ -70,19 +72,21 @@ for each call (only for the first query which defines a property) if the `Vertex
 ### Version 0.4.0 (Release Date: July 1, 2019)
 Legacy documentation: <https://old-docs.janusgraph.org/0.4.0/index.html>
 
-=== "Maven"
-    ```xml
-    <dependency>
-        <groupId>org.janusgraph</groupId>
-        <artifactId>janusgraph-core</artifactId>
-        <version>0.4.0</version>
-    </dependency>
-    ```
+/// tab | Maven
+```xml
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.4.0</version>
+</dependency>
+```
+///
 
-=== "Gradle"
-    ```groovy
-    compile "org.janusgraph:janusgraph-core:0.4.0"
-    ```
+/// tab | Gradle
+```groovy
+compile "org.janusgraph:janusgraph-core:0.4.0"
+```
+///
 
 **Tested Compatibility:**
 
@@ -129,19 +133,21 @@ If the config distributed by JanusGraph is used for an existing Solr installatio
 
 ### Version 0.3.3 (Release Date: January 11, 2020)
 
-=== "Maven"
-    ```xml
-    <dependency>
-        <groupId>org.janusgraph</groupId>
-        <artifactId>janusgraph-core</artifactId>
-        <version>0.3.3</version>
-    </dependency>
-    ```
+/// tab | Maven
+```xml
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.3.3</version>
+</dependency>
+```
+///
 
-=== "Gradle"
-    ```groovy
-    compile "org.janusgraph:janusgraph-core:0.3.3"
-    ```
+/// tab | Gradle
+```groovy
+compile "org.janusgraph:janusgraph-core:0.3.3"
+```
+///
 
 **Tested Compatibility:**
 
@@ -162,19 +168,21 @@ For more information on features and bug fixes in 0.3.3, see the GitHub mileston
 ### Version 0.3.2 (Release Date: June 16, 2019)
 Legacy documentation: <https://old-docs.janusgraph.org/0.3.2/index.html>
 
-=== "Maven"
-    ```xml
-    <dependency>
-        <groupId>org.janusgraph</groupId>
-        <artifactId>janusgraph-core</artifactId>
-        <version>0.3.2</version>
-    </dependency>
-    ```
+/// tab | Maven
+```xml
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.3.2</version>
+</dependency>
+```
+///
 
-=== "Gradle"
-    ```groovy
-    compile "org.janusgraph:janusgraph-core:0.3.2"
-    ```
+/// tab | Gradle
+```groovy
+compile "org.janusgraph:janusgraph-core:0.3.2"
+```
+///
 
 **Tested Compatibility:**
 
@@ -195,19 +203,21 @@ For more information on features and bug fixes in 0.3.2, see the GitHub mileston
 ### Version 0.3.1 (Release Date: October 2, 2018)
 Legacy documentation: <https://old-docs.janusgraph.org/0.3.1/index.html>
 
-=== "Maven"
-    ```xml
-    <dependency>
-        <groupId>org.janusgraph</groupId>
-        <artifactId>janusgraph-core</artifactId>
-        <version>0.3.1</version>
-    </dependency>
-    ```
+/// tab | Maven
+```xml
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.3.1</version>
+</dependency>
+```
+///
 
-=== "Gradle"
-    ```groovy
-    compile "org.janusgraph:janusgraph-core:0.3.1"
-    ```
+/// tab | Gradle
+```groovy
+compile "org.janusgraph:janusgraph-core:0.3.1"
+```
+///
 
 **Tested Compatibility:**
 
@@ -228,19 +238,21 @@ For more information on features and bug fixes in 0.3.1, see the GitHub mileston
 ### Version 0.3.0 (Release Date: July 31, 2018)
 Legacy documentation: <https://old-docs.janusgraph.org/0.3.0/index.html>
 
-=== "Maven"
-    ```xml
-    <dependency>
-        <groupId>org.janusgraph</groupId>
-        <artifactId>janusgraph-core</artifactId>
-        <version>0.3.0</version>
-    </dependency>
-    ```
+/// tab | Maven
+```xml
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.3.0</version>
+</dependency>
+```
+///
 
-=== "Gradle"
-    ```groovy
-    compile "org.janusgraph:janusgraph-core:0.3.0"
-    ```
+/// tab | Gradle
+```groovy
+compile "org.janusgraph:janusgraph-core:0.3.0"
+```
+///
 
 **Tested Compatibility:**
 
@@ -310,19 +322,21 @@ Once the storage version has been set you should remove `graph.allow-upgrade=tru
 ### Version 0.2.3 (Release Date: May 21, 2019)
 Legacy documentation: <https://old-docs.janusgraph.org/0.2.3/index.html>
 
-=== "Maven"
-    ```xml
-    <dependency>
-        <groupId>org.janusgraph</groupId>
-        <artifactId>janusgraph-core</artifactId>
-        <version>0.2.3</version>
-    </dependency>
-    ```
+/// tab | Maven
+```xml
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.2.3</version>
+</dependency>
+```
+///
 
-=== "Gradle"
-    ```groovy
-    compile "org.janusgraph:janusgraph-core:0.2.3"
-    ```
+/// tab | Gradle
+```groovy
+compile "org.janusgraph:janusgraph-core:0.2.3"
+```
+///
 
 **Tested Compatibility:**
 
@@ -344,19 +358,21 @@ milestone:
 ### Version 0.2.2 (Release Date: October 9, 2018)
 Legacy documentation: <https://old-docs.janusgraph.org/0.2.2/index.html>
 
-=== "Maven"
-    ```xml
-    <dependency>
-        <groupId>org.janusgraph</groupId>
-        <artifactId>janusgraph-core</artifactId>
-        <version>0.2.2</version>
-    </dependency>
-    ```
+/// tab | Maven
+```xml
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.2.2</version>
+</dependency>
+```
+///
 
-=== "Gradle"
-    ```groovy
-    compile "org.janusgraph:janusgraph-core:0.2.2"
-    ```
+/// tab | Gradle
+```groovy
+compile "org.janusgraph:janusgraph-core:0.2.2"
+```
+///
 
 **Tested Compatibility:**
 
@@ -378,19 +394,21 @@ milestone:
 ### Version 0.2.1 (Release Date: July 9, 2018)
 Legacy documentation: <https://old-docs.janusgraph.org/0.2.1/index.html>
 
-=== "Maven"
-    ```xml
-    <dependency>
-        <groupId>org.janusgraph</groupId>
-        <artifactId>janusgraph-core</artifactId>
-        <version>0.2.1</version>
-    </dependency>
-    ```
+/// tab | Maven
+```xml
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.2.1</version>
+</dependency>
+```
+///
 
-=== "Gradle"
-    ```groovy
-    compile "org.janusgraph:janusgraph-core:0.2.1"
-    ```
+/// tab | Gradle
+```groovy
+compile "org.janusgraph:janusgraph-core:0.2.1"
+```
+///
 
 **Tested Compatibility:**
 
@@ -423,19 +441,21 @@ is FIXED, a new graph needs to be created to make any change of the
 ### Version 0.2.0 (Release Date: October 11, 2017)
 Legacy documentation: <https://old-docs.janusgraph.org/0.2.0/index.html>
 
-=== "Maven"
-    ```xml
-    <dependency>
-        <groupId>org.janusgraph</groupId>
-        <artifactId>janusgraph-core</artifactId>
-        <version>0.2.0</version>
-    </dependency>
-    ```
+/// tab | Maven
+```xml
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.2.0</version>
+</dependency>
+```
+///
 
-=== "Gradle"
-    ```groovy
-    compile "org.janusgraph:janusgraph-core:0.2.0"
-    ```
+/// tab | Gradle
+```groovy
+compile "org.janusgraph:janusgraph-core:0.2.0"
+```
+///
 
 **Tested Compatibility:**
 
@@ -530,19 +550,21 @@ the previous sections and migrate to the `REST_CLIENT`.
 ### Version 0.1.1 (Release Date: May 11, 2017)
 Documentation: <https://old-docs.janusgraph.org/0.1.1/index.html>
 
-=== "Maven"
-    ```xml
-    <dependency>
-        <groupId>org.janusgraph</groupId>
-        <artifactId>janusgraph-core</artifactId>
-        <version>0.1.1</version>
-    </dependency>
-    ```
+/// tab | Maven
+```xml
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.1.1</version>
+</dependency>
+```
+///
 
-=== "Gradle"
-    ```groovy
-    compile "org.janusgraph:janusgraph-core:0.1.1"
-    ```
+/// tab | Gradle
+```groovy
+compile "org.janusgraph:janusgraph-core:0.1.1"
+```
+///
 
 **Tested Compatibility:**
 
@@ -564,19 +586,21 @@ milestone:
 ### Version 0.1.0 (Release Date: April 11, 2017)
 Documentation: <https://old-docs.janusgraph.org/0.1.0/index.html>
 
-=== "Maven"
-    ```xml
-    <dependency>
-        <groupId>org.janusgraph</groupId>
-        <artifactId>janusgraph-core</artifactId>
-        <version>0.1.0</version>
-    </dependency>
-    ```
+/// tab | Maven
+```xml
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.1.0</version>
+</dependency>
+```
+///
 
-=== "Gradle"
-    ```groovy
-    compile "org.janusgraph:janusgraph-core:0.1.0"
-    ```
+/// tab | Gradle
+```groovy
+compile "org.janusgraph:janusgraph-core:0.1.0"
+```
+///
 
 **Tested Compatibility:**
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,25 +12,27 @@ $ docker run -it -p 8182:8182 janusgraph/janusgraph
 We run the image interactively and request Docker to make the container's port `8182` available for us to see.
 The server may need a few seconds to start up so be patient and wait for the corresponding log messages to appear.
 
-??? note "Example log"
-    ```
-    SLF4J: Class path contains multiple SLF4J bindings.
-    SLF4J: Found binding in [jar:file:/opt/janusgraph/lib/slf4j-log4j12-1.7.12.jar!/org/slf4j/impl/StaticLoggerBinder.class]
-    SLF4J: Found binding in [jar:file:/opt/janusgraph/lib/logback-classic-1.1.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
-    SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
-    SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
-    0    [main] INFO  com.jcabi.manifests.Manifests  - 110 attributes loaded from 283 stream(s) in 130ms, 110 saved, 3770 ignored: ["Agent-Class", "Ant-Version", "Archiver-Version", "Automatic-Module-Name", "Bnd-LastModified", "Boot-Class-Path", "Branch", "Build-Date", "Build-Host", "Build-Id", "Build-Java-Version", "Build-Jdk", "Build-Job", "Build-Number", "Build-Timestamp", "Build-Version", "Built-At", "Built-By", "Built-Date", "Built-OS", "Built-On", "Built-Status", "Bundle-ActivationPolicy", "Bundle-Activator", "Bundle-BuddyPolicy", "Bundle-Category", "Bundle-ClassPath", "Bundle-ContactAddress", "Bundle-Description", "Bundle-DocURL", "Bundle-License", "Bundle-ManifestVersion", "Bundle-Name", "Bundle-NativeCode", "Bundle-RequiredExecutionEnvironment", "Bundle-SymbolicName", "Bundle-Vendor", "Bundle-Version", "Can-Redefine-Classes", "Change", "Class-Path", "Created-By", "DSTAMP", "DynamicImport-Package", "Eclipse-BuddyPolicy", "Eclipse-ExtensibleAPI", "Embed-Dependency", "Embed-Transitive", "Export-Package", "Extension-Name", "Extension-name", "Fragment-Host", "Gradle-Version", "Gremlin-Lib-Paths", "Gremlin-Plugin-Dependencies", "Gremlin-Plugin-Paths", "Ignore-Package", "Implementation-Build", "Implementation-Build-Date", "Implementation-Title", "Implementation-URL", "Implementation-Vendor", "Implementation-Vendor-Id", "Implementation-Version", "Import-Package", "Include-Resource", "JCabi-Build", "JCabi-Date", "JCabi-Version", "Java-Vendor", "Java-Version", "Main-Class", "Manifest-Version", "Maven-Version", "Module-Email", "Module-Origin", "Module-Owner", "Module-Source", "Originally-Created-By", "Os-Arch", "Os-Name", "Os-Version", "Package", "Premain-Class", "Private-Package", "Provide-Capability", "Require-Bundle", "Require-Capability", "Scm-Connection", "Scm-Revision", "Scm-Url", "Specification-Title", "Specification-Vendor", "Specification-Version", "TODAY", "TSTAMP", "Time-Zone-Database-Version", "Tool", "X-Compile-Elasticsearch-Snapshot", "X-Compile-Elasticsearch-Version", "X-Compile-Lucene-Version", "X-Compile-Source-JDK", "X-Compile-Target-JDK", "hash", "implementation-version", "mode", "package", "service", "url", "version"]
-    1    [main] INFO  org.apache.tinkerpop.gremlin.server.GremlinServer  - 3.4.1
-             \,,,/
-             (o o)
-    -----oOOo-(3)-oOOo-----
+/// details | Example log
+    type: note
+```
+SLF4J: Class path contains multiple SLF4J bindings.
+SLF4J: Found binding in [jar:file:/opt/janusgraph/lib/slf4j-log4j12-1.7.12.jar!/org/slf4j/impl/StaticLoggerBinder.class]
+SLF4J: Found binding in [jar:file:/opt/janusgraph/lib/logback-classic-1.1.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
+SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
+SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
+0    [main] INFO  com.jcabi.manifests.Manifests  - 110 attributes loaded from 283 stream(s) in 130ms, 110 saved, 3770 ignored: ["Agent-Class", "Ant-Version", "Archiver-Version", "Automatic-Module-Name", "Bnd-LastModified", "Boot-Class-Path", "Branch", "Build-Date", "Build-Host", "Build-Id", "Build-Java-Version", "Build-Jdk", "Build-Job", "Build-Number", "Build-Timestamp", "Build-Version", "Built-At", "Built-By", "Built-Date", "Built-OS", "Built-On", "Built-Status", "Bundle-ActivationPolicy", "Bundle-Activator", "Bundle-BuddyPolicy", "Bundle-Category", "Bundle-ClassPath", "Bundle-ContactAddress", "Bundle-Description", "Bundle-DocURL", "Bundle-License", "Bundle-ManifestVersion", "Bundle-Name", "Bundle-NativeCode", "Bundle-RequiredExecutionEnvironment", "Bundle-SymbolicName", "Bundle-Vendor", "Bundle-Version", "Can-Redefine-Classes", "Change", "Class-Path", "Created-By", "DSTAMP", "DynamicImport-Package", "Eclipse-BuddyPolicy", "Eclipse-ExtensibleAPI", "Embed-Dependency", "Embed-Transitive", "Export-Package", "Extension-Name", "Extension-name", "Fragment-Host", "Gradle-Version", "Gremlin-Lib-Paths", "Gremlin-Plugin-Dependencies", "Gremlin-Plugin-Paths", "Ignore-Package", "Implementation-Build", "Implementation-Build-Date", "Implementation-Title", "Implementation-URL", "Implementation-Vendor", "Implementation-Vendor-Id", "Implementation-Version", "Import-Package", "Include-Resource", "JCabi-Build", "JCabi-Date", "JCabi-Version", "Java-Vendor", "Java-Version", "Main-Class", "Manifest-Version", "Maven-Version", "Module-Email", "Module-Origin", "Module-Owner", "Module-Source", "Originally-Created-By", "Os-Arch", "Os-Name", "Os-Version", "Package", "Premain-Class", "Private-Package", "Provide-Capability", "Require-Bundle", "Require-Capability", "Scm-Connection", "Scm-Revision", "Scm-Url", "Specification-Title", "Specification-Vendor", "Specification-Version", "TODAY", "TSTAMP", "Time-Zone-Database-Version", "Tool", "X-Compile-Elasticsearch-Snapshot", "X-Compile-Elasticsearch-Version", "X-Compile-Lucene-Version", "X-Compile-Source-JDK", "X-Compile-Target-JDK", "hash", "implementation-version", "mode", "package", "service", "url", "version"]
+1    [main] INFO  org.apache.tinkerpop.gremlin.server.GremlinServer  - 3.4.1
+            \,,,/
+            (o o)
+-----oOOo-(3)-oOOo-----
 
-    100  [main] INFO  org.apache.tinkerpop.gremlin.server.GremlinServer  - Configuring Gremlin Server from /etc/opt/janusgraph/gremlin-server.yaml
-    ...
-    ...
-    3965 [gremlin-server-boss-1] INFO  org.apache.tinkerpop.gremlin.server.GremlinServer  - Gremlin Server configured with worker thread pool of 1, gremlin pool of 8 and boss thread pool of 1.
-    3965 [gremlin-server-boss-1] INFO  org.apache.tinkerpop.gremlin.server.GremlinServer  - Channel started at port 8182.
-    ```
+100  [main] INFO  org.apache.tinkerpop.gremlin.server.GremlinServer  - Configuring Gremlin Server from /etc/opt/janusgraph/gremlin-server.yaml
+...
+...
+3965 [gremlin-server-boss-1] INFO  org.apache.tinkerpop.gremlin.server.GremlinServer  - Gremlin Server configured with worker thread pool of 1, gremlin pool of 8 and boss thread pool of 1.
+3965 [gremlin-server-boss-1] INFO  org.apache.tinkerpop.gremlin.server.GremlinServer  - Channel started at port 8182.
+```
+///
 
 We can now start a Gremlin Console on our local device and try to connect to the new server:
 ```bash

--- a/docs/index-backend/search-predicates.md
+++ b/docs/index-backend/search-predicates.md
@@ -132,37 +132,41 @@ Geoshape.geoshape(Geoshape.getGeometryCollectionBuilder()
 
 In addition, when importing a graph via GraphSON the geometry may be represented by GeoJSON:
 
-=== "string"
-    ```json
-    "37.97, 23.72"
-    ```
+/// tab | string
+```json
+"37.97, 23.72"
+```
+///
 
-=== "list"
-    ```json
-    [37.97, 23.72]
-    ```
+/// tab | list
+```json
+[37.97, 23.72]
+```
+///
 
-=== "GeoJSON feature"
-    ```json
-    {
-      "type": "Feature",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [125.6, 10.1]
-      },
-      "properties": {
-        "name": "Dinagat Islands"
-      }
+/// tab | GeoJSON feature
+```json
+{
+    "type": "Feature",
+    "geometry": {
+    "type": "Point",
+    "coordinates": [125.6, 10.1]
+    },
+    "properties": {
+    "name": "Dinagat Islands"
     }
-    ```
+}
+```
+///
 
-=== "GeoJSON geometry"
-    ```json
-    {
-      "type": "Point",
-      "coordinates": [125.6, 10.1]
-    }
-    ```
+/// tab | GeoJSON geometry
+```json
+{
+    "type": "Point",
+    "coordinates": [125.6, 10.1]
+}
+```
+///
 
 [GeoJSON](http://geojson.org/) may be specified as Point, Circle, LineString or Polygon. Polygons must be closed.
 Note that unlike the JanusGraph API GeoJSON specifies coordinates as lng lat.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,8 +21,9 @@ repo_url: 'https://github.com/janusgraph/janusgraph'
 copyright: 'Copyright &copy; 2020 JanusGraph Authors. All rights reserved.<br> The Linux Foundation has registered trademarks and uses trademarks. For a list of<br> trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page.<br> Cassandra, Groovy, HBase, Hadoop, Lucene, Solr, and TinkerPop are trademarks of the Apache Software Foundation.<br> Berkeley DB and Berkeley DB Java Edition are trademarks of Oracle.'
 
 plugins:
-    - search
-    - markdownextradata
+  - search
+  - macros
+  - include-markdown
 
 theme:
     language: 'en'
@@ -42,25 +43,35 @@ extra_css:
 
 extra:
   social:
-    - type: github-alt
+    - icon: fontawesome/brands/github
       link: https://github.com/janusgraph
-    - type: twitter
+    - icon: fontawesome/brands/discord
+      link: https://discord.gg/5n4fjv4QAf
+    - icon: fontawesome/brands/x-twitter
       link: https://twitter.com/janusgraph
-    - type: envelope
-      link: https://groups.google.com/group/janusgraph-users
-    - type: envelope
-      link: https://groups.google.com/group/janusgraph-dev
+    - icon: fontawesome/brands/linkedin
+      link: https://www.linkedin.com/company/janusgraph
+    - icon: fontawesome/solid/envelope
+      link: https://lists.lfaidata.foundation/g/janusgraph-users
+    - icon: fontawesome/solid/envelope
+      link: https://lists.lfaidata.foundation/g/janusgraph-dev
+  latest_version: 0.4.1
+  snapshot_version: 0.4.2-SNAPSHOT
+  tinkerpop_version: 3.4.4
+  hadoop2_version: 2.7.7
+  jamm_version: 0.3.0
 
 markdown_extensions:
-    - pymdownx.superfences
-    - pymdownx.tabbed
-    - pymdownx.snippets
-    - pymdownx.details
-    - markdown.extensions.admonition
-    - markdown_include.include:
-        base_path: docs
-    - markdown.extensions.codehilite:
-          linenums: True
+  - pymdownx.superfences
+  - pymdownx.blocks.details
+  - pymdownx.blocks.tab:
+      alternate_style: true
+  - markdown.extensions.admonition
+  - markdown.extensions.codehilite:
+      linenums: True
+  - codehilite
+  - attr_list
+  - def_list
 
 nav:
     - Introduction: index.md
@@ -124,10 +135,3 @@ nav:
     - Development: development.md
     - Appendices: appendices.md
     - Changelog: changelog.md
-
-extra:
-    latest_version: 0.4.1
-    snapshot_version: 0.4.2-SNAPSHOT
-    tinkerpop_version: 3.4.4
-    hadoop2_version: 2.7.7
-    jamm_version: 0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
-mkdocs==1.1.2
-mkdocs-material==5.4.0
-Pygments==2.6.1
-pymdown-extensions==7.1
-markdown==3.2.2
-mkdocs-markdownextradata-plugin==0.1.7
-markdown-include==0.5.1
+mkdocs==1.5.3
+mkdocs-material==9.4.8
+Pygments==2.16.1
+pymdown-extensions==10.4
+markdown==3.5.1
+mkdocs-include-markdown-plugin==6.0.2
+mkdocs-redirects==1.2.1
+jinja2==3.1.2
+mkdocs-macros-plugin==1.0.4


### PR DESCRIPTION
# Backport

This will backport the following commits from `v1.0` to `v0.4`:
 - [fix update mkdocs](https://github.com/JanusGraph/janusgraph/pull/4102)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)