### PR TITLE
Inlining vertex properties into a CompositeIndex structure

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -98,6 +98,23 @@ For more information on features and bug fixes in 1.1.0, see the GitHub mileston
 * [JanusGraph zip](https://github.com/JanusGraph/janusgraph/releases/download/v1.1.0/janusgraph-1.1.0.zip)
 * [JanusGraph zip with embedded Cassandra and ElasticSearch](https://github.com/JanusGraph/janusgraph/releases/download/v1.1.0/janusgraph-full-1.1.0.zip)
 
+##### Upgrade Instructions
+
+##### Inlining vertex properties into a Composite Index
+
+Inlining vertex properties into a Composite Index structure can offer significant performance and efficiency benefits.
+See [documentation](./schema/index-management/index-performance.md#inlining-vertex-properties-into-a-composite-index) on how to inline vertex properties into a composite index.
+
+**Important Notes on Compatibility**
+
+1. **Backward Incompatibility**
+   Once a JanusGraph instance adopts this new schema feature, it cannot be rolled back to a prior version of JanusGraph.
+   The changes in the schema structure are not compatible with earlier versions of the system.
+
+2. **Migration Considerations**
+   It is critical that users carefully plan their migration to this new version, as there is no automated or manual rollback process
+   to revert to an older version of JanusGraph once this feature is used.
+
 ### Version 1.0.1 (Release Date: ???)
 
 /// tab | Maven

--- a/docs/schema/index-management/index-performance.md
+++ b/docs/schema/index-management/index-performance.md
@@ -323,6 +323,44 @@ index with label restriction is defined as unique, the uniqueness
 constraint only applies to properties on vertices or edges for the
 specified label.
 
+### Inlining vertex properties into a Composite Index
+
+Inlining vertex properties into a Composite Index structure can offer significant performance and efficiency benefits.
+
+1. **Performance Improvements**
+Faster Querying: Inlining vertex properties directly within the index allows the search engine to retrieve all relevant data from the index itself. 
+This means, queries don’t need to make additional calls to data stores to fetch full vertex information, significantly reducing lookup time.
+
+2. **Data Locality**
+In distributed storages, having inlined properties ensures that more complete data exists within individual partitions or shards.
+This reduces cross-node network calls and improves the overall query performance by ensuring data is more local to the request being processed.
+
+3. **Cost of Indexing vs. Storage Trade-off**
+While inlining properties increases the size of the index (potentially leading to more extensive index storage requirements), 
+it is often a worthwhile trade-off for performance, mainly when query speed is critical. 
+This is a typical pattern in systems optimized for read-heavy workloads.
+
+#### Usage
+In order to take advantage of the inlined properties feature, JanusGraph Transaction should be set to use `.propertyPrefetching(false)`
+
+Example:
+
+```groovy
+//Build index
+mgmt.buildIndex("composite", Vertex.class)
+    .addKey(idKey)
+    .addInlinePropertyKey(nameKey)
+    .buildCompositeIndex()
+mgmt.commit()
+
+//Query
+tx = graph.buildTransaction()
+    .propertyPrefetching(false) //this is important
+    .start()
+
+tx.traversal().V().has("id", 100).next().value("name")
+```
+
 ### Composite versus Mixed Indexes
 
 1.  Use a composite index for exact match index retrievals. Composite

--- a/janusgraph-benchmark/src/main/java/org/janusgraph/CQLCompositeIndexInlinePropBenchmark.java
+++ b/janusgraph-benchmark/src/main/java/org/janusgraph/CQLCompositeIndexInlinePropBenchmark.java
@@ -1,0 +1,136 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph;
+
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.janusgraph.core.Cardinality;
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.JanusGraphFactory;
+import org.janusgraph.core.JanusGraphTransaction;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.diskstorage.BackendException;
+import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
+import org.janusgraph.diskstorage.configuration.WriteConfiguration;
+import org.janusgraph.diskstorage.cql.CQLConfigOptions;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@BenchmarkMode(Mode.AverageTime)
+@Fork(1)
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class CQLCompositeIndexInlinePropBenchmark {
+
+    @Param({"5000"})
+    int verticesAmount;
+
+    @Param({"true", "false"})
+    boolean isInlined;
+
+    JanusGraph graph;
+
+    public WriteConfiguration getConfiguration() {
+        ModifiableConfiguration config = GraphDatabaseConfiguration.buildGraphConfiguration();
+        config.set(GraphDatabaseConfiguration.STORAGE_BACKEND, "cql");
+        config.set(CQLConfigOptions.LOCAL_DATACENTER, "dc1");
+        return config.getConfiguration();
+    }
+
+    @Setup
+    public void setUp() throws Exception {
+        graph = JanusGraphFactory.open(getConfiguration());
+
+        JanusGraphManagement mgmt = graph.openManagement();
+        PropertyKey idProp = mgmt.makePropertyKey("id").dataType(Integer.class).cardinality(Cardinality.SINGLE).make();
+        PropertyKey cityProp = mgmt.makePropertyKey("city").dataType(String.class).cardinality(Cardinality.SINGLE).make();
+        PropertyKey nameProp = mgmt.makePropertyKey("name").dataType(String.class).cardinality(Cardinality.SINGLE).make();
+        mgmt.makePropertyKey("details").dataType(String.class).cardinality(Cardinality.SINGLE).make();
+
+        JanusGraphManagement.IndexBuilder indexBuilder = mgmt.buildIndex("cityIndex", Vertex.class)
+            .addKey(cityProp);
+
+        if (isInlined) {
+            indexBuilder
+                .addInlinePropertyKey(nameProp)
+                .addInlinePropertyKey(idProp);
+        }
+
+        indexBuilder.buildCompositeIndex();
+        mgmt.commit();
+        addVertices();
+    }
+
+    @TearDown
+    public void tearDown() throws BackendException {
+        JanusGraphFactory.drop(graph);
+    }
+
+    @Benchmark
+    public Integer searchVertices() {
+
+        JanusGraphTransaction tx = graph.buildTransaction()
+            .propertyPrefetching(!isInlined)
+            .start();
+
+        List<String> names = tx.traversal()
+            .V()
+            .has("city", "Toulouse")
+            .toList()
+            .stream()
+            .map(v -> v.value("id").toString() + ":" + v.value("name").toString())
+            .collect(Collectors.toList());
+
+        tx.rollback();
+        return names.size();
+    }
+
+    private void addVertices() {
+        for (int i = 0; i < verticesAmount; i++) {
+            Vertex vertex = graph.addVertex("id", i);
+            vertex.property("name", "name_test_" + i);
+            vertex.property("city", "Toulouse");
+            vertex.property("details", "details_" + i);
+        }
+
+        graph.tx().commit();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options options = new OptionsBuilder()
+            .include(CQLCompositeIndexInlinePropBenchmark.class.getSimpleName())
+            .warmupIterations(3)
+            .measurementIterations(10)
+            .build();
+        new Runner(options).run();
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/JanusGraphIndex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/JanusGraphIndex.java
@@ -84,6 +84,13 @@ public interface JanusGraphIndex extends Index {
     PropertyKey[] getFieldKeys();
 
     /**
+     * Returns the inlined keys of this index.
+     *
+     * @return
+     */
+    String[] getInlineFieldKeys();
+
+    /**
      * Returns the parameters associated with an indexed key of this index. Parameters modify the indexing
      * behavior of the underlying indexing backend.
      *

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/JanusGraphManagement.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/JanusGraphManagement.java
@@ -182,6 +182,8 @@ public interface JanusGraphManagement extends JanusGraphConfiguration, SchemaMan
 
     void addIndexKey(final JanusGraphIndex index, final PropertyKey key, Parameter... parameters);
 
+    void addInlinePropertyKey(final JanusGraphIndex index, final PropertyKey key);
+
     /**
      * Builder for {@link JanusGraphIndex}. Allows for the configuration of a graph index prior to its construction.
      */
@@ -194,6 +196,13 @@ public interface JanusGraphManagement extends JanusGraphConfiguration, SchemaMan
          * @return this IndexBuilder
          */
         IndexBuilder addKey(PropertyKey key);
+
+        /**
+         * Adds the given key to inline properties of the composite key of this index
+         * @param key
+         * @return this IndexBuilder
+         */
+        IndexBuilder addInlinePropertyKey(PropertyKey key);
 
         /**
          * Adds the given key and associated parameters to the composite key of this index

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
@@ -43,13 +43,16 @@ import org.janusgraph.diskstorage.indexing.IndexQuery;
 import org.janusgraph.diskstorage.indexing.RawQuery;
 import org.janusgraph.diskstorage.indexing.StandardKeyInformation;
 import org.janusgraph.diskstorage.keycolumnvalue.KeySliceQuery;
+import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
 import org.janusgraph.diskstorage.util.BufferUtil;
+import org.janusgraph.diskstorage.util.EntryArrayList;
 import org.janusgraph.diskstorage.util.HashingUtil;
 import org.janusgraph.graphdb.database.idhandling.IDHandler;
 import org.janusgraph.graphdb.database.index.IndexInfoRetriever;
 import org.janusgraph.graphdb.database.index.IndexMutationType;
 import org.janusgraph.graphdb.database.index.IndexRecords;
 import org.janusgraph.graphdb.database.index.IndexUpdate;
+import org.janusgraph.graphdb.database.index.IndexUpdateContainer;
 import org.janusgraph.graphdb.database.serialize.Serializer;
 import org.janusgraph.graphdb.database.util.IndexAppliesToFunction;
 import org.janusgraph.graphdb.database.util.IndexRecordUtil;
@@ -66,6 +69,7 @@ import org.janusgraph.graphdb.query.graph.IndexQueryBuilder;
 import org.janusgraph.graphdb.query.graph.JointIndexQuery;
 import org.janusgraph.graphdb.query.graph.MultiKeySliceQuery;
 import org.janusgraph.graphdb.query.index.IndexSelectionUtil;
+import org.janusgraph.graphdb.query.vertex.VertexWithInlineProps;
 import org.janusgraph.graphdb.relations.RelationIdentifier;
 import org.janusgraph.graphdb.tinkerpop.optimize.step.Aggregation;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
@@ -74,6 +78,8 @@ import org.janusgraph.graphdb.types.IndexType;
 import org.janusgraph.graphdb.types.MixedIndexType;
 import org.janusgraph.graphdb.types.ParameterIndexField;
 import org.janusgraph.graphdb.types.ParameterType;
+import org.janusgraph.graphdb.types.TypeInspector;
+import org.janusgraph.graphdb.types.indextype.IndexReferenceType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,6 +120,7 @@ public class IndexSerializer {
 
     private static final Logger log = LoggerFactory.getLogger(IndexSerializer.class);
 
+    private final EdgeSerializer edgeSerializer;
     private final Serializer serializer;
     private final Configuration configuration;
     private final Map<String, ? extends IndexInformation> mixedIndexes;
@@ -121,8 +128,13 @@ public class IndexSerializer {
     private final boolean hashKeys;
     private final HashingUtil.HashLength hashLength = HashingUtil.HashLength.SHORT;
 
-    public IndexSerializer(Configuration config, Serializer serializer, Map<String, ? extends IndexInformation> indexes, final boolean hashKeys) {
+    public IndexSerializer(Configuration config,
+                           EdgeSerializer edgeSerializer,
+                           Serializer serializer,
+                           Map<String, ? extends IndexInformation> indexes,
+                           final boolean hashKeys) {
         this.serializer = serializer;
+        this.edgeSerializer = edgeSerializer;
         this.configuration = config;
         this.mixedIndexes = indexes;
         this.hashKeys=hashKeys;
@@ -186,27 +198,27 @@ public class IndexSerializer {
                Index Updates
     ################################################### */
 
-    public Collection<IndexUpdate> getIndexUpdates(InternalRelation relation) {
-        return getIndexUpdates(relation, FULL_INDEX_APPLIES_TO_FILTER);
+    public Collection<IndexUpdate> getIndexUpdates(InternalRelation relation, TypeInspector typeInspector) {
+        return getIndexUpdates(relation, FULL_INDEX_APPLIES_TO_FILTER, typeInspector);
     }
 
-    public Collection<IndexUpdate> getIndexUpdates(InternalVertex vertex, Collection<InternalRelation> updatedProperties) {
-        return getIndexUpdates(vertex, updatedProperties, FULL_INDEX_APPLIES_TO_FILTER);
+    public Stream<IndexUpdate> getIndexUpdates(InternalVertex vertex, Collection<InternalRelation> updatedProperties, TypeInspector typeInspector) {
+        return getIndexUpdates(vertex, updatedProperties, FULL_INDEX_APPLIES_TO_FILTER, typeInspector);
     }
 
-    public Collection<IndexUpdate> getIndexUpdatesNoConstraints(InternalRelation relation) {
-        return getIndexUpdates(relation, INDEX_APPLIES_TO_NO_CONSTRAINTS_FILTER);
+    public Collection<IndexUpdate> getIndexUpdatesNoConstraints(InternalRelation relation, TypeInspector typeInspector) {
+        return getIndexUpdates(relation, INDEX_APPLIES_TO_NO_CONSTRAINTS_FILTER, typeInspector);
     }
 
-    public Collection<IndexUpdate> getIndexUpdatesNoConstraints(InternalVertex vertex, Collection<InternalRelation> updatedProperties) {
-        return getIndexUpdates(vertex, updatedProperties, INDEX_APPLIES_TO_NO_CONSTRAINTS_FILTER);
+    public Stream<IndexUpdate> getIndexUpdatesNoConstraints(InternalVertex vertex, Collection<InternalRelation> updatedProperties, TypeInspector typeInspector) {
+        return getIndexUpdates(vertex, updatedProperties, INDEX_APPLIES_TO_NO_CONSTRAINTS_FILTER, typeInspector);
     }
 
-    public Collection<IndexUpdate> getIndexUpdates(InternalRelation relation, IndexAppliesToFunction indexFilter) {
+    public Collection<IndexUpdate> getIndexUpdates(InternalRelation relation, IndexAppliesToFunction indexFilter, TypeInspector typeInspector) {
         assert relation.isNew() || relation.isRemoved();
         final Set<IndexUpdate> updates = new HashSet<>();
-        final IndexMutationType updateType = getUpdateType(relation);
-        final int ttl = updateType==IndexMutationType.ADD?StandardJanusGraph.getTTL(relation):0;
+        final IndexMutationType updateType = getUpdateType(relation, false);
+        final int ttl = updateType == IndexMutationType.DELETE ? 0: StandardJanusGraph.getTTL(relation);
         for (final PropertyKey type : relation.getPropertyKeysDirect()) {
             if (type == null) continue;
             for (final IndexType index : ((InternalRelationType) type).getKeyIndexes()) {
@@ -216,7 +228,7 @@ public class IndexSerializer {
                     final CompositeIndexType iIndex= (CompositeIndexType) index;
                     final IndexRecordEntry[] record = indexMatch(relation, iIndex);
                     if (record==null) continue;
-                    update = getCompositeIndexUpdate(iIndex, updateType, record, relation, serializer, hashKeys, hashLength);
+                    update = getCompositeIndexUpdate(iIndex, updateType, record, relation, serializer, typeInspector, edgeSerializer, hashKeys, hashLength);
                 } else {
                     assert relation.valueOrNull(type)!=null;
                     if (((MixedIndexType)index).getField(type).getStatus()== SchemaStatus.DISABLED) continue;
@@ -229,40 +241,58 @@ public class IndexSerializer {
         return updates;
     }
 
-    public Collection<IndexUpdate> getIndexUpdates(InternalVertex vertex, Collection<InternalRelation> updatedProperties, IndexAppliesToFunction indexFilter) {
-        if (updatedProperties.isEmpty()) return Collections.emptyList();
-        final Set<IndexUpdate> updates = new HashSet<>();
+    public Stream<IndexUpdate> getIndexUpdates(InternalVertex vertex,
+                                                   Collection<InternalRelation> updatedProperties,
+                                                   IndexAppliesToFunction indexFilter,
+                                                   TypeInspector typeInspector) {
+
+        if (updatedProperties.isEmpty()) return Stream.empty();
+        final Map<Object, IndexUpdateContainer> updates = new HashMap<>();
 
         for (final InternalRelation rel : updatedProperties) {
             assert rel.isProperty();
             final JanusGraphVertexProperty p = (JanusGraphVertexProperty)rel;
             assert rel.isNew() || rel.isRemoved(); assert rel.getVertex(0).equals(vertex);
-            final IndexMutationType updateType = getUpdateType(rel);
-            for (final IndexType index : ((InternalRelationType)p.propertyKey()).getKeyIndexes()) {
-                if (!indexFilter.indexAppliesTo(index,vertex)) continue;
-                if (index.isCompositeIndex()) { //Gather composite indexes
-                    final CompositeIndexType cIndex = (CompositeIndexType)index;
-                    final IndexRecords updateRecords = indexMatches(vertex,cIndex,updateType==IndexMutationType.DELETE,p.propertyKey(),new IndexRecordEntry(p));
+
+            for (final IndexReferenceType indexRef : ((InternalRelationType) p.propertyKey()).getKeyIndexesReferences()) {
+                final IndexMutationType updateType = getUpdateType(rel, indexRef.isInlined());
+
+                if (vertex.isRemoved() && indexRef.isInlined()) continue;
+                if (!indexFilter.indexAppliesTo(indexRef.getIndexType(), vertex)) continue;
+
+                if (indexRef.getIndexType().isCompositeIndex()) { //Gather composite indexes
+                    final CompositeIndexType cIndex = (CompositeIndexType) indexRef.getIndexType();
+                    final IndexRecords updateRecords = indexMatches(vertex,cIndex, rel.isRemoved(), p.propertyKey(), new IndexRecordEntry(p));
                     for (final IndexRecordEntry[] record : updateRecords) {
-                        final IndexUpdate update = getCompositeIndexUpdate(cIndex, updateType, record, vertex, serializer, hashKeys, hashLength);
-                        final int ttl = getIndexTTL(vertex,getKeysOfRecords(record));
-                        if (ttl>0 && updateType== IndexMutationType.ADD) update.setTTL(ttl);
-                        updates.add(update);
+                        final IndexUpdate update = getCompositeIndexUpdate(cIndex, updateType, record, vertex, serializer, typeInspector, edgeSerializer, hashKeys, hashLength);
+                        final int ttl = getIndexTTL(vertex, getKeysOfRecords(record));
+                        if (ttl > 0 && updateType != IndexMutationType.DELETE) update.setTTL(ttl);
+                        if (updates.containsKey(update.getKey())) {
+                            updates.get(update.getKey()).add(update);
+                        } else {
+                            updates.put(update.getKey(), new IndexUpdateContainer(update));
+                        }
                     }
                 } else { //Update mixed indexes
-                    ParameterIndexField field = ((MixedIndexType)index).getField(p.propertyKey());
+                    ParameterIndexField field = ((MixedIndexType) indexRef.getIndexType()).getField(p.propertyKey());
                     if (field == null) {
-                        throw new SchemaViolationException(p.propertyKey() + " is not available in mixed index " + index);
+                        throw new SchemaViolationException(p.propertyKey() + " is not available in mixed index " + indexRef.getIndexType());
                     }
                     if (field.getStatus() == SchemaStatus.DISABLED) continue;
-                    final IndexUpdate update = getMixedIndexUpdate(vertex, p.propertyKey(), p.value(), (MixedIndexType) index, updateType);
-                    final int ttl = getIndexTTL(vertex,p.propertyKey());
-                    if (ttl>0 && updateType== IndexMutationType.ADD) update.setTTL(ttl);
-                    updates.add(update);
+                    final IndexUpdate update = getMixedIndexUpdate(vertex, p.propertyKey(), p.value(), (MixedIndexType) indexRef.getIndexType(), updateType);
+                    final int ttl = getIndexTTL(vertex, p.propertyKey());
+
+                    if (ttl>0 && updateType != IndexMutationType.DELETE) update.setTTL(ttl);
+                    if (updates.containsKey(update.getKey())) {
+                        updates.get(update.getKey()).add(update);
+                    } else {
+                        updates.put(update.getKey(), new IndexUpdateContainer(update));
+                    }
                 }
             }
         }
-        return updates;
+
+        return updates.values().stream().flatMap(IndexUpdateContainer::getUpdates);
     }
 
     public boolean reindexElement(JanusGraphElement element, MixedIndexType index, Map<String,Map<String,List<IndexEntry>>> documentsPerStore) {
@@ -292,7 +322,7 @@ public class IndexSerializer {
         getDocuments(documentsPerStore,index).put(element2String(elementId),new ArrayList<>());
     }
 
-    public Set<IndexUpdate<StaticBuffer,Entry>> reindexElement(JanusGraphElement element, CompositeIndexType index) {
+    public Set<IndexUpdate<StaticBuffer,Entry>> reindexElement(JanusGraphElement element, CompositeIndexType index, TypeInspector typeInspector) {
         final Set<IndexUpdate<StaticBuffer,Entry>> indexEntries = new HashSet<>();
         if (!indexAppliesTo(index,element)) {
             return indexEntries;
@@ -306,7 +336,8 @@ public class IndexSerializer {
             records = (record == null) ? Collections.emptyList() : Collections.singletonList(record);
         }
         for (final IndexRecordEntry[] record : records) {
-            indexEntries.add(getCompositeIndexUpdate(index, IndexMutationType.ADD, record, element, serializer, hashKeys, hashLength));
+            indexEntries.add(getCompositeIndexUpdate(index, IndexMutationType.ADD, record, element, serializer,
+                typeInspector, edgeSerializer, hashKeys, hashLength));
         }
         return indexEntries;
     }
@@ -315,23 +346,28 @@ public class IndexSerializer {
                 Querying
     ################################################### */
 
-    public Stream<Object> query(final JointIndexQuery.Subquery query, final BackendTransaction tx) {
+    public Stream<Object> query(final JointIndexQuery.Subquery query, final BackendTransaction tx, StandardJanusGraphTx standardJanusGraphTx) {
         final IndexType index = query.getIndex();
         if (index.isCompositeIndex()) {
+            Map<String, SliceQuery> inlineQueries = IndexRecordUtil.getInlinePropertiesQueries((CompositeIndexType) index, standardJanusGraphTx);
             final MultiKeySliceQuery sq = query.getCompositeQuery();
             final List<EntryList> rs = sq.execute(tx);
             final List<Object> results = new ArrayList<>(rs.get(0).size());
             for (final EntryList r : rs) {
                 for (final java.util.Iterator<Entry> iterator = r.reuseIterator(); iterator.hasNext(); ) {
                     final Entry entry = iterator.next();
-                    final ReadBuffer entryValue = entry.asReadBuffer();
-                    entryValue.movePositionTo(entry.getValuePosition());
-                    switch(index.getElement()) {
+                    final ReadBuffer readBuffer = entry.asReadBuffer();
+                    readBuffer.movePositionTo(entry.getValuePosition());
+                    switch (index.getElement()) {
                         case VERTEX:
-                            results.add(IDHandler.readVertexId(entryValue, true));
+                            Object vertexId = IDHandler.readVertexId(readBuffer, true);
+                            results.add(new VertexWithInlineProps(vertexId,
+                                EntryArrayList.of(IndexRecordUtil.readInlineProperties(readBuffer)),
+                                inlineQueries,
+                                standardJanusGraphTx));
                             break;
                         default:
-                            results.add(bytebuffer2RelationId(entryValue));
+                            results.add(bytebuffer2RelationId(readBuffer));
                     }
                 }
             }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
@@ -242,9 +242,9 @@ public class IndexSerializer {
     }
 
     public Stream<IndexUpdate> getIndexUpdates(InternalVertex vertex,
-                                                   Collection<InternalRelation> updatedProperties,
-                                                   IndexAppliesToFunction indexFilter,
-                                                   TypeInspector typeInspector) {
+                                               Collection<InternalRelation> updatedProperties,
+                                               IndexAppliesToFunction indexFilter,
+                                               TypeInspector typeInspector) {
 
         if (updatedProperties.isEmpty()) return Stream.empty();
         final Map<Object, IndexUpdateContainer> updates = new HashMap<>();

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/cache/CacheInvalidationService.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/cache/CacheInvalidationService.java
@@ -90,8 +90,8 @@ public interface CacheInvalidationService {
      * <p>
      * `key` is the encoded key of {@link org.janusgraph.graphdb.database.index.IndexUpdate} which can be retrieved via
      * {@link IndexUpdate#getKey()}. To form the `IndexUpdate` it is possible to use
-     * {@link org.janusgraph.graphdb.database.IndexSerializer#getIndexUpdates(InternalRelation)} or
-     * {@link org.janusgraph.graphdb.database.IndexSerializer#getIndexUpdates(InternalVertex, Collection)}.
+     * {@link org.janusgraph.graphdb.database.IndexSerializer#getIndexUpdates(InternalRelation, org.janusgraph.graphdb.types.TypeInspector)} or
+     * {@link org.janusgraph.graphdb.database.IndexSerializer#getIndexUpdates(InternalVertex, Collection, org.janusgraph.graphdb.types.TypeInspector)}.
      * <p>
      * Usually updated vertices and relations (edges or properties) can be found in retrieved mutation logs which are
      * passed via {@link org.janusgraph.core.log.ChangeState} (described in `Transaction Log` documentation of JanusGraph).

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/index/IndexUpdate.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/index/IndexUpdate.java
@@ -64,8 +64,8 @@ public class IndexUpdate<K,E> {
         return entry;
     }
 
-    public boolean isAddition() {
-        return mutationType== IndexMutationType.ADD;
+    public boolean isUpdate() {
+        return mutationType == IndexMutationType.UPDATE;
     }
 
     public boolean isDeletion() {
@@ -81,8 +81,8 @@ public class IndexUpdate<K,E> {
     }
 
     public void setTTL(int ttl) {
-        Preconditions.checkArgument(ttl>0 && mutationType == IndexMutationType.ADD);
-        ((MetaAnnotatable)entry).setMetaData(EntryMetaData.TTL,ttl);
+        Preconditions.checkArgument(ttl > 0 && mutationType != IndexMutationType.DELETE);
+        ((MetaAnnotatable) entry).setMetaData(EntryMetaData.TTL, ttl);
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/index/IndexUpdateContainer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/index/IndexUpdateContainer.java
@@ -1,0 +1,58 @@
+// Copyright 2022 Unified Catalog Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.database.index;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+public class IndexUpdateContainer {
+
+    private Set<IndexUpdate> addDelete = null;
+
+    private IndexUpdate updateOnly = null;
+
+    public IndexUpdateContainer(IndexUpdate indexUpdate) {
+        if (indexUpdate.isUpdate()) {
+            updateOnly = indexUpdate;
+        } else {
+            initSet(indexUpdate);
+        }
+    }
+
+    public void add(IndexUpdate indexUpdate) {
+        if (!indexUpdate.isUpdate()) {
+            initSet(indexUpdate);
+        }
+    }
+
+    public Stream<IndexUpdate> getUpdates() {
+        if (updateOnly != null) {
+            return Stream.of(updateOnly);
+        } else {
+            return this.addDelete.stream();
+        }
+    }
+
+    private void initSet(IndexUpdate indexUpdate) {
+        if (this.addDelete == null) {
+            this.addDelete = new HashSet<>();
+        }
+
+        this.addDelete.add(indexUpdate);
+        updateOnly = null;
+    }
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/JanusGraphIndexWrapper.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/JanusGraphIndexWrapper.java
@@ -36,6 +36,8 @@ public class JanusGraphIndexWrapper implements JanusGraphIndex {
 
     private final IndexType index;
 
+    private static final String[] EMPTY_STRING_ARRAY = new String[0];
+
     public JanusGraphIndexWrapper(IndexType index) {
         this.index = index;
     }
@@ -77,6 +79,15 @@ public class JanusGraphIndexWrapper implements JanusGraphIndex {
             keys[i]=fields[i].getFieldKey();
         }
         return keys;
+    }
+
+    @Override
+    public String[] getInlineFieldKeys() {
+        if (index.isMixedIndex()) {
+            return EMPTY_STRING_ARRAY;
+        } else {
+            return ((CompositeIndexType) index).getInlineFieldKeys();
+        }
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/internal/InternalRelationType.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/internal/InternalRelationType.java
@@ -20,6 +20,7 @@ import org.janusgraph.core.RelationType;
 import org.janusgraph.core.schema.ConsistencyModifier;
 import org.janusgraph.core.schema.SchemaStatus;
 import org.janusgraph.graphdb.types.IndexType;
+import org.janusgraph.graphdb.types.indextype.IndexReferenceType;
 
 /**
  * Internal Type interface adding methods that should only be used by JanusGraph
@@ -51,4 +52,6 @@ public interface InternalRelationType extends RelationType, InternalVertex {
     SchemaStatus getStatus();
 
     Iterable<IndexType> getKeyIndexes();
+
+    Iterable<IndexReferenceType> getKeyIndexesReferences();
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/job/IndexRepairJob.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/job/IndexRepairJob.java
@@ -200,7 +200,7 @@ public class IndexRepairJob extends IndexUpdateJob implements VertexScanJob {
                     while (elements.hasNext()) {
                         JanusGraphElement element = elements.next();
                         Set<IndexUpdate<StaticBuffer,Entry>> updates =
-                                indexSerializer.reindexElement(element, (CompositeIndexType) indexType);
+                                indexSerializer.reindexElement(element, (CompositeIndexType) indexType, writeTx);
                         for (IndexUpdate<StaticBuffer,Entry> update : updates) {
                             log.debug("Mutating index {}: {}", indexType, update.getEntry());
                             mutator.mutateIndex(update.getKey(), new ArrayList<Entry>(1){{add(update.getEntry());}}, KCVSCache.NO_DELETIONS);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/VertexWithInlineProps.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/query/vertex/VertexWithInlineProps.java
@@ -1,0 +1,92 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.query.vertex;
+
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.EntryList;
+import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
+import org.janusgraph.diskstorage.util.EntryArrayList;
+import org.janusgraph.graphdb.internal.InternalRelationType;
+import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class VertexWithInlineProps {
+    private final Object vertexId;
+    private final Map<SliceQuery, EntryList> inlineProperties;
+
+    private static final Logger log = LoggerFactory.getLogger(VertexWithInlineProps.class);
+
+    public VertexWithInlineProps(Object vertexId, EntryList inlineProperties, Map<String, SliceQuery> inlineQueries, StandardJanusGraphTx tx) {
+        this.vertexId = vertexId;
+        this.inlineProperties = loadInlineProperties(inlineProperties, inlineQueries, tx);
+    }
+
+    public Object getVertexId() {
+        return vertexId;
+    }
+
+    public Map<SliceQuery, EntryList> getInlineProperties() {
+        return inlineProperties;
+    }
+
+    private Map<SliceQuery, EntryList> loadInlineProperties(EntryList inlineProperties,
+                                                            Map<String, SliceQuery> inlineQueries,
+                                                            StandardJanusGraphTx tx) {
+        if (inlineProperties.isEmpty()) {
+            return Collections.emptyMap();
+        } else {
+            Map<SliceQuery, EntryList> result = new HashMap<>();
+            for (Entry dataEntry : inlineProperties) {
+                long typeId = tx.getEdgeSerializer().parseTypeId(dataEntry);
+                InternalRelationType type = tx.getOrLoadRelationTypeById(typeId);
+                assert type.isPropertyKey();
+
+                SliceQuery sq = inlineQueries.get(type.name());
+                if(sq != null) {
+                    if (result.containsKey(sq)) {
+                        result.get(sq).add(dataEntry);
+                    } else {
+                        EntryList entryList = new EntryArrayList();
+                        entryList.add(dataEntry);
+                        result.put(sq, entryList);
+                    }
+                } else {
+                    log.error("Missing key=" + type.name() + " in inlineQueries. Check index definition.");
+                }
+            }
+            return result;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return vertexId.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object oth) {
+        if (this == oth) return true;
+        if (getClass().isInstance(oth)) {
+            return vertexId.equals((((VertexWithInlineProps) oth).vertexId));
+        } else {
+            return vertexId.equals(oth);
+        }
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/CompositeIndexType.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/CompositeIndexType.java
@@ -23,6 +23,8 @@ import org.janusgraph.core.schema.SchemaStatus;
 */
 public interface CompositeIndexType extends IndexType {
 
+    static final String[] EMPTY_INLINE_PROPS = new String[0];
+
     /**
      * @deprecated use longId()
      * @return return index id
@@ -31,6 +33,8 @@ public interface CompositeIndexType extends IndexType {
     long getID();
 
     IndexField[] getFieldKeys();
+
+    String[] getInlineFieldKeys();
 
     SchemaStatus getStatus();
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/TypeDefinitionCategory.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/TypeDefinitionCategory.java
@@ -75,7 +75,8 @@ public enum TypeDefinitionCategory {
     INDEX_SCHEMA_CONSTRAINT(),
     PROPERTY_KEY_EDGE(),
     CONNECTION_EDGE(RelationCategory.EDGE, String.class),
-    UPDATE_CONNECTION_EDGE();
+    UPDATE_CONNECTION_EDGE(),
+    INDEX_INLINE_KEY();
 
     public static final Set<TypeDefinitionCategory> PROPERTYKEY_DEFINITION_CATEGORIES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(STATUS, INVISIBLE, SORT_KEY, SORT_ORDER, SIGNATURE, MULTIPLICITY, DATATYPE)));
     public static final Set<TypeDefinitionCategory> EDGELABEL_DEFINITION_CATEGORIES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(STATUS, INVISIBLE, SORT_KEY, SORT_ORDER, SIGNATURE, MULTIPLICITY, UNIDIRECTIONAL)));

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/indextype/CompositeIndexTypeWrapper.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/indextype/CompositeIndexTypeWrapper.java
@@ -37,6 +37,8 @@ public class CompositeIndexTypeWrapper extends IndexTypeWrapper implements Compo
 
     private IndexField[] fields = null;
 
+    private String[] inlineKeys = null;
+
     public CompositeIndexTypeWrapper(SchemaSource base) {
         super(base);
     }
@@ -83,9 +85,28 @@ public class CompositeIndexTypeWrapper extends IndexTypeWrapper implements Compo
     }
 
     @Override
+    public String[] getInlineFieldKeys() {
+        String[] result = inlineKeys;
+        if (result == null) {
+            List<SchemaSource.Entry> entries = base.getRelated(TypeDefinitionCategory.INDEX_INLINE_KEY, Direction.OUT);
+            int numFields = entries.size();
+            result = new String[numFields];
+            int pos = 0;
+            for (SchemaSource.Entry entry : entries) {
+                assert entry.getSchemaType() instanceof PropertyKey;
+                result[pos] = ((PropertyKey) entry.getSchemaType()).name();
+                pos++;
+            }
+            inlineKeys = result;
+        }
+        return result;
+    }
+
+    @Override
     public void resetCache() {
         super.resetCache();
         fields = null;
+        inlineKeys = null;
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/indextype/IndexReferenceType.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/indextype/IndexReferenceType.java
@@ -1,4 +1,4 @@
-// Copyright 2022 JanusGraph Authors
+// Copyright 2024 JanusGraph Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.janusgraph.graphdb.database.index;
+package org.janusgraph.graphdb.types.indextype;
 
-public enum IndexMutationType {
-    ADD,
-    UPDATE,
-    DELETE
+import org.janusgraph.graphdb.types.IndexType;
+
+public class IndexReferenceType {
+
+    private final boolean isInlined;
+
+    private final IndexType indexType;
+
+    public IndexReferenceType(boolean isInlined, IndexType indexType) {
+        this.isInlined = isInlined;
+        this.indexType = indexType;
+    }
+
+    public boolean isInlined() {
+        return isInlined;
+    }
+
+    public IndexType getIndexType() {
+        return indexType;
+    }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/BaseKey.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/BaseKey.java
@@ -15,6 +15,7 @@
 package org.janusgraph.graphdb.types.system;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.janusgraph.core.Cardinality;
 import org.janusgraph.core.Multiplicity;
@@ -29,6 +30,7 @@ import org.janusgraph.graphdb.types.CompositeIndexType;
 import org.janusgraph.graphdb.types.IndexField;
 import org.janusgraph.graphdb.types.IndexType;
 import org.janusgraph.graphdb.types.TypeDefinitionDescription;
+import org.janusgraph.graphdb.types.indextype.IndexReferenceType;
 
 import java.util.Collections;
 
@@ -105,6 +107,11 @@ public class BaseKey extends BaseRelationType implements PropertyKey {
         return Collections.singletonList(indexDef);
     }
 
+    @Override
+    public Iterable<IndexReferenceType> getKeyIndexesReferences() {
+        return Iterables.transform(getKeyIndexes(), indexType -> new IndexReferenceType(false, indexType));
+    }
+
     private final CompositeIndexType indexDef = new CompositeIndexType() {
 
         private final IndexField[] fields = {IndexField.of(BaseKey.this)};
@@ -128,6 +135,11 @@ public class BaseKey extends BaseRelationType implements PropertyKey {
         @Override
         public IndexField[] getFieldKeys() {
             return fields;
+        }
+
+        @Override
+        public String[] getInlineFieldKeys() {
+            return CompositeIndexType.EMPTY_INLINE_PROPS;
         }
 
         @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/EmptyRelationType.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/EmptyRelationType.java
@@ -18,6 +18,7 @@ import org.janusgraph.core.schema.SchemaStatus;
 import org.janusgraph.graphdb.internal.InternalRelationType;
 import org.janusgraph.graphdb.internal.Order;
 import org.janusgraph.graphdb.types.IndexType;
+import org.janusgraph.graphdb.types.indextype.IndexReferenceType;
 
 import java.util.Collections;
 
@@ -63,6 +64,11 @@ public abstract class EmptyRelationType extends EmptyVertex implements InternalR
 
     @Override
     public Iterable<IndexType> getKeyIndexes() {
+        return Collections.EMPTY_LIST;
+    }
+
+    @Override
+    public Iterable<IndexReferenceType> getKeyIndexesReferences(){
         return Collections.EMPTY_LIST;
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/SubqueryIterator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/util/SubqueryIterator.java
@@ -23,6 +23,7 @@ import org.janusgraph.diskstorage.BackendTransaction;
 import org.janusgraph.graphdb.database.IndexSerializer;
 import org.janusgraph.graphdb.query.graph.JointIndexQuery;
 import org.janusgraph.graphdb.query.profile.QueryProfiler;
+import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.janusgraph.graphdb.transaction.subquerycache.SubqueryCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +52,9 @@ public class SubqueryIterator extends CloseableAbstractIterator<JanusGraphElemen
 
     private boolean isTimerRunning;
 
-    public SubqueryIterator(JointIndexQuery.Subquery subQuery, IndexSerializer indexSerializer, BackendTransaction tx,
+    public SubqueryIterator(JointIndexQuery.Subquery subQuery, IndexSerializer indexSerializer,
+                            BackendTransaction backendTx,
+                            StandardJanusGraphTx tx,
                             SubqueryCache indexCache, int limit,
                             Function<Object, ? extends JanusGraphElement> function, List<Object> otherResults) {
         this.subQuery = subQuery;
@@ -65,7 +68,7 @@ public class SubqueryIterator extends CloseableAbstractIterator<JanusGraphElemen
                 currentIds = new ArrayList<>();
                 profiler = QueryProfiler.startProfile(subQuery.getProfiler(), subQuery);
                 isTimerRunning = true;
-                stream = indexSerializer.query(subQuery, tx).peek(r -> currentIds.add(r));
+                stream = indexSerializer.query(subQuery, backendTx, tx).peek(r -> currentIds.add(r));
             } catch (final Exception e) {
                 throw new JanusGraphException("Could not call index", e);
             }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/CacheVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/vertices/CacheVertex.java
@@ -48,7 +48,7 @@ public class CacheVertex extends StandardVertex {
         return queryCache.get(query);
     }
 
-    protected void addToQueryCache(final SliceQuery query, final EntryList entries) {
+    public void addToQueryCache(final SliceQuery query, final EntryList entries) {
         synchronized (queryCache) {
             //TODO: become smarter about what to cache and when (e.g. memory pressure)
             queryCache.put(query, entries);

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/database/IndexSerializerTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/database/IndexSerializerTest.java
@@ -52,9 +52,10 @@ public class IndexSerializerTest {
     public void testReindexElementNotAppliesTo() {
         Configuration config = mock(Configuration.class);
         Serializer serializer = mock(Serializer.class);
+        EdgeSerializer edgeSerializer = mock(EdgeSerializer.class);
         Map<String, ? extends IndexInformation> indexes = new HashMap<>();
 
-        IndexSerializer mockSerializer = new IndexSerializer(config, serializer, indexes, true);
+        IndexSerializer mockSerializer = new IndexSerializer(config, edgeSerializer, serializer, indexes, true);
         JanusGraphElement nonIndexableElement = mock(JanusGraphElement.class);
         MixedIndexType mit = mock(MixedIndexType.class);
         doReturn(ElementCategory.VERTEX).when(mit).getElement();
@@ -92,8 +93,9 @@ public class IndexSerializerTest {
     private IndexSerializer mockSerializer() {
         Configuration config = mock(Configuration.class);
         Serializer serializer = mock(Serializer.class);
+        EdgeSerializer edgeSerializer = mock(EdgeSerializer.class);
         Map<String, ? extends IndexInformation> indexes = new HashMap<>();
-        return spy(new IndexSerializer(config, serializer, indexes, true));
+        return spy(new IndexSerializer(config, edgeSerializer, serializer, indexes, true));
     }
 
     private JanusGraphElement mockIndexAppliesTo(MixedIndexType mit, boolean indexable) {


### PR DESCRIPTION
### Overview

Inlining vertex properties into a search index structure (CompositeIndex) can offer significant performance and efficiency benefits.

1. **Performance Improvements**
Faster Querying: Inlining vertex properties directly within the index allows the search engine to retrieve all relevant data from the index itself. This means queries don’t need to make additional calls to data stores to fetch full vertex information, significantly reducing lookup time.

2. **Data Locality**
In distributed storages, having inlined properties ensures that more complete data exists within individual partitions or shards. This reduces cross-node network calls and improves the overall query performance by ensuring data is more local to the request being processed.

3. **Cost of Indexing vs. Storage Trade-off**
While inlining properties increases the size of the index (potentially leading to more extensive index storage requirements), it is often a worthwhile trade-off for performance, mainly when query speed is critical. This is a typical pattern in systems optimized for read-heavy workloads.

### Usage

In order to take advantage of the inlined properties feature, JanusGraph Transaction should be set to use ` .propertyPrefetching(false)`

Example:
```
//Build index
 mgmt.buildIndex("composite", Vertex.class)
            .addKey(idKey)
            .addInlinePropertyKey(nameKey)
            .buildCompositeIndex();

//Query
tx = graph.buildTransaction()
            .propertyPrefetching(false) //this is important
            .start();
tx.traversal().V().has("id", 100).next().value("name");
```

