### PR TITLE
[v1.0] Bump com.google.code.gson:gson from 2.10.1 to 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <protobuf.version>3.25.3</protobuf.version>
         <grpc.version>1.65.1</grpc.version>
         <protoc.version>3.23.4</protoc.version>
-        <gson.version>2.10.1</gson.version>
+        <gson.version>2.11.0</gson.version>
         <jcabi.version>2.1.0</jcabi.version>
         <jmh.version>1.33</jmh.version>
         <!-- align with org.apache.solr:solr-solrj -->


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump com.google.code.gson:gson from 2.10.1 to 2.11.0](https://github.com/JanusGraph/janusgraph/pull/4603)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)