### PR TITLE
[v1.0] Bump ch.qos.logback:logback-classic from 1.2.11 to 1.2.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <jamm.version>0.3.3</jamm.version>
         <metrics.version>4.2.22</metrics.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <logback.version>1.2.11</logback.version>
+        <logback.version>1.2.13</logback.version>
         <httpcomponents.httpclient.version>4.5.14</httpcomponents.httpclient.version>
         <httpcomponents.httpcore.version>4.4.16</httpcomponents.httpcore.version>
         <hadoop.version>3.3.6</hadoop.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump ch.qos.logback:logback-classic from 1.2.11 to 1.2.13](https://github.com/JanusGraph/janusgraph/pull/4173)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)