### PR TITLE
[v1.0] Bump org.apache.maven.plugins:maven-deploy-plugin from 3.1.1 to 3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -445,7 +445,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.apache.maven.plugins:maven-deploy-plugin from 3.1.1 to 3.1.2](https://github.com/JanusGraph/janusgraph/pull/4500)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)