### PR TITLE
[v1.0] Bump org.cyclonedx:cyclonedx-maven-plugin from 2.7.10 to 2.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,7 @@
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>2.7.10</version>
+                <version>2.8.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.cyclonedx:cyclonedx-maven-plugin from 2.7.10 to 2.8.0](https://github.com/JanusGraph/janusgraph/pull/4394)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)