### PR TITLE
[v1.0] get rid of htrace cves

### DIFF
--- a/janusgraph-hbase/pom.xml
+++ b/janusgraph-hbase/pom.xml
@@ -54,7 +54,16 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.htrace</groupId>
+                    <artifactId>htrace-core4</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hbase.thirdparty</groupId>
+            <artifactId>hbase-noop-htrace</artifactId>
+            <version>${htrace.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <httpcomponents.httpcore.version>4.4.16</httpcomponents.httpcore.version>
         <hadoop.version>3.3.5</hadoop.version>
         <hbase2.version>2.5.3-hadoop3</hbase2.version>
-        <htrace.version>4.2.0-incubating</htrace.version>
+        <htrace.version>4.1.5</htrace.version>
         <bigtable.version>1.24.0</bigtable.version>
         <!-- align with org.apache.spark:spark-core_2.12 -->
         <jackson2.version>2.15.3</jackson2.version>
@@ -1392,8 +1392,13 @@
                 <version>6.5.1</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.htrace</groupId>
-                <artifactId>htrace-core4</artifactId>
+                <groupId>org.apache.hbase.thirdparty</groupId>
+                <artifactId>hbase-noop-htrace</artifactId>
+                <version>${htrace.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hbase.thirdparty</groupId>
+                <artifactId>hbase-noop-htrace</artifactId>
                 <version>${htrace.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [get rid of htrace cves](https://github.com/JanusGraph/janusgraph/pull/4123)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)