### PR TITLE
[v1.0] Bump org.jctools:jctools-core from 4.0.1 to 4.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1032,7 +1032,7 @@
             <dependency>
                 <groupId>org.jctools</groupId>
                 <artifactId>jctools-core</artifactId>
-                <version>4.0.1</version>
+                <version>4.0.3</version>
             </dependency>
             <dependency>
                 <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.jctools:jctools-core from 4.0.1 to 4.0.3](https://github.com/JanusGraph/janusgraph/pull/4290)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)