### PR TITLE
[v1.0] Bump scylla-driver.version from 4.17.0.0 to 4.17.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <cassandra-dist.version>4.0.6</cassandra-dist.version>
         <cassandra-dist.version.sha256>86d14a8e158e4e8554388b1aab598efcb879ddb09c480edecabb3c350b58fe6b</cassandra-dist.version.sha256>
         <cassandra-driver.version>4.17.0</cassandra-driver.version>
-        <scylla-driver.version>4.17.0.0</scylla-driver.version>
+        <scylla-driver.version>4.17.0.1</scylla-driver.version>
         <scylladb.version>5.1.4</scylladb.version>
         <testcontainers.version>1.19.8</testcontainers.version>
         <easymock.version>5.2.0</easymock.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump scylla-driver.version from 4.17.0.0 to 4.17.0.1](https://github.com/JanusGraph/janusgraph/pull/4482)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)