### PR TITLE
[v1.0] Bump the junit group with 6 updates | Add missing JUnit annotations to Berkeley tests

### DIFF
--- a/janusgraph-berkeleyje/src/test/java/org/janusgraph/graphdb/berkeleyje/BerkeleyGraphTest.java
+++ b/janusgraph-berkeleyje/src/test/java/org/janusgraph/graphdb/berkeleyje/BerkeleyGraphTest.java
@@ -68,6 +68,7 @@ public class BerkeleyGraphTest extends JanusGraphTest {
     }
 
     @Override
+    @Test
     public void testClearStorage() throws Exception {
         tearDown();
         config.set(ConfigElement.getPath(GraphDatabaseConfiguration.DROP_ON_CLEAR), true);
@@ -86,6 +87,8 @@ public class BerkeleyGraphTest extends JanusGraphTest {
     }
 
     @Override
+    @Test
+    @Disabled("#4153: Tests fails with NPE for some reason")
     public void testConsistencyEnforcement() {
         // Check that getConfiguration() explicitly set serializable isolation
         // This could be enforced with a JUnit assertion instead of a Precondition,
@@ -96,27 +99,34 @@ public class BerkeleyGraphTest extends JanusGraphTest {
         super.testConsistencyEnforcement();
     }
 
-    // BerkeleyJE support only hour discrete TTL, we try speed up internal
-    // clock but tests so flaky. See BerkeleyStorageSetup
     @Override
-    public void testEdgeTTLTiming() throws Exception {
+    @Test
+    @Disabled("BerkeleyJE support only hour discrete TTL, we try speed up internal clock but tests so flaky. See BerkeleyStorageSetup")
+    public void testEdgeTTLTiming() {
     }
 
     @Override
-    public void testEdgeTTLWithTransactions() throws Exception {
+    @Test
+    @Disabled
+    public void testEdgeTTLWithTransactions() {
     }
 
     @Override
-    public void testUnsettingTTL() throws InterruptedException {
+    @Test
+    @Disabled
+    public void testUnsettingTTL() {
     }
 
     @Override
-    public void testVertexTTLWithCompositeIndex() throws Exception {
+    @Test
+    @Disabled
+    public void testVertexTTLWithCompositeIndex() {
     }
 
     @Override
+    @Test
+    @Disabled("TODO: Figure out why this is failing in BerkeleyDB!!")
     public void testConcurrentConsistencyEnforcement() {
-        //Do nothing TODO: Figure out why this is failing in BerkeleyDB!!
     }
 
     @Disabled("Unable to run on GitHub Actions.")

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
         <titan.compatible-versions>1.0.0,1.1.0-SNAPSHOT</titan.compatible-versions>
         <tinkerpop.version>3.7.0</tinkerpop.version>
         <avro.version>1.11.3</avro.version>
-        <junit-platform.version>1.10.0</junit-platform.version>
-        <junit.version>5.10.0</junit.version>
+        <junit-platform.version>1.10.1</junit-platform.version>
+        <junit.version>5.10.1</junit.version>
         <mockito.version>4.11.0</mockito.version>
         <jamm.version>0.3.3</jamm.version>
         <metrics.version>4.2.22</metrics.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump the junit group with 6 updates](https://github.com/JanusGraph/janusgraph/pull/4135)
 - [Add missing JUnit annotations to Berkeley tests](https://github.com/JanusGraph/janusgraph/pull/4135)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)