### PR TITLE
[v1.0] Bump org.ow2.asm:asm from 9.6 to 9.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -652,7 +652,7 @@
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>9.6</version>
+                <version>9.7</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.ow2.asm:asm from 9.6 to 9.7](https://github.com/JanusGraph/janusgraph/pull/4406)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)