### PR TITLE
[v1.0] Fix HBase test Dockerfile

### DIFF
--- a/janusgraph-hbase/docker/Dockerfile
+++ b/janusgraph-hbase/docker/Dockerfile
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:buster-20220822 as builder
+FROM debian:bookworm-20240211 as builder
 
 ARG HBASE_VERSION=2.5.0
-ARG HBASE_DIST="http://archive.apache.org/dist/hbase"
+ARG HBASE_DIST="https://archive.apache.org/dist/hbase"
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl
+    DEBIAN_FRONTEND=noninteractive apt-get install -y curl
 
 RUN curl -SL ${HBASE_DIST}/${HBASE_VERSION}/hbase-${HBASE_VERSION}-bin.tar.gz | tar -x -z && mv hbase-${HBASE_VERSION} /opt/hbase
 WORKDIR /opt/hbase


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Fix HBase test Dockerfile](https://github.com/JanusGraph/janusgraph/pull/4268)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)