### PR TITLE
[v1.0] Bump org.javassist:javassist from 3.29.2-GA to 3.30.2-GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1063,7 +1063,7 @@
             <dependency>
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
-                <version>3.29.2-GA</version>
+                <version>3.30.2-GA</version>
             </dependency>
             <dependency>
                 <groupId>com.carrotsearch</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.javassist:javassist from 3.29.2-GA to 3.30.2-GA](https://github.com/JanusGraph/janusgraph/pull/4429)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)