### PR TITLE
[v1.0] Bump grpc.version from 1.65.1 to 1.66.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <testcontainers.version>1.20.0</testcontainers.version>
         <easymock.version>5.3.0</easymock.version>
         <protobuf.version>3.25.4</protobuf.version>
-        <grpc.version>1.65.1</grpc.version>
+        <grpc.version>1.66.0</grpc.version>
         <protoc.version>3.23.4</protoc.version>
         <gson.version>2.11.0</gson.version>
         <jcabi.version>2.1.0</jcabi.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump grpc.version from 1.65.1 to 1.66.0](https://github.com/JanusGraph/janusgraph/pull/4626)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)