### PR TITLE
[v1.0] Bump jackson2.version from 2.17.1 to 2.17.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <htrace.version>4.1.7</htrace.version>
         <bigtable.version>1.24.0</bigtable.version>
         <!-- align with org.apache.spark:spark-core_2.12 -->
-        <jackson2.version>2.17.1</jackson2.version>
+        <jackson2.version>2.17.2</jackson2.version>
         <lucene-solr.version>8.11.3</lucene-solr.version>
         <elasticsearch.version>8.10.4</elasticsearch.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump jackson2.version from 2.17.1 to 2.17.2](https://github.com/JanusGraph/janusgraph/pull/4544)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)