### PR TITLE
[v1.0] Bump org.objenesis:objenesis from 3.3 to 3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -889,7 +889,7 @@
             <dependency>
                 <groupId>org.objenesis</groupId>
                 <artifactId>objenesis</artifactId>
-                <version>3.3</version>
+                <version>3.4</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.objenesis:objenesis from 3.3 to 3.4](https://github.com/JanusGraph/janusgraph/pull/4469)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)