### PR TITLE
[v1.0] Bump org.apache.maven.plugins:maven-jar-plugin from 3.3.0 to 3.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -449,7 +449,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.4.1</version>
                     <configuration>
                         <archive>
                             <manifestEntries>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.apache.maven.plugins:maven-jar-plugin from 3.3.0 to 3.4.1](https://github.com/JanusGraph/janusgraph/pull/4463)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)