### PR TITLE
[v1.0] Bump org.apache.kerby:kerb-simplekdc from 2.0.3 to 2.1.0

### DIFF
--- a/janusgraph-solr/pom.xml
+++ b/janusgraph-solr/pom.xml
@@ -165,7 +165,7 @@
         <dependency>
             <groupId>org.apache.kerby</groupId>
             <artifactId>kerb-simplekdc</artifactId>
-            <version>2.0.3</version>
+            <version>2.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.apache.kerby:kerb-simplekdc from 2.0.3 to 2.1.0](https://github.com/JanusGraph/janusgraph/pull/4644)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)