### PR TITLE
[v1.0] Bump com.googlecode.maven-download-plugin:download-maven-plugin

### DIFF
--- a/janusgraph-dist/pom.xml
+++ b/janusgraph-dist/pom.xml
@@ -192,7 +192,7 @@
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.7.1</version>
+                <version>1.9.0</version>
                 <executions>
                     <execution>
                         <id>get-elasticsearch</id>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump com.googlecode.maven-download-plugin:download-maven-plugin](https://github.com/JanusGraph/janusgraph/pull/4389)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)