### PR TITLE
Bump lucene-solr.version from 8.11.2 to 8.11.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <bigtable.version>1.24.0</bigtable.version>
         <!-- align with org.apache.spark:spark-core_2.12 -->
         <jackson2.version>2.17.1</jackson2.version>
-        <lucene-solr.version>8.11.2</lucene-solr.version>
+        <lucene-solr.version>8.11.3</lucene-solr.version>
         <elasticsearch.version>8.10.4</elasticsearch.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.collections.version>3.2.2</commons.collections.version>


### PR DESCRIPTION
This performs the update from Dependabot's PR #4452 manually as Dependabot for some reason thinks that this update is for some reason no longer possible.

The update includes (copied from Dependabot's description):

Bumps lucene-solr.version from 8.11.2 to 8.11.3.
Updates org.apache.lucene:lucene-core from 8.11.2 to 8.11.3

Updates org.apache.lucene:lucene-analyzers-common from 8.11.2 to 8.11.3

Updates org.apache.lucene:lucene-queryparser from 8.11.2 to 8.11.3

Updates org.apache.lucene:lucene-spatial-extras from 8.11.2 to 8.11.3

Updates org.apache.lucene:lucene-backward-codecs from 8.11.2 to 8.11.3

Updates org.apache.solr:solr-solrj from 8.11.2 to 8.11.3

Updates org.apache.solr:solr-test-framework from 8.11.2 to 8.11.3