### PR TITLE
[v1.0] Enable janusgraph-core unit tests in CI

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -82,6 +82,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - module: core
+            java: 8
           - module: driver
             java: 8
           - module: server
@@ -95,6 +97,9 @@ jobs:
             java: 8
           - module: lucene
             java: 8
+          - module: core
+            install-args: "-Pjava-11"
+            java: 11
           - module: driver
             install-args: "-Pjava-11"
             java: 11


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Enable janusgraph-core unit tests in CI](https://github.com/JanusGraph/janusgraph/pull/4158)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)