### PR TITLE
[v1.0] Bump org.apache.maven.plugins:maven-failsafe-plugin from 3.2.5 to 3.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -441,7 +441,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.apache.maven.plugins:maven-failsafe-plugin from 3.2.5 to 3.3.1](https://github.com/JanusGraph/janusgraph/pull/4565)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)