### PR TITLE
[v1.0] Bump commons-logging:commons-logging from 1.3.3 to 1.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -727,7 +727,7 @@
             <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
-                <version>1.3.3</version>
+                <version>1.3.4</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump commons-logging:commons-logging from 1.3.3 to 1.3.4](https://github.com/JanusGraph/janusgraph/pull/4649)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)