### PR TITLE
Fix the circular initialization dependency #4658

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ModifierType.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ModifierType.java
@@ -20,13 +20,14 @@ import org.janusgraph.graphdb.types.TypeDefinitionCategory;
  * @author Joshua Shinavier (http://fortytwo.net)
  */
 public enum ModifierType {
-    CONSISTENCY(TypeDefinitionCategory.CONSISTENCY_LEVEL),
-    TTL(TypeDefinitionCategory.TTL);
+    CONSISTENCY,
+    TTL;
 
-    private final TypeDefinitionCategory category;
+    private TypeDefinitionCategory category;
 
-    ModifierType(final TypeDefinitionCategory category) {
-        this.category = category;
+    static {
+        CONSISTENCY.category = TypeDefinitionCategory.CONSISTENCY_LEVEL;
+        TTL.category = TypeDefinitionCategory.TTL;
     }
 
     public TypeDefinitionCategory getCategory() {

--- a/janusgraph-core/src/test/java/org/janusgraph/graphdb/TestModifierType.java
+++ b/janusgraph-core/src/test/java/org/janusgraph/graphdb/TestModifierType.java
@@ -1,0 +1,33 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb;
+
+import org.janusgraph.graphdb.database.management.ModifierType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestModifierType {
+    // Verify whether the circular initialization dependency was resolved for ModifierType and TypeDefinitionCategory
+    @Test
+    public void testLoadModifierType() {
+        try {
+            ModifierType m = ModifierType.CONSISTENCY;
+            assert(m != null);
+        } catch (Exception | Error e) {
+            fail("Fail to access ModifierType");
+        }
+    }
+}


### PR DESCRIPTION
Fix the issue https://github.com/JanusGraph/janusgraph/issues/4658:

ModifierType and TypeDefinitionCategory has circular initialization dependency, as a result, if we access ModifierType before TypeDefinitionCategory, it will cause java.lang.ExceptionInInitializerError problem.

A UT is included. No document change.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
