### PR TITLE
Increase maven wget timeout for ElasticSearch and Cassandra to 30 minutes

### DIFF
--- a/janusgraph-dist/pom.xml
+++ b/janusgraph-dist/pom.xml
@@ -212,6 +212,7 @@
                             <unpack>true</unpack>
                             <!-- https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.17.8-linux-x86_64.tar.gz.sha512 -->
                             <sha512>cd02b40e8b32e78f17bac12245326e10482214ab452b2e5d1745ddc7944e60a5b07c01c949c68625d78640bdd46806aeece4e8d620788133993055732d388443</sha512>
+                            <readTimeOut>1800000</readTimeOut>
                         </configuration>
                     </execution>
                     <execution>
@@ -226,6 +227,7 @@
                             <outputDirectory>${project.build.directory}/</outputDirectory>
                             <unpack>true</unpack>
                             <sha256>${cassandra-dist.version.sha256}</sha256>
+                            <readTimeOut>1800000</readTimeOut>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Often times I see read timeout during janusgraph-distribution building process in GitHub Actions. It seems mostly it happens while downloading ElasticSearch or Cassandra. It usually downloads the packages almost fully (like ~80%) but then for some of the files parts the timeout happens which prevent build from passing.
The was no any default timeout prior to 1.7.0 release of maven-download plugin, but starting from 1.7.0 the default timeout is 3 seconds.
This PR sets `readTimeOut` for ElasticSearch and Cassandra downloads up to 30 minutes. Alternatively, we could remove timeout as it was previously, but knowing that the GitHub Action will timeout in 60 minutes anyways it seems unreasonable to having this timeout more than 30 minutes. I'm also OK setting it to lower values or remove timeout at all if you think it makes sense.
See configuration options here: https://maven-download-plugin.github.io/maven-download-plugin/docsite/1.9.0/wget-mojo.html

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
