### PR TITLE
[v1.0] Bump jackson2.version from 2.15.3 to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <htrace.version>4.1.5</htrace.version>
         <bigtable.version>1.24.0</bigtable.version>
         <!-- align with org.apache.spark:spark-core_2.12 -->
-        <jackson2.version>2.15.3</jackson2.version>
+        <jackson2.version>2.16.0</jackson2.version>
         <lucene-solr.version>8.11.2</lucene-solr.version>
         <elasticsearch.version>8.10.4</elasticsearch.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump jackson2.version from 2.15.3 to 2.16.0](https://github.com/JanusGraph/janusgraph/pull/4136)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)