### PR TITLE
[v1.0] Bump aquasecurity/trivy-action from 0.16.1 to 0.17.0

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -105,7 +105,7 @@ jobs:
           echo "JG_VER=${JG_VER}" >> $GITHUB_ENV
       - name: Run Trivy vulnerability scanner
         if: github.repository == 'janusgraph/janusgraph'
-        uses: aquasecurity/trivy-action@0.16.1
+        uses: aquasecurity/trivy-action@0.17.0
         with:
           image-ref: 'ghcr.io/janusgraph/janusgraph:${{ env.JG_VER }}${{ matrix.tag_suffix }}'
           format: 'sarif'


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump aquasecurity/trivy-action from 0.16.1 to 0.17.0](https://github.com/JanusGraph/janusgraph/pull/4244)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)