### PR TITLE
[v1.0] Bump curator.version from 5.5.0 to 5.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <graalvm-nativeimage.version>24.0.0</graalvm-nativeimage.version>
         <caffeine.version>2.9.3</caffeine.version>
         <checker-qual.version>3.42.0</checker-qual.version>
-        <curator.version>5.5.0</curator.version>
+        <curator.version>5.6.0</curator.version>
     </properties>
     <modules>
         <module>janusgraph-grpc</module>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump curator.version from 5.5.0 to 5.6.0](https://github.com/JanusGraph/janusgraph/pull/4432)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)