### PR TITLE
[v1.0] Bump com.google.guava:guava from 32.1.3-jre to 33.1.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -958,12 +958,12 @@
                 -->
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.1.3-jre</version>
+                <version>33.1.0-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_annotations</artifactId>
-                <version>2.25.0</version>
+                <version>2.26.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>
@@ -1088,6 +1088,10 @@
                     <exclusion>
                         <groupId>com.google.code.gson</groupId>
                         <artifactId>gson</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.j2objc</groupId>
+                        <artifactId>j2objc-annotations</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump com.google.guava:guava from 32.1.3-jre to 33.1.0-jre](https://github.com/JanusGraph/janusgraph/pull/4329)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)