### PR TITLE
[v1.0] Bump org.ow2.asm:asm-commons from 9.6 to 9.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -657,7 +657,7 @@
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-commons</artifactId>
-                <version>9.6</version>
+                <version>9.7</version>
             </dependency>
 
             <!-- Jackson 2.x -->


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.ow2.asm:asm-commons from 9.6 to 9.7](https://github.com/JanusGraph/janusgraph/pull/4501)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)