### PR TITLE
[v1.0] Bump commons-io:commons-io from 2.15.1 to 2.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1018,7 +1018,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.15.1</version>
+                <version>2.16.1</version>
             </dependency>
             <dependency>
                 <groupId>org.jacoco</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump commons-io:commons-io from 2.15.1 to 2.16.1](https://github.com/JanusGraph/janusgraph/pull/4382)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)