### PR TITLE
[v1.0] halve docker image size

### DIFF
--- a/janusgraph-dist/docker/Dockerfile
+++ b/janusgraph-dist/docker/Dockerfile
@@ -64,7 +64,7 @@ RUN groupadd -r janusgraph --gid=999 && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends krb5-user && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /opt/janusgraph/ /opt/janusgraph/
+COPY --from=builder --chown=999:999 /opt/janusgraph/ /opt/janusgraph/
 COPY --from=builder /opt/yq /usr/bin/yq
 COPY docker/docker-entrypoint.sh /usr/local/bin/
 COPY docker/load-initdb.sh /usr/local/bin/
@@ -73,7 +73,7 @@ RUN chmod 755 /usr/local/bin/docker-entrypoint.sh && \
     chmod 755 /usr/local/bin/load-initdb.sh && \
     chmod 755 /usr/bin/yq && \
     mkdir -p ${JANUS_INITDB_DIR} ${JANUS_CONFIG_DIR} ${JANUS_DATA_DIR} && \
-    chown -R janusgraph:janusgraph ${JANUS_HOME} ${JANUS_INITDB_DIR} ${JANUS_CONFIG_DIR} ${JANUS_DATA_DIR}
+    chown -R janusgraph:janusgraph ${JANUS_INITDB_DIR} ${JANUS_CONFIG_DIR} ${JANUS_DATA_DIR}
 
 EXPOSE 8182
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [halve docker image size](https://github.com/JanusGraph/janusgraph/pull/4527)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)