### PR TITLE
[v1.0] Bump com.google.errorprone:error_prone_annotations from 2.29.2 to 2.30.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -950,7 +950,7 @@
             <dependency>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_annotations</artifactId>
-                <version>2.29.2</version>
+                <version>2.30.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump com.google.errorprone:error_prone_annotations from 2.29.2 to 2.30.0](https://github.com/JanusGraph/janusgraph/pull/4652)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)