### PR TITLE
[v1.0] Bump commons-codec:commons-codec from 1.15 to 1.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -947,7 +947,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.15</version>
+                <version>1.16.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-cli</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump commons-codec:commons-codec from 1.15 to 1.16.1](https://github.com/JanusGraph/janusgraph/pull/4296)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)