### PR TITLE
Fix HBase test Dockerfile

### DIFF
--- a/janusgraph-hbase/docker/Dockerfile
+++ b/janusgraph-hbase/docker/Dockerfile
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:buster-20220822 as builder
+FROM debian:bookworm-20240211 as builder
 
 ARG HBASE_VERSION=2.5.0
-ARG HBASE_DIST="http://archive.apache.org/dist/hbase"
+ARG HBASE_DIST="https://archive.apache.org/dist/hbase"
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl
+    DEBIAN_FRONTEND=noninteractive apt-get install -y curl
 
 RUN curl -SL ${HBASE_DIST}/${HBASE_VERSION}/hbase-${HBASE_VERSION}-bin.tar.gz | tar -x -z && mv hbase-${HBASE_VERSION} /opt/hbase
 WORKDIR /opt/hbase


### PR DESCRIPTION
The curl command to download the HBase distribution failed with the following error:

```
curl: (60) SSL certificate problem: unable to get local issuer certificate
```

Simply removing the `--no-install-recommends` option when installing curl fixed the issue. So it looks like curl now needs another package to verify the SSL certificate.
Note that whether `http://` or `https://` is used for the URL doesn't make a difference here. I guess archive.apache.org simply redirects to the HTTPS version anyway.

This also updates the debian image used to be more up to date. The previously used Buster image is only maintained by the LTS team right now and support will completely end in June:
https://wiki.debian.org/LTS