### PR TITLE
[v1.0] Bump net.bytebuddy:byte-buddy from 1.14.18 to 1.15.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -927,7 +927,7 @@
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.14.18</version>
+                <version>1.15.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apiguardian</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump net.bytebuddy:byte-buddy from 1.14.18 to 1.15.1](https://github.com/JanusGraph/janusgraph/pull/4666)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)