### PR TITLE
[v1.0] Add CycloneDX SBOM to release process

### DIFF
--- a/.github/workflows/ci-publish-official.yml
+++ b/.github/workflows/ci-publish-official.yml
@@ -112,7 +112,7 @@ jobs:
           artifactErrorsFailBuild: true
           draft: true
           tag: "${{ env.RELEASE_TAG }}"
-          artifacts: "KEYS,${{ env.JG_DOC_DIST_NAME }}.zip.asc,${{ env.JG_DOC_DIST_NAME }}.zip,janusgraph-dist/target/${{ env.JG_DIST_NAME }}.zip.asc,janusgraph-dist/target/${{ env.JG_DIST_NAME }}.zip,janusgraph-dist/target/${{ env.JG_FULL_DIST_NAME }}.zip.asc,janusgraph-dist/target/${{ env.JG_FULL_DIST_NAME }}.zip"
+          artifacts: "KEYS,${{ env.JG_DOC_DIST_NAME }}.zip.asc,${{ env.JG_DOC_DIST_NAME }}.zip,janusgraph-dist/target/${{ env.JG_DIST_NAME }}.zip.asc,janusgraph-dist/target/${{ env.JG_DIST_NAME }}.zip,janusgraph-dist/target/${{ env.JG_FULL_DIST_NAME }}.zip.asc,janusgraph-dist/target/${{ env.JG_FULL_DIST_NAME }}.zip,target/bom.json,target/bom.xml"
           name: "${{ env.JG_VER }}"
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true

--- a/pom.xml
+++ b/pom.xml
@@ -354,6 +354,22 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>2.7.10</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>makeAggregateBom</goal>
+                        </goals>
+                        <configuration>
+                            <excludeArtifactId>janusgraph-examples,example-common,example-hbase,example-cql,example-berkeleyje,example-remotegraph,example-tinkergraph,janusgraph-test,janusgraph-backend-testutils,janusgraph-benchmark</excludeArtifactId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Add CycloneDX SBOM to release process](https://github.com/JanusGraph/janusgraph/pull/4100)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)