### PR TITLE
[v1.0] Bump org.codehaus.mojo:exec-maven-plugin from 3.1.1 to 3.2.0

### DIFF
--- a/janusgraph-dist/pom.xml
+++ b/janusgraph-dist/pom.xml
@@ -625,7 +625,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>3.1.1</version>
+                        <version>3.2.0</version>
                         <executions>
                             <execution>
                                 <id>docker-build</id>

--- a/janusgraph-examples/pom.xml
+++ b/janusgraph-examples/pom.xml
@@ -34,7 +34,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -485,7 +485,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.codehaus.mojo:exec-maven-plugin from 3.1.1 to 3.2.0](https://github.com/JanusGraph/janusgraph/pull/4327)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)