### PR TITLE
[v1.0] Fix missing setuptools package for regression test

### DIFF
--- a/.github/workflows/ci-benchmark.yml
+++ b/.github/workflows/ci-benchmark.yml
@@ -58,6 +58,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+      - run: pip install setuptools
       - run: pip install git+https://github.com/li-boxuan/ccm.git
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Fix missing setuptools package for regression test](https://github.com/JanusGraph/janusgraph/pull/4262)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)