### PR TITLE
[v1.0] Bump org.apache.maven.plugins:maven-clean-plugin from 3.2.0 to 3.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -483,7 +483,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.apache.maven.plugins:maven-clean-plugin from 3.2.0 to 3.3.2](https://github.com/JanusGraph/janusgraph/pull/4396)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)