### PR TITLE
[v1.0] Bump testcontainers.version from 1.19.7 to 1.19.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <cassandra-driver.version>4.17.0</cassandra-driver.version>
         <scylla-driver.version>4.17.0.0</scylla-driver.version>
         <scylladb.version>5.1.4</scylladb.version>
-        <testcontainers.version>1.19.7</testcontainers.version>
+        <testcontainers.version>1.19.8</testcontainers.version>
         <easymock.version>5.2.0</easymock.version>
         <protobuf.version>3.25.3</protobuf.version>
         <grpc.version>1.63.0</grpc.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump testcontainers.version from 1.19.7 to 1.19.8](https://github.com/JanusGraph/janusgraph/pull/4446)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)