### PR TITLE
[v1.0] Bump org.codehaus.mojo:build-helper-maven-plugin from 3.4.0 to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -480,7 +480,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.4.0</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.codehaus.mojo:build-helper-maven-plugin from 3.4.0 to 3.5.0](https://github.com/JanusGraph/janusgraph/pull/4150)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)