### PR TITLE
[v1.0] Bump org.apache.maven.plugins:maven-dependency-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -487,7 +487,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.8.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.0`:
 - [Bump org.apache.maven.plugins:maven-dependency-plugin](https://github.com/JanusGraph/janusgraph/pull/4665)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)