### PR TITLE
[v1.0] Bump org.apache.maven.plugins:maven-surefire-plugin from 3.2.5 to 3.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,7 +389,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>3.3.1</version>
                     <configuration>
                         <argLine>${default.test.jvm.opts}</argLine>
                         <runOrder>alphabetical</runOrder>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.apache.maven.plugins:maven-surefire-plugin from 3.2.5 to 3.3.1](https://github.com/JanusGraph/janusgraph/pull/4591)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)