### PR TITLE
[v1.0] Bump org.apache.commons:commons-text from 1.11.0 to 1.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1209,7 +1209,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
-                <version>1.11.0</version>
+                <version>1.12.0</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.apache.commons:commons-text from 1.11.0 to 1.12.0](https://github.com/JanusGraph/janusgraph/pull/4513)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)