### PR TITLE
[v1.0] Bump org.cyclonedx:cyclonedx-maven-plugin from 2.8.0 to 2.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,7 @@
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>2.8.0</version>
+                <version>2.8.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.cyclonedx:cyclonedx-maven-plugin from 2.8.0 to 2.8.1](https://github.com/JanusGraph/janusgraph/pull/4648)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)