### PR TITLE
fix index-name config option name

### DIFF
--- a/docs/index-backend/elasticsearch.md
+++ b/docs/index-backend/elasticsearch.md
@@ -106,7 +106,7 @@ JanusGraph only uses default values for `index-name` and
 `health-request-timeout`. See [Configuration Reference](../configs/configuration-reference.md) for descriptions of
 these options and their accepted values.
 
--   `index.[X].elasticsearch.index-name`
+-   `index.[X].index-name`
 -   `index.[X].elasticsearch.health-request-timeout`
 
 ### REST Client Options


### PR DESCRIPTION
`index.[X].elasticsearch.index-name` is incorrect and does not result in changing the default index name prefix in Elasticsearch.   The fix makes the option name consistent with [janusgraph-cfg.md](https://github.com/JanusGraph/janusgraph/blob/master/docs/configs/janusgraph-cfg.md). Testing confirmed that `index.[X].index-name` indeed results in the index name prefix change, as expected.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there an issue associated with this PR? Is it referenced in the commit message?
- [X] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered?