### PR TITLE
[v1.0] Bump sqren/backport-github-action from 9.3.1 to 9.5.1

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -29,7 +29,7 @@ jobs:
       )
     steps:
       - name: Backport Action
-        uses: sqren/backport-github-action@v9.3.1
+        uses: sqren/backport-github-action@v9.5.1
         with:
           github_token: ${{ secrets.ACCESS_TOKEN }}
           auto_backport_label_prefix: backport/


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump sqren/backport-github-action from 9.3.1 to 9.5.1](https://github.com/JanusGraph/janusgraph/pull/4447)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)