### PR TITLE
[v1.0] Mark test as flaky for all backends

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphCustomIdTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphCustomIdTest.java
@@ -15,6 +15,7 @@
 package org.janusgraph.graphdb;
 
 import com.google.common.base.Preconditions;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.T;
@@ -300,7 +301,8 @@ public abstract class JanusGraphCustomIdTest extends JanusGraphBaseTest {
      * @throws ExecutionException
      * @throws InterruptedException
      */
-    @Test
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/1498
+    @RepeatedIfExceptionsTest(repeats = 3)
     public void testIndexUpdatesWithReindexAndRemove() throws ExecutionException, InterruptedException {
         ModifiableConfiguration config = getModifiableConfiguration();
         config.set(ALLOW_SETTING_VERTEX_ID, true, new String[0]);

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.commons.configuration2.MapConfiguration;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
@@ -1939,7 +1940,8 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         finishSchema();
     }
 
-    @Test
+    // flaky test: https://github.com/JanusGraph/janusgraph/issues/1498
+    @RepeatedIfExceptionsTest(repeats = 3)
     public void testIndexUpdatesWithReindexAndRemove() throws InterruptedException, ExecutionException {
         clopen(option(LOG_SEND_DELAY, MANAGEMENT_LOG), Duration.ofMillis(0),
                 option(KCVSLog.LOG_READ_LAG_TIME, MANAGEMENT_LOG), Duration.ofMillis(50),

--- a/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLGraphCacheTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/graphdb/cql/CQLGraphCacheTest.java
@@ -37,13 +37,6 @@ public class CQLGraphCacheTest extends JanusGraphTest {
         return StorageSetup.addPermanentCache(cqlContainer.getConfiguration(getClass().getSimpleName()));
     }
 
-    // flaky test: https://github.com/JanusGraph/janusgraph/issues/1498
-    @RepeatedIfExceptionsTest(repeats = 3)
-    @Override
-    public void testIndexUpdatesWithReindexAndRemove() throws InterruptedException, ExecutionException {
-        super.testIndexUpdatesWithReindexAndRemove();
-    }
-
     // flaky test: https://github.com/JanusGraph/janusgraph/issues/1457
     @ParameterizedRepeatedIfExceptionsTest(repeats = 3)
     @ValueSource(booleans = {true, false})


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Mark test as flaky for all backends](https://github.com/JanusGraph/janusgraph/pull/4309)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)