### PR TITLE
[v1.0] Bump lucene-solr.version from 8.11.2 to 8.11.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <bigtable.version>1.24.0</bigtable.version>
         <!-- align with org.apache.spark:spark-core_2.12 -->
         <jackson2.version>2.17.1</jackson2.version>
-        <lucene-solr.version>8.11.2</lucene-solr.version>
+        <lucene-solr.version>8.11.3</lucene-solr.version>
         <elasticsearch.version>8.10.4</elasticsearch.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.collections.version>3.2.2</commons.collections.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump lucene-solr.version from 8.11.2 to 8.11.3](https://github.com/JanusGraph/janusgraph/pull/4458)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)