### PR TITLE
Allow skipping Docker build from main build process

### DIFF
--- a/docs/storage-backend/scylladb.md
+++ b/docs/storage-backend/scylladb.md
@@ -95,7 +95,9 @@ mvn clean install -Pjanusgraph-release -Puse-scylla -DskipTests=true --batch-mod
 ///
 
 This command will generate distribution builds (both normal and full distribution build) in the 
-following directory: `janusgraph-dist/target/`.   
+following directory: `janusgraph-dist/target/` as well as build local JanusGraph Docker image.  
+If you don't have Docker installed or wish to avoid Docker image build process you can pass `-Pskip-docker` 
+(notice, all tests are automatically disabled when this flag is used).  
 
 Otherwise, if you can't build distribution on your own, you can use the JanusGraph provided distribution and replace 
 the following libraries in `lib` directory (all libraries can be downloaded via Maven Central Repository). 

--- a/janusgraph-dist/pom.xml
+++ b/janusgraph-dist/pom.xml
@@ -38,6 +38,7 @@
         <skipDefaultDistroIT>${it.skip}</skipDefaultDistroIT>
 
         <doc.dir>${project.parent.basedir}/docs</doc.dir>
+        <docker.build.skip>false</docker.build.skip>
 
         <cql-module>janusgraph-cql</cql-module>
         <cql-hadoop-module>cassandra-hadoop-util</cql-hadoop-module>
@@ -364,6 +365,13 @@
             </properties>
         </profile>
         <profile>
+            <id>skip-docker</id>
+            <properties>
+                <docker.build.skip>true</docker.build.skip>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+        <profile>
             <id>janusgraph-release</id>
             <dependencies>
                 <dependency>
@@ -636,6 +644,7 @@
                                     <goal>exec</goal>
                                 </goals>
                                 <configuration>
+                                    <skip>${docker.build.skip}</skip>
                                     <executable>./docker/build-and-push-image.sh</executable>
                                     <workingDirectory>${project.basedir}</workingDirectory>
                                     <arguments>
@@ -669,6 +678,7 @@
                                     <goal>exec</goal>
                                 </goals>
                                 <configuration>
+                                    <skip>${docker.build.skip}</skip>
                                     <executable>./docker/build-and-push-image.sh</executable>
                                     <workingDirectory>${project.basedir}</workingDirectory>
                                     <arguments>


### PR DESCRIPTION
Currently on a system with disabled docker if you try to build a project with the following command:
```
mvn clean install -Pjanusgraph-release -DskipTests=true --batch-mode --also-make -Dgpg.skip=true
```

You will get an exception:
```
ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

In some situations users don't need to build the docker image during JanusGraph build process. Thus, `-Pskip-docker` argument is added to allow skipping Docker image build.
I.e. the following command is passing normally and JanusGraph artifacts are built as expected:
```
mvn clean install -Pjanusgraph-release -Pskip-docker -DskipTests=true --batch-mode --also-make -Dgpg.skip=true
```

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
