### PR TITLE
[v1.0] Bump org.json:json from 20231013 to 20240303

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1440,7 +1440,7 @@
             <dependency>
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
-                <version>20231013</version>
+                <version>20240303</version>
             </dependency>
             <dependency>
                 <groupId>javax.enterprise</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.json:json from 20231013 to 20240303](https://github.com/JanusGraph/janusgraph/pull/4321)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)