### PR TITLE
[v1.0] Bump org.checkerframework:checker-qual from 3.39.0 to 3.40.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <log4j2.version>2.20.0</log4j2.version>
         <graalvm-nativeimage.version>23.1.1</graalvm-nativeimage.version>
         <caffeine.version>2.9.3</caffeine.version>
-        <checker-qual.version>3.39.0</checker-qual.version>
+        <checker-qual.version>3.40.0</checker-qual.version>
         <curator.version>5.5.0</curator.version>
     </properties>
     <modules>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.checkerframework:checker-qual from 3.39.0 to 3.40.0](https://github.com/JanusGraph/janusgraph/pull/4089)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)