### PR TITLE
[v1.0] Bump org.jacoco:org.jacoco.ant from 0.8.11 to 0.8.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1028,7 +1028,7 @@
             <dependency>
                 <groupId>org.jacoco</groupId>
                 <artifactId>org.jacoco.ant</artifactId>
-                <version>0.8.11</version>
+                <version>0.8.12</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
@@ -1722,7 +1722,7 @@
                             <dependency>
                                 <groupId>org.jacoco</groupId>
                                 <artifactId>org.jacoco.ant</artifactId>
-                                <version>0.8.11</version>
+                                <version>0.8.12</version>
                             </dependency>
                         </dependencies>
                     </plugin>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.jacoco:org.jacoco.ant from 0.8.11 to 0.8.12](https://github.com/JanusGraph/janusgraph/pull/4422)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)