### PR TITLE
[v1.0] Bump org.projectlombok:lombok from 1.18.30 to 1.18.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1219,7 +1219,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.30</version>
+                <version>1.18.32</version>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.projectlombok:lombok from 1.18.30 to 1.18.32](https://github.com/JanusGraph/janusgraph/pull/4460)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)