### PR TITLE
[v1.0] Bump org.apache.commons:commons-exec from 1.3 to 1.4.0

### DIFF
--- a/janusgraph-benchmark/pom.xml
+++ b/janusgraph-benchmark/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-exec</artifactId>
-            <version>1.3</version>
+            <version>1.4.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.apache.commons:commons-exec from 1.3 to 1.4.0](https://github.com/JanusGraph/janusgraph/pull/4390)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)