### PR TITLE
[v1.0] Bump the junit group with 6 updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
         <titan.compatible-versions>1.0.0,1.1.0-SNAPSHOT</titan.compatible-versions>
         <tinkerpop.version>3.7.2</tinkerpop.version>
         <avro.version>1.11.3</avro.version>
-        <junit-platform.version>1.10.2</junit-platform.version>
-        <junit.version>5.10.2</junit.version>
+        <junit-platform.version>1.10.3</junit-platform.version>
+        <junit.version>5.10.3</junit.version>
         <mockito.version>4.11.0</mockito.version>
         <jamm.version>0.3.3</jamm.version>
         <metrics.version>4.2.25</metrics.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump the junit group with 6 updates](https://github.com/JanusGraph/janusgraph/pull/4538)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)