### PR TITLE
[v1.0] Bump org.jctools:jctools-core from 4.0.3 to 4.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1053,7 +1053,7 @@
             <dependency>
                 <groupId>org.jctools</groupId>
                 <artifactId>jctools-core</artifactId>
-                <version>4.0.3</version>
+                <version>4.0.5</version>
             </dependency>
             <dependency>
                 <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.jctools:jctools-core from 4.0.3 to 4.0.5](https://github.com/JanusGraph/janusgraph/pull/4547)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)