### PR TITLE
[v1.0] Bump commons-codec:commons-codec from 1.17.0 to 1.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -968,7 +968,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.17.0</version>
+                <version>1.17.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-cli</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump commons-codec:commons-codec from 1.17.0 to 1.17.1](https://github.com/JanusGraph/janusgraph/pull/4573)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)