### PR TITLE
[v1.0] Bump codecov/codecov-action from 3 to 4 | Add Codecov token (required in v4)

### DIFF
--- a/.github/workflows/ci-backend-cql.yml
+++ b/.github/workflows/ci-backend-cql.yml
@@ -247,7 +247,7 @@ jobs:
         with:
           name: jacoco-reports
           path: target/jacoco-combined.exec
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           name: codecov-cql-${{ matrix.name }}-java-${{ matrix.java }}
 

--- a/.github/workflows/ci-backend-cql.yml
+++ b/.github/workflows/ci-backend-cql.yml
@@ -248,6 +248,8 @@ jobs:
           name: jacoco-reports
           path: target/jacoco-combined.exec
       - uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           name: codecov-cql-${{ matrix.name }}-java-${{ matrix.java }}
 

--- a/.github/workflows/ci-backend-hbase.yml
+++ b/.github/workflows/ci-backend-hbase.yml
@@ -112,6 +112,6 @@ jobs:
         with:
           name: jacoco-reports
           path: target/jacoco-combined.exec
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           name: codecov-hbase-${{ matrix.name }}-java-${{ matrix.java }}

--- a/.github/workflows/ci-backend-hbase.yml
+++ b/.github/workflows/ci-backend-hbase.yml
@@ -113,5 +113,7 @@ jobs:
           name: jacoco-reports
           path: target/jacoco-combined.exec
       - uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           name: codecov-hbase-${{ matrix.name }}-java-${{ matrix.java }}

--- a/.github/workflows/ci-backend-scylla.yml
+++ b/.github/workflows/ci-backend-scylla.yml
@@ -144,5 +144,7 @@ jobs:
           name: jacoco-reports
           path: target/jacoco-combined.exec
       - uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           name: codecov-cql-${{ matrix.name }}-java-${{ matrix.java }}

--- a/.github/workflows/ci-backend-scylla.yml
+++ b/.github/workflows/ci-backend-scylla.yml
@@ -143,6 +143,6 @@ jobs:
         with:
           name: jacoco-reports
           path: target/jacoco-combined.exec
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           name: codecov-cql-${{ matrix.name }}-java-${{ matrix.java }}

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -140,5 +140,7 @@ jobs:
           name: jacoco-reports
           path: target/jacoco-combined.exec
       - uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           name: codecov-core-${{ matrix.module }}-java-${{ matrix.java }}

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -139,6 +139,6 @@ jobs:
         with:
           name: jacoco-reports
           path: target/jacoco-combined.exec
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           name: codecov-core-${{ matrix.module }}-java-${{ matrix.java }}

--- a/.github/workflows/ci-index-es.yml
+++ b/.github/workflows/ci-index-es.yml
@@ -123,5 +123,7 @@ jobs:
           name: jacoco-reports
           path: target/jacoco-combined.exec
       - uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           name: codecov-index-${{ matrix.name }}-java-${{ matrix.java }}

--- a/.github/workflows/ci-index-es.yml
+++ b/.github/workflows/ci-index-es.yml
@@ -122,6 +122,6 @@ jobs:
         with:
           name: jacoco-reports
           path: target/jacoco-combined.exec
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           name: codecov-index-${{ matrix.name }}-java-${{ matrix.java }}

--- a/.github/workflows/ci-index-solr.yml
+++ b/.github/workflows/ci-index-solr.yml
@@ -96,5 +96,7 @@ jobs:
           name: jacoco-reports
           path: target/jacoco-combined.exec
       - uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           name: codecov-index-${{ matrix.name }}-java-${{ matrix.java }}

--- a/.github/workflows/ci-index-solr.yml
+++ b/.github/workflows/ci-index-solr.yml
@@ -95,6 +95,6 @@ jobs:
         with:
           name: jacoco-reports
           path: target/jacoco-combined.exec
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           name: codecov-index-${{ matrix.name }}-java-${{ matrix.java }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump codecov/codecov-action from 3 to 4](https://github.com/JanusGraph/janusgraph/pull/4240)
 - [Add Codecov token (required in v4)](https://github.com/JanusGraph/janusgraph/pull/4240)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)