### PR TITLE
[v1.0] Bump netty4.version from 4.1.101.Final to 4.1.105.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <zookeeper.version>3.9.1</zookeeper.version>
-        <netty4.version>4.1.101.Final</netty4.version>
+        <netty4.version>4.1.105.Final</netty4.version>
         <jna.version>5.13.0</jna.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump netty4.version from 4.1.101.Final to 4.1.105.Final](https://github.com/JanusGraph/janusgraph/pull/4211)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)