### PR TITLE
Fix io step read path for string-type vertex ID

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphFeatures.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphFeatures.java
@@ -197,7 +197,7 @@ public class JanusGraphFeatures implements Graph.Features {
         @Override
         public boolean supportsStringIds()
         {
-            return false;
+            return JanusGraphFeatures.this.graph.getConfiguration().allowCustomVertexIdType();
         }
 
         @Override


### PR DESCRIPTION
g.io(path).read() would fail if the vertex contains custom string-type vertex ID due to a bug in JanusGraphVertexFeatures. This fixes this bug and adds two unit tests for gryo and graphson format.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
