### PR TITLE
Fix junit group config for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   groups:
     junit:
       patterns:
-        - "junit*"
+        - "org.junit.*"
   labels:
     - "backport/v1.0"
     - "dependencies"


### PR DESCRIPTION
Looks like Dependabot applies the `pattern` to the `groupId` and not the `artifactId` which explains why the feature didn't work for us so far (which I originally tried in #3918). I tried this out on a small demo project and successfully managed to get Dependabot to create a group update PR:
https://github.com/FlorianHockmann/dependabot-grouped-update-test/pull/6

