### PR TITLE
[v1.0] Bump protobuf.version from 3.25.1 to 3.25.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <scylladb.version>5.1.4</scylladb.version>
         <testcontainers.version>1.19.3</testcontainers.version>
         <easymock.version>5.2.0</easymock.version>
-        <protobuf.version>3.25.1</protobuf.version>
+        <protobuf.version>3.25.3</protobuf.version>
         <grpc.version>1.61.1</grpc.version>
         <protoc.version>3.23.4</protoc.version>
         <gson.version>2.10.1</gson.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump protobuf.version from 3.25.1 to 3.25.3](https://github.com/JanusGraph/janusgraph/pull/4274)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)