### PR TITLE
[v1.0] Bump org.easymock:easymock from 5.2.0 to 5.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <scylla-driver.version>4.17.0.1</scylla-driver.version>
         <scylladb.version>5.1.4</scylladb.version>
         <testcontainers.version>1.19.8</testcontainers.version>
-        <easymock.version>5.2.0</easymock.version>
+        <easymock.version>5.3.0</easymock.version>
         <protobuf.version>3.25.3</protobuf.version>
         <grpc.version>1.65.1</grpc.version>
         <protoc.version>3.23.4</protoc.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.easymock:easymock from 5.2.0 to 5.3.0](https://github.com/JanusGraph/janusgraph/pull/4569)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)