### PR TITLE
[v1.0] Bump metrics.version from 4.2.21 to 4.2.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <junit.version>5.10.0</junit.version>
         <mockito.version>4.11.0</mockito.version>
         <jamm.version>0.3.3</jamm.version>
-        <metrics.version>4.2.21</metrics.version>
+        <metrics.version>4.2.22</metrics.version>
         <slf4j.version>1.7.36</slf4j.version>
         <logback.version>1.2.11</logback.version>
         <httpcomponents.httpclient.version>4.5.14</httpcomponents.httpclient.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump metrics.version from 4.2.21 to 4.2.22](https://github.com/JanusGraph/janusgraph/pull/4091)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)