### PR TITLE
[v1.0] Bump org.checkerframework:checker-qual from 3.43.0 to 3.45.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <log4j2.version>2.23.1</log4j2.version>
         <graalvm-nativeimage.version>24.0.2</graalvm-nativeimage.version>
         <caffeine.version>2.9.3</caffeine.version>
-        <checker-qual.version>3.43.0</checker-qual.version>
+        <checker-qual.version>3.45.0</checker-qual.version>
         <curator.version>5.7.0</curator.version>
     </properties>
     <modules>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.checkerframework:checker-qual from 3.43.0 to 3.45.0](https://github.com/JanusGraph/janusgraph/pull/4609)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)