### PR TITLE
[v1.0] Bump graalvm-nativeimage.version from 23.1.2 to 24.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <!-- align with org.apache.solr:solr-solrj -->
         <jetty.version>9.4.53.v20231009</jetty.version>
         <log4j2.version>2.23.1</log4j2.version>
-        <graalvm-nativeimage.version>23.1.2</graalvm-nativeimage.version>
+        <graalvm-nativeimage.version>24.0.0</graalvm-nativeimage.version>
         <caffeine.version>2.9.3</caffeine.version>
         <checker-qual.version>3.42.0</checker-qual.version>
         <curator.version>5.5.0</curator.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump graalvm-nativeimage.version from 23.1.2 to 24.0.0](https://github.com/JanusGraph/janusgraph/pull/4357)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)