### PR TITLE
[v1.0] Fix io step read path for string-type vertex ID

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphFeatures.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphFeatures.java
@@ -197,7 +197,7 @@ public class JanusGraphFeatures implements Graph.Features {
         @Override
         public boolean supportsStringIds()
         {
-            return false;
+            return JanusGraphFeatures.this.graph.getConfiguration().allowCustomVertexIdType();
         }
 
         @Override


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Fix io step read path for string-type vertex ID](https://github.com/JanusGraph/janusgraph/pull/4278)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)