### PR TITLE
Remove 2 unused Maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -495,21 +495,8 @@
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.5.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>3.2.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.7</version>
-                    <configuration>
-                        <aggregate>true</aggregate>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION
Cobertura can be used to calculate test coverage, but I don't think that we are using it any more. I at least cannot find any usage of this plugin.
Docs can be found here:
https://www.mojohaus.org/cobertura-maven-plugin/

Build Helper Maven Plugin provides several build utilities, but I also can't find any place where we actually use the plugin. Docs: https://www.mojohaus.org/build-helper-maven-plugin/

I just noticed these plugins as Dependabot created a PR to update the build helper plugin: #4554.

~_Note: I'm opening this in draft state because I want to verify first that coverage data is still included in the PR and not broken by removing Cobertura._~
