### PR TITLE
Removed missing external reference in Elasticsearch index backend docs

### DIFF
--- a/docs/index-backend/elasticsearch.md
+++ b/docs/index-backend/elasticsearch.md
@@ -342,9 +342,6 @@ on how to increase the refresh interval and its impact on write
 performance. Note, that a higher refresh interval means that it takes a
 longer time for graph mutations to be available in the index.
 
-For additional suggestions on how to increase write performance in
-Elasticsearch with detailed instructions, please read [this blog post](http://blog.bugsense.com/post/35580279634/indexing-bigdata-with-elasticsearch).
-
 ### Further Reading
 
 -   Please refer to the [Elasticsearch homepage](https://www.elastic.co)


### PR DESCRIPTION
The following section of the JanusGraph docs https://docs.janusgraph.org/index-backend/elasticsearch/#write-optimization contains an external reference that is not available any more. Following the suggestion from @li-boxuan on Discord, I open this PR to remove the missing external reference.