### PR TITLE
[v1.0] Bump log4j2.version from 2.22.1 to 2.23.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <jmh.version>1.33</jmh.version>
         <!-- align with org.apache.solr:solr-solrj -->
         <jetty.version>9.4.53.v20231009</jetty.version>
-        <log4j2.version>2.22.1</log4j2.version>
+        <log4j2.version>2.23.1</log4j2.version>
         <graalvm-nativeimage.version>23.1.2</graalvm-nativeimage.version>
         <caffeine.version>2.9.3</caffeine.version>
         <checker-qual.version>3.42.0</checker-qual.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump log4j2.version from 2.22.1 to 2.23.1](https://github.com/JanusGraph/janusgraph/pull/4307)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)