### PR TITLE
[v1.0] Bump commons-cli:commons-cli from 1.5.0 to 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -952,7 +952,7 @@
             <dependency>
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
-                <version>1.5.0</version>
+                <version>1.6.0</version>
             </dependency>
 
             <!-- Spatial4j -->


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump commons-cli:commons-cli from 1.5.0 to 1.6.0](https://github.com/JanusGraph/janusgraph/pull/4320)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)