### PR TITLE
[v1.0] Returning a copied collection to avoid corrupted iterator by multiple threads

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -1568,7 +1568,7 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
         }
         try {
             if (hasModifications()) {
-                graph.commit(addedRelations.getAll(), deletedRelations.values(), this);
+                graph.commit(addedRelations.getAllUnsafe(), deletedRelations.values(), this);
             } else {
                 txHandle.commit();
             }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/addedrelations/AddedRelationsContainer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/addedrelations/AddedRelationsContainer.java
@@ -39,7 +39,7 @@ public interface AddedRelationsContainer {
      * of the transaction after there are no additional changes. Otherwise the behavior is non deterministic.
      * @return
      */
-    Collection<InternalRelation> getAll();
+    Collection<InternalRelation> getAllUnsafe();
 
     /**
      * Clears the container which releases allocated memory.
@@ -69,7 +69,7 @@ public interface AddedRelationsContainer {
         }
 
         @Override
-        public Collection<InternalRelation> getAll() {
+        public Collection<InternalRelation> getAllUnsafe() {
             return Collections.emptyList();
         }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/addedrelations/ConcurrentAddedRelations.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/addedrelations/ConcurrentAddedRelations.java
@@ -15,8 +15,10 @@
 package org.janusgraph.graphdb.transaction.addedrelations;
 
 import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
 import org.janusgraph.graphdb.internal.InternalRelation;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 /**
@@ -37,11 +39,17 @@ public class ConcurrentAddedRelations extends SimpleAddedRelations {
 
     @Override
     public synchronized Iterable<InternalRelation> getView(final Predicate<InternalRelation> filter) {
-        return super.getView(filter);
+        return copyView(super.getView(filter));
     }
 
     @Override
-    public synchronized Collection<InternalRelation> getAll() {
-        return super.getAll();
+    public synchronized Collection<InternalRelation> getAllUnsafe() {
+        return super.getAllUnsafe();
+    }
+
+    private Iterable<InternalRelation> copyView(Iterable<InternalRelation> currentView) {
+        ArrayList<InternalRelation> view = new ArrayList<>();
+        Iterables.addAll(view, currentView);
+        return view;
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/addedrelations/EmptyAddedRelations.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/addedrelations/EmptyAddedRelations.java
@@ -52,7 +52,7 @@ public class EmptyAddedRelations implements AddedRelationsContainer {
     }
 
     @Override
-    public Collection<InternalRelation> getAll() {
+    public Collection<InternalRelation> getAllUnsafe() {
         return Collections.emptyList();
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/addedrelations/SimpleAddedRelations.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/addedrelations/SimpleAddedRelations.java
@@ -62,7 +62,7 @@ public class SimpleAddedRelations implements AddedRelationsContainer {
     }
 
     @Override
-    public Collection<InternalRelation> getAll() {
+    public Collection<InternalRelation> getAllUnsafe() {
         return Collections.unmodifiableCollection(new AbstractCollection<InternalRelation>() {
             @Override
             @Nonnull

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/transaction/addedrelations/EmptyAddedRelationsTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/transaction/addedrelations/EmptyAddedRelationsTest.java
@@ -41,8 +41,8 @@ public class EmptyAddedRelationsTest {
     }
 
     @Test
-    public void getAllReturnsEmpty() {
-        assertTrue(EmptyAddedRelations.getInstance().getAll().isEmpty());
+    public void getAllUnsafeReturnsEmpty() {
+        assertTrue(EmptyAddedRelations.getInstance().getAllUnsafe().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Returning a copied collection to avoid corrupted iterator by multiple threads](https://github.com/JanusGraph/janusgraph/pull/3913)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)