### PR TITLE
Retry bulk request if all errors are configured retry error codes & Split large bulk requests

### DIFF
--- a/docs/configs/janusgraph-cfg.md
+++ b/docs/configs/janusgraph-cfg.md
@@ -150,6 +150,7 @@ Elasticsearch index configuration
 
 | Name | Description | Datatype | Default Value | Mutability |
 | ---- | ---- | ---- | ---- | ---- |
+| index.[X].elasticsearch.bulk-chunk-size-limit-bytes | The total size limit in bytes of a bulk request. Mutation batches in excess of this limit will be chunked to this size. | Integer | 100000000 | LOCAL |
 | index.[X].elasticsearch.bulk-refresh | Elasticsearch bulk API refresh setting used to control when changes made by this request are made visible to search | String | false | MASKABLE |
 | index.[X].elasticsearch.client-keep-alive | Set a keep-alive timeout (in milliseconds) | Long | (no default value) | GLOBAL_OFFLINE |
 | index.[X].elasticsearch.connect-timeout | Sets the maximum connection timeout (in milliseconds). | Integer | 1000 | MASKABLE |

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
@@ -324,6 +324,11 @@ public class ElasticSearchIndex implements IndexProvider {
             "Comma separated list of Elasticsearch REST client ResponseException error codes to retry. " +
                 "E.g. \"408,429\"", ConfigOption.Type.LOCAL, String[].class, new String[0]);
 
+    public static final ConfigOption<Integer> BULK_CHUNK_SIZE_LIMIT_BYTES =
+        new ConfigOption<>(ELASTICSEARCH_NS, "bulk-chunk-size-limit-bytes",
+            "The total size limit in bytes of a bulk request. Mutation batches in excess of this limit will be " +
+                "chunked to this size.", ConfigOption.Type.LOCAL, Integer.class, 100_000_000);
+
     public static final int HOST_PORT_DEFAULT = 9200;
 
     /**

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestClientSetup.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestClientSetup.java
@@ -81,8 +81,9 @@ public class RestClientSetup {
         long retryMaxWaitMs = config.getOrDefault(ElasticSearchIndex.RETRY_MAX_WAIT);
         Set<Integer> errorCodesToRetry = Arrays.stream(config.getOrDefault(ElasticSearchIndex.RETRY_ERROR_CODES))
             .mapToInt(Integer::parseInt).boxed().collect(Collectors.toSet());
+        int bulkChunkLimitBytes = config.getOrDefault(ElasticSearchIndex.BULK_CHUNK_SIZE_LIMIT_BYTES);
         final RestElasticSearchClient client = getElasticSearchClient(rc, scrollKeepAlive, useMappingTypesForES7,
-            retryLimit, errorCodesToRetry, retryInitialWaitMs, retryMaxWaitMs);
+            retryLimit, errorCodesToRetry, retryInitialWaitMs, retryMaxWaitMs, bulkChunkLimitBytes);
         if (config.has(ElasticSearchIndex.BULK_REFRESH)) {
             client.setBulkRefresh(config.get(ElasticSearchIndex.BULK_REFRESH));
         }
@@ -115,9 +116,9 @@ public class RestClientSetup {
 
     protected RestElasticSearchClient getElasticSearchClient(RestClient rc, int scrollKeepAlive, boolean useMappingTypesForES7,
                                                              int retryAttemptLimit, Set<Integer> retryOnErrorCodes, long retryInitialWaitMs,
-                                                             long retryMaxWaitMs) {
+                                                             long retryMaxWaitMs, int bulkChunkSerializedLimit) {
         return new RestElasticSearchClient(rc, scrollKeepAlive, useMappingTypesForES7, retryAttemptLimit, retryOnErrorCodes,
-            retryInitialWaitMs, retryMaxWaitMs);
+            retryInitialWaitMs, retryMaxWaitMs, bulkChunkSerializedLimit);
     }
 
     /**

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/rest/RestClientBulkRequestsTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/rest/RestClientBulkRequestsTest.java
@@ -1,0 +1,122 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.es.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.janusgraph.diskstorage.es.ElasticSearchMutation;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.IntStream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class RestClientBulkRequestsTest {
+    @Mock
+    private RestClient restClientMock;
+
+    @Mock
+    private Response response;
+
+    @Mock
+    private StatusLine statusLine;
+
+    @Captor
+    private ArgumentCaptor<Request> requestCaptor;
+
+    RestElasticSearchClient createClient(int bulkChunkSerializedLimitBytes) throws IOException {
+        //Just throw an exception when there's an attempt to look up the ES version during instantiation
+        when(restClientMock.performRequest(any())).thenThrow(new IOException());
+
+        RestElasticSearchClient clientUnderTest = new RestElasticSearchClient(restClientMock, 0, false,
+            0, Collections.emptySet(), 0, 0, bulkChunkSerializedLimitBytes);
+        //There's an initial query to get the ES version we need to accommodate, and then reset for the actual test
+        Mockito.reset(restClientMock);
+        return clientUnderTest;
+    }
+
+    @Test
+    public void testSplittingOfLargeBulkItems() throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        when(statusLine.getStatusCode()).thenReturn(200);
+
+        //In both cases return a "success"
+        RestBulkResponse singletonBulkItemResponseSuccess = new RestBulkResponse();
+        singletonBulkItemResponseSuccess.setItems(
+            Collections.singletonList(Collections.singletonMap("index", new RestBulkResponse.RestBulkItemResponse())));
+        byte [] singletonBulkItemResponseSuccessBytes = mapper.writeValueAsBytes(singletonBulkItemResponseSuccess);
+        HttpEntity singletonBulkItemHttpEntityMock = mock(HttpEntity.class);
+        when(singletonBulkItemHttpEntityMock.getContent())
+            .thenReturn(new ByteArrayInputStream(singletonBulkItemResponseSuccessBytes))
+            //Have to setup a second input stream because it will have been consumed by the first pass
+            .thenReturn(new ByteArrayInputStream(singletonBulkItemResponseSuccessBytes));
+        when(response.getEntity()).thenReturn(singletonBulkItemHttpEntityMock);
+        when(response.getStatusLine()).thenReturn(statusLine);
+
+        int bulkLimit = 800;
+        try (RestElasticSearchClient restClientUnderTest = createClient(bulkLimit)) {
+            //prime the restClientMock again after it's reset after creation
+            when(restClientMock.performRequest(any())).thenReturn(response).thenReturn(response);
+            StringBuilder payloadBuilder = new StringBuilder();
+            IntStream.range(0, bulkLimit - 100).forEach(value -> payloadBuilder.append("a"));
+            String largePayload = payloadBuilder.toString();
+            restClientUnderTest.bulkRequest(Arrays.asList(
+                //There should be enough characters in the payload that they can't both be sent in a single bulk call
+                ElasticSearchMutation.createIndexRequest("some_index", "some_type", "some_doc_id1",
+                    Collections.singletonMap("someKey", largePayload)),
+                ElasticSearchMutation.createIndexRequest("some_index", "some_type", "some_doc_id2",
+                    Collections.singletonMap("someKey", largePayload))
+            ), null);
+            //Verify that despite only calling bulkRequest() once, we had 2 calls to the underlying rest client's
+            //perform request (due to the mutations being split across 2 calls)
+            verify(restClientMock, times(2)).performRequest(requestCaptor.capture());
+        }
+    }
+
+    @Test
+    public void testThrowingIfSingleBulkItemIsLargerThanLimit() throws IOException {
+        int bulkLimit = 800;
+        try (RestElasticSearchClient restClientUnderTest = createClient(bulkLimit)) {
+            StringBuilder payloadBuilder = new StringBuilder();
+            //This payload is too large to send given the set limit, since it is a single item we can't split it
+            IntStream.range(0, bulkLimit * 10).forEach(value -> payloadBuilder.append("a"));
+            Assertions.assertThrows(IllegalArgumentException.class, () -> restClientUnderTest.bulkRequest(
+                Collections.singletonList(
+                    ElasticSearchMutation.createIndexRequest("some_index", "some_type", "some_doc_id",
+                        Collections.singletonMap("someKey", payloadBuilder.toString()))
+            ), null), "Should have thrown due to bulk request item being too large");
+        }
+    }
+}

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/rest/RestClientSetupTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/rest/RestClientSetupTest.java
@@ -123,6 +123,9 @@ public class RestClientSetupTest {
     @Captor
     ArgumentCaptor<Set<Integer>> retryErrorCodesCaptor;
 
+    @Captor
+    ArgumentCaptor<Integer> bulkChunkSerializedLimitCaptor;
+
     @Spy
     private RestClientSetup restClientSetup = new RestClientSetup();
 
@@ -158,7 +161,7 @@ public class RestClientSetupTest {
             when(restClientSetup).getRestClientBuilder(any());
         doReturn(restElasticSearchClientMock).when(restClientSetup).
             getElasticSearchClient(any(RestClient.class), anyInt(), anyBoolean(),
-                anyInt(), anySet(), anyLong(), anyLong());
+                anyInt(), anySet(), anyLong(), anyLong(), anyInt());
 
         return restClientSetup.connect(config.restrictTo(INDEX_NAME));
     }
@@ -190,7 +193,7 @@ public class RestClientSetupTest {
         assertEquals(ElasticSearchIndex.HOST_PORT_DEFAULT, host0.getPort());
 
         verify(restClientSetup).getElasticSearchClient(same(restClientMock), scrollKACaptor.capture(), anyBoolean(),
-            anyInt(), anySet(), anyLong(), anyLong());
+            anyInt(), anySet(), anyLong(), anyLong(), anyInt());
         assertEquals(ElasticSearchIndex.ES_SCROLL_KEEP_ALIVE.getDefaultValue().intValue(),
                 scrollKACaptor.getValue().intValue());
 
@@ -218,7 +221,7 @@ public class RestClientSetupTest {
 
         verify(restClientSetup).getElasticSearchClient(same(restClientMock), scrollKACaptor.capture(), anyBoolean(),
             retryAttemptLimitCaptor.capture(), retryErrorCodesCaptor.capture(), retryInitialWaitCaptor.capture(),
-            retryMaxWaitCaptor.capture());
+            retryMaxWaitCaptor.capture(), bulkChunkSerializedLimitCaptor.capture());
         assertEquals(ElasticSearchIndex.ES_SCROLL_KEEP_ALIVE.getDefaultValue().intValue(),
                 scrollKACaptor.getValue().intValue());
 
@@ -238,6 +241,7 @@ public class RestClientSetupTest {
                 put("index." + INDEX_NAME + ".elasticsearch.retry-initial-wait", String.valueOf(RETRY_INITIAL_WAIT)).
                 put("index." + INDEX_NAME + ".elasticsearch.retry-max-wait", String.valueOf(RETRY_MAX_WAIT)).
                 put("index." + INDEX_NAME + ".elasticsearch.retry-error-codes", "408,429").
+                put("index." + INDEX_NAME + ".elasticsearch.bulk-chunk-size-limit-bytes", "1000000").
                 build());
 
         assertNotNull(hostsConfigured);
@@ -250,7 +254,7 @@ public class RestClientSetupTest {
 
         verify(restClientSetup).getElasticSearchClient(same(restClientMock), scrollKACaptor.capture(), anyBoolean(),
             retryAttemptLimitCaptor.capture(), retryErrorCodesCaptor.capture(), retryInitialWaitCaptor.capture(),
-            retryMaxWaitCaptor.capture());
+            retryMaxWaitCaptor.capture(), bulkChunkSerializedLimitCaptor.capture());
         assertEquals(ES_SCROLL_KA,
                 scrollKACaptor.getValue().intValue());
         assertEquals(RETRY_LIMIT,
@@ -261,6 +265,7 @@ public class RestClientSetupTest {
             retryInitialWaitCaptor.getValue().longValue());
         assertEquals(RETRY_MAX_WAIT,
             retryMaxWaitCaptor.getValue().longValue());
+        assertEquals(1_000_000, bulkChunkSerializedLimitCaptor.getValue().intValue());
 
         verify(restElasticSearchClientMock).setBulkRefresh(eq(ES_BULK_REFRESH));
         verify(restElasticSearchClientMock).setRetryOnConflict(eq(RETRY_ON_CONFLICT));
@@ -283,7 +288,7 @@ public class RestClientSetupTest {
         assertEquals(ElasticSearchIndex.HOST_PORT_DEFAULT, host0.getPort());
 
         verify(restClientSetup).getElasticSearchClient(same(restClientMock), scrollKACaptor.capture(), anyBoolean(),
-            anyInt(), anySet(), anyLong(), anyLong());
+            anyInt(), anySet(), anyLong(), anyLong(), anyInt());
         assertEquals(ElasticSearchIndex.ES_SCROLL_KEEP_ALIVE.getDefaultValue().intValue(),
                 scrollKACaptor.getValue().intValue());
 


### PR DESCRIPTION
Closes #4488

Reused the retry logic from https://github.com/JanusGraph/janusgraph/pull/4409 to also apply to bulk requests if an inner bulk item request failed.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there an issue associated with this PR? Is it referenced in the commit message?
- [X] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
