### PR TITLE
[v1.0] Bump org.apache.maven.plugins:maven-source-plugin from 3.2.1 to 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -463,7 +463,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.apache.maven.plugins:maven-source-plugin from 3.2.1 to 3.3.0](https://github.com/JanusGraph/janusgraph/pull/4239)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)