### PR TITLE
[v1.0] Bump commons-cli:commons-cli from 1.6.0 to 1.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -973,7 +973,7 @@
             <dependency>
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
-                <version>1.6.0</version>
+                <version>1.8.0</version>
             </dependency>
 
             <!-- Spatial4j -->


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump commons-cli:commons-cli from 1.6.0 to 1.8.0](https://github.com/JanusGraph/janusgraph/pull/4543)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)