### PR TITLE
[v1.0] Bump org.hdrhistogram:HdrHistogram from 2.1.12 to 2.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1128,7 +1128,7 @@
             <dependency>
                 <groupId>org.hdrhistogram</groupId>
                 <artifactId>HdrHistogram</artifactId>
-                <version>2.1.12</version>
+                <version>2.2.2</version>
             </dependency>
             <dependency>
                 <groupId>org.elasticsearch.client</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.hdrhistogram:HdrHistogram from 2.1.12 to 2.2.2](https://github.com/JanusGraph/janusgraph/pull/4552)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)