### PR TITLE
[v1.0] Bump jinja2 from 3.1.3 to 3.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ pymdown-extensions==10.4
 markdown==3.5.1
 mkdocs-include-markdown-plugin==6.0.2
 mkdocs-redirects==1.2.1
-jinja2==3.1.3
+jinja2==3.1.4
 mkdocs-macros-plugin==1.0.4


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump jinja2 from 3.1.3 to 3.1.4](https://github.com/JanusGraph/janusgraph/pull/4436)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)