### PR TITLE
[v1.0] Bump hbase2.version from 2.5.6-hadoop3 to 2.5.8-hadoop3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <httpcomponents.httpclient.version>4.5.14</httpcomponents.httpclient.version>
         <httpcomponents.httpcore.version>4.4.16</httpcomponents.httpcore.version>
         <hadoop.version>3.3.6</hadoop.version>
-        <hbase2.version>2.5.6-hadoop3</hbase2.version>
+        <hbase2.version>2.5.8-hadoop3</hbase2.version>
         <htrace.version>4.1.6</htrace.version>
         <bigtable.version>1.24.0</bigtable.version>
         <!-- align with org.apache.spark:spark-core_2.12 -->


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump hbase2.version from 2.5.6-hadoop3 to 2.5.8-hadoop3](https://github.com/JanusGraph/janusgraph/pull/4421)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)