### PR TITLE
[v1.0] Bump graalvm-nativeimage.version from 24.0.0 to 24.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <!-- align with org.apache.solr:solr-solrj -->
         <jetty.version>9.4.54.v20240208</jetty.version>
         <log4j2.version>2.23.1</log4j2.version>
-        <graalvm-nativeimage.version>24.0.0</graalvm-nativeimage.version>
+        <graalvm-nativeimage.version>24.0.2</graalvm-nativeimage.version>
         <caffeine.version>2.9.3</caffeine.version>
         <checker-qual.version>3.43.0</checker-qual.version>
         <curator.version>5.7.0</curator.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump graalvm-nativeimage.version from 24.0.0 to 24.0.2](https://github.com/JanusGraph/janusgraph/pull/4580)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)