### PR TITLE
Fix NPE on keyspace creation

### DIFF
--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLStoreManager.java
@@ -291,7 +291,7 @@ public class CQLStoreManager extends DistributedStoreManager implements KeyColum
             ExceptionWrapper exceptionWrapper = new ExceptionWrapper();
             executeWithCatching(this::clearJmxMetrics, exceptionWrapper);
             executeWithCatching(session::close, exceptionWrapper);
-            executeWithCatching(queriesBackPressure::close, exceptionWrapper);
+            if (queriesBackPressure != null) executeWithCatching(queriesBackPressure::close, exceptionWrapper);
             throwIfException(exceptionWrapper);
         } finally {
             gracefulExecutorServiceShutdown(executorService, threadPoolShutdownMaxWaitTime);


### PR DESCRIPTION
Hello,

While using JanusGraph, i have sometimes encountered a case where cassandra keyspace fails. When it happens, the real exception is swallowed by a NullPointerException.

This PR fixes this.

Cordially,