### PR TITLE
halve docker image size

### DIFF
--- a/janusgraph-dist/docker/Dockerfile
+++ b/janusgraph-dist/docker/Dockerfile
@@ -64,7 +64,7 @@ RUN groupadd -r janusgraph --gid=999 && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends krb5-user && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /opt/janusgraph/ /opt/janusgraph/
+COPY --from=builder --chown=999:999 /opt/janusgraph/ /opt/janusgraph/
 COPY --from=builder /opt/yq /usr/bin/yq
 COPY docker/docker-entrypoint.sh /usr/local/bin/
 COPY docker/load-initdb.sh /usr/local/bin/
@@ -73,7 +73,7 @@ RUN chmod 755 /usr/local/bin/docker-entrypoint.sh && \
     chmod 755 /usr/local/bin/load-initdb.sh && \
     chmod 755 /usr/bin/yq && \
     mkdir -p ${JANUS_INITDB_DIR} ${JANUS_CONFIG_DIR} ${JANUS_DATA_DIR} && \
-    chown -R janusgraph:janusgraph ${JANUS_HOME} ${JANUS_INITDB_DIR} ${JANUS_CONFIG_DIR} ${JANUS_DATA_DIR}
+    chown -R janusgraph:janusgraph ${JANUS_INITDB_DIR} ${JANUS_CONFIG_DIR} ${JANUS_DATA_DIR}
 
 EXPOSE 8182
 


### PR DESCRIPTION
Hello,

The current docker image for janusgraph is huge. After analysis, it seems that the `chown` instruction [here](https://github.com/JanusGraph/janusgraph/blob/v1.0.0/janusgraph-dist/docker/Dockerfile#L76) has the undesirable side effect of doubling the size of the docker image, because the whole janusgraph installation has changed owner and is then copied into the layer.

This PR makes use of the `--chown` flag of the Dockerfile `COPY` command, and should greatly decrease the size of the Janusgraph docker image.