### PR TITLE
[v1.0] Bump curator.version from 5.6.0 to 5.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <graalvm-nativeimage.version>24.0.0</graalvm-nativeimage.version>
         <caffeine.version>2.9.3</caffeine.version>
         <checker-qual.version>3.43.0</checker-qual.version>
-        <curator.version>5.6.0</curator.version>
+        <curator.version>5.7.0</curator.version>
     </properties>
     <modules>
         <module>janusgraph-grpc</module>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump curator.version from 5.6.0 to 5.7.0](https://github.com/JanusGraph/janusgraph/pull/4574)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)