### PR TITLE
[v1.0] Bump org.apache.maven.plugins:maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -375,7 +375,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.12.1</version>
+                    <version>3.13.0</version>
                     <configuration>
                         <source>${compiler.source}</source>
                         <target>${compiler.target}</target>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.apache.maven.plugins:maven-compiler-plugin](https://github.com/JanusGraph/janusgraph/pull/4375)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)