### PR TITLE
[v1.0] Support new text predicates via JanusGraph Server

### DIFF
--- a/janusgraph-driver/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphPSerializer.java
+++ b/janusgraph-driver/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphPSerializer.java
@@ -52,12 +52,21 @@ public class JanusGraphPSerializer extends Serializer<JanusGraphP> {
             case "geoWithin":
             case "geoContains":
             case "textContains":
+            case "textNotContains":
             case "textContainsFuzzy":
+            case "textNotContainsFuzzy":
             case "textContainsPrefix":
+            case "textNotContainsPrefix":
             case "textContainsRegex":
+            case "textNotContainsRegex":
+            case "textContainsPhrase":
+            case "textNotContainsPhrase":
             case "textFuzzy":
+            case "textNotFuzzy":
             case "textPrefix":
+            case "textNotPrefix":
             case "textRegex":
+            case "textNotRegex":
                 return true;
             default:
                 return false;
@@ -76,18 +85,36 @@ public class JanusGraphPSerializer extends Serializer<JanusGraphP> {
                 return Geo.geoContains(value);
             case "textContains":
                 return Text.textContains(value);
+            case "textNotContains":
+                return Text.textNotContains(value);
             case "textContainsFuzzy":
                 return Text.textContainsFuzzy(value);
+            case "textNotContainsFuzzy":
+                return Text.textNotContainsFuzzy(value);
             case "textContainsPrefix":
                 return Text.textContainsPrefix(value);
+            case "textNotContainsPrefix":
+                return Text.textNotContainsPrefix(value);
             case "textContainsRegex":
                 return Text.textContainsRegex(value);
+            case "textNotContainsRegex":
+                return Text.textNotContainsRegex(value);
+            case "textContainsPhrase":
+                return Text.textContainsPhrase(value);
+            case "textNotContainsPhrase":
+                return Text.textNotContainsPhrase(value);
             case "textFuzzy":
                 return Text.textFuzzy(value);
+            case "textNotFuzzy":
+                return Text.textNotFuzzy(value);
             case "textPrefix":
                 return Text.textPrefix(value);
+            case "textNotPrefix":
+                return Text.textNotPrefix(value);
             case "textRegex":
                 return Text.textRegex(value);
+            case "textNotRegex":
+                return Text.textNotRegex(value);
             default:
                 throw new UnsupportedOperationException("Matched predicate {" + predicateName + "} is not support by JanusGraphPSerializer");
         }

--- a/janusgraph-driver/src/test/java/org/janusgraph/graphdb/tinkerpop/io/binary/JanusGraphPGraphBinarySerializerTest.java
+++ b/janusgraph-driver/src/test/java/org/janusgraph/graphdb/tinkerpop/io/binary/JanusGraphPGraphBinarySerializerTest.java
@@ -53,12 +53,21 @@ public class JanusGraphPGraphBinarySerializerTest {
             Geo.geoDisjoint(Geoshape.circle(37.97, 23.72, 50)),
             Geo.geoContains(Geoshape.point(37.97, 23.72)),
             Text.textContains("neptune"),
+            Text.textNotContains("neptune"),
             Text.textContainsPrefix("nep"),
+            Text.textNotContainsPrefix("nep"),
             Text.textContainsRegex("nep.*"),
+            Text.textNotContainsRegex("nep.*"),
+            Text.textContainsPhrase("neptune,pluto"),
+            Text.textNotContainsPhrase("neptune,pluto"),
             Text.textPrefix("n"),
+            Text.textNotPrefix("n"),
             Text.textRegex(".*n.*"),
+            Text.textNotRegex(".*n.*"),
             Text.textContainsFuzzy("neptun"),
-            Text.textFuzzy("nepitne")
+            Text.textNotContainsFuzzy("neptun"),
+            Text.textFuzzy("nepitne"),
+            Text.textNotFuzzy("nepitne")
         );
     }
 

--- a/janusgraph-driver/src/test/java/org/janusgraph/graphdb/tinkerpop/io/graphson/JanusGraphSONModuleTest.java
+++ b/janusgraph-driver/src/test/java/org/janusgraph/graphdb/tinkerpop/io/graphson/JanusGraphSONModuleTest.java
@@ -67,6 +67,7 @@ public class JanusGraphSONModuleTest {
             g.E().has("place", Geo.geoDisjoint(Geoshape.circle(37.97, 23.72, 50))),
             g.V().has("place", Geo.geoContains(Geoshape.point(37.97, 23.72))),
             g.V().has("name", Text.textContains("neptune")), g.V().has("name", Text.textContainsPrefix("nep")),
+            g.V().has("name", Text.textNotContains("neptune")), g.V().has("name", Text.textNotContainsPrefix("nep")),
             g.V().has("name", Text.textContainsRegex("nep.*")), g.V().has("name", Text.textPrefix("n")),
             g.V().has("name", Text.textRegex(".*n.*")), g.V().has("name", Text.textContainsFuzzy("neptun")),
             g.V().has("name", Text.textFuzzy("nepitne")) };


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Support new text predicates via JanusGraph Server](https://github.com/JanusGraph/janusgraph/pull/4279)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)