### PR TITLE
[v1.0] Bump org.apache.hbase.thirdparty:hbase-noop-htrace from 4.1.6 to 4.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <httpcomponents.httpcore.version>4.4.16</httpcomponents.httpcore.version>
         <hadoop.version>3.3.6</hadoop.version>
         <hbase2.version>2.5.8-hadoop3</hbase2.version>
-        <htrace.version>4.1.6</htrace.version>
+        <htrace.version>4.1.7</htrace.version>
         <bigtable.version>1.24.0</bigtable.version>
         <!-- align with org.apache.spark:spark-core_2.12 -->
         <jackson2.version>2.17.0</jackson2.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.apache.hbase.thirdparty:hbase-noop-htrace from 4.1.6 to 4.1.7](https://github.com/JanusGraph/janusgraph/pull/4442)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)