### PR TITLE
[v1.0] Bump org.apache.maven.plugins:maven-enforcer-plugin from 3.4.1 to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <id>enforce-dependency-convergence</id>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.apache.maven.plugins:maven-enforcer-plugin from 3.4.1 to 3.5.0](https://github.com/JanusGraph/janusgraph/pull/4507)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)