### PR TITLE
[v1.0] Bump com.google.guava:guava from 33.1.0-jre to 33.2.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -958,7 +958,7 @@
                 -->
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.1.0-jre</version>
+                <version>33.2.1-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.google.errorprone</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump com.google.guava:guava from 33.1.0-jre to 33.2.1-jre](https://github.com/JanusGraph/janusgraph/pull/4581)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)