### PR TITLE
[v1.0] fix ci-docs with typo repository-name

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -90,6 +90,7 @@ jobs:
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
           token: ${{ secrets.ACCESS_TOKEN }}
-          repository-nam: JanusGraph/docs.janusgraph.org
+          repository-name: JanusGraph/docs.janusgraph.org
           branch: master
           folder: site
+          force: false


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [fix ci-docs with typo repository-name](https://github.com/JanusGraph/janusgraph/pull/4112)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)