### PR TITLE
[v1.0] Bump org.apache.maven.plugins:maven-release-plugin from 3.0.1 to 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -467,7 +467,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.apache.maven.plugins:maven-release-plugin from 3.0.1 to 3.1.1](https://github.com/JanusGraph/janusgraph/pull/4611)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)