### PR TITLE
[v1.0] Bump jackson2.version from 2.16.1 to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <htrace.version>4.1.6</htrace.version>
         <bigtable.version>1.24.0</bigtable.version>
         <!-- align with org.apache.spark:spark-core_2.12 -->
-        <jackson2.version>2.16.1</jackson2.version>
+        <jackson2.version>2.17.0</jackson2.version>
         <lucene-solr.version>8.11.2</lucene-solr.version>
         <elasticsearch.version>8.10.4</elasticsearch.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
@@ -936,6 +936,11 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
                 <version>${mockito.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>1.14.13</version>
             </dependency>
             <dependency>
                 <groupId>org.apiguardian</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump jackson2.version from 2.16.1 to 2.17.0](https://github.com/JanusGraph/janusgraph/pull/4331)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)