### PR TITLE
[v1.0] Bump github/codeql-action from 2 to 3

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -112,7 +112,7 @@ jobs:
           output: 'trivy-results.sarif'
       - name: Upload Trivy scan results to GitHub Security tab
         if: github.repository == 'janusgraph/janusgraph'
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump github/codeql-action from 2 to 3](https://github.com/JanusGraph/janusgraph/pull/4183)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)