### PR TITLE
[v0.6] Fix the circular initialization dependency

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ModifierType.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ModifierType.java
@@ -20,13 +20,14 @@ import org.janusgraph.graphdb.types.TypeDefinitionCategory;
  * @author Joshua Shinavier (http://fortytwo.net)
  */
 public enum ModifierType {
-    CONSISTENCY(TypeDefinitionCategory.CONSISTENCY_LEVEL),
-    TTL(TypeDefinitionCategory.TTL);
+    CONSISTENCY,
+    TTL;
 
-    private final TypeDefinitionCategory category;
+    private TypeDefinitionCategory category;
 
-    ModifierType(final TypeDefinitionCategory category) {
-        this.category = category;
+    static {
+        CONSISTENCY.category = TypeDefinitionCategory.CONSISTENCY_LEVEL;
+        TTL.category = TypeDefinitionCategory.TTL;
     }
 
     public TypeDefinitionCategory getCategory() {

--- a/janusgraph-core/src/test/java/org/janusgraph/graphdb/TestModifierType.java
+++ b/janusgraph-core/src/test/java/org/janusgraph/graphdb/TestModifierType.java
@@ -1,0 +1,33 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb;
+
+import org.janusgraph.graphdb.database.management.ModifierType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestModifierType {
+    // Verify whether the circular initialization dependency was resolved for ModifierType and TypeDefinitionCategory
+    @Test
+    public void testLoadModifierType() {
+        try {
+            ModifierType m = ModifierType.CONSISTENCY;
+            assert(m != null);
+        } catch (Exception | Error e) {
+            fail("Fail to access ModifierType");
+        }
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v0.6`:
 - [Fix the circular initialization dependency](https://github.com/JanusGraph/janusgraph/pull/4664)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)