### PR TITLE
[v1.0] Bump tinkerpop.version from 3.7.1 to 3.7.2 [tp-tests][cql-tests]

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,7 +96,7 @@ extra:
       link: https://lists.lfaidata.foundation/g/janusgraph-dev
   latest_version: 1.0.0
   snapshot_version: 1.0.1-SNAPSHOT
-  tinkerpop_version: 3.7.1
+  tinkerpop_version: 3.7.2
   hadoop_version: 3.3.5
 
 markdown_extensions:

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     </distributionManagement>
     <properties>
         <titan.compatible-versions>1.0.0,1.1.0-SNAPSHOT</titan.compatible-versions>
-        <tinkerpop.version>3.7.1</tinkerpop.version>
+        <tinkerpop.version>3.7.2</tinkerpop.version>
         <avro.version>1.11.3</avro.version>
         <junit-platform.version>1.10.2</junit-platform.version>
         <junit.version>5.10.2</junit.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump tinkerpop.version from 3.7.1 to 3.7.2 [tp-tests][cql-tests]](https://github.com/JanusGraph/janusgraph/pull/4404)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)