### PR TITLE
[v1.0] Bump grpc.version from 1.61.1 to 1.62.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <testcontainers.version>1.19.7</testcontainers.version>
         <easymock.version>5.2.0</easymock.version>
         <protobuf.version>3.25.3</protobuf.version>
-        <grpc.version>1.61.1</grpc.version>
+        <grpc.version>1.62.2</grpc.version>
         <protoc.version>3.23.4</protoc.version>
         <gson.version>2.10.1</gson.version>
         <jcabi.version>2.1.0</jcabi.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump grpc.version from 1.61.1 to 1.62.2](https://github.com/JanusGraph/janusgraph/pull/4319)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)