### PR TITLE
[v1.0] Bump com.fasterxml.woodstox:woodstox-core from 6.6.1 to 6.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1430,7 +1430,7 @@
             <dependency>
                 <groupId>com.fasterxml.woodstox</groupId>
                 <artifactId>woodstox-core</artifactId>
-                <version>6.6.1</version>
+                <version>6.6.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.hbase.thirdparty</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump com.fasterxml.woodstox:woodstox-core from 6.6.1 to 6.6.2](https://github.com/JanusGraph/janusgraph/pull/4374)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)