### PR TITLE
[v1.0] fix index-name config option name

### DIFF
--- a/docs/index-backend/elasticsearch.md
+++ b/docs/index-backend/elasticsearch.md
@@ -106,7 +106,7 @@ JanusGraph only uses default values for `index-name` and
 `health-request-timeout`. See [Configuration Reference](../configs/configuration-reference.md) for descriptions of
 these options and their accepted values.
 
--   `index.[X].elasticsearch.index-name`
+-   `index.[X].index-name`
 -   `index.[X].elasticsearch.health-request-timeout`
 
 ### REST Client Options


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [fix index-name config option name](https://github.com/JanusGraph/janusgraph/pull/4225)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)