### PR TITLE
[v1.0] Bump com.nimbusds:nimbus-jose-jwt from 9.37 to 9.37.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1179,7 +1179,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
-                <version>9.37</version>
+                <version>9.37.3</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump com.nimbusds:nimbus-jose-jwt from 9.37 to 9.37.3](https://github.com/JanusGraph/janusgraph/pull/4179)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)