### PR TITLE
[v1.0] Fix two unit tests failing locally

### DIFF
--- a/janusgraph-core/src/test/java/org/janusgraph/diskstorage/util/CompletableFutureUtilTest.java
+++ b/janusgraph-core/src/test/java/org/janusgraph/diskstorage/util/CompletableFutureUtilTest.java
@@ -124,13 +124,11 @@ public class CompletableFutureUtilTest {
             otherFuture.completeExceptionally(new IllegalArgumentException());
             futureMap.put(new Object(), otherFuture);
         }
-        ExecutionException executionException = Assertions.assertThrows(ExecutionException.class, () -> unwrap(futureMap));
-        Assertions.assertTrue(executionException.getCause() instanceof IllegalStateException);
-        Throwable[] suppressedExceptions = executionException.getSuppressed();
+        IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class, () -> unwrap(futureMap));
+        Throwable[] suppressedExceptions = exception.getSuppressed();
         Assertions.assertEquals(10, suppressedExceptions.length);
         for(int i=0; i<10; i++){
-            Assertions.assertTrue(suppressedExceptions[i] instanceof ExecutionException &&
-                suppressedExceptions[i].getCause() instanceof IllegalArgumentException);
+            Assertions.assertTrue(suppressedExceptions[i] instanceof IllegalArgumentException);
         }
     }
 
@@ -154,13 +152,11 @@ public class CompletableFutureUtilTest {
             otherFuture.completeExceptionally(new IllegalArgumentException());
             futureList.add(otherFuture);
         }
-        ExecutionException executionException = Assertions.assertThrows(ExecutionException.class, () -> awaitAll(futureList));
-        Assertions.assertTrue(executionException.getCause() instanceof IllegalStateException);
-        Throwable[] suppressedExceptions = executionException.getSuppressed();
+        IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class, () -> awaitAll(futureList));
+        Throwable[] suppressedExceptions = exception.getSuppressed();
         Assertions.assertEquals(10, suppressedExceptions.length);
         for(int i=0; i<10; i++){
-            Assertions.assertTrue(suppressedExceptions[i] instanceof ExecutionException &&
-                suppressedExceptions[i].getCause() instanceof IllegalArgumentException);
+            Assertions.assertTrue(suppressedExceptions[i] instanceof IllegalArgumentException);
         }
     }
 

--- a/janusgraph-core/src/test/java/org/janusgraph/graphdb/tinkerpop/optimize/step/fetcher/MultiQueriableStepBatchFetcherTest.java
+++ b/janusgraph-core/src/test/java/org/janusgraph/graphdb/tinkerpop/optimize/step/fetcher/MultiQueriableStepBatchFetcherTest.java
@@ -30,6 +30,8 @@ import org.mockito.Mockito;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.anyCollection;
+
 public class MultiQueriableStepBatchFetcherTest {
 
     private Vertex mockVertex;
@@ -46,7 +48,7 @@ public class MultiQueriableStepBatchFetcherTest {
         Mockito.doReturn(traversal).when(traversal).asAdmin();
         Mockito.doReturn(Optional.of(tx)).when(traversal).getGraph();
         Mockito.doReturn(true).when(tx).isOpen();
-        Mockito.doReturn(multiQuery).when(tx).multiQuery();
+        Mockito.doReturn(multiQuery).when(tx).multiQuery(anyCollection());
     }
 
     @Test


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Fix two unit tests failing locally](https://github.com/JanusGraph/janusgraph/pull/4140)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)