### PR TITLE
[v1.0] Bump net.bytebuddy:byte-buddy from 1.14.17 to 1.14.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -940,7 +940,7 @@
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.14.17</version>
+                <version>1.14.18</version>
             </dependency>
             <dependency>
                 <groupId>org.apiguardian</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump net.bytebuddy:byte-buddy from 1.14.17 to 1.14.18](https://github.com/JanusGraph/janusgraph/pull/4548)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)