### PR TITLE
fix: chown fail when OS create folders or files with root only permission

### DIFF
--- a/janusgraph-dist/docker/docker-entrypoint.sh
+++ b/janusgraph-dist/docker/docker-entrypoint.sh
@@ -20,7 +20,7 @@ JANUSGRAPH_SERVER_YAML="${JANUS_CONFIG_DIR}/janusgraph-server.yaml"
 # running as root; step down to run as janusgraph user
 if [ "$1" == 'janusgraph' ] && [ "$(id -u)" == "0" ]; then
   mkdir -p ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
-  chown -R janusgraph:janusgraph ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
+  chown janusgraph:janusgraph ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
   chmod 700 ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
 
   exec chroot --skip-chdir --userspec janusgraph:janusgraph / "${BASH_SOURCE}" "$@"
@@ -32,7 +32,7 @@ if [ "$1" == 'janusgraph' ]; then
   mkdir -p ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
   cp conf/janusgraph-${JANUS_PROPS_TEMPLATE}-server.properties ${JANUS_PROPS}
   cp conf/janusgraph-server.yaml ${JANUSGRAPH_SERVER_YAML}
-  chown -R "$(id -u):$(id -g)" ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
+  chown "$(id -u):$(id -g)" ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
   chmod 700 ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
   chmod -R 600 ${JANUS_CONFIG_DIR}/*
 


### PR DESCRIPTION
I'm having issue with Janusgraph whenever the OS create files or folders in the Janusgraph owned directory. For example, when the system restart unexpectedly and a `lost+found` folder is created. The `lost+found` created by `fsck` have root only access, so `chown` will fail.

I don't think `chown` need to be recursive because files that are created & used by Janusgraph will all be created by the default user (`janusgraph`) anyway.