### PR TITLE
[v1.0] Bump jetty.version from 9.4.53.v20231009 to 9.4.54.v20240208

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <jcabi.version>2.1.0</jcabi.version>
         <jmh.version>1.33</jmh.version>
         <!-- align with org.apache.solr:solr-solrj -->
-        <jetty.version>9.4.53.v20231009</jetty.version>
+        <jetty.version>9.4.54.v20240208</jetty.version>
         <log4j2.version>2.23.1</log4j2.version>
         <graalvm-nativeimage.version>24.0.0</graalvm-nativeimage.version>
         <caffeine.version>2.9.3</caffeine.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump jetty.version from 9.4.53.v20231009 to 9.4.54.v20240208](https://github.com/JanusGraph/janusgraph/pull/4378)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)