### PR TITLE
[v1.0] Bump com.fasterxml.woodstox:woodstox-core from 6.6.2 to 7.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1442,7 +1442,7 @@
             <dependency>
                 <groupId>com.fasterxml.woodstox</groupId>
                 <artifactId>woodstox-core</artifactId>
-                <version>6.6.2</version>
+                <version>7.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.hbase.thirdparty</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump com.fasterxml.woodstox:woodstox-core from 6.6.2 to 7.0.0](https://github.com/JanusGraph/janusgraph/pull/4614)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)