### PR TITLE
[v0.2] fix update mkdocs

### DIFF
--- a/docs.Dockerfile
+++ b/docs.Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.8
+FROM python:3.12
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin
 

--- a/docs/advanced-topics/hadoop.md
+++ b/docs/advanced-topics/hadoop.md
@@ -36,7 +36,7 @@ computations of various OLAP queries may be persisted on the Hadoop file
 system.
 
 For configuring a single node Hadoop cluster, please refer to official
-[Apache Hadoop Docs](https://hadoop.apache.org/docs/r{{hadoop2_version }}/hadoop-project-dist/hadoop-common/SingleCluster.html)
+[Apache Hadoop Docs](https://hadoop.apache.org/docs/r{{ hadoop2_version }}/hadoop-project-dist/hadoop-common/SingleCluster.html)
 
 Once you have a Hadoop cluster up and running, we will need to specify
 the Hadoop configuration files in the `CLASSPATH`. The below document

--- a/docs/basics/configuration-reference.md
+++ b/docs/basics/configuration-reference.md
@@ -62,6 +62,7 @@ configuration
 log.user.send-batch-size = 100
 ```
 
-Configuration Namespaces and Options
-------------------------------------
-{!basics/janusgraph-cfg.md!}
+## Configuration Namespaces and Options
+{%
+    include "basics/janusgraph-cfg.md"
+%}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,19 +26,21 @@ use the latest versions of the software.
 ### Version 0.2.3 (Release Date: May 21, 2019)
 Legacy documentation: <https://old-docs.janusgraph.org/0.2.3/index.html>
 
-=== "Maven"
-    ```xml
-    <dependency>
-        <groupId>org.janusgraph</groupId>
-        <artifactId>janusgraph-core</artifactId>
-        <version>0.2.3</version>
-    </dependency>
-    ```
+/// tab | Maven
+```xml
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.2.3</version>
+</dependency>
+```
+///
 
-=== "Gradle"
-    ```groovy
-    compile "org.janusgraph:janusgraph-core:0.2.3"
-    ```
+/// tab | Gradle
+```groovy
+compile "org.janusgraph:janusgraph-core:0.2.3"
+```
+///
 
 **Tested Compatibility:**
 
@@ -60,19 +62,21 @@ milestone:
 ### Version 0.2.2 (Release Date: October 9, 2018)
 Legacy documentation: <https://old-docs.janusgraph.org/0.2.2/index.html>
 
-=== "Maven"
-    ```xml
-    <dependency>
-        <groupId>org.janusgraph</groupId>
-        <artifactId>janusgraph-core</artifactId>
-        <version>0.2.2</version>
-    </dependency>
-    ```
+/// tab | Maven
+```xml
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.2.2</version>
+</dependency>
+```
+///
 
-=== "Gradle"
-    ```groovy
-    compile "org.janusgraph:janusgraph-core:0.2.2"
-    ```
+/// tab | Gradle
+```groovy
+compile "org.janusgraph:janusgraph-core:0.2.2"
+```
+///
 
 **Tested Compatibility:**
 
@@ -94,19 +98,21 @@ milestone:
 ### Version 0.2.1 (Release Date: July 9, 2018)
 Legacy documentation: <https://old-docs.janusgraph.org/0.2.1/index.html>
 
-=== "Maven"
-    ```xml
-    <dependency>
-        <groupId>org.janusgraph</groupId>
-        <artifactId>janusgraph-core</artifactId>
-        <version>0.2.1</version>
-    </dependency>
-    ```
+/// tab | Maven
+```xml
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.2.1</version>
+</dependency>
+```
+///
 
-=== "Gradle"
-    ```groovy
-    compile "org.janusgraph:janusgraph-core:0.2.1"
-    ```
+/// tab | Gradle
+```groovy
+compile "org.janusgraph:janusgraph-core:0.2.1"
+```
+///
 
 **Tested Compatibility:**
 
@@ -139,19 +145,21 @@ is FIXED, a new graph needs to be created to make any change of the
 ### Version 0.2.0 (Release Date: October 11, 2017)
 Legacy documentation: <https://old-docs.janusgraph.org/0.2.0/index.html>
 
-=== "Maven"
-    ```xml
-    <dependency>
-        <groupId>org.janusgraph</groupId>
-        <artifactId>janusgraph-core</artifactId>
-        <version>0.2.0</version>
-    </dependency>
-    ```
+/// tab | Maven
+```xml
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.2.0</version>
+</dependency>
+```
+///
 
-=== "Gradle"
-    ```groovy
-    compile "org.janusgraph:janusgraph-core:0.2.0"
-    ```
+/// tab | Gradle
+```groovy
+compile "org.janusgraph:janusgraph-core:0.2.0"
+```
+///
 
 **Tested Compatibility:**
 
@@ -246,19 +254,21 @@ the previous sections and migrate to the `REST_CLIENT`.
 ### Version 0.1.1 (Release Date: May 11, 2017)
 Documentation: <https://old-docs.janusgraph.org/0.1.1/index.html>
 
-=== "Maven"
-    ```xml
-    <dependency>
-        <groupId>org.janusgraph</groupId>
-        <artifactId>janusgraph-core</artifactId>
-        <version>0.1.1</version>
-    </dependency>
-    ```
+/// tab | Maven
+```xml
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.1.1</version>
+</dependency>
+```
+///
 
-=== "Gradle"
-    ```groovy
-    compile "org.janusgraph:janusgraph-core:0.1.1"
-    ```
+/// tab | Gradle
+```groovy
+compile "org.janusgraph:janusgraph-core:0.1.1"
+```
+///
 
 **Tested Compatibility:**
 
@@ -280,19 +290,21 @@ milestone:
 ### Version 0.1.0 (Release Date: April 11, 2017)
 Documentation: <https://old-docs.janusgraph.org/0.1.0/index.html>
 
-=== "Maven"
-    ```xml
-    <dependency>
-        <groupId>org.janusgraph</groupId>
-        <artifactId>janusgraph-core</artifactId>
-        <version>0.1.0</version>
-    </dependency>
-    ```
+/// tab | Maven
+```xml
+<dependency>
+    <groupId>org.janusgraph</groupId>
+    <artifactId>janusgraph-core</artifactId>
+    <version>0.1.0</version>
+</dependency>
+```
+///
 
-=== "Gradle"
-    ```groovy
-    compile "org.janusgraph:janusgraph-core:0.1.0"
-    ```
+/// tab | Gradle
+```groovy
+compile "org.janusgraph:janusgraph-core:0.1.0"
+```
+///
 
 **Tested Compatibility:**
 

--- a/docs/index-backend/search-predicates.md
+++ b/docs/index-backend/search-predicates.md
@@ -127,15 +127,20 @@ Geoshape.geoshape(Geoshape.getGeometryCollectionBuilder()
 
 In addition, when importing a graph via GraphSON the geometry may be represented by GeoJSON:
 
-```json tab="string"
+/// tab | string
+```json
 "37.97, 23.72"
 ```
+///
 
-```json tab="list"
+/// tab | list
+```json
 [37.97, 23.72]
 ```
+///
 
-```json tab="GeoJSON feature"
+/// tab | GeoJSON feature
+```json
 {
   "type": "Feature",
   "geometry": {
@@ -147,13 +152,16 @@ In addition, when importing a graph via GraphSON the geometry may be represented
   }
 }
 ```
+///
 
-```json tab="GeoJSON geometry"
+/// tab | GeoJSON geometry
+```json
 {
   "type": "Point",
   "coordinates": [125.6, 10.1]
 }
 ```
+///
 
 [GeoJSON](http://geojson.org/) may be specified as Point, Circle, LineString or Polygon. Polygons must be closed.
 Note that unlike the JanusGraph API GeoJSON specifies coordinates as lng lat.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,8 +6,9 @@ repo_url: 'https://github.com/janusgraph/janusgraph'
 copyright: 'Copyright &copy; 2020 JanusGraph Authors. All rights reserved.<br> The Linux Foundation has registered trademarks and uses trademarks. For a list of<br> trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page.<br> Cassandra, Groovy, HBase, Hadoop, Lucene, Solr, and TinkerPop are trademarks of the Apache Software Foundation.<br> Berkeley DB and Berkeley DB Java Edition are trademarks of Oracle.'
 
 plugins:
-    - search
-    - markdownextradata
+  - search
+  - macros
+  - include-markdown
 
 theme:
     language: 'en'
@@ -27,24 +28,35 @@ extra_css:
 
 extra:
   social:
-    - type: github-alt
+    - icon: fontawesome/brands/github
       link: https://github.com/janusgraph
-    - type: twitter
+    - icon: fontawesome/brands/discord
+      link: https://discord.gg/5n4fjv4QAf
+    - icon: fontawesome/brands/x-twitter
       link: https://twitter.com/janusgraph
-    - type: envelope
-      link: https://groups.google.com/group/janusgraph-users
-    - type: envelope
-      link: https://groups.google.com/group/janusgraph-dev
+    - icon: fontawesome/brands/linkedin
+      link: https://www.linkedin.com/company/janusgraph
+    - icon: fontawesome/solid/envelope
+      link: https://lists.lfaidata.foundation/g/janusgraph-users
+    - icon: fontawesome/solid/envelope
+      link: https://lists.lfaidata.foundation/g/janusgraph-dev
+  latest_version: 0.2.3
+  snapshot_version: 0.2.3-SNAPSHOT
+  tinkerpop_version: 3.2.9
+  hadoop2_version: 2.7.2
+  jamm_version: 0.3.0
 
 markdown_extensions:
-    - pymdownx.superfences
-    - pymdownx.tabbed
-    - pymdownx.snippets
-    - markdown.extensions.admonition
-    - markdown_include.include:
-        base_path: docs
-    - markdown.extensions.codehilite:
-          linenums: True
+  - pymdownx.superfences
+  - pymdownx.blocks.details
+  - pymdownx.blocks.tab:
+      alternate_style: true
+  - markdown.extensions.admonition
+  - markdown.extensions.codehilite:
+      linenums: True
+  - codehilite
+  - attr_list
+  - def_list
 
 nav:
     - Introduction: index.md
@@ -102,10 +114,3 @@ nav:
     - Development: development.md
     - Appendices: appendices.md
     - Changelog: changelog.md
-
-extra:
-    latest_version: 0.2.3
-    snapshot_version: 0.2.3-SNAPSHOT
-    tinkerpop_version: 3.2.9
-    hadoop2_version: 2.7.2
-    jamm_version: 0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
-mkdocs==1.1.2
-mkdocs-material==5.4.0
-Pygments==2.6.1
-pymdown-extensions==7.1
-markdown==3.2.2
-mkdocs-markdownextradata-plugin==0.1.7
-markdown-include==0.5.1
+mkdocs==1.5.3
+mkdocs-material==9.4.8
+Pygments==2.16.1
+pymdown-extensions==10.4
+markdown==3.5.1
+mkdocs-include-markdown-plugin==6.0.2
+mkdocs-redirects==1.2.1
+jinja2==3.1.2
+mkdocs-macros-plugin==1.0.4


### PR DESCRIPTION
# Backport

This will backport the following commits from `v1.0` to `v0.2`:
 - [fix update mkdocs](https://github.com/JanusGraph/janusgraph/pull/4102)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)