### PR TITLE
[v1.0] Bump commons-net:commons-net from 3.10.0 to 3.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -712,7 +712,7 @@
             <dependency>
                 <groupId>commons-net</groupId>
                 <artifactId>commons-net</artifactId>
-                <version>3.10.0</version>
+                <version>3.11.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-beanutils</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump commons-net:commons-net from 3.10.0 to 3.11.1](https://github.com/JanusGraph/janusgraph/pull/4621)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)