### PR TITLE
[v1.0] Bump org.apache.maven.plugins:maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.11.0</version>
+                    <version>3.12.1</version>
                     <configuration>
                         <source>${compiler.source}</source>
                         <target>${compiler.target}</target>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.apache.maven.plugins:maven-compiler-plugin](https://github.com/JanusGraph/janusgraph/pull/4238)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)