### PR TITLE
[v1.0] Bump org.apache.commons:commons-compress from 1.24.0 to 1.26.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1052,7 +1052,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.24.0</version>
+                <version>1.26.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.apache.commons:commons-compress from 1.24.0 to 1.26.0](https://github.com/JanusGraph/janusgraph/pull/4267)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)