### PR TITLE
[v1.0] Bump org.apache.commons:commons-compress from 1.26.1 to 1.26.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1073,7 +1073,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.26.1</version>
+                <version>1.26.2</version>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.apache.commons:commons-compress from 1.26.1 to 1.26.2](https://github.com/JanusGraph/janusgraph/pull/4497)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)