### PR TITLE
[v1.0] Bump testcontainers.version from 1.20.0 to 1.20.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <cassandra-driver.version>4.17.0</cassandra-driver.version>
         <scylla-driver.version>4.18.0.1</scylla-driver.version>
         <scylladb.version>5.1.4</scylladb.version>
-        <testcontainers.version>1.20.0</testcontainers.version>
+        <testcontainers.version>1.20.1</testcontainers.version>
         <easymock.version>5.3.0</easymock.version>
         <protobuf.version>3.25.4</protobuf.version>
         <grpc.version>1.65.1</grpc.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump testcontainers.version from 1.20.0 to 1.20.1](https://github.com/JanusGraph/janusgraph/pull/4620)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)