### PR TITLE
[v1.0] Bump org.apache.rat:apache-rat-plugin from 0.15 to 0.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
-                <version>0.15</version>
+                <version>0.16.1</version>
                 <executions>
                     <execution>
                         <id>rat-checks</id>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.apache.rat:apache-rat-plugin from 0.15 to 0.16.1](https://github.com/JanusGraph/janusgraph/pull/4364)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)