### PR TITLE
[v1.0] Bump shrink/actions-docker-registry-tag from 3 to 4

### DIFF
--- a/.github/workflows/docker-release-tags.yml
+++ b/.github/workflows/docker-release-tags.yml
@@ -41,7 +41,7 @@ jobs:
           echo "PATCH_VERSION=${PATCH_VERSION}" >> $GITHUB_ENV
           echo "REVISION=${REVISION}" >> $GITHUB_ENV
       - name: Run minor tag for ghcr.io
-        uses: shrink/actions-docker-registry-tag@v3
+        uses: shrink/actions-docker-registry-tag@v4
         with:
           registry: ghcr.io
           repository: janusgraph/janusgraph
@@ -50,7 +50,7 @@ jobs:
             ${{ env.PATCH_VERSION }}
             ${{ env.MINOR_VERSION }}
       - name: Run minor tag for docker.io
-        uses: shrink/actions-docker-registry-tag@v3
+        uses: shrink/actions-docker-registry-tag@v4
         with:
           registry: index.docker.io
           repository: janusgraph/janusgraph
@@ -61,7 +61,7 @@ jobs:
             ${{ env.MINOR_VERSION }}
       - name: Run latest tag for ghcr.io
         if: "env.MINOR_VERSION == '${{ env.LATEST_RELEASE }}'"
-        uses: shrink/actions-docker-registry-tag@v3
+        uses: shrink/actions-docker-registry-tag@v4
         with:
           registry: ghcr.io
           repository: janusgraph/janusgraph
@@ -70,7 +70,7 @@ jobs:
             latest
       - name: Run latest tag for docker.io
         if: "env.MINOR_VERSION == '${{ env.LATEST_RELEASE }}'"
-        uses: shrink/actions-docker-registry-tag@v3
+        uses: shrink/actions-docker-registry-tag@v4
         with:
           registry: index.docker.io
           repository: janusgraph/janusgraph


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump shrink/actions-docker-registry-tag from 3 to 4](https://github.com/JanusGraph/janusgraph/pull/4227)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)