### PR TITLE
[v1.0] Bump actions/upload-artifact from 3 to 4

### DIFF
--- a/.github/workflows/ci-backend-cql.yml
+++ b/.github/workflows/ci-backend-cql.yml
@@ -67,99 +67,99 @@ jobs:
         include:
           - module: cql
             args: "-Pcassandra3-byteordered -Dtest=\"**/diskstorage/cql/*\""
-            name: byteordered-diskstorage
+            name: cassandra3-byteordered-diskstorage-java8
             java: 8
           - module: cql
             args: "-Pcassandra3-murmur -Dtest=\"**/diskstorage/cql/*\""
-            name: murmur-diskstorage
+            name: cassandra3-murmur-diskstorage-java8
             java: 8
           - module: cql
             args: "-Pcassandra3-byteordered -Dtest=\"**/graphdb/cql/*\""
-            name: byteordered-graphdb
+            name: cassandra3-byteordered-graphdb-java8
             java: 8
           - module: cql
             args: "-Pcassandra3-murmur -Dtest=\"**/graphdb/cql/*\""
-            name: murmur-graphdb
+            name: cassandra3-murmur-graphdb-java8
             java: 8
           - module: cql
             args: "-Pcassandra3-murmur -Dtest=\"**/hadoop/*\""
-            name: murmur-hadoop
+            name: cassandra3-murmur-hadoop-java8
             java: 8
           - module: cql
             args: "-Pcassandra3-byteordered -Dtest=\"**/core/cql/*\""
-            name: byteordered-core
+            name: cassandra3-byteordered-core-java8
             java: 8
           - module: cql
             args: "-Pcassandra3-murmur -Dtest=\"**/core/cql/*\""
-            name: murmur-core
+            name: cassandra3-murmur-core-java8
             java: 8
           - module: cql
             args: "-Pcassandra3-murmur-ssl -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
-            name: murmur-ssl
+            name: cassandra3-murmur-ssl-java8
             java: 8
           - module: cql
             args: "-Pcassandra3-murmur-client-auth -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
-            name: murmur-client-auth
+            name: cassandra3-murmur-client-auth-java8
             java: 8
           - module: cql
             args: "-Pscylladb -Dtest=\"**/diskstorage/cql/*\""
-            name: scylladb-diskstorage
+            name: cassandra3-scylladb-diskstorage-java8
             java: 8
           - module: cql
             args: "-Pscylladb -Dtest=\"**/graphdb/cql/*\""
-            name: scylladb-graphdb
+            name: cassandra3-scylladb-graphdb-java8
             java: 8
           - module: cql
             args: "-Pscylladb -Dtest=\"**/hadoop/*\""
-            name: scylladb-hadoop
+            name: cassandra3-scylladb-hadoop-java8
             java: 8
           - module: cql
             args: "-Pscylladb -Dtest=\"**/core/cql/*\""
-            name: scylladb-core
+            name: cassandra3-scylladb-core-java8
             java: 8
           - module: cql
             args: "-Pcassandra3-byteordered -Dtest=\"**/diskstorage/cql/*\""
-            name: byteordered-diskstorage
+            name: cassandra3-byteordered-diskstorage
             install-args: "-Pjava-11"
             java: 11
           - module: cql
             args: "-Pcassandra3-murmur -Dtest=\"**/diskstorage/cql/*\""
-            name: murmur-diskstorage
+            name: cassandra3-murmur-diskstorage
             install-args: "-Pjava-11"
             java: 11
           - module: cql
             args: "-Pcassandra3-byteordered -Dtest=\"**/graphdb/cql/*\""
-            name: byteordered-graphdb
+            name: cassandra3-byteordered-graphdb
             install-args: "-Pjava-11"
             java: 11
           - module: cql
             args: "-Pcassandra3-murmur -Dtest=\"**/graphdb/cql/*\""
-            name: murmur-graphdb
+            name: cassandra3-murmur-graphdb
             install-args: "-Pjava-11"
             java: 11
           - module: cql
             args: "-Pcassandra3-murmur -Dtest=\"**/hadoop/*\""
-            name: murmur-hadoop
+            name: cassandra3-murmur-hadoop
             install-args: "-Pjava-11"
             java: 11
           - module: cql
             args: "-Pcassandra3-byteordered -Dtest=\"**/core/cql/*\""
-            name: byteordered-core
+            name: cassandra3-byteordered-core
             install-args: "-Pjava-11"
             java: 11
           - module: cql
             args: "-Pcassandra3-murmur -Dtest=\"**/core/cql/*\""
-            name: murmur-core
+            name: cassandra3-murmur-core
             install-args: "-Pjava-11"
             java: 11
           - module: cql
             args: "-Pcassandra3-murmur-ssl -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
-            name: murmur-ssl
+            name: cassandra3-murmur-ssl
             install-args: "-Pjava-11"
             java: 11
           - module: cql
             args: "-Pcassandra3-murmur-client-auth -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
-            name: murmur-client-auth
+            name: cassandra3-murmur-client-auth
             install-args: "-Pjava-11"
             java: 11
           - module: cql
@@ -184,47 +184,47 @@ jobs:
             java: 11
           - module: cql
             args: "-Pcassandra4-byteordered -Dtest=\"**/diskstorage/cql/*\""
-            name: byteordered-diskstorage
+            name: cassandra4-byteordered-diskstorage
             install-args: "-Pjava-11"
             java: 11
           - module: cql
             args: "-Pcassandra4-murmur -Dtest=\"**/diskstorage/cql/*\""
-            name: murmur-diskstorage
+            name: cassandra4-murmur-diskstorage
             install-args: "-Pjava-11"
             java: 11
           - module: cql
             args: "-Pcassandra4-byteordered -Dtest=\"**/graphdb/cql/*\""
-            name: byteordered-graphdb
+            name: cassandra4-byteordered-graphdb
             install-args: "-Pjava-11"
             java: 11
           - module: cql
             args: "-Pcassandra4-murmur -Dtest=\"**/graphdb/cql/*\""
-            name: murmur-graphdb
+            name: cassandra4-murmur-graphdb
             install-args: "-Pjava-11"
             java: 11
           - module: cql
             args: "-Pcassandra4-murmur -Dtest=\"**/hadoop/*\""
-            name: murmur-hadoop
+            name: cassandra4-murmur-hadoop
             install-args: "-Pjava-11"
             java: 11
           - module: cql
             args: "-Pcassandra4-byteordered -Dtest=\"**/core/cql/*\""
-            name: byteordered-core
+            name: cassandra4-byteordered-core
             install-args: "-Pjava-11"
             java: 11
           - module: cql
             args: "-Pcassandra4-murmur -Dtest=\"**/core/cql/*\""
-            name: murmur-core
+            name: cassandra4-murmur-core
             install-args: "-Pjava-11"
             java: 11
           - module: cql
             args: "-Pcassandra4-murmur-ssl -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
-            name: murmur-ssl
+            name: cassandra4-murmur-ssl
             install-args: "-Pjava-11"
             java: 11
           - module: cql
             args: "-Pcassandra4-murmur-client-auth -Dtest=\"**/diskstorage/cql/CQLStoreTest.java\""
-            name: murmur-client-auth
+            name: cassandra4-murmur-client-auth
             install-args: "-Pjava-11"
             java: 11
     steps:
@@ -243,9 +243,9 @@ jobs:
           distribution: zulu
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.install-args }} ${{ matrix.args }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: jacoco-reports
+          name: jacoco-reports-${{ matrix.module }}-${{ matrix.name }}
           path: target/jacoco-combined.exec
       - uses: codecov/codecov-action@v4
         env:

--- a/.github/workflows/ci-backend-hbase.yml
+++ b/.github/workflows/ci-backend-hbase.yml
@@ -67,15 +67,15 @@ jobs:
         include:
           - module: hbase
             args: "-Dtest=\"**/diskstorage/hbase/*\""
-            name: hbase2-diskstorage
+            name: hbase2-diskstorage-java8
             java: 8
           - module: hbase
             args: "-Dtest=\"**/graphdb/hbase/*\""
-            name: hbase2-graphdb
+            name: hbase2-graphdb-java8
             java: 8
           - module: hbase
             args: "-Dtest=\"**/hadoop/*\""
-            name: hbase2-hadoop
+            name: hbase2-hadoop-java8
             java: 8
           - module: hbase
             install-args: "-Pjava-11"
@@ -108,9 +108,9 @@ jobs:
           distribution: zulu
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.install-args }} ${{ matrix.args }} -Dhbase.docker.uid=$(id -u) -Dhbase.docker.gid=$(id -g)
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: jacoco-reports
+          name: jacoco-reports-${{ matrix.module }}-${{ matrix.name }}
           path: target/jacoco-combined.exec
       - uses: codecov/codecov-action@v4
         env:

--- a/.github/workflows/ci-backend-scylla.yml
+++ b/.github/workflows/ci-backend-scylla.yml
@@ -67,19 +67,19 @@ jobs:
         include:
           - module: scylla
             args: "-Pscylla-murmur -Dtest=\"**/diskstorage/cql/*\""
-            name: murmur-diskstorage
+            name: murmur-diskstorage-java8
             java: 8
           - module: scylla
             args: "-Pscylla-murmur -Dtest=\"**/graphdb/cql/*\""
-            name: murmur-graphdb
+            name: murmur-graphdb-java8
             java: 8
           - module: scylla
             args: "-Pscylla-murmur -Dtest=\"**/hadoop/*\""
-            name: murmur-hadoop
+            name: murmur-hadoop-java8
             java: 8
           - module: scylla
             args: "-Pscylla-murmur -Dtest=\"**/core/cql/*\""
-            name: murmur-core
+            name: murmur-core-java8
             java: 8
         # FIXME: this test is failing due to problems with ScyllaDB startup for Testcontainers. Issue: https://github.com/JanusGraph/janusgraph/issues/3595
         #  - module: scylla
@@ -139,9 +139,9 @@ jobs:
           distribution: zulu
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.install-args }} ${{ matrix.args }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: jacoco-reports
+          name: jacoco-reports-${{ matrix.module }}-${{ matrix.name }}
           path: target/jacoco-combined.exec
       - uses: codecov/codecov-action@v4
         env:

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -135,9 +135,9 @@ jobs:
           distribution: zulu
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.install-args }} ${{ matrix.args }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: jacoco-reports
+          name: jacoco-reports-${{ matrix.module }}-java-${{ matrix.java }}
           path: target/jacoco-combined.exec
       - uses: codecov/codecov-action@v4
         env:

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -62,29 +62,29 @@ jobs:
       - run: git diff  --exit-code docs/configs/janusgraph-cfg.md
       - run: docker build -t doc-site:mkdocs -f docs.Dockerfile .
       - run: docker run --rm -v $PWD:/mkdocs doc-site:mkdocs mkdocs build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: github.ref != 'refs/heads/master'
         with:
-          name: distribution-builds
+          name: distribution-doc-builds
           path: site
 
   deploy-doc:
     runs-on: ubuntu-22.04
     if: github.ref == 'refs/heads/master'
     needs: build-doc
-    steps: 
+    steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
       - run: mkdir ./bin
       - run: curl -sfL https://raw.githubusercontent.com/traefik/structor/master/godownloader.sh | bash -s -- -b ./bin ${STRUCTOR_VERSION}
-      - run: sudo ./bin/structor -o janusgraph -r janusgraph 
-            --force-edit-url 
-            --rqts-url="https://raw.githubusercontent.com/JanusGraph/janusgraph/master/requirements.txt" 
-            --dockerfile-url="https://raw.githubusercontent.com/JanusGraph/janusgraph/master/docs.Dockerfile" 
-            --dockerfile-name="https://raw.githubusercontent.com/JanusGraph/janusgraph/master/docs.Dockerfile" 
-            --menu.js-url="https://raw.githubusercontent.com/JanusGraph/janusgraph/master/docs/theme/structor-menu.js.gotmpl" 
+      - run: sudo ./bin/structor -o janusgraph -r janusgraph
+            --force-edit-url
+            --rqts-url="https://raw.githubusercontent.com/JanusGraph/janusgraph/master/requirements.txt"
+            --dockerfile-url="https://raw.githubusercontent.com/JanusGraph/janusgraph/master/docs.Dockerfile"
+            --dockerfile-name="https://raw.githubusercontent.com/JanusGraph/janusgraph/master/docs.Dockerfile"
+            --menu.js-url="https://raw.githubusercontent.com/JanusGraph/janusgraph/master/docs/theme/structor-menu.js.gotmpl"
             --exp-branch=master --debug
       - run: sudo chown -R $(id -u):$(id -g) .
       - uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/ci-index-es.yml
+++ b/.github/workflows/ci-index-es.yml
@@ -68,19 +68,19 @@ jobs:
         include:
           - module: es
             args: "-Pelasticsearch8"
-            name: es8
+            name: es8-java8
             java: 8
           - module: es
             args: "-Pelasticsearch7"
-            name: es7
+            name: es7-java8
             java: 8
           - module: es
             args: "-Pelasticsearch6"
-            name: es6
+            name: es6-java8
             java: 8
           - module: es
             args: "-Pelasticsearch60"
-            name: es60
+            name: es60-java8
             java: 8
           - module: es
             install-args: "-Pjava-11"
@@ -118,9 +118,9 @@ jobs:
           distribution: zulu
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.install-args }} ${{ matrix.args }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: jacoco-reports
+          name: jacoco-reports-${{ matrix.module }}-${{ matrix.name }}
           path: target/jacoco-combined.exec
       - uses: codecov/codecov-action@v4
         env:

--- a/.github/workflows/ci-index-solr.yml
+++ b/.github/workflows/ci-index-solr.yml
@@ -68,7 +68,7 @@ jobs:
         include:
           - module: solr
             args: "-Psolr8"
-            name: solr8
+            name: solr8-java8
             java: 8
           - module: solr
             install-args: "-Pjava-11"
@@ -91,9 +91,9 @@ jobs:
           distribution: zulu
       - run: mvn clean install --projects janusgraph-${{ matrix.module }} ${{ env.BUILD_MAVEN_OPTS }} ${{ matrix.install-args }}
       - run: mvn verify --projects janusgraph-${{ matrix.module }} ${{ env.VERIFY_MAVEN_OPTS }} ${{ matrix.install-args }} ${{ matrix.args }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: jacoco-reports
+          name: jacoco-reports-${{ matrix.module }}-${{ matrix.name }}
           path: target/jacoco-combined.exec
       - uses: codecov/codecov-action@v4
         env:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -95,10 +95,14 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y expect
       - run: mvn clean install -Pjanusgraph-release ${{ env.BUILD_MAVEN_OPTS }} -Dgpg.skip=true ${{ matrix.args }}
       - run: mvn verify -pl janusgraph-dist -Pjanusgraph-release -Dgpg.skip=true ${{ matrix.args }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: distribution-builds
-          path: janusgraph-dist/target/janusgraph-*.zip
+          name: distribution-build-full-java-${{ matrix.java }}
+          path: janusgraph-dist/target/janusgraph-full-*.zip
+      - uses: actions/upload-artifact@v4
+        with:
+          name: distribution-build-core-java-${{ matrix.java }}
+          path: janusgraph-dist/target/janusgraph-[!full]*.zip
       - name: Set JanusGraph version environment variable
         run: |
           export JG_VER="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$(git rev-parse --short HEAD)"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump actions/upload-artifact from 3 to 4](https://github.com/JanusGraph/janusgraph/pull/4184)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)