### PR TITLE
JSON schema importer

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -105,15 +105,14 @@ For more information on features and bug fixes in 1.1.0, see the GitHub mileston
 Inlining vertex properties into a Composite Index structure can offer significant performance and efficiency benefits.
 See [documentation](./schema/index-management/index-performance.md#inlining-vertex-properties-into-a-composite-index) on how to inline vertex properties into a composite index.
 
-**Important Notes on Compatibility**
-
-1. **Backward Incompatibility**
-   Once a JanusGraph instance adopts this new schema feature, it cannot be rolled back to a prior version of JanusGraph.
-   The changes in the schema structure are not compatible with earlier versions of the system.
-
-2. **Migration Considerations**
-   It is critical that users carefully plan their migration to this new version, as there is no automated or manual rollback process
-   to revert to an older version of JanusGraph once this feature is used.
+!!! warning
+    Important Notes on Compatibility. 
+    1. Backward Incompatibility: 
+       Once a JanusGraph instance adopts this new schema feature, it cannot be rolled back to a prior version of JanusGraph.
+       The changes in the schema structure are not compatible with earlier versions of the system.
+    2. Migration Considerations: 
+       It is critical that users carefully plan their migration to this new version, as there is no automated or manual rollback process
+       to revert to an older version of JanusGraph once this feature is used.
 
 ##### BerkeleyJE ability to overwrite arbitrary settings applied at `EnvironmentConfig` creation
 
@@ -123,6 +122,11 @@ The full list of possible setting is available inside the Java class `com.sleepy
 All configurations values should be specified as `String` and be formated the same as specified in the official sleepycat
 [documentation](https://docs.oracle.com/cd/E17277_02/html/java/com/sleepycat/je/EnvironmentConfig.html).
 Example: `storage.berkeleyje.ext.je.lock.timeout=5000 ms`
+
+##### JSON schema initializer
+
+For simplicity JSON schema initialization options has been added into JanusGraph.
+See [documentation](./schema/schema-init-strategies.md) to learn more about JSON schema initialization process.
 
 ### Version 1.0.1 (Release Date: ???)
 

--- a/docs/configs/janusgraph-cfg.md
+++ b/docs/configs/janusgraph-cfg.md
@@ -384,6 +384,29 @@ Schema related configuration options
 | schema.default | Configures the DefaultSchemaMaker to be used by this graph. Either one of the following shorthands can be used: <br> - `default` (a blueprints compatible schema maker with MULTI edge labels and SINGLE property keys),<br> - `tp3` (same as default, but has LIST property keys),<br> - `none` (automatic schema creation is disabled)<br> - `ignore-prop` (same as none, but simply ignore unknown properties rather than throw exceptions)<br> - or to the full package and classname of a custom/third-party implementing the interface `org.janusgraph.core.schema.DefaultSchemaMaker` | String | default | MASKABLE |
 | schema.logging | Controls whether logging is enabled for schema makers. This only takes effect if you set `schema.default` to `default` or `ignore-prop`. For `default` schema maker, warning messages will be logged before schema types are created automatically. For `ignore-prop` schema maker, warning messages will be logged before unknown properties are ignored. | Boolean | false | MASKABLE |
 
+### schema.init
+Configuration options for schema initialization on startup.
+
+
+| Name | Description | Datatype | Default Value | Mutability |
+| ---- | ---- | ---- | ---- | ---- |
+| schema.init.drop-before-startup | Drops the entire schema with graph data before JanusGraph schema initialization. Note that the schema will be dropped regardless of the selected initialization strategy, including when `schema.init.strategy` is set to `none`. | Boolean | false | LOCAL |
+| schema.init.strategy | Specifies the strategy for schema initialization before starting JanusGraph. You must provide the full class path of a class that implements the `SchemaInitStrategy` interface and has parameterless constructor.<br>The following shortcuts are also available:<br>- `none` - Skips schema initialization.<br>- `json` - Schema initialization via provided JSON file or JSON string.<br> | String | none | LOCAL |
+
+### schema.init.json
+Options for JSON schema initialization strategy.
+
+
+| Name | Description | Datatype | Default Value | Mutability |
+| ---- | ---- | ---- | ---- | ---- |
+| schema.init.json.await-index-status-timeout | Timeout for awaiting index status operation defined in milliseconds. If the status await timeouts the exception will be thrown during schema initialization process. | Long | 180000 | LOCAL |
+| schema.init.json.file | File path to JSON formated schema definition. | String | (no default value) | LOCAL |
+| schema.init.json.force-close-other-instances | Force closes other JanusGraph instances before schema initialization, regardless if they are active or not. This is a dangerous operation. This option exists to help people initialize schema who struggle with zombie JanusGraph instances. It's not recommended to be used unless you know what you are doing. Instead of this parameter, it's recommended to check `graph.unique-instance-id` and `graph.replace-instance-if-exists` options to not create zombie instances in the cluster. | Boolean | false | LOCAL |
+| schema.init.json.indices-activation | Indices activation type:<br>- `reindex_and_enable_updated_only` - Reindex process will be triggered for any updated index. After this all updated indexes will be enabled.<br>- `reindex_and_enable_non_enabled` - Reindex process will be triggered for any index which is not enabled (including previously created indices). After reindexing all indices will be enabled.<br>- `skip_activation` - Skip reindex process for any updated indexes.<br>- `force_enable_updated_only` - Force enable all updated indexes without running any reindex process (previous data may not be available for such indices).<br>- `force_enable_non_enabled` - Force enable all indexes (including previously created indices) without running any reindex process (previous data may not be available for such indices).<br> | String | reindex_and_enable_non_enabled | LOCAL |
+| schema.init.json.skip-elements | Skip creation of VertexLabel, EdgeLabel, and PropertyKey. | Boolean | false | LOCAL |
+| schema.init.json.skip-indices | Skip creation of indices. | Boolean | false | LOCAL |
+| schema.init.json.string | JSON formated schema definition string. This option takes precedence if both `file` and `string` are used. | String | (no default value) | LOCAL |
+
 ### storage
 Configuration options for the storage backend.  Some options are applicable only for certain backends.
 

--- a/docs/schema/schema-init-strategies.md
+++ b/docs/schema/schema-init-strategies.md
@@ -1,0 +1,434 @@
+# Schema Initialization Strategies
+
+Besides the ability to provide groovy code to JanusGraph server to initialize
+schema or execute any custom logic, JanusGraph provides ability to execute 
+custom schema initialization strategies on startup. 
+These strategies are made to help users define and maintain their schema easier, 
+but they are not replacement to custom schema management processes which can 
+be developed by using `JanusGraphManagement` directly. 
+
+Each time JanusGraph instance is started via `JanusGraphFactory` or `ConfiguredGraphFactory`, 
+a schema initialization strategy gets executed before startup. 
+Schema initialization strategy can be chosen via `schema.init.strategy` configuration parameter. 
+By default `none` is selected, meaning schema initialization process is skipped.
+
+Parameter `schema.init.schema-drop-before-startup` can be used to configure 
+schema and data removal on startup (can be convenient in testing environments).
+
+## JSON Schema Initialization
+
+When `json` configuration option is selected in `schema.init.strategy` it 
+triggers schema initialization via JSON formated schema definition which 
+can be provided via file or string.
+
+Configurations for this strategy are provided under `schema.init.json` namespace. 
+The easiest way to set up JSON schema initialization it by providing JSON schema 
+file path to `schema.init.json.file` or directly insert JSON schema into 
+`schema.init.json.string` configuration option.
+
+### JSON Schema Format
+
+Schema defined via JSON must be a deserialized JSON version of 
+`org.janusgraph.core.schema.json.definition.JsonSchemaDefinition` class where top
+level object elements will be the following:
+- `vertexLabels`
+- `edgeLabels`
+- `propertyKeys`
+- `compositeIndexes`
+- `vertexCentricEdgeIndexes`
+- `vertexCentricPropertyIndexes`
+- `mixedIndexes`
+
+Each value is an array representing a list of vertex labels, edges labels, property 
+keys, composite indexes, vertex-centric edge indexes, vertex-centric property indexes, 
+or mixed indexes.
+
+#### JSON Vertex Label Definition
+
+Each vertex label object consists of the following keys:
+- `label` - `string` datatype. (**Required**)
+- `staticVertex` - `boolean` datatype.
+- `partition` - `boolean` datatype.
+- `ttl` - `number` datatype.
+
+#### JSON Edge Label Definition
+
+Each edge label object consists of the following keys:
+- `label` - `string` datatype. (**Required**)
+- `multiplicity` - `string` datatype. Allowed values: `MULTI`, `SIMPLE`, `ONE2MANY`, `MANY2ONE`, `ONE2ONE`.
+- `unidirected` - `boolean` datatype.
+- `ttl` - `number` datatype.
+
+#### JSON Property Key Definition
+
+Each property key object consists of the following keys:
+- `key` - `string` datatype. (**Required**)
+- `className` - `string` datatype. This must be a full class path of the selected property datatype. For example, `java.lang.String`, `java.lang.Long`,`org.janusgraph.core.attribute.Geoshape`. (**Required**)
+- `cardinality` - `string` datatype. Allowed values: `SINGLE`, `LIST`, `SET`.
+- `ttl` - `number` datatype.
+
+#### JSON Composite Index Definition
+
+Each composite index object consists of the following keys:
+- `name` - `string` datatype. (**Required**)
+- `typeClass` - `string` datatype. Full class path of the datatype of an indexed element. Allowed values: `org.apache.tinkerpop.gremlin.structure.Vertex`, `org.apache.tinkerpop.gremlin.structure.Edge`. (**Required**)
+- `indexOnly` - `string` datatype. Vertex or Edge label.
+- `unique` - `boolean` datatype.
+- `consistency` - `string` datatype. Allowed values: `DEFAULT`, `LOCK`, `FORK`.
+- `keys` - an array of objects representing `org.janusgraph.core.schema.json.definition.index.JsonIndexedPropertyKeyDefinition` (see definition below after indexes definition). These are used index keys. (**Required**)
+- `inlinePropertyKeys` - an array of property keys to be inlined into the composite index. Currently supported for vertex composite indexes only. See [documentation](./schema/index-management/index-performance.md#inlining-vertex-properties-into-a-composite-index) for more information about this feature.
+
+#### JSON Mixed Index Definition
+
+Each mixed index object consists of the following keys:
+- `name` - `string` datatype. (**Required**)
+- `typeClass` - `string` datatype. Full class path of the datatype of an indexed element. Allowed values: `org.apache.tinkerpop.gremlin.structure.Vertex`, `org.apache.tinkerpop.gremlin.structure.Edge`. (**Required**)
+- `indexOnly` - `string` datatype. Vertex or Edge label.
+- `indexBackend` - `string` datatype. Name for index backend configuration. (**Required**)
+- `keys` - an array of objects representing `org.janusgraph.core.schema.json.definition.index.JsonIndexedPropertyKeyDefinition` (see definition below after indexes definition). These are used index keys. (**Required**)
+
+#### JSON Vertex-Centric Edge Index Definition
+
+Each vertex-centric edge index object consists of the following keys:
+- `name` - `string` datatype. (**Required**)
+- `propertyKeys` - an array of strings (each value has `string` datatype). These are the Edge properties which will be used for the index. (**Required**)
+- `order` - `string` datatype. Allowed values: `asc`, `desc`.
+- `indexedEdgeLabel` - `string` datatype. Edge label to be indexed. (**Required**)
+- `direction` - `string` datatype. Allowed values: `OUT`, `IN`, `BOTH`.
+
+#### JSON Vertex-Centric Property Index Definition
+
+Each vertex-centric property index object consists of the following keys:
+- `name` - `string` datatype. (**Required**)
+- `propertyKeys` - an array of strings (each value has `string` datatype). These are the meta-properties which will be used for the index. (**Required**)
+- `order` - `string` datatype. Allowed values: `asc`, `desc`.
+- `indexedPropertyKey` - `string` datatype. Property key to be indexed. (**Required**)
+
+#### JSON Definition of Property Keys defined in Composite and Mixed indexes (`keys`)
+
+Each property key object defined as `keys` representation of composite or mixed index consists of the following keys:
+- `propertyKey` - `string` datatype. (**Required**)
+- `parameters` - an array of objects representing `org.janusgraph.core.schema.json.definition.JsonParameterDefinition`. These are optional parameters to let index know of additional configurations for the property key. (See description below)
+
+#### JSON Definition of Parameters defined in Property Keys for Composite and Mixed indexes (`parameters`)
+
+Each parameter is a configuration for to let underlying index backend configure relative properties better. Each such parameter consists of the following keys:
+- `key` - `string` datatype. (**Required**)
+- `value` - `string` datatype. (**Required**)
+- `parser` - `string` datatype. This must be a full class pass of the parser which will be used to parse `value` of the parameter or a pre-defined shortcut. This parser must implement `org.janusgraph.core.schema.json.parser.JsonParameterParser` interface and have a parameterless constructor. If none is provided then `string` parser is used by default.
+
+Pre-defined `parser` shortcuts:
+- `string` - doesn't change `value` and uses it as is (`String` datatype).
+- `enum` - replaces the provided string (defined as `<full class path>.<enum option>`) to actual enum value. 
+For example, if `value` has a string `org.janusgraph.core.schema.Mapping.STRING` it will be replaced to actual `STRING` enum, 
+and it won't be treated as a string.
+- `boolean` - parses value to `Boolean`.
+- `byte` - parses value to `Byte`.
+- `short` - parses value to `Short`.
+- `integer` - parses value to `Integer`.
+- `long` - parses value to `Long`.
+- `float` - parses value to `Float`.
+- `double` - parses value to `Double`.
+
+Parameters may include [custom keys](../index-backend/field-mapping.md#custom-parameters) defined as `ParameterType.customParameterName("<your custom key>")`. 
+To define such keys in JSON it's necessary to use specific prefix for `key` - %\`custom%\` (in total the prefix consists of 10 characters. 
+In case some characters are not rendered correctly here, you can always reference to `org.janusgraph.graphdb.types.ParameterType.CUSTOM_PARAMETER_PREFIX` 
+to find out those 10 prefix characters).
+As such, to define custom keys like `similarity` you should write your key as: %\`custom%\`similarity
+
+### JSON Schema definition example
+
+Following the rules above (defined in `JSON Schema Format`) an example of JSON schema definition could look like the one below.
+
+!!! note
+    Below schema is valid and tested using Cassandra and ElasticSearch. It uses some of the parameters related to 
+    either eventual consistent databases and ElasticSearch in particular. Thus, some of the database specific schema definitions 
+    may not work properly with other databases (like `similarity` or `string-analyzer`).
+    The schema below is used for demonstration purposes only.
+
+```json
+{
+    "vertexLabels": [
+        {
+            "label": "normalVertex"
+        },
+        {
+            "label": "partitionedVertex",
+            "partition": true
+        },
+        {
+            "label": "unmodifiableVertex",
+            "staticVertex": true
+        },
+        {
+            "label": "temporaryVertexForTwoHours",
+            "staticVertex": true,
+            "ttl": 7200000
+        }
+    ],
+    "edgeLabels": [
+        {
+            "label": "normalSimpleEdge",
+            "multiplicity": "SIMPLE",
+            "unidirected": false
+        },
+        {
+            "label": "unidirectedMultiEdge",
+            "multiplicity": "MULTI",
+            "unidirected": true
+        },
+        {
+            "label": "temporaryEdgeForOneHour",
+            "ttl": 3600000
+        },
+        {
+            "label": "edgeWhichUsesLocksInEventualConsistentDBs",
+            "consistency": "LOCK"
+        },
+        {
+            "label": "edgeWhichUsesForkingInEventualConsistentDBs",
+            "consistency": "FORK"
+        }
+    ],
+    "propertyKeys": [
+        {
+            "key": "normalProperty",
+            "className": "java.lang.Long"
+        },
+        {
+            "key": "stringProperty",
+            "className": "java.lang.String",
+            "cardinality": "SINGLE"
+        },
+        {
+            "key": "anotherStringProperty",
+            "className": "java.lang.String",
+            "cardinality": "SINGLE"
+        },
+        {
+            "key": "listProperty",
+            "className": "java.lang.Long",
+            "cardinality": "LIST"
+        },
+        {
+            "key": "geoshapeProperty",
+            "className": "org.janusgraph.core.attribute.Geoshape"
+        },
+        {
+            "key": "setProperty",
+            "className": "java.lang.String",
+            "cardinality": "SET"
+        },
+        {
+            "key": "propertyWhichUsesLocksInEventualConsistentDBs",
+            "className": "java.lang.Long",
+            "cardinality": "SET",
+            "consistency": "LOCK"
+        },
+        {
+            "key": "temporaryPropertyForOneHour",
+            "className": "java.lang.Long",
+            "ttl": 3600000
+        }
+    ],
+    "compositeIndexes": [
+        {
+            "name": "simpleCompositeIndex",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "keys": [
+                {
+                    "propertyKey": "normalProperty"
+                }
+            ]
+        },
+        {
+            "name": "indexOnlyForNormalVerticesOnListProperty",
+            "indexOnly": "normalVertex",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "keys": [
+                {
+                    "propertyKey": "listProperty"
+                }
+            ]
+        },
+        {
+            "name": "compositeIndexOnEdge",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Edge",
+            "keys": [
+                {
+                    "propertyKey": "normalProperty"
+                }
+            ]
+        },
+        {
+            "name": "uniqueCompositeIndexWithLocking",
+            "indexOnly": "unmodifiableVertex",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "unique": true,
+            "consistency": "LOCK",
+            "keys": [
+                {
+                    "propertyKey": "stringProperty"
+                }
+            ]
+        },
+        {
+            "name": "multiKeysCompositeIndex",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "keys": [
+                {
+                    "propertyKey": "normalProperty"
+                },
+                {
+                    "propertyKey": "anotherStringProperty"
+                }
+            ]
+        },
+        {
+            "name": "compositeIndexWithInlinedProperties",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "keys": [
+                {
+                    "propertyKey": "setProperty"
+                }
+            ],
+            "inlinePropertyKeys": ["normalProperty", "stringProperty", "anotherStringProperty"]
+        }
+    ],
+    "vertexCentricEdgeIndexes": [
+        {
+            "name": "vertexCentricBothDirectionsEdgeIndex",
+            "indexedEdgeLabel": "normalSimpleEdge",
+            "direction": "BOTH",
+            "propertyKeys": [
+                "normalProperty"
+            ],
+            "order": "asc"
+        },
+        {
+            "name": "vertexCentricUnidirectedEdgeIndexOnMultipleProperties",
+            "indexedEdgeLabel": "unidirectedMultiEdge",
+            "direction": "OUT",
+            "propertyKeys": [
+                "stringProperty",
+                "anotherStringProperty"
+            ],
+            "order": "desc"
+        }
+    ],
+    "vertexCentricPropertyIndexes": [
+        {
+            "name": "normalVertexCentricPropertyKey",
+            "indexedPropertyKey": "listProperty",
+            "propertyKeys": [
+                "normalProperty"
+            ],
+            "order": "asc"
+        }
+    ],
+    "mixedIndexes": [
+        {
+            "name": "simpleMixedIndexOnMultipleProperties",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "indexBackend": "search",
+            "keys": [
+                {
+                    "propertyKey": "normalProperty"
+                },
+                {
+                    "propertyKey": "geoshapeProperty"
+                }
+            ]
+        },
+        {
+            "name": "mixedIndexWithParametersOnProperties",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "indexBackend": "search",
+            "keys": [
+                {
+                    "propertyKey": "stringProperty",
+                    "parameters": [
+                        {
+                            "key": "string-analyzer",
+                            "value": "standard",
+                            "parser": "string"
+                        },
+                        {
+                            "key": "mapping",
+                            "value": "org.janusgraph.core.schema.Mapping.STRING",
+                            "parser": "enum"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "mixedIndexWithCustomParameterKeyAndParserFullClassPath",
+            "indexOnly": "unidirectedMultiEdge",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Edge",
+            "indexBackend": "search",
+            "keys": [
+                {
+                    "propertyKey": "anotherStringProperty",
+                    "parameters": [
+                        {
+                            "key": "%`custom%`similarity",
+                            "value": "boolean",
+                            "parser": "string"
+                        },
+                        {
+                            "key": "mapping",
+                            "value": "org.janusgraph.core.schema.Mapping.TEXTSTRING",
+                            "parser": "org.janusgraph.core.schema.json.parser.EnumJsonParameterParser"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
+```
+
+### JSON schema initialization flow
+
+Currently, JSON schema initialization flow is simple and doesn't include any schema update or schema migration features. 
+The flow is split on multiple phases:
+1) Creation of simple elements: `PropertyKey`, `VertexLabel`, `EdgeLabel`.
+2) Creation of indices: Composite indexes, Vertex-centric Edge indexes, Vertex-centric Property indexes, Mixed indexes.
+3) Indexes activation phase (configured via `schema.init.json.indices-activation`).
+
+!!! note
+    Current implementation of JSON schema importer only creates elements, but it never updates them even if you change 
+    definition of your property, edge, vertex, or index. If an element with such name exists - schema importer will skip it 
+    without doing any updates on the element. Also, it never deletes any existing schema elements from the graph.
+    For schema migration and removal processes use `graph.openManagement()` directly.
+
+Users who struggle to initialize schema due to created zombie JanusGraph instances in the cluster may leverage 
+configuration option `schema.init.json.force-close-other-instances`. This option will automatically close all 
+JanusGraph instance in the cluster (including activate instances). 
+
+!!! warning
+    When using `schema.init.json.force-close-other-instances` JanusGraph will force-close any other instances in 
+    the cluster. However, they may not know about it and continue to work in the cluster without receiving any schema 
+    updates. This could lead to split brain problem and corrupt current data. 
+    It's advised to use `graph.unique-instance-id` and `graph.replace-instance-if-exists` options instead to prevent 
+    creation of JanusGraph zombie instances.
+
+### JSON Schema Definition API
+
+It's also possible to manually trigger JSON schema definition API instead of relaying on startup schema 
+initialization process. All helper methods for JSON schema initialization are located in 
+`org.janusgraph.core.schema.JsonSchemaInitStrategy`.
+
+```groovy
+// Schema from file
+JsonSchemaInitStrategy.initializeSchemaFromFile(graph, "/path/to/schema.json")
+
+// Schema from string
+JsonSchemaInitStrategy.initializeSchemaFromString(graph, "{ \"vertexLabels\": [ { \"label\": \"my_vertex\" } ] }")
+```
+
+Also, there are additional `initializeSchemaFromFile` and `initializeSchemaFromString` methods where it's possible to 
+provide all configuration options directly instead of fetching them from the configuration of the graph:
+- `initializeSchemaFromFile(JanusGraph graph, boolean createSchemaElements, boolean createSchemaIndices, IndicesActivationType indicesActivationType, boolean forceRollBackActiveTransactions, boolean forceCloseOtherInstances, long indexStatusTimeout, String jsonSchemaFilePath)`
+- `initializeSchemaFromString(JanusGraph graph, boolean createSchemaElements, boolean createSchemaIndices, IndicesActivationType indicesActivationType, boolean forceRollBackActiveTransactions, boolean forceCloseOtherInstances, long indexStatusTimeout, String jsonSchemaString)`

--- a/janusgraph-backend-testutils/src/main/resources/test_simple_schema_example.json
+++ b/janusgraph-backend-testutils/src/main/resources/test_simple_schema_example.json
@@ -1,0 +1,48 @@
+{
+  "vertexLabels": [
+    {
+      "label": "organization"
+    },
+    {
+      "label": "user"
+    }
+  ],
+
+  "edgeLabels": [
+    {
+      "label": "connects",
+      "multiplicity": "SIMPLE",
+      "unidirected": false
+    },
+    {
+      "label": "viewed",
+      "multiplicity": "MULTI",
+      "unidirected": true
+    }
+  ],
+
+  "propertyKeys": [
+    {
+      "key": "time",
+      "className": "java.lang.Long"
+    },
+    {
+      "key": "doubleProp",
+      "className": "java.lang.Double"
+    },
+    {
+      "key": "integerProp",
+      "className": "java.lang.Integer"
+    },
+    {
+      "key": "longPropCardinalityList",
+      "className": "java.lang.Long",
+      "cardinality": "LIST"
+    },
+    {
+      "key": "name",
+      "className": "java.lang.String",
+      "cardinality": "SINGLE"
+    }
+  ]
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/ConfiguredGraphFactory.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/ConfiguredGraphFactory.java
@@ -18,9 +18,9 @@ import com.google.common.base.Preconditions;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.MapConfiguration;
 import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.janusgraph.core.util.GraphFactoryUtils;
 import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.configuration.backend.CommonsConfiguration;
-import org.janusgraph.graphdb.configuration.builder.GraphDatabaseConfigurationBuilder;
 import org.janusgraph.graphdb.database.StandardJanusGraph;
 import org.janusgraph.graphdb.database.management.ManagementSystem;
 import org.janusgraph.graphdb.management.ConfigurationManagementGraph;
@@ -87,7 +87,7 @@ public class ConfiguredGraphFactory {
         final JanusGraphManager jgm = JanusGraphManagerUtility.getInstance();
         Preconditions.checkNotNull(jgm, JANUS_GRAPH_MANAGER_EXPECTED_STATE_MSG);
         final CommonsConfiguration config = new CommonsConfiguration(ConfigurationUtil.loadMapConfiguration(templateConfigMap));
-        final JanusGraph g = (JanusGraph) jgm.openGraph(graphName, (String gName) -> new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(config)));
+        final JanusGraph g = (JanusGraph) jgm.openGraph(graphName, (String gName) -> GraphFactoryUtils.defineSchemaAndStart((config)));
         configManagementGraph.createConfiguration(new MapConfiguration(templateConfigMap));
         return g;
     }
@@ -112,7 +112,7 @@ public class ConfiguredGraphFactory {
         final JanusGraphManager jgm = JanusGraphManagerUtility.getInstance();
         Preconditions.checkNotNull(jgm, JANUS_GRAPH_MANAGER_EXPECTED_STATE_MSG);
         final CommonsConfiguration config = new CommonsConfiguration(ConfigurationUtil.loadMapConfiguration(graphConfigMap));
-        return (JanusGraph) jgm.openGraph(graphName, (String gName) -> new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(config)));
+        return (JanusGraph) jgm.openGraph(graphName, (String gName) -> GraphFactoryUtils.defineSchemaAndStart(config));
     }
 
     /**

--- a/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphFactory.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphFactory.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.janusgraph.core.log.LogProcessorFramework;
 import org.janusgraph.core.log.TransactionRecovery;
+import org.janusgraph.core.util.GraphFactoryUtils;
 import org.janusgraph.diskstorage.Backend;
 import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.StandardStoreManager;
@@ -33,7 +34,6 @@ import org.janusgraph.diskstorage.configuration.ReadConfiguration;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
 import org.janusgraph.diskstorage.configuration.backend.CommonsConfiguration;
 import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
-import org.janusgraph.graphdb.configuration.builder.GraphDatabaseConfigurationBuilder;
 import org.janusgraph.graphdb.database.StandardJanusGraph;
 import org.janusgraph.graphdb.log.StandardLogProcessorFramework;
 import org.janusgraph.graphdb.log.StandardTransactionLogProcessor;
@@ -162,7 +162,7 @@ public class JanusGraphFactory {
         final JanusGraphManager jgm = JanusGraphManagerUtility.getInstance();
         if (null != graphName) {
             Preconditions.checkNotNull(jgm, JANUS_GRAPH_MANAGER_EXPECTED_STATE_MSG);
-            return (JanusGraph) jgm.openGraph(graphName, gName -> new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(configuration)));
+            return (JanusGraph) jgm.openGraph(graphName, gName -> GraphFactoryUtils.defineSchemaAndStart(configuration));
         } else {
             if (jgm != null) {
                 log.warn("You should supply \"graph.graphname\" in your .properties file configuration if you are opening " +
@@ -173,7 +173,7 @@ public class JanusGraphFactory {
                          "\"graph.graphname\" so these graphs should be accessed dynamically by supplying a .properties file here " +
                          "or by using the ConfiguredGraphFactory.");
             }
-            return new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(configuration));
+            return GraphFactoryUtils.defineSchemaAndStart(configuration);
         }
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/IndicesActivationType.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/IndicesActivationType.java
@@ -1,0 +1,36 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema;
+
+import org.janusgraph.graphdb.configuration.ConfigName;
+
+public enum IndicesActivationType implements ConfigName {
+    SKIP_ACTIVATION("skip_activation"),
+    REINDEX_AND_ENABLE_UPDATED_ONLY("reindex_and_enable_updated_only"),
+    REINDEX_AND_ENABLE_NON_ENABLED("reindex_and_enable_non_enabled"),
+    FORCE_ENABLE_UPDATED_ONLY("force_enable_updated_only"),
+    FORCE_ENABLE_NON_ENABLED("force_enable_non_enabled");
+
+    private final String configurationOptionName;
+
+    IndicesActivationType(String configurationOptionName){
+        this.configurationOptionName = configurationOptionName;
+    }
+
+    @Override
+    public String getConfigName() {
+        return configurationOptionName;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/JsonSchemaInitStrategy.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/JsonSchemaInitStrategy.java
@@ -1,0 +1,265 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema;
+
+import org.apache.commons.lang3.StringUtils;
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.Namifiable;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.RelationType;
+import org.janusgraph.core.schema.json.creator.GeneralJsonSchemaCreator;
+import org.janusgraph.core.schema.json.creator.JsonSchemaCreationContext;
+import org.janusgraph.core.schema.json.creator.SchemaCreationException;
+import org.janusgraph.core.schema.json.definition.JsonSchemaDefinition;
+import org.janusgraph.core.schema.json.definition.index.AbstractJsonGraphCentricIndexDefinition;
+import org.janusgraph.core.schema.json.definition.index.AbstractJsonIndexDefinition;
+import org.janusgraph.core.schema.json.definition.index.AbstractJsonVertexCentricIndexDefinition;
+import org.janusgraph.core.schema.json.definition.index.JsonVertexCentricEdgeIndexDefinition;
+import org.janusgraph.core.schema.json.definition.index.JsonVertexCentricPropertyIndexDefinition;
+import org.janusgraph.core.util.JsonUtil;
+import org.janusgraph.core.util.ManagementUtil;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.janusgraph.graphdb.database.StandardJanusGraph;
+import org.janusgraph.graphdb.database.management.ManagementSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class JsonSchemaInitStrategy implements SchemaInitStrategy{
+
+    private static final Logger LOG = LoggerFactory.getLogger(JsonSchemaInitStrategy.class);
+
+    @Override
+    public JanusGraph initializeSchemaAndStart(GraphDatabaseConfiguration graphDatabaseConfiguration) {
+
+        JanusGraph graph = new StandardJanusGraph(graphDatabaseConfiguration);
+
+        try{
+            if(StringUtils.isNotEmpty(graphDatabaseConfiguration.getSchemaInitJsonString())) {
+
+                initializeSchemaFromString(graph, graphDatabaseConfiguration.getSchemaInitJsonString());
+
+            } else if(StringUtils.isNotEmpty(graphDatabaseConfiguration.getSchemaInitJsonFile())){
+
+                initializeSchemaFromFile(graph, graphDatabaseConfiguration.getSchemaInitJsonFile());
+
+            } else {
+                throw new SchemaCreationException("When JSON schema initialization is enabled it's necessary to provide either JSON file or string for schema initialization.");
+            }
+        } catch (Throwable throwable){
+            graph.close();
+            if(throwable instanceof SchemaCreationException){
+                throw (SchemaCreationException)throwable;
+            }
+            throw new SchemaCreationException(throwable);
+        }
+
+        return graph;
+    }
+
+    public static void initializeSchemaFromFile(JanusGraph graph, String jsonSchemaFilePath) {
+        GraphDatabaseConfiguration graphDatabaseConfiguration = ((StandardJanusGraph) graph).getConfiguration();
+        IndicesActivationType indicesActivationType = graphDatabaseConfiguration.getSchemaInitJsonIndicesActivationType();
+        boolean createSchemaElements = !graphDatabaseConfiguration.getSchemaInitJsonSkipElements();
+        boolean createSchemaIndices = !graphDatabaseConfiguration.getSchemaInitJsonSkipIndices();
+        long indexStatusTimeout = graphDatabaseConfiguration.getSchemaInitJsonIndexStatusAwaitTimeout();
+
+        initializeSchemaFromFile(graph, createSchemaElements, createSchemaIndices, indicesActivationType, true,
+            graphDatabaseConfiguration.getSchemaInitJsonForceCloseOtherInstances(), indexStatusTimeout, jsonSchemaFilePath);
+    }
+
+    public static void initializeSchemaFromString(JanusGraph graph, String jsonSchemaString) {
+        GraphDatabaseConfiguration graphDatabaseConfiguration = ((StandardJanusGraph) graph).getConfiguration();
+        IndicesActivationType indicesActivationType = graphDatabaseConfiguration.getSchemaInitJsonIndicesActivationType();
+        boolean createSchemaElements = !graphDatabaseConfiguration.getSchemaInitJsonSkipElements();
+        boolean createSchemaIndices = !graphDatabaseConfiguration.getSchemaInitJsonSkipIndices();
+        long indexStatusTimeout = graphDatabaseConfiguration.getSchemaInitJsonIndexStatusAwaitTimeout();
+
+        initializeSchemaFromString(graph, createSchemaElements, createSchemaIndices, indicesActivationType, true,
+            graphDatabaseConfiguration.getSchemaInitJsonForceCloseOtherInstances(), indexStatusTimeout, jsonSchemaString);
+    }
+
+    public static void initializeSchemaFromFile(JanusGraph graph, boolean createSchemaElements, boolean createSchemaIndices,
+                                                IndicesActivationType indicesActivationType,
+                                                boolean forceRollBackActiveTransactions, boolean forceCloseOtherInstances,
+                                                long indexStatusTimeout, String jsonSchemaFilePath) {
+
+        JsonSchemaDefinition generalDefinition;
+        try {
+            generalDefinition = JsonUtil.jsonFilePathToObject(jsonSchemaFilePath, JsonSchemaDefinition.class);
+        } catch (IOException e) {
+            throw new SchemaCreationException(e);
+        }
+
+        initializeSchema(graph, createSchemaElements, createSchemaIndices, indicesActivationType,
+            forceRollBackActiveTransactions, forceCloseOtherInstances, indexStatusTimeout, generalDefinition);
+    }
+
+    public static void initializeSchemaFromString(JanusGraph graph, boolean createSchemaElements, boolean createSchemaIndices,
+                                                  IndicesActivationType indicesActivationType,
+                                                  boolean forceRollBackActiveTransactions, boolean forceCloseOtherInstances,
+                                                  long indexStatusTimeout, String jsonSchemaString) {
+
+        JsonSchemaDefinition generalDefinition;
+        try {
+            generalDefinition = JsonUtil.jsonStringToObject(jsonSchemaString, JsonSchemaDefinition.class);
+        } catch (IOException e) {
+            throw new SchemaCreationException(e);
+        }
+
+        initializeSchema(graph, createSchemaElements, createSchemaIndices, indicesActivationType,
+            forceRollBackActiveTransactions, forceCloseOtherInstances, indexStatusTimeout, generalDefinition);
+    }
+
+    public static void initializeSchema(JanusGraph graph, boolean createSchemaElements, boolean createSchemaIndices,
+                                        IndicesActivationType indicesActivationType,
+                                        boolean forceRollBackActiveTransactions, boolean forceCloseOtherInstances,
+                                        long indexStatusTimeout, JsonSchemaDefinition generalDefinition) {
+
+        LOG.info("Starting schema initialization.");
+
+        if(forceCloseOtherInstances){
+            ManagementUtil.forceCloseOtherInstances(graph);
+        }
+
+        if(forceRollBackActiveTransactions){
+            ManagementUtil.forceRollbackAllTransactions(graph);
+        }
+
+        final ManagementSystem schemaCreationMgmt = (ManagementSystem) graph.openManagement();
+        JsonSchemaCreationContext schemaCreationContext = new JsonSchemaCreationContext(
+            schemaCreationMgmt,
+            createSchemaElements,
+            createSchemaIndices);
+
+        GeneralJsonSchemaCreator generalJsonSchemaCreator = new GeneralJsonSchemaCreator();
+
+        // initialize schema
+        generalJsonSchemaCreator.create(generalDefinition, schemaCreationContext);
+
+        List<String> updatedButNonEnabledIndicesNames = schemaCreationContext.getCreatedOrUpdatedIndices().stream()
+            .filter(indexDefinition -> !isIndexEnabled(indexDefinition, schemaCreationMgmt))
+            .map(AbstractJsonIndexDefinition::getName)
+            .collect(Collectors.toList());
+
+        schemaCreationMgmt.commit();
+
+        // process indices activation (re-index and enable)
+        processIndicesActivation(graph, updatedButNonEnabledIndicesNames, indicesActivationType, indexStatusTimeout);
+
+        LOG.info("Schema initialization completed.");
+    }
+
+    private static void processIndicesActivation(JanusGraph graph, List<String> updatedButNonEnabledIndicesNames,
+                                                 IndicesActivationType indicesActivationType, long indexStatusTimeout){
+
+        if(IndicesActivationType.SKIP_ACTIVATION.equals(indicesActivationType)){
+            return;
+        }
+
+        ManagementSystem schemaFetchMgmt = (ManagementSystem) graph.openManagement();
+
+        List<JanusGraphIndex> nonEnabledGraphIndices = schemaFetchMgmt.getGraphIndices(SchemaStatus.ENABLED);
+        List<RelationTypeIndex> nonEnabledRelationTypeIndices = schemaFetchMgmt.getVertexCentricIndices(SchemaStatus.ENABLED);
+
+        if(IndicesActivationType.REINDEX_AND_ENABLE_UPDATED_ONLY.equals(indicesActivationType) || IndicesActivationType.FORCE_ENABLE_UPDATED_ONLY.equals(indicesActivationType)){
+            List<JanusGraphIndex> nonEnabledGraphIndicesCopy = nonEnabledGraphIndices;
+            List<RelationTypeIndex> nonEnabledRelationTypeIndicesCopy = nonEnabledRelationTypeIndices;
+            nonEnabledGraphIndices = new ArrayList<>(nonEnabledGraphIndices.size());
+            nonEnabledRelationTypeIndices = new ArrayList<>(nonEnabledRelationTypeIndices.size());
+            for (JanusGraphIndex index : nonEnabledGraphIndicesCopy) {
+                if(updatedButNonEnabledIndicesNames.contains(index.name())){
+                    nonEnabledGraphIndices.add(index);
+                }
+            }
+            for (RelationTypeIndex index : nonEnabledRelationTypeIndicesCopy) {
+                if(updatedButNonEnabledIndicesNames.contains(index.name())){
+                    nonEnabledRelationTypeIndices.add(index);
+                }
+            }
+        }
+
+        List<String> nonEnabledGraphIndexNames = nonEnabledGraphIndices.stream().map(JanusGraphIndex::name).collect(Collectors.toList());
+        Map<String, String> nonEnabledRelationTypeIndexNamesAndTypes = nonEnabledRelationTypeIndices.stream().collect(Collectors.toMap(Namifiable::name, o -> o.getType().name()));
+
+        schemaFetchMgmt.rollback();
+
+        List<String> nonEnabledIndexNames = Stream.concat(nonEnabledGraphIndexNames.stream(), nonEnabledRelationTypeIndexNamesAndTypes.keySet().stream()).collect(Collectors.toList());
+
+        if(!nonEnabledIndexNames.isEmpty()){
+
+            String nonEnabledIndexNamesJoined = String.join(", ", nonEnabledIndexNames);
+            if(!nonEnabledIndexNames.isEmpty() && LOG.isInfoEnabled()){
+                LOG.info("Found {} non-enabled indices. Awaiting for their status updates. Indexes [{}].",
+                    nonEnabledIndexNames.size(), nonEnabledIndexNamesJoined);
+            }
+
+            if(IndicesActivationType.REINDEX_AND_ENABLE_UPDATED_ONLY.equals(indicesActivationType) || IndicesActivationType.REINDEX_AND_ENABLE_NON_ENABLED.equals(indicesActivationType)){
+
+                ManagementUtil.reindexAndEnableIndices(graph, nonEnabledGraphIndexNames, nonEnabledRelationTypeIndexNamesAndTypes, indexStatusTimeout);
+
+            } else if(IndicesActivationType.FORCE_ENABLE_UPDATED_ONLY.equals(indicesActivationType) || IndicesActivationType.FORCE_ENABLE_NON_ENABLED.equals(indicesActivationType)){
+
+                ManagementUtil.forceEnableIndices(graph, nonEnabledGraphIndexNames, nonEnabledRelationTypeIndexNamesAndTypes, indexStatusTimeout);
+
+            } else {
+                throw new IllegalStateException("Unknown indicesActivationType: " + indicesActivationType);
+            }
+        }
+    }
+
+    private static boolean isIndexEnabled(AbstractJsonIndexDefinition createdIndexesDefinition, JanusGraphManagement graphManagement){
+        return isIndexHasStatus(createdIndexesDefinition, graphManagement, SchemaStatus.ENABLED);
+    }
+
+    private static boolean isIndexHasStatus(AbstractJsonIndexDefinition createdIndexesDefinition, JanusGraphManagement graphManagement, SchemaStatus schemaStatus){
+        if(createdIndexesDefinition instanceof AbstractJsonVertexCentricIndexDefinition){
+
+            AbstractJsonVertexCentricIndexDefinition vertexCentricIndex =
+                (AbstractJsonVertexCentricIndexDefinition) createdIndexesDefinition;
+            String indexedElement;
+            if(vertexCentricIndex instanceof JsonVertexCentricEdgeIndexDefinition){
+                indexedElement = ((JsonVertexCentricEdgeIndexDefinition) vertexCentricIndex).getIndexedEdgeLabel();
+            } else if (vertexCentricIndex instanceof JsonVertexCentricPropertyIndexDefinition){
+                indexedElement = ((JsonVertexCentricPropertyIndexDefinition) vertexCentricIndex).getIndexedPropertyKey();
+            } else {
+                throw new SchemaCreationException("Unknown index type definition: "+createdIndexesDefinition.getClass().getName());
+            }
+            RelationType relationType = graphManagement.getRelationType(indexedElement);
+            RelationTypeIndex relationIndex = graphManagement.getRelationIndex(relationType, vertexCentricIndex.getName());
+            return schemaStatus.equals(relationIndex.getIndexStatus());
+
+        } else if (createdIndexesDefinition instanceof AbstractJsonGraphCentricIndexDefinition) {
+
+            JanusGraphIndex janusGraphIndex = graphManagement.getGraphIndex(createdIndexesDefinition.getName());
+            for(PropertyKey propertyKey : janusGraphIndex.getFieldKeys()){
+                if(!schemaStatus.equals(janusGraphIndex.getIndexStatus(propertyKey))){
+                    return false;
+                }
+            }
+            return true;
+
+        } else {
+            throw new SchemaCreationException("Unknown index type definition: "+createdIndexesDefinition.getClass().getName());
+        }
+    }
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/NoneSchemaInitStrategy.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/NoneSchemaInitStrategy.java
@@ -1,0 +1,29 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema;
+
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.janusgraph.graphdb.database.StandardJanusGraph;
+
+/**
+ * Skips any schema initialization on startup
+ */
+public class NoneSchemaInitStrategy implements SchemaInitStrategy{
+    @Override
+    public JanusGraph initializeSchemaAndStart(GraphDatabaseConfiguration graphDatabaseConfiguration) {
+        return new StandardJanusGraph(graphDatabaseConfiguration);
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/SchemaInitStrategy.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/SchemaInitStrategy.java
@@ -1,0 +1,24 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema;
+
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+
+public interface SchemaInitStrategy {
+
+    JanusGraph initializeSchemaAndStart(GraphDatabaseConfiguration graphDatabaseConfiguration);
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/SchemaInitType.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/SchemaInitType.java
@@ -1,0 +1,33 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema;
+
+import org.janusgraph.graphdb.configuration.ConfigName;
+
+public enum SchemaInitType implements ConfigName {
+        NONE("none"), // skips any schema initialization during startup
+        JSON("json"); // initializes schema using provided JSON file
+
+    private final String configurationOptionName;
+
+    SchemaInitType(String configurationOptionName){
+        this.configurationOptionName = configurationOptionName;
+    }
+
+    @Override
+    public String getConfigName() {
+        return configurationOptionName;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/SchemaInitializationManager.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/SchemaInitializationManager.java
@@ -1,0 +1,78 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema;
+
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.JanusGraphFactory;
+import org.janusgraph.core.schema.json.creator.SchemaCreationException;
+import org.janusgraph.diskstorage.BackendException;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.janusgraph.graphdb.database.StandardJanusGraph;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SchemaInitializationManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SchemaInitializationManager.class);
+
+    public static final Map<String, SchemaInitStrategy> SCHEMA_INIT_STRATEGIES;
+
+    static {
+        SCHEMA_INIT_STRATEGIES = new HashMap<>(1);
+        SCHEMA_INIT_STRATEGIES.put(SchemaInitType.NONE.getConfigName(), new NoneSchemaInitStrategy());
+        SCHEMA_INIT_STRATEGIES.put(SchemaInitType.JSON.getConfigName(), new JsonSchemaInitStrategy());
+    }
+
+    public static JanusGraph initializeSchemaAndStart(GraphDatabaseConfiguration graphDatabaseConfiguration){
+
+        // drop schema before init is selected
+        if(graphDatabaseConfiguration.isDropSchemaBeforeInit()){
+            try {
+                LOG.info("Dropping current JanusGraph schema and data.");
+                JanusGraphFactory.drop(new StandardJanusGraph(graphDatabaseConfiguration));
+                LOG.info("Current JanusGraph schema and data were removed.");
+            } catch (BackendException e) {
+                throw new SchemaCreationException(e);
+            }
+        }
+
+        // get schema initialization strategy
+        String schemaInitStrategyPath = graphDatabaseConfiguration.getSchemaInitStrategy();
+        SchemaInitStrategy schemaInitStrategy = SCHEMA_INIT_STRATEGIES.get(schemaInitStrategyPath);
+        if(schemaInitStrategy == null){
+            try {
+                Class schemaInitStrategyClass = Class.forName(schemaInitStrategyPath);
+                schemaInitStrategy = (SchemaInitStrategy) schemaInitStrategyClass.getDeclaredConstructor().newInstance();
+            } catch (ClassNotFoundException | InvocationTargetException | InstantiationException |
+                     IllegalAccessException | NoSuchMethodException e) {
+                throw new SchemaCreationException(e);
+            }
+        }
+
+        // initialize schema
+        JanusGraph graph = schemaInitStrategy.initializeSchemaAndStart(graphDatabaseConfiguration);
+
+        if(graph == null){
+            graph = new StandardJanusGraph(graphDatabaseConfiguration);
+        }
+
+        return graph;
+    }
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/GeneralJsonSchemaCreator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/GeneralJsonSchemaCreator.java
@@ -1,0 +1,113 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.creator;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.janusgraph.core.schema.json.creator.index.JsonCompositeIndexCreator;
+import org.janusgraph.core.schema.json.creator.index.JsonMixedIndexCreator;
+import org.janusgraph.core.schema.json.creator.index.JsonVertexCentricEdgeIndexCreator;
+import org.janusgraph.core.schema.json.creator.index.JsonVertexCentricPropertyIndexCreator;
+import org.janusgraph.core.schema.json.definition.JsonEdgeLabelDefinition;
+import org.janusgraph.core.schema.json.definition.JsonPropertyKeyDefinition;
+import org.janusgraph.core.schema.json.definition.JsonSchemaDefinition;
+import org.janusgraph.core.schema.json.definition.JsonVertexLabelDefinition;
+import org.janusgraph.core.schema.json.definition.index.JsonCompositeIndexDefinition;
+import org.janusgraph.core.schema.json.definition.index.JsonMixedIndexDefinition;
+import org.janusgraph.core.schema.json.definition.index.JsonVertexCentricEdgeIndexDefinition;
+import org.janusgraph.core.schema.json.definition.index.JsonVertexCentricPropertyIndexDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GeneralJsonSchemaCreator implements JsonSchemaCreator<JsonSchemaDefinition>{
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GeneralJsonSchemaCreator.class);
+
+    private final JsonPropertySchemaCreator propertySchemaCreator = new JsonPropertySchemaCreator();
+    private final JsonVertexSchemaCreator vertexSchemaCreator = new JsonVertexSchemaCreator();
+    private final JsonEdgeSchemaCreator edgeSchemaCreator = new JsonEdgeSchemaCreator();
+    private final JsonCompositeIndexCreator compositeIndexCreator = new JsonCompositeIndexCreator();
+    private final JsonMixedIndexCreator mixedIndexCreator = new JsonMixedIndexCreator();
+    private final JsonVertexCentricEdgeIndexCreator vertexCentricEdgeIndexCreator = new JsonVertexCentricEdgeIndexCreator();
+    private final JsonVertexCentricPropertyIndexCreator vertexCentricPropertyIndexCreator = new JsonVertexCentricPropertyIndexCreator();
+
+    @Override
+    public boolean create(JsonSchemaDefinition generalDefinition, JsonSchemaCreationContext context) {
+
+        LOGGER.info("Starting general schema initialization.");
+
+        boolean wasUpdated = false;
+
+        if(context.isCreateSchemaElements()){
+            // Create all properties
+            if(CollectionUtils.isNotEmpty(generalDefinition.getPropertyKeys())){
+                for(JsonPropertyKeyDefinition definition : generalDefinition.getPropertyKeys()){
+                    wasUpdated |= propertySchemaCreator.create(definition, context);
+                }
+            }
+
+            // Create all vertices
+            if(CollectionUtils.isNotEmpty(generalDefinition.getVertexLabels())){
+                for(JsonVertexLabelDefinition definition : generalDefinition.getVertexLabels()){
+                    wasUpdated |= vertexSchemaCreator.create(definition, context);
+                }
+            }
+
+            // Create all edges
+            if(CollectionUtils.isNotEmpty(generalDefinition.getEdgeLabels())){
+                for(JsonEdgeLabelDefinition definition : generalDefinition.getEdgeLabels()){
+                    wasUpdated |= edgeSchemaCreator.create(definition, context);
+                }
+            }
+        }
+
+        if(context.isCreateIndices()){
+            // Create all composite indices
+            if(CollectionUtils.isNotEmpty(generalDefinition.getCompositeIndexes())){
+                for(JsonCompositeIndexDefinition definition : generalDefinition.getCompositeIndexes()){
+                    wasUpdated |= compositeIndexCreator.create(definition, context);
+                }
+            }
+
+            // Create all mixed indices
+            if(CollectionUtils.isNotEmpty(generalDefinition.getMixedIndexes())){
+                for(JsonMixedIndexDefinition definition : generalDefinition.getMixedIndexes()){
+                    wasUpdated |= mixedIndexCreator.create(definition, context);
+                }
+            }
+
+            // Create all vertex-centric edge indices
+            if(CollectionUtils.isNotEmpty(generalDefinition.getVertexCentricEdgeIndexes())){
+                for(JsonVertexCentricEdgeIndexDefinition definition : generalDefinition.getVertexCentricEdgeIndexes()){
+                    wasUpdated |= vertexCentricEdgeIndexCreator.create(definition, context);
+                }
+            }
+
+            // Create all vertex-centric property indices
+            if(CollectionUtils.isNotEmpty(generalDefinition.getVertexCentricPropertyIndexes())){
+                for(JsonVertexCentricPropertyIndexDefinition definition : generalDefinition.getVertexCentricPropertyIndexes()){
+                    wasUpdated |= vertexCentricPropertyIndexCreator.create(definition, context);
+                }
+            }
+        }
+
+        if(wasUpdated){
+            LOGGER.info("Schema initialization complete.");
+        } else {
+            LOGGER.info("There was no any changes during schema initialization. Schema initialization is skipped.");
+        }
+
+        return wasUpdated;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/JsonEdgeSchemaCreator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/JsonEdgeSchemaCreator.java
@@ -1,0 +1,76 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.creator;
+
+import org.janusgraph.core.EdgeLabel;
+import org.janusgraph.core.schema.EdgeLabelMaker;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.core.schema.json.definition.JsonEdgeLabelDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+
+public class JsonEdgeSchemaCreator implements JsonSchemaCreator<JsonEdgeLabelDefinition> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JsonEdgeSchemaCreator.class);
+
+    @Override
+    public boolean create(JsonEdgeLabelDefinition definition, JsonSchemaCreationContext context) {
+
+        JanusGraphManagement graphManagement = context.getGraphManagement();
+
+        if(isEdgeExists(graphManagement, definition)) {
+            LOGGER.info("Creation of the edge {} was skipped because it is already exists.", definition.getLabel());
+            return false;
+        }
+
+        EdgeLabel edgeLabel = createEdge(graphManagement, definition);
+        if(definition.getTtl() != null){
+            graphManagement.setTTL(edgeLabel, Duration.ofMillis(definition.getTtl()));
+        }
+        if(definition.getConsistency() != null){
+            graphManagement.setConsistency(edgeLabel, definition.getConsistency());
+        }
+
+        LOGGER.info("Edge {} was created", definition.getLabel());
+
+        return true;
+
+    }
+
+    private EdgeLabel createEdge(JanusGraphManagement graphManagement,
+                                 JsonEdgeLabelDefinition definition) {
+
+        EdgeLabelMaker edgeLabelMaker = graphManagement.makeEdgeLabel(definition.getLabel());
+
+        if(Boolean.TRUE.equals(definition.getUnidirected())) {
+            edgeLabelMaker.unidirected();
+        } else {
+            edgeLabelMaker.directed();
+        }
+
+        if(definition.getMultiplicity() != null){
+            edgeLabelMaker.multiplicity(definition.getMultiplicity());
+        }
+
+        return edgeLabelMaker.make();
+    }
+
+    private boolean isEdgeExists(JanusGraphManagement graphManagement,
+                                 JsonEdgeLabelDefinition definition) {
+        return graphManagement.containsEdgeLabel(definition.getLabel());
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/JsonPropertySchemaCreator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/JsonPropertySchemaCreator.java
@@ -1,0 +1,78 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.creator;
+
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.core.schema.PropertyKeyMaker;
+import org.janusgraph.core.schema.json.definition.JsonPropertyKeyDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+
+public class JsonPropertySchemaCreator implements JsonSchemaCreator<JsonPropertyKeyDefinition> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JsonPropertySchemaCreator.class);
+
+    @Override
+    public boolean create(JsonPropertyKeyDefinition definition, JsonSchemaCreationContext context) {
+
+        JanusGraphManagement graphManagement = context.getGraphManagement();
+
+        if(isPropertyExists(graphManagement, definition)) {
+            LOGGER.info("Creation of the property {} was skipped because it is already exists.", definition.getKey());
+            return false;
+        }
+
+        PropertyKey propertyKey = createProperty(graphManagement, definition);
+        if(definition.getTtl() != null){
+            graphManagement.setTTL(propertyKey, Duration.ofMillis(definition.getTtl()));
+        }
+        if(definition.getConsistency() != null){
+            graphManagement.setConsistency(propertyKey, definition.getConsistency());
+        }
+
+        LOGGER.info("Property {} was created", definition.getKey());
+
+        return true;
+    }
+
+    private PropertyKey createProperty(JanusGraphManagement graphManagement,
+                                       JsonPropertyKeyDefinition definition) {
+
+        Class propertyTypeClass;
+        try{
+            propertyTypeClass = Class.forName(definition.getClassName());
+        } catch (Exception e){
+            throw new SchemaCreationException(e);
+        }
+
+        PropertyKeyMaker propertyKeyMaker = graphManagement.makePropertyKey(definition.getKey())
+                .dataType(propertyTypeClass);
+
+        if(definition.getCardinality() != null){
+            propertyKeyMaker.cardinality(definition.getCardinality());
+        }
+
+        return propertyKeyMaker.make();
+    }
+
+    private boolean isPropertyExists(JanusGraphManagement graphManagement,
+                                     JsonPropertyKeyDefinition definition) {
+        return graphManagement.containsPropertyKey(definition.getKey());
+    }
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/JsonSchemaCreationContext.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/JsonSchemaCreationContext.java
@@ -1,0 +1,55 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.creator;
+
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.core.schema.json.definition.index.AbstractJsonIndexDefinition;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class JsonSchemaCreationContext {
+
+    private JanusGraphManagement graphManagement;
+    private final boolean createSchemaElements;
+    private final boolean createIndices;
+    private final Set<AbstractJsonIndexDefinition> createdOrUpdatedIndices = new HashSet<>();
+
+    public JsonSchemaCreationContext(JanusGraphManagement graphManagement, boolean createSchemaElements, boolean createIndices) {
+        this.graphManagement=graphManagement;
+        this.createSchemaElements = createSchemaElements;
+        this.createIndices = createIndices;
+    }
+
+    public void setGraphManagement(JanusGraphManagement graphManagement) {
+        this.graphManagement = graphManagement;
+    }
+
+    public JanusGraphManagement getGraphManagement() {
+        return graphManagement;
+    }
+
+    public boolean isCreateSchemaElements() {
+        return createSchemaElements;
+    }
+
+    public boolean isCreateIndices() {
+        return createIndices;
+    }
+
+    public Set<AbstractJsonIndexDefinition> getCreatedOrUpdatedIndices() {
+        return createdOrUpdatedIndices;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/JsonSchemaCreator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/JsonSchemaCreator.java
@@ -1,0 +1,21 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.creator;
+
+public interface JsonSchemaCreator <T> {
+
+    boolean create(T definition, JsonSchemaCreationContext context);
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/JsonVertexSchemaCreator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/JsonVertexSchemaCreator.java
@@ -1,0 +1,71 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.creator;
+
+import org.janusgraph.core.VertexLabel;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.core.schema.VertexLabelMaker;
+import org.janusgraph.core.schema.json.definition.JsonVertexLabelDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+
+public class JsonVertexSchemaCreator implements JsonSchemaCreator<JsonVertexLabelDefinition> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JsonVertexSchemaCreator.class);
+
+    @Override
+    public boolean create(JsonVertexLabelDefinition definition, JsonSchemaCreationContext context) {
+
+        JanusGraphManagement graphManagement = context.getGraphManagement();
+
+        if(isVertexExists(graphManagement, definition)){
+            LOGGER.info("Creation of the vertex {} was skipped because it is already exists.", definition.getLabel());
+            return false;
+        }
+
+        VertexLabel vertexLabel = createVertex(graphManagement, definition);
+        if(definition.getTtl() != null){
+            graphManagement.setTTL(vertexLabel, Duration.ofMillis(definition.getTtl()));
+        }
+
+        LOGGER.info("Vertex {} was created", definition.getLabel());
+
+        return true;
+    }
+
+    private VertexLabel createVertex(JanusGraphManagement graphManagement,
+                                     JsonVertexLabelDefinition definition) {
+
+        VertexLabelMaker vertexLabelMaker = graphManagement.makeVertexLabel(definition.getLabel());
+
+        if(Boolean.TRUE.equals(definition.getPartition())) {
+            vertexLabelMaker.partition();
+        }
+
+        if(Boolean.TRUE.equals(definition.getStaticVertex())) {
+            vertexLabelMaker.setStatic();
+        }
+
+        return vertexLabelMaker.make();
+    }
+
+    private boolean isVertexExists(JanusGraphManagement graphManagement,
+                                   JsonVertexLabelDefinition definition) {
+        return graphManagement.containsVertexLabel(definition.getLabel());
+    }
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/SchemaCreationException.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/SchemaCreationException.java
@@ -1,0 +1,27 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.creator;
+
+public class SchemaCreationException extends RuntimeException {
+
+    public SchemaCreationException(Throwable throwable) {
+        super(throwable);
+    }
+
+    public SchemaCreationException(String msg) {
+        super(msg);
+    }
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/index/AbstractJsonGraphCentricIndexCreator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/index/AbstractJsonGraphCentricIndexCreator.java
@@ -1,0 +1,101 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.creator.index;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.janusgraph.core.schema.Index;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.core.schema.JanusGraphSchemaType;
+import org.janusgraph.core.schema.Parameter;
+import org.janusgraph.core.schema.json.creator.JsonSchemaCreationContext;
+import org.janusgraph.core.schema.json.creator.SchemaCreationException;
+import org.janusgraph.core.schema.json.definition.index.AbstractJsonGraphCentricIndexDefinition;
+import org.janusgraph.core.schema.json.parser.JsonParameterDefinitionParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractJsonGraphCentricIndexCreator<T extends AbstractJsonGraphCentricIndexDefinition>
+        extends AbstractJsonIndexCreator<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractJsonGraphCentricIndexCreator.class);
+    private final JsonParameterDefinitionParser jsonParameterDefinitionParser = new JsonParameterDefinitionParser();
+
+    @Override
+    protected Index buildIndex(T definition, JsonSchemaCreationContext context) {
+
+        JanusGraphManagement graphManagement = context.getGraphManagement();
+
+        Class<? extends Element> typeClass = toClass(definition.getTypeClass());
+        JanusGraphManagement.IndexBuilder indexBuilder = graphManagement.buildIndex(definition.getName(), typeClass);
+        addKeys(graphManagement, indexBuilder, definition);
+        addIndexOnly(graphManagement, indexBuilder, definition, typeClass);
+
+        return buildSpecificIndex(graphManagement, indexBuilder, definition);
+    }
+
+    @Override
+    protected boolean containsIndex(T definition, JsonSchemaCreationContext context) {
+        return context.getGraphManagement().containsGraphIndex(definition.getName());
+    }
+
+    protected void addKeys(JanusGraphManagement graphManagement,
+                           JanusGraphManagement.IndexBuilder builder,
+                           T definition) {
+        if(CollectionUtils.isEmpty(definition.getKeys())){
+            return;
+        }
+        definition.getKeys().forEach(entry -> {
+            if (CollectionUtils.isEmpty(entry.getParameters())) {
+                builder.addKey(graphManagement.getPropertyKey(entry.getPropertyKey()));
+            } else {
+                Parameter[] parameters = entry.getParameters().stream()
+                    .map(jsonParameterDefinitionParser::parse).toArray(Parameter[]::new);
+                builder.addKey(graphManagement.getPropertyKey(entry.getPropertyKey()), parameters);
+            }
+        });
+    }
+
+    protected void addIndexOnly(JanusGraphManagement graphManagement,
+                                JanusGraphManagement.IndexBuilder indexBuilder,
+                                T definition, Class<? extends Element> typeClass) {
+        if(StringUtils.isNotEmpty(definition.getIndexOnly())){
+            JanusGraphSchemaType schemaLabel;
+            if(Vertex.class.isAssignableFrom(typeClass)){
+                schemaLabel = graphManagement.getVertexLabel(definition.getIndexOnly());
+            } else if(Edge.class.isAssignableFrom(typeClass)){
+                schemaLabel = graphManagement.getEdgeLabel(definition.getIndexOnly());
+            } else {
+                throw new SchemaCreationException("No implementation for type "+typeClass.getName());
+            }
+            indexBuilder.indexOnly(schemaLabel);
+        }
+    }
+
+    private Class<? extends Element> toClass(String type){
+        try{
+            return (Class<? extends Element>) Class.forName(type);
+        } catch (Exception e){
+            LOGGER.error("Class [{}] is not a child of {}", type, Element.class.getName());
+            throw new SchemaCreationException(e);
+        }
+    }
+
+    protected abstract Index buildSpecificIndex(JanusGraphManagement graphManagement, JanusGraphManagement.IndexBuilder indexBuilder, T definition);
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/index/AbstractJsonIndexCreator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/index/AbstractJsonIndexCreator.java
@@ -1,0 +1,48 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.creator.index;
+
+import org.janusgraph.core.schema.Index;
+import org.janusgraph.core.schema.json.creator.JsonSchemaCreationContext;
+import org.janusgraph.core.schema.json.creator.JsonSchemaCreator;
+import org.janusgraph.core.schema.json.definition.index.AbstractJsonIndexDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractJsonIndexCreator<T extends AbstractJsonIndexDefinition> implements JsonSchemaCreator<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractJsonIndexCreator.class);
+
+    @Override
+    public boolean create(T definition, JsonSchemaCreationContext context) {
+
+        if (containsIndex(definition, context)) {
+            LOG.info("Index with name [{}] was skipped because it already exists.", definition.getName());
+            return false;
+        }
+
+        Index index = buildIndex(definition, context);
+        LOG.info("Index {} was created", index.name());
+
+        context.getCreatedOrUpdatedIndices().add(definition);
+
+        return true;
+    }
+
+    protected abstract boolean containsIndex(T definition, JsonSchemaCreationContext context);
+
+    protected abstract Index buildIndex(T definition, JsonSchemaCreationContext context);
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/index/AbstractJsonVertexCentricIndexCreator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/index/AbstractJsonVertexCentricIndexCreator.java
@@ -1,0 +1,47 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.creator.index;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.RelationType;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.core.schema.json.creator.JsonSchemaCreationContext;
+import org.janusgraph.core.schema.json.definition.index.AbstractJsonVertexCentricIndexDefinition;
+
+public abstract class AbstractJsonVertexCentricIndexCreator
+        <T extends AbstractJsonVertexCentricIndexDefinition> extends AbstractJsonIndexCreator<T> {
+
+    private static final PropertyKey[] EMPTY_PROPERTY_KEYS = new PropertyKey[0];
+
+    @Override
+    protected boolean containsIndex(T definition, JsonSchemaCreationContext context) {
+        JanusGraphManagement graphManagement = context.getGraphManagement();
+        RelationType relationType = graphManagement.getRelationType(getIndexedElementName(definition));
+        return graphManagement.containsRelationIndex(relationType, definition.getName());
+    }
+
+    protected PropertyKey[] toPropertyKeys(T definition, JsonSchemaCreationContext context){
+        if(CollectionUtils.isEmpty(definition.getPropertyKeys())){
+            return EMPTY_PROPERTY_KEYS;
+        }
+        return definition.getPropertyKeys().stream()
+                .map(propertyKey -> context.getGraphManagement().getPropertyKey(propertyKey))
+                .toArray(PropertyKey[]::new);
+    }
+
+    protected abstract String getIndexedElementName(T definition);
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/index/JsonCompositeIndexCreator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/index/JsonCompositeIndexCreator.java
@@ -1,0 +1,48 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.creator.index;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.Index;
+import org.janusgraph.core.schema.JanusGraphIndex;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.core.schema.json.definition.index.JsonCompositeIndexDefinition;
+
+public class JsonCompositeIndexCreator extends AbstractJsonGraphCentricIndexCreator<JsonCompositeIndexDefinition> {
+
+    @Override
+    protected Index buildSpecificIndex(JanusGraphManagement graphManagement, JanusGraphManagement.IndexBuilder indexBuilder,
+                                       JsonCompositeIndexDefinition definition){
+        if(Boolean.TRUE.equals(definition.getUnique())){
+            indexBuilder.unique();
+        }
+
+        if(CollectionUtils.isNotEmpty(definition.getInlinePropertyKeys())){
+            for(String inlinePropertyKey : definition.getInlinePropertyKeys()){
+                PropertyKey propertyKey = graphManagement.getPropertyKey(inlinePropertyKey);
+                indexBuilder.addInlinePropertyKey(propertyKey);
+            }
+        }
+
+        JanusGraphIndex index = indexBuilder.buildCompositeIndex();
+
+        if(definition.getConsistency() != null){
+            graphManagement.setConsistency(index, definition.getConsistency());
+        }
+
+        return index;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/index/JsonMixedIndexCreator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/index/JsonMixedIndexCreator.java
@@ -1,0 +1,30 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.creator.index;
+
+import org.janusgraph.core.schema.Index;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.core.schema.json.definition.index.JsonMixedIndexDefinition;
+
+public class JsonMixedIndexCreator
+        extends AbstractJsonGraphCentricIndexCreator<JsonMixedIndexDefinition> {
+
+    @Override
+    protected Index buildSpecificIndex(JanusGraphManagement graphManagement, JanusGraphManagement.IndexBuilder indexBuilder,
+                                       JsonMixedIndexDefinition definition){
+
+        return indexBuilder.buildMixedIndex(definition.getIndexBackend());
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/index/JsonVertexCentricEdgeIndexCreator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/index/JsonVertexCentricEdgeIndexCreator.java
@@ -1,0 +1,54 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.creator.index;
+
+import org.janusgraph.core.EdgeLabel;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.Index;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.core.schema.json.creator.JsonSchemaCreationContext;
+import org.janusgraph.core.schema.json.definition.index.JsonVertexCentricEdgeIndexDefinition;
+
+public class JsonVertexCentricEdgeIndexCreator extends AbstractJsonVertexCentricIndexCreator<JsonVertexCentricEdgeIndexDefinition> {
+
+    @Override
+    protected Index buildIndex(JsonVertexCentricEdgeIndexDefinition definition, JsonSchemaCreationContext context){
+        JanusGraphManagement graphManagement = context.getGraphManagement();
+        EdgeLabel edgeLabel = graphManagement.getEdgeLabel(definition.getIndexedEdgeLabel());
+        PropertyKey[] propertyKeys = toPropertyKeys(definition, context);
+
+        if (definition.getOrder() == null) {
+            return graphManagement.buildEdgeIndex(
+                edgeLabel,
+                definition.getName(),
+                definition.getDirection(),
+                propertyKeys
+            );
+        } else {
+            return graphManagement.buildEdgeIndex(
+                edgeLabel,
+                definition.getName(),
+                definition.getDirection(),
+                definition.getOrder(),
+                propertyKeys
+            );
+        }
+    }
+
+    @Override
+    protected String getIndexedElementName(JsonVertexCentricEdgeIndexDefinition definition) {
+        return definition.getIndexedEdgeLabel();
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/index/JsonVertexCentricPropertyIndexCreator.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/creator/index/JsonVertexCentricPropertyIndexCreator.java
@@ -1,0 +1,51 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.creator.index;
+
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.Index;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.core.schema.json.creator.JsonSchemaCreationContext;
+import org.janusgraph.core.schema.json.definition.index.JsonVertexCentricPropertyIndexDefinition;
+
+public class JsonVertexCentricPropertyIndexCreator extends AbstractJsonVertexCentricIndexCreator<JsonVertexCentricPropertyIndexDefinition> {
+
+    @Override
+    protected Index buildIndex(JsonVertexCentricPropertyIndexDefinition definition, JsonSchemaCreationContext context){
+        JanusGraphManagement graphManagement = context.getGraphManagement();
+        PropertyKey propertyKey = graphManagement.getPropertyKey(definition.getIndexedPropertyKey());
+        PropertyKey[] propertyKeys = toPropertyKeys(definition, context);
+
+        if (definition.getOrder() == null) {
+            return graphManagement.buildPropertyIndex(
+                propertyKey,
+                definition.getName(),
+                propertyKeys
+            );
+        } else {
+            return graphManagement.buildPropertyIndex(
+                propertyKey,
+                definition.getName(),
+                definition.getOrder(),
+                propertyKeys
+            );
+        }
+    }
+
+    @Override
+    protected String getIndexedElementName(JsonVertexCentricPropertyIndexDefinition definition) {
+        return definition.getIndexedPropertyKey();
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/JsonEdgeLabelDefinition.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/JsonEdgeLabelDefinition.java
@@ -1,0 +1,71 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.definition;
+
+import org.janusgraph.core.Multiplicity;
+import org.janusgraph.core.schema.ConsistencyModifier;
+
+public class JsonEdgeLabelDefinition {
+
+    private String label;
+
+    private Multiplicity multiplicity;
+
+    private Boolean unidirected;
+
+    private Long ttl;
+
+    private ConsistencyModifier consistency;
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public Multiplicity getMultiplicity() {
+        return multiplicity;
+    }
+
+    public void setMultiplicity(Multiplicity multiplicity) {
+        this.multiplicity = multiplicity;
+    }
+
+    public Boolean getUnidirected() {
+        return unidirected;
+    }
+
+    public void setUnidirected(Boolean unidirected) {
+        this.unidirected = unidirected;
+    }
+
+    public Long getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(Long ttl) {
+        this.ttl = ttl;
+    }
+
+    public ConsistencyModifier getConsistency() {
+        return consistency;
+    }
+
+    public void setConsistency(ConsistencyModifier consistency) {
+        this.consistency = consistency;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/JsonParameterDefinition.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/JsonParameterDefinition.java
@@ -1,0 +1,48 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.definition;
+
+public class JsonParameterDefinition {
+
+    private String key;
+
+    private String value;
+
+    private String parser;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getParser() {
+        return parser;
+    }
+
+    public void setParser(String parser) {
+        this.parser = parser;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/JsonPropertyKeyDefinition.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/JsonPropertyKeyDefinition.java
@@ -1,0 +1,71 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.definition;
+
+import org.janusgraph.core.Cardinality;
+import org.janusgraph.core.schema.ConsistencyModifier;
+
+public class JsonPropertyKeyDefinition {
+
+    private String key;
+
+    private String className;
+
+    private Cardinality cardinality;
+
+    private Long ttl;
+
+    private ConsistencyModifier consistency;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    public Cardinality getCardinality() {
+        return cardinality;
+    }
+
+    public void setCardinality(Cardinality cardinality) {
+        this.cardinality = cardinality;
+    }
+
+    public Long getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(Long ttl) {
+        this.ttl = ttl;
+    }
+
+    public ConsistencyModifier getConsistency() {
+        return consistency;
+    }
+
+    public void setConsistency(ConsistencyModifier consistency) {
+        this.consistency = consistency;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/JsonSchemaDefinition.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/JsonSchemaDefinition.java
@@ -1,0 +1,89 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.definition;
+
+import org.janusgraph.core.schema.json.definition.index.JsonCompositeIndexDefinition;
+import org.janusgraph.core.schema.json.definition.index.JsonMixedIndexDefinition;
+import org.janusgraph.core.schema.json.definition.index.JsonVertexCentricEdgeIndexDefinition;
+import org.janusgraph.core.schema.json.definition.index.JsonVertexCentricPropertyIndexDefinition;
+
+import java.util.List;
+
+public class JsonSchemaDefinition {
+
+    private List<JsonVertexLabelDefinition> vertexLabels;
+    private List<JsonEdgeLabelDefinition> edgeLabels;
+    private List<JsonPropertyKeyDefinition> propertyKeys;
+    private List<JsonCompositeIndexDefinition> compositeIndexes;
+    private List<JsonVertexCentricEdgeIndexDefinition> vertexCentricEdgeIndexes;
+    private List<JsonVertexCentricPropertyIndexDefinition> vertexCentricPropertyIndexes;
+    private List<JsonMixedIndexDefinition> mixedIndexes;
+
+    public List<JsonVertexLabelDefinition> getVertexLabels() {
+        return vertexLabels;
+    }
+
+    public void setVertexLabels(List<JsonVertexLabelDefinition> vertexLabels) {
+        this.vertexLabels = vertexLabels;
+    }
+
+    public List<JsonEdgeLabelDefinition> getEdgeLabels() {
+        return edgeLabels;
+    }
+
+    public void setEdgeLabels(List<JsonEdgeLabelDefinition> edgeLabels) {
+        this.edgeLabels = edgeLabels;
+    }
+
+    public List<JsonPropertyKeyDefinition> getPropertyKeys() {
+        return propertyKeys;
+    }
+
+    public void setPropertyKeys(List<JsonPropertyKeyDefinition> propertyKeys) {
+        this.propertyKeys = propertyKeys;
+    }
+
+    public List<JsonCompositeIndexDefinition> getCompositeIndexes() {
+        return compositeIndexes;
+    }
+
+    public void setCompositeIndexes(List<JsonCompositeIndexDefinition> compositeIndexes) {
+        this.compositeIndexes = compositeIndexes;
+    }
+
+    public List<JsonVertexCentricEdgeIndexDefinition> getVertexCentricEdgeIndexes() {
+        return vertexCentricEdgeIndexes;
+    }
+
+    public void setVertexCentricEdgeIndexes(List<JsonVertexCentricEdgeIndexDefinition> vertexCentricEdgeIndexes) {
+        this.vertexCentricEdgeIndexes = vertexCentricEdgeIndexes;
+    }
+
+    public List<JsonVertexCentricPropertyIndexDefinition> getVertexCentricPropertyIndexes() {
+        return vertexCentricPropertyIndexes;
+    }
+
+    public void setVertexCentricPropertyIndexes(List<JsonVertexCentricPropertyIndexDefinition> vertexCentricPropertyIndexes) {
+        this.vertexCentricPropertyIndexes = vertexCentricPropertyIndexes;
+    }
+
+    public List<JsonMixedIndexDefinition> getMixedIndexes() {
+        return mixedIndexes;
+    }
+
+    public void setMixedIndexes(List<JsonMixedIndexDefinition> mixedIndexes) {
+        this.mixedIndexes = mixedIndexes;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/JsonVertexLabelDefinition.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/JsonVertexLabelDefinition.java
@@ -1,0 +1,58 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.definition;
+
+public class JsonVertexLabelDefinition {
+
+    private String label;
+
+    private Boolean staticVertex;
+
+    private Boolean partition;
+
+    private Long ttl;
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public Boolean getStaticVertex() {
+        return staticVertex;
+    }
+
+    public void setStaticVertex(Boolean staticVertex) {
+        this.staticVertex = staticVertex;
+    }
+
+    public Boolean getPartition() {
+        return partition;
+    }
+
+    public void setPartition(Boolean partition) {
+        this.partition = partition;
+    }
+
+    public Long getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(Long ttl) {
+        this.ttl = ttl;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/index/AbstractJsonGraphCentricIndexDefinition.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/index/AbstractJsonGraphCentricIndexDefinition.java
@@ -1,0 +1,48 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.definition.index;
+
+import java.util.List;
+
+public abstract class AbstractJsonGraphCentricIndexDefinition extends AbstractJsonIndexDefinition {
+
+    private String indexOnly;
+    private String typeClass;
+    private List<JsonIndexedPropertyKeyDefinition> keys;
+
+    public String getIndexOnly() {
+        return indexOnly;
+    }
+
+    public void setIndexOnly(String indexOnly) {
+        this.indexOnly = indexOnly;
+    }
+
+    public String getTypeClass() {
+        return typeClass;
+    }
+
+    public void setTypeClass(String typeClass) {
+        this.typeClass = typeClass;
+    }
+
+    public List<JsonIndexedPropertyKeyDefinition> getKeys() {
+        return keys;
+    }
+
+    public void setKeys(List<JsonIndexedPropertyKeyDefinition> keys) {
+        this.keys = keys;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/index/AbstractJsonIndexDefinition.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/index/AbstractJsonIndexDefinition.java
@@ -1,0 +1,28 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.definition.index;
+
+public abstract class AbstractJsonIndexDefinition {
+
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/index/AbstractJsonVertexCentricIndexDefinition.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/index/AbstractJsonVertexCentricIndexDefinition.java
@@ -1,0 +1,41 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.definition.index;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
+
+import java.util.List;
+
+public abstract class AbstractJsonVertexCentricIndexDefinition extends AbstractJsonIndexDefinition {
+
+    private List<String> propertyKeys;
+    private Order order;
+
+    public List<String> getPropertyKeys() {
+        return propertyKeys;
+    }
+
+    public void setPropertyKeys(List<String> propertyKeys) {
+        this.propertyKeys = propertyKeys;
+    }
+
+    public Order getOrder() {
+        return order;
+    }
+
+    public void setOrder(Order order) {
+        this.order = order;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/index/JsonCompositeIndexDefinition.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/index/JsonCompositeIndexDefinition.java
@@ -1,0 +1,52 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.definition.index;
+
+import org.janusgraph.core.schema.ConsistencyModifier;
+
+import java.util.List;
+
+public class JsonCompositeIndexDefinition extends AbstractJsonGraphCentricIndexDefinition {
+
+    private ConsistencyModifier consistency;
+
+    private Boolean unique;
+
+    private List<String> inlinePropertyKeys;
+
+    public ConsistencyModifier getConsistency() {
+        return consistency;
+    }
+
+    public void setConsistency(ConsistencyModifier consistency) {
+        this.consistency = consistency;
+    }
+
+    public Boolean getUnique() {
+        return unique;
+    }
+
+    public void setUnique(Boolean unique) {
+        this.unique = unique;
+    }
+
+    public List<String> getInlinePropertyKeys() {
+        return inlinePropertyKeys;
+    }
+
+    public void setInlinePropertyKeys(List<String> inlinePropertyKeys) {
+        this.inlinePropertyKeys = inlinePropertyKeys;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/index/JsonIndexedPropertyKeyDefinition.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/index/JsonIndexedPropertyKeyDefinition.java
@@ -1,0 +1,42 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.definition.index;
+
+import org.janusgraph.core.schema.json.definition.JsonParameterDefinition;
+
+import java.util.List;
+
+public class JsonIndexedPropertyKeyDefinition {
+
+    private String propertyKey;
+
+    private List<JsonParameterDefinition> parameters;
+
+    public String getPropertyKey() {
+        return propertyKey;
+    }
+
+    public void setPropertyKey(String propertyKey) {
+        this.propertyKey = propertyKey;
+    }
+
+    public List<JsonParameterDefinition> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(List<JsonParameterDefinition> parameters) {
+        this.parameters = parameters;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/index/JsonMixedIndexDefinition.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/index/JsonMixedIndexDefinition.java
@@ -1,0 +1,29 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.definition.index;
+
+public class JsonMixedIndexDefinition extends AbstractJsonGraphCentricIndexDefinition {
+
+    private String indexBackend;
+
+    public String getIndexBackend() {
+        return indexBackend;
+    }
+
+    public void setIndexBackend(String indexBackend) {
+        this.indexBackend = indexBackend;
+    }
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/index/JsonVertexCentricEdgeIndexDefinition.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/index/JsonVertexCentricEdgeIndexDefinition.java
@@ -1,0 +1,41 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.definition.index;
+
+import org.apache.tinkerpop.gremlin.structure.Direction;
+
+public class JsonVertexCentricEdgeIndexDefinition extends AbstractJsonVertexCentricIndexDefinition {
+
+    private String indexedEdgeLabel;
+
+    private Direction direction;
+
+    public String getIndexedEdgeLabel() {
+        return indexedEdgeLabel;
+    }
+
+    public void setIndexedEdgeLabel(String indexedEdgeLabel) {
+        this.indexedEdgeLabel = indexedEdgeLabel;
+    }
+
+    public Direction getDirection() {
+        return direction;
+    }
+
+    public void setDirection(Direction direction) {
+        this.direction = direction;
+    }
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/index/JsonVertexCentricPropertyIndexDefinition.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/definition/index/JsonVertexCentricPropertyIndexDefinition.java
@@ -1,0 +1,29 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.definition.index;
+
+public class JsonVertexCentricPropertyIndexDefinition extends AbstractJsonVertexCentricIndexDefinition {
+
+    private String indexedPropertyKey;
+
+    public String getIndexedPropertyKey() {
+        return indexedPropertyKey;
+    }
+
+    public void setIndexedPropertyKey(String indexedPropertyKey) {
+        this.indexedPropertyKey = indexedPropertyKey;
+    }
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/BooleanJsonParameterParser.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/BooleanJsonParameterParser.java
@@ -1,0 +1,24 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.parser;
+
+import org.janusgraph.core.schema.Parameter;
+
+public class BooleanJsonParameterParser implements JsonParameterParser {
+    @Override
+    public Parameter parse(String key, String value) {
+        return Parameter.of(key, Boolean.valueOf(value));
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/ByteJsonParameterParser.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/ByteJsonParameterParser.java
@@ -1,0 +1,24 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.parser;
+
+import org.janusgraph.core.schema.Parameter;
+
+public class ByteJsonParameterParser implements JsonParameterParser {
+    @Override
+    public Parameter parse(String key, String value) {
+        return Parameter.of(key, Byte.valueOf(value));
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/DoubleJsonParameterParser.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/DoubleJsonParameterParser.java
@@ -1,0 +1,24 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.parser;
+
+import org.janusgraph.core.schema.Parameter;
+
+public class DoubleJsonParameterParser implements JsonParameterParser {
+    @Override
+    public Parameter parse(String key, String value) {
+        return Parameter.of(key, Double.valueOf(value));
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/EnumJsonParameterParser.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/EnumJsonParameterParser.java
@@ -1,0 +1,50 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.parser;
+
+import org.apache.commons.lang.UnhandledException;
+import org.janusgraph.core.schema.Parameter;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class EnumJsonParameterParser implements JsonParameterParser {
+
+    @Override
+    public Parameter parse(String key, String value) {
+        return Parameter.of(key, toEnum(value));
+    }
+
+    private Object toEnum(String value){
+
+        int indexOfValue = value.lastIndexOf(".");
+
+        if(indexOfValue == -1){
+            throw new AssertionError(value+" isn't a valid enum value. Please use full path (package + class + value) to enum value. " +
+                "Example: org.janusgraph.core.schema.Mapping.TEXT");
+        }
+
+        Class enumClass;
+        Method method;
+
+        try {
+            enumClass = Class.forName(value.substring(0,indexOfValue));
+            method = enumClass.getMethod("valueOf", String.class);
+            return method.invoke(null, value.substring(indexOfValue+1));
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new UnhandledException(e);
+        }
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/FloatJsonParameterParser.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/FloatJsonParameterParser.java
@@ -1,0 +1,24 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.parser;
+
+import org.janusgraph.core.schema.Parameter;
+
+public class FloatJsonParameterParser implements JsonParameterParser {
+    @Override
+    public Parameter parse(String key, String value) {
+        return Parameter.of(key, Float.valueOf(value));
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/IntegerJsonParameterParser.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/IntegerJsonParameterParser.java
@@ -1,0 +1,24 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.parser;
+
+import org.janusgraph.core.schema.Parameter;
+
+public class IntegerJsonParameterParser implements JsonParameterParser {
+    @Override
+    public Parameter parse(String key, String value) {
+        return Parameter.of(key, Integer.valueOf(value));
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/JsonParameterDefinitionParser.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/JsonParameterDefinitionParser.java
@@ -1,0 +1,82 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.parser;
+
+import org.apache.commons.lang3.StringUtils;
+import org.janusgraph.core.schema.Parameter;
+import org.janusgraph.core.schema.json.creator.SchemaCreationException;
+import org.janusgraph.core.schema.json.definition.JsonParameterDefinition;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class JsonParameterDefinitionParser {
+
+    public static final String STRING_PARAMETER_PARSER_NAME = "string";
+    public static final String ENUM_PARAMETER_PARSER_NAME = "enum";
+    public static final String BOOLEAN_PARAMETER_PARSER_NAME = "boolean";
+    public static final String BYTE_PARAMETER_PARSER_NAME = "byte";
+    public static final String SHORT_PARAMETER_PARSER_NAME = "short";
+    public static final String INTEGER_PARAMETER_PARSER_NAME = "integer";
+    public static final String LONG_PARAMETER_PARSER_NAME = "long";
+    public static final String FLOAT_PARAMETER_PARSER_NAME = "float";
+    public static final String DOUBLE_PARAMETER_PARSER_NAME = "double";
+
+    public final Map<String, JsonParameterParser> jsonParameterParsers;
+
+    public JsonParameterDefinitionParser() {
+        jsonParameterParsers = new HashMap<>();
+        jsonParameterParsers.put(STRING_PARAMETER_PARSER_NAME, new StringJsonParameterParser());
+        jsonParameterParsers.put(ENUM_PARAMETER_PARSER_NAME, new EnumJsonParameterParser());
+        jsonParameterParsers.put(BOOLEAN_PARAMETER_PARSER_NAME, new BooleanJsonParameterParser());
+        jsonParameterParsers.put(BYTE_PARAMETER_PARSER_NAME, new ByteJsonParameterParser());
+        jsonParameterParsers.put(SHORT_PARAMETER_PARSER_NAME, new ShortJsonParameterParser());
+        jsonParameterParsers.put(INTEGER_PARAMETER_PARSER_NAME, new IntegerJsonParameterParser());
+        jsonParameterParsers.put(LONG_PARAMETER_PARSER_NAME, new LongJsonParameterParser());
+        jsonParameterParsers.put(FLOAT_PARAMETER_PARSER_NAME, new FloatJsonParameterParser());
+        jsonParameterParsers.put(DOUBLE_PARAMETER_PARSER_NAME, new DoubleJsonParameterParser());
+    }
+
+    public Parameter parse(JsonParameterDefinition definition){
+
+        String parserClassPath = definition.getParser();
+        if(StringUtils.isEmpty(parserClassPath)){
+            parserClassPath = STRING_PARAMETER_PARSER_NAME;
+        }
+
+        JsonParameterParser parameterParser = jsonParameterParsers.get(parserClassPath);
+
+        if(parameterParser == null){
+
+            try {
+                Class parserClass = Class.forName(parserClassPath);
+                Object instance = parserClass.newInstance();
+
+                if (!(instance instanceof JsonParameterParser)){
+                    throw new SchemaCreationException("Class "+parserClassPath+" does not implement JsonParameterParser");
+                }
+
+                parameterParser = (JsonParameterParser) instance;
+
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+                throw new SchemaCreationException(e);
+            }
+
+            jsonParameterParsers.put(parserClassPath, parameterParser);
+        }
+
+        return parameterParser.parse(definition.getKey(), definition.getValue());
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/JsonParameterParser.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/JsonParameterParser.java
@@ -1,0 +1,23 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.parser;
+
+import org.janusgraph.core.schema.Parameter;
+
+public interface JsonParameterParser {
+
+    Parameter parse(String key, String value);
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/LongJsonParameterParser.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/LongJsonParameterParser.java
@@ -1,0 +1,24 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.parser;
+
+import org.janusgraph.core.schema.Parameter;
+
+public class LongJsonParameterParser implements JsonParameterParser {
+    @Override
+    public Parameter parse(String key, String value) {
+        return Parameter.of(key, Long.valueOf(value));
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/ShortJsonParameterParser.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/ShortJsonParameterParser.java
@@ -1,0 +1,24 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.parser;
+
+import org.janusgraph.core.schema.Parameter;
+
+public class ShortJsonParameterParser implements JsonParameterParser {
+    @Override
+    public Parameter parse(String key, String value) {
+        return Parameter.of(key, Short.valueOf(value));
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/StringJsonParameterParser.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/json/parser/StringJsonParameterParser.java
@@ -1,0 +1,24 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.parser;
+
+import org.janusgraph.core.schema.Parameter;
+
+public class StringJsonParameterParser implements JsonParameterParser {
+    @Override
+    public Parameter parse(String key, String value) {
+        return Parameter.of(key, value);
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/util/GraphFactoryUtils.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/util/GraphFactoryUtils.java
@@ -1,0 +1,29 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.util;
+
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.schema.SchemaInitializationManager;
+import org.janusgraph.diskstorage.configuration.ReadConfiguration;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.janusgraph.graphdb.configuration.builder.GraphDatabaseConfigurationBuilder;
+
+public class GraphFactoryUtils {
+
+    public static JanusGraph defineSchemaAndStart(ReadConfiguration configuration) {
+        GraphDatabaseConfiguration graphDatabaseConfiguration = new GraphDatabaseConfigurationBuilder().build(configuration);
+        return SchemaInitializationManager.initializeSchemaAndStart(graphDatabaseConfiguration);
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/util/JsonUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/util/JsonUtil.java
@@ -1,0 +1,46 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.util;
+
+import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
+
+public class JsonUtil {
+
+    public static <T> T jsonResourcePathToObject(String resourcePath, Class<T> parsedClass) throws IOException {
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        InputStream resourceStream = loader.getResourceAsStream(resourcePath);
+        return jsonToObject(new InputStreamReader(resourceStream), parsedClass);
+    }
+
+    public static <T> T jsonFilePathToObject(String filePath, Class<T> parsedClass) throws IOException {
+        return jsonToObject(new FileReader(filePath), parsedClass);
+    }
+
+    public static <T> T jsonStringToObject(String json, Class<T> parsedClass) throws IOException {
+        return jsonToObject(new StringReader(json), parsedClass);
+    }
+
+    public static <T> T jsonToObject(Reader reader, Class<T> parsedClass) throws IOException {
+        return new ObjectMapper().readValue(reader, parsedClass);
+    }
+
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/util/ManagementUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/util/ManagementUtil.java
@@ -18,22 +18,35 @@ import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
 import org.janusgraph.core.JanusGraph;
 import org.janusgraph.core.JanusGraphException;
+import org.janusgraph.core.JanusGraphTransaction;
 import org.janusgraph.core.PropertyKey;
 import org.janusgraph.core.schema.Index;
 import org.janusgraph.core.schema.JanusGraphIndex;
 import org.janusgraph.core.schema.JanusGraphManagement;
 import org.janusgraph.core.schema.RelationTypeIndex;
+import org.janusgraph.core.schema.SchemaAction;
+import org.janusgraph.core.schema.SchemaStatus;
 import org.janusgraph.diskstorage.util.time.TimestampProvider;
 import org.janusgraph.graphdb.database.StandardJanusGraph;
+import org.janusgraph.graphdb.database.management.GraphIndexStatusReport;
+import org.janusgraph.graphdb.database.management.ManagementSystem;
+import org.janusgraph.graphdb.database.management.RelationIndexStatusReport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
  */
 public class ManagementUtil {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ManagementUtil.class);
 
     /**
      * This method blocks and waits until the provided index has been updated across the entire JanusGraph cluster
@@ -94,6 +107,198 @@ public class ManagementUtil {
         }
         if (!isStable) throw new JanusGraphException("Index did not stabilize within the given amount of time. For sufficiently long " +
                 "wait periods this is most likely caused by a failed/incorrectly shut down JanusGraph instance or a lingering transaction.");
+    }
+
+    /**
+     * Force rollback all transactions which are opened on the graph.
+     * @param graph - graph on which to rollback all current transactions
+     */
+    public static void forceRollbackAllTransactions(JanusGraph graph){
+        if(graph instanceof StandardJanusGraph){
+            for(JanusGraphTransaction janusGraphTransaction : ((StandardJanusGraph) graph).getOpenTransactions()){
+                janusGraphTransaction.rollback();
+            }
+        }
+    }
+
+    /**
+     * Force closes all instances except current instance. This is a dangerous operation as it will close any other active instances.
+     * @param graph - graph instance to keep (this instance will not be closed).
+     */
+    public static void forceCloseOtherInstances(JanusGraph graph){
+        String currentInstanceId = ((StandardJanusGraph) graph).getConfiguration().getUniqueGraphId();
+        String currentInstanceIdWithSuffix = currentInstanceId + ManagementSystem.CURRENT_INSTANCE_SUFFIX;
+        JanusGraphManagement mgmt = graph.openManagement();
+        mgmt.getOpenInstances().forEach(instanceId -> {
+            if(!currentInstanceId.equals(instanceId) && !currentInstanceIdWithSuffix.equals(instanceId)){
+                mgmt.forceCloseInstance(instanceId);
+            }
+        });
+        mgmt.commit();
+    }
+
+    public static void reindexAndEnableIndices(JanusGraph graph, List<String> nonEnabledGraphIndexNames, Map<String, String> nonEnabledRelationTypeIndexNamesAndTypes, long indexStatusTimeout){
+        nonEnabledGraphIndexNames.forEach(indexName -> awaitGraphIndexStatus(graph, indexName, indexStatusTimeout));
+        nonEnabledRelationTypeIndexNamesAndTypes.forEach((indexName, indexedElementName) -> awaitVertexCentricIndexStatus(graph, indexName, indexedElementName, indexStatusTimeout));
+
+        nonEnabledGraphIndexNames.forEach(indexName -> {
+            try {
+                LOG.info("Start re-indexing graph index {}", indexName);
+
+                ManagementSystem schemaUpdateMgmt = (ManagementSystem) graph.openManagement();
+                Index index = schemaUpdateMgmt.getGraphIndex(indexName);
+                schemaUpdateMgmt.updateIndex(index, SchemaAction.REINDEX).get();
+                schemaUpdateMgmt.commit();
+
+                LOG.info("Finished re-indexing graph index {}", indexName);
+            } catch (Exception e) {
+                LOG.error("Couldn't execute re-index for the graph index [{}]", indexName, e);
+                throw new RuntimeException(e);
+            }
+        });
+
+        nonEnabledRelationTypeIndexNamesAndTypes.forEach((indexName, indexedElementName) -> {
+            try {
+                LOG.info("Start re-indexing vertex-centric index {}", indexName);
+
+                ManagementSystem schemaUpdateMgmt = (ManagementSystem) graph.openManagement();
+                Index index = schemaUpdateMgmt.getRelationIndex(schemaUpdateMgmt.getRelationType(indexedElementName), indexName);
+                schemaUpdateMgmt.updateIndex(index, SchemaAction.REINDEX).get();
+                schemaUpdateMgmt.commit();
+
+                LOG.info("Finished re-indexing vertex-centric index {}", indexName);
+            } catch (Exception e) {
+                LOG.error("Couldn't execute re-index for the vertex-centric index [{}]", indexName, e);
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public static void forceEnableIndices(JanusGraph graph, List<String> nonEnabledGraphIndexNames, Map<String, String> nonEnabledRelationTypeIndexNamesAndTypes, long indexStatusTimeout){
+        nonEnabledGraphIndexNames.forEach(indexName -> {
+            try{
+                awaitGraphIndexStatus(graph, indexName, indexStatusTimeout);
+            } catch (Exception e){
+                LOG.warn("Await for status update of the graph index {} finished with exception", indexName, e);
+            }
+        });
+        nonEnabledRelationTypeIndexNamesAndTypes.forEach((indexName, indexedElementName) -> {
+            try{
+                awaitVertexCentricIndexStatus(graph, indexName, indexedElementName, indexStatusTimeout);
+            } catch (Exception e){
+                LOG.warn("Await for status update of the vertex-centric index {} finished with exception", indexName, e);
+            }
+        });
+
+        nonEnabledGraphIndexNames.forEach(indexName -> {
+            try {
+                LOG.info("Start force-enabling graph index {}", indexName);
+
+                ManagementSystem schemaUpdateMgmt = (ManagementSystem) graph.openManagement();
+                Index index = schemaUpdateMgmt.getGraphIndex(indexName);
+                schemaUpdateMgmt.updateIndex(index, SchemaAction.ENABLE_INDEX).get();
+                schemaUpdateMgmt.commit();
+
+                LOG.info("Finished force-enabling graph index {}", indexName);
+            } catch (Exception e) {
+                LOG.error("Couldn't execute force-enable for the graph index [{}]", indexName, e);
+                throw new RuntimeException(e);
+            }
+        });
+
+        nonEnabledRelationTypeIndexNamesAndTypes.forEach((indexName, indexedElementName) -> {
+            try {
+                LOG.info("Start force-enabling vertex-centric index {}", indexName);
+
+                ManagementSystem schemaUpdateMgmt = (ManagementSystem) graph.openManagement();
+                Index index = schemaUpdateMgmt.getRelationIndex(schemaUpdateMgmt.getRelationType(indexedElementName), indexName);
+                schemaUpdateMgmt.updateIndex(index, SchemaAction.ENABLE_INDEX).get();
+                schemaUpdateMgmt.commit();
+
+                LOG.info("Finished force-enabling vertex-centric index {}", indexName);
+            } catch (Exception e) {
+                LOG.error("Couldn't execute force-enable for the vertex-centric index [{}]", indexName, e);
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public static void awaitVertexCentricIndexStatus(JanusGraph janusGraph, String indexName, String indexedElement, long indexStatusTimeout) {
+
+        RelationIndexStatusReport relationIndexStatusReport;
+        try {
+
+            relationIndexStatusReport =
+                ManagementSystem.awaitRelationIndexStatus(
+                    janusGraph,
+                    indexName,
+                    indexedElement
+                ).timeout(indexStatusTimeout, ChronoUnit.MILLIS).call();
+
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (!relationIndexStatusReport.getSucceeded()){
+            LOG.error("Await wasn't successful for index [{}]. Actual status [{}]. Time elapsed [{}]. Target statuses [{}]",
+                indexName,
+                relationIndexStatusReport.getActualStatus().toString(),
+                relationIndexStatusReport.getElapsed().toString(),
+                StringUtils.join(relationIndexStatusReport.getTargetStatuses())
+            );
+
+            throw new IllegalStateException("Couldn't await for vertex-centric index status in time [" + indexName + "]");
+        }
+    }
+
+    public static void awaitGraphIndexStatus(JanusGraph janusGraph, String indexName, long indexStatusTimeout) {
+
+        GraphIndexStatusReport graphIndexStatusReport;
+        try {
+            graphIndexStatusReport =
+                ManagementSystem.awaitGraphIndexStatus(
+                    janusGraph,
+                    indexName
+                ).timeout(indexStatusTimeout, ChronoUnit.MILLIS).call();
+
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (!graphIndexStatusReport.getSucceeded()){
+            LOG.warn("Await wasn't successful for index [{}]. Covered keys [{}]. Not covered keys [{}]. Time elapsed [{}]. Target statuses [{}]",
+                indexName,
+                StringUtils.join(graphIndexStatusReport.getConvergedKeys()),
+                StringUtils.join(graphIndexStatusReport.getNotConvergedKeys()),
+                graphIndexStatusReport.getElapsed().toString(),
+                StringUtils.join(graphIndexStatusReport.getTargetStatuses())
+            );
+
+            throw new IllegalStateException("Couldn't await for graph-centric index status in time [" + indexName + "]");
+        }
+    }
+
+    public static boolean isIndexHasStatus(Index index, SchemaStatus status){
+        if(index instanceof JanusGraphIndex){
+            return isGraphIndexHasStatus((JanusGraphIndex) index, status);
+        }
+        if(index instanceof RelationTypeIndex){
+            return isRelationIndexHasStatus((RelationTypeIndex) index, status);
+        }
+        throw new IllegalStateException("Unexpected index type: " + index.getClass() + ", indexName: " + index.name());
+    }
+
+    public static boolean isGraphIndexHasStatus(JanusGraphIndex graphIndex, SchemaStatus status){
+        for(PropertyKey propertyKey : graphIndex.getFieldKeys()){
+            if(!status.equals(graphIndex.getIndexStatus(propertyKey))){
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean isRelationIndexHasStatus(RelationTypeIndex relationTypeIndex, SchemaStatus status){
+        return status.equals(relationTypeIndex.getIndexStatus());
     }
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/StandardJanusGraph.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/StandardJanusGraph.java
@@ -113,6 +113,7 @@ import org.janusgraph.util.system.TXUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -359,6 +360,9 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
             IOUtils.closeQuietly(backend);
             IOUtils.closeQuietly(queryCache);
             IOUtils.closeQuietly(serializer);
+            if(config instanceof Closeable){
+                IOUtils.closeQuietly((Closeable)config);
+            }
         } finally {
             isOpen = false;
         }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
@@ -585,6 +585,39 @@ public class ManagementSystem implements JanusGraphManagement {
         return sb.toString();
     }
 
+    public List<JanusGraphIndex> getGraphIndices(SchemaStatus withoutStatusFilter){
+        List<JanusGraphIndex> indices = filter(getGraphIndexes(Vertex.class), withoutStatusFilter);
+        indices.addAll(filter(getGraphIndexes(Edge.class), withoutStatusFilter));
+        return indices;
+    }
+
+    private List<JanusGraphIndex> filter(Iterable<JanusGraphIndex> graphIndices, SchemaStatus withoutStatusFilter){
+        List<JanusGraphIndex> indicesWithStatus = new ArrayList<>();
+        for(JanusGraphIndex graphIndex : graphIndices){
+            for(PropertyKey propertyKey : graphIndex.getFieldKeys()){
+                if(!withoutStatusFilter.equals(graphIndex.getIndexStatus(propertyKey))){
+                    indicesWithStatus.add(graphIndex);
+                    break;
+                }
+            }
+        }
+        return indicesWithStatus;
+    }
+
+    public List<RelationTypeIndex> getVertexCentricIndices(SchemaStatus withoutStatusFilter){
+        Iterable<RelationType> relationTypes = getRelationTypes(RelationType.class);
+        LinkedList<RelationTypeIndex> relationIndexes  = new LinkedList<>();
+        for (RelationType rt :relationTypes) {
+            Iterable<RelationTypeIndex> rti = getRelationIndexes(rt);
+            rti.forEach(relationTypeIndex -> {
+                if(!withoutStatusFilter.equals(relationTypeIndex.getIndexStatus())){
+                    relationIndexes.add(relationTypeIndex);
+                }
+            });
+        }
+        return relationIndexes;
+    }
+
     private String iterateIndexes(String pattern, Iterable<JanusGraphIndex> indexes) {
         StringBuilder sb = new StringBuilder();
         for (JanusGraphIndex index: indexes) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/ParameterType.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/ParameterType.java
@@ -48,7 +48,7 @@ public enum ParameterType {
     TEXT_ANALYZER("text-analyzer"),
     ;
 
-    private static final String CUSTOM_PARAMETER_PREFIX = "%`custom%`";
+    public static final String CUSTOM_PARAMETER_PREFIX = "%`custom%`";
 
     private final String name;
 

--- a/janusgraph-core/src/test/java/org/janusgraph/core/schema/json/parser/JsonParameterDefinitionParserTest.java
+++ b/janusgraph-core/src/test/java/org/janusgraph/core/schema/json/parser/JsonParameterDefinitionParserTest.java
@@ -1,0 +1,94 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema.json.parser;
+
+import org.janusgraph.core.schema.Mapping;
+import org.janusgraph.core.schema.json.creator.SchemaCreationException;
+import org.janusgraph.core.schema.json.definition.JsonParameterDefinition;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class JsonParameterDefinitionParserTest {
+
+    private final JsonParameterDefinitionParser parser = new JsonParameterDefinitionParser();
+
+    @Test
+    void shouldParseDefinedShortcutParsers(){
+        JsonParameterDefinition definition = new JsonParameterDefinition();
+        definition.setKey("test");
+
+        definition.setParser(JsonParameterDefinitionParser.STRING_PARAMETER_PARSER_NAME);
+        definition.setValue("testStr");
+        Assertions.assertEquals("testStr", parser.parse(definition).value());
+
+        definition.setParser(JsonParameterDefinitionParser.ENUM_PARAMETER_PARSER_NAME);
+        definition.setValue("org.janusgraph.core.schema.Mapping.TEXTSTRING");
+        Assertions.assertEquals(Mapping.TEXTSTRING, parser.parse(definition).value());
+
+        definition.setParser(JsonParameterDefinitionParser.BOOLEAN_PARAMETER_PARSER_NAME);
+        definition.setValue("true");
+        Assertions.assertEquals(true, parser.parse(definition).value());
+
+        definition.setParser(JsonParameterDefinitionParser.BYTE_PARAMETER_PARSER_NAME);
+        definition.setValue("127");
+        Assertions.assertEquals(((byte) 127), parser.parse(definition).value());
+
+        definition.setParser(JsonParameterDefinitionParser.SHORT_PARAMETER_PARSER_NAME);
+        definition.setValue("12345");
+        Assertions.assertEquals(((short) 12345), parser.parse(definition).value());
+
+        definition.setParser(JsonParameterDefinitionParser.INTEGER_PARAMETER_PARSER_NAME);
+        definition.setValue("12345678");
+        Assertions.assertEquals(12345678, parser.parse(definition).value());
+
+        definition.setParser(JsonParameterDefinitionParser.LONG_PARAMETER_PARSER_NAME);
+        definition.setValue("123456789012");
+        Assertions.assertEquals(123456789012L, parser.parse(definition).value());
+
+        definition.setParser(JsonParameterDefinitionParser.FLOAT_PARAMETER_PARSER_NAME);
+        definition.setValue("123.45");
+        Assertions.assertEquals(123.45f, parser.parse(definition).value());
+
+        definition.setParser(JsonParameterDefinitionParser.DOUBLE_PARAMETER_PARSER_NAME);
+        definition.setValue("12345.6789012");
+        Assertions.assertEquals(12345.6789012d, parser.parse(definition).value());
+    }
+
+    @Test
+    void shouldParseByFullClassPathParser(){
+        JsonParameterDefinition definition = new JsonParameterDefinition();
+        definition.setKey("test");
+
+        definition.setParser(EnumJsonParameterParser.class.getName());
+        definition.setValue("org.janusgraph.core.schema.Mapping.TEXTSTRING");
+        Assertions.assertEquals(Mapping.TEXTSTRING, parser.parse(definition).value());
+    }
+
+    @Test
+    void shouldFailParsingOnWrongClass(){
+        JsonParameterDefinition definition = new JsonParameterDefinition();
+        definition.setKey("test");
+        definition.setValue("org.janusgraph.core.schema.Mapping.TEXTSTRING");
+
+        definition.setParser(Integer.class.getName());
+        Assertions.assertThrows(SchemaCreationException.class, () -> parser.parse(definition));
+
+        definition.setParser("Unknown class");
+        Assertions.assertThrows(SchemaCreationException.class, () -> parser.parse(definition));
+
+        definition.setParser("integer");
+        Assertions.assertThrows(NumberFormatException.class, () -> parser.parse(definition));
+    }
+}

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/CQLElasticsearchTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/CQLElasticsearchTest.java
@@ -14,11 +14,47 @@
 
 package org.janusgraph.diskstorage.es;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.janusgraph.JanusGraphCassandraContainer;
+import org.janusgraph.core.Cardinality;
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.Multiplicity;
+import org.janusgraph.core.schema.IndicesActivationType;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.core.schema.SchemaInitType;
+import org.janusgraph.core.schema.SchemaStatus;
+import org.janusgraph.core.schema.json.definition.JsonSchemaDefinition;
+import org.janusgraph.core.util.JsonUtil;
+import org.janusgraph.core.util.ManagementUtil;
 import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Callable;
+
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.SCHEMA_DROP_BEFORE_INIT;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.SCHEMA_INIT_JSON_FILE;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.SCHEMA_INIT_JSON_FORCE_CLOSE_OTHER_INSTANCES;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.SCHEMA_INIT_JSON_INDICES_ACTIVATION_TYPE;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.SCHEMA_INIT_JSON_SKIP_ELEMENTS;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.SCHEMA_INIT_JSON_SKIP_INDICES;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.SCHEMA_INIT_STRATEGY;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.UNIQUE_INSTANCE_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Testcontainers
 public class CQLElasticsearchTest extends ElasticsearchJanusGraphIndexTest {
@@ -34,4 +70,302 @@ public class CQLElasticsearchTest extends ElasticsearchJanusGraphIndexTest {
     @Override
     @Disabled("CQL seems to not clear storage correctly")
     public void testClearStorage() {}
+
+    @Test
+    public void testJsonFreshSchemaImport() {
+        String jsonFilePath = createJsonFileAndReturnPath();
+
+        clopen(
+            option(SCHEMA_INIT_STRATEGY), SchemaInitType.JSON.getConfigName(),
+            option(SCHEMA_DROP_BEFORE_INIT), true,
+            option(SCHEMA_INIT_JSON_FILE), jsonFilePath,
+            option(SCHEMA_INIT_JSON_INDICES_ACTIVATION_TYPE), IndicesActivationType.REINDEX_AND_ENABLE_UPDATED_ONLY.getConfigName()
+        );
+        assertSchemaElements();
+        assertIndices(SchemaStatus.ENABLED);
+
+        // Check additional run doesn't change anything
+        clopen(
+            option(SCHEMA_INIT_STRATEGY), SchemaInitType.JSON.getConfigName(),
+            option(SCHEMA_DROP_BEFORE_INIT), false,
+            option(SCHEMA_INIT_JSON_FILE), jsonFilePath
+        );
+        assertSchemaElements();
+        assertIndices(SchemaStatus.ENABLED);
+
+        // Check schema from documentation can be initialized
+        String jsonFromDocFilePath = createJsonFileAndReturnPath("test_schema_from_doc.json");
+        clopen(
+            option(SCHEMA_INIT_STRATEGY), SchemaInitType.JSON.getConfigName(),
+            option(SCHEMA_DROP_BEFORE_INIT), true,
+            option(SCHEMA_INIT_JSON_FILE), jsonFromDocFilePath,
+            option(SCHEMA_INIT_JSON_INDICES_ACTIVATION_TYPE), IndicesActivationType.REINDEX_AND_ENABLE_NON_ENABLED.getConfigName()
+        );
+    }
+
+    @Test
+    public void testJsonGradualSchemaImport() {
+        String jsonFilePath = createJsonFileAndReturnPath();
+
+        clopen(
+            option(SCHEMA_INIT_STRATEGY), SchemaInitType.JSON.getConfigName(),
+            option(SCHEMA_DROP_BEFORE_INIT), true,
+            option(SCHEMA_INIT_JSON_FILE), jsonFilePath,
+            option(SCHEMA_INIT_JSON_INDICES_ACTIVATION_TYPE), IndicesActivationType.REINDEX_AND_ENABLE_NON_ENABLED.getConfigName(),
+            option(SCHEMA_INIT_JSON_SKIP_ELEMENTS), false,
+            option(SCHEMA_INIT_JSON_SKIP_INDICES), true
+        );
+
+        createData();
+        assertDataFetch(false, true);
+
+        clopen(
+            option(SCHEMA_INIT_STRATEGY), SchemaInitType.JSON.getConfigName(),
+            option(SCHEMA_DROP_BEFORE_INIT), false,
+            option(SCHEMA_INIT_JSON_FILE), jsonFilePath,
+            option(SCHEMA_INIT_JSON_INDICES_ACTIVATION_TYPE), IndicesActivationType.REINDEX_AND_ENABLE_UPDATED_ONLY.getConfigName(),
+            option(SCHEMA_INIT_JSON_SKIP_ELEMENTS), true,
+            option(SCHEMA_INIT_JSON_SKIP_INDICES), false
+        );
+
+        assertSchemaElements();
+        assertIndices(SchemaStatus.ENABLED);
+        assertDataFetch(true, true);
+    }
+
+    @Test
+    public void testJsonForceSchemaImport() {
+        String jsonFilePath = createJsonFileAndReturnPath();
+
+        clopen(
+            option(SCHEMA_INIT_STRATEGY), SchemaInitType.JSON.getConfigName(),
+            option(SCHEMA_DROP_BEFORE_INIT), true,
+            option(SCHEMA_INIT_JSON_FILE), jsonFilePath,
+            option(SCHEMA_INIT_JSON_INDICES_ACTIVATION_TYPE), IndicesActivationType.FORCE_ENABLE_NON_ENABLED.getConfigName(),
+            option(SCHEMA_INIT_JSON_SKIP_ELEMENTS), false,
+            option(SCHEMA_INIT_JSON_SKIP_INDICES), true
+        );
+
+        createData();
+        assertDataFetch(false, true);
+
+        clopen(
+            option(SCHEMA_INIT_STRATEGY), SchemaInitType.JSON.getConfigName(),
+            option(SCHEMA_DROP_BEFORE_INIT), false,
+            option(SCHEMA_INIT_JSON_FILE), jsonFilePath,
+            option(SCHEMA_INIT_JSON_INDICES_ACTIVATION_TYPE), IndicesActivationType.FORCE_ENABLE_UPDATED_ONLY.getConfigName(),
+            option(SCHEMA_INIT_JSON_SKIP_ELEMENTS), true,
+            option(SCHEMA_INIT_JSON_SKIP_INDICES), false
+        );
+
+        assertSchemaElements();
+        assertIndices(SchemaStatus.ENABLED);
+        assertDataFetch(true, false);
+    }
+
+    @Test
+    public void testJsonSchemaImportSkipIndicesActivation() {
+        String jsonFilePath = createJsonFileAndReturnPath();
+
+        clopen(
+            option(SCHEMA_INIT_STRATEGY), SchemaInitType.JSON.getConfigName(),
+            option(SCHEMA_DROP_BEFORE_INIT), true,
+            option(SCHEMA_INIT_JSON_FILE), jsonFilePath,
+            option(SCHEMA_INIT_JSON_INDICES_ACTIVATION_TYPE), IndicesActivationType.FORCE_ENABLE_NON_ENABLED.getConfigName(),
+            option(SCHEMA_INIT_JSON_SKIP_ELEMENTS), false,
+            option(SCHEMA_INIT_JSON_SKIP_INDICES), true
+        );
+
+        createData();
+        assertDataFetch(false, true);
+
+        clopen(
+            option(SCHEMA_INIT_STRATEGY), SchemaInitType.JSON.getConfigName(),
+            option(SCHEMA_DROP_BEFORE_INIT), false,
+            option(SCHEMA_INIT_JSON_FILE), jsonFilePath,
+            option(SCHEMA_INIT_JSON_INDICES_ACTIVATION_TYPE), IndicesActivationType.SKIP_ACTIVATION.getConfigName(),
+            option(SCHEMA_INIT_JSON_SKIP_ELEMENTS), true,
+            option(SCHEMA_INIT_JSON_SKIP_INDICES), false
+        );
+
+        assertSchemaElements();
+        assertIndices(SchemaStatus.INSTALLED);
+        assertDataFetch(false, true);
+    }
+
+    @Test
+    public void testJsonGradualSchemaImportForceClosingOtherInstances() {
+        String jsonFilePath = createJsonFileAndReturnPath();
+
+        clopen(
+            option(SCHEMA_INIT_STRATEGY), SchemaInitType.JSON.getConfigName(),
+            option(SCHEMA_DROP_BEFORE_INIT), true,
+            option(SCHEMA_INIT_JSON_FILE), jsonFilePath,
+            option(SCHEMA_INIT_JSON_INDICES_ACTIVATION_TYPE), IndicesActivationType.REINDEX_AND_ENABLE_NON_ENABLED.getConfigName(),
+            option(SCHEMA_INIT_JSON_SKIP_ELEMENTS), false,
+            option(SCHEMA_INIT_JSON_SKIP_INDICES), true,
+            option(UNIQUE_INSTANCE_ID), "graph1"
+
+        );
+
+        createData();
+        assertDataFetch(false, true);
+
+        setupConfig(option(SCHEMA_INIT_STRATEGY), SchemaInitType.JSON.getConfigName(),
+            option(SCHEMA_DROP_BEFORE_INIT), false,
+            option(SCHEMA_INIT_JSON_FILE), jsonFilePath,
+            option(SCHEMA_INIT_JSON_INDICES_ACTIVATION_TYPE), IndicesActivationType.REINDEX_AND_ENABLE_UPDATED_ONLY.getConfigName(),
+            option(SCHEMA_INIT_JSON_SKIP_ELEMENTS), true,
+            option(SCHEMA_INIT_JSON_SKIP_INDICES), false,
+            option(SCHEMA_INIT_JSON_FORCE_CLOSE_OTHER_INSTANCES), true,
+            option(UNIQUE_INSTANCE_ID), "graph2"
+        );
+
+        JanusGraph prevGraph = graph;
+        JanusGraphManagement prevMgmt = mgmt;
+        if(!prevMgmt.isOpen()){
+            prevMgmt = graph.openManagement();
+        }
+        open(config);
+
+        assertSchemaElements();
+        assertIndices(SchemaStatus.ENABLED);
+        assertDataFetch(true, true);
+
+        if(prevMgmt.isOpen()){
+            prevMgmt.rollback();
+        }
+        if(prevGraph.isOpen()){
+            prevGraph.close();
+        }
+    }
+
+    @Test
+    public void testCustomSchemaInitStrategy() {
+        assertFalse(CustomTestSchemaInitStrategy.initialized);
+        clopen(
+            option(SCHEMA_INIT_STRATEGY), CustomTestSchemaInitStrategy.class.getName()
+        );
+        assertTrue(CustomTestSchemaInitStrategy.initialized);
+    }
+
+    @Test
+    public void testJsonSchemaResourceParseToObject() throws IOException {
+        JsonSchemaDefinition jsonSchemaDefinition = JsonUtil
+            .jsonResourcePathToObject("test_schema_example.json", JsonSchemaDefinition.class);
+        assertNotNull(jsonSchemaDefinition);
+    }
+
+    private void assertDataFetch(boolean indicesUsed, boolean indexedDataShouldBeFound){
+        GraphTraversalSource g = graph.traversal();
+
+        try {
+            Callable<GraphTraversal<?,?>> query = () -> g.V().hasLabel("organization").has("name", "test_org1");
+            assertEquals(indicesUsed, query.call().profile().next().toString().contains("index="));
+            assertEquals(indexedDataShouldBeFound, query.call().hasNext());
+
+            query = () -> g.V().hasLabel("organization").has("name", "test_org2");
+            assertEquals(indicesUsed, query.call().profile().next().toString().contains("index="));
+            assertEquals(indexedDataShouldBeFound, query.call().hasNext());
+
+            query = () -> g.V().hasLabel("device").has("name", "test_org3");
+            assertEquals(indicesUsed, query.call().profile().next().toString().contains("index="));
+            assertEquals(indexedDataShouldBeFound, query.call().hasNext());
+
+            if(indexedDataShouldBeFound){
+                Vertex vertex = g.V().hasLabel("organization").has("name", "test_org1").next();
+                query = () -> g.V(vertex).properties("longPropCardinalityList").has("time", P.lt(300));
+                assertEquals(indicesUsed, query.call().profile().next().toString().contains("longPropCardinalityListMetaPropertyVertexCentricIndexForTime"));
+                assertTrue(query.call().hasNext());
+            }
+
+            query = () -> g.E().hasLabel("connects").has("name", "connectsEdge1");
+            assertEquals(indicesUsed, query.call().profile().next().toString().contains("index="));
+            assertEquals(indexedDataShouldBeFound, query.call().hasNext());
+
+            query = () -> g.E().hasLabel("viewed").has("name", "connectsEdge4");
+            // No indices were defined for such query. Thus, it should always be `false`.
+            assertFalse(query.call().profile().next().toString().contains("index="));
+            assertTrue(query.call().profile().next().toString().contains("fullscan=true"));
+            assertTrue(query.call().hasNext());
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            g.tx().rollback();
+        }
+    }
+
+    private void assertSchemaElements(){
+        assertEquals(Long.class, mgmt.getPropertyKey("time").dataType());
+        assertEquals(Double.class, mgmt.getPropertyKey("doubleProp").dataType());
+        assertEquals(Cardinality.LIST, mgmt.getPropertyKey("longPropCardinalityList").cardinality());
+
+        assertEquals("organization", mgmt.getVertexLabel("organization").name());
+
+        assertEquals(Multiplicity.SIMPLE, mgmt.getEdgeLabel("connects").multiplicity());
+        assertTrue(mgmt.getEdgeLabel("connects").isDirected());
+        assertEquals(Multiplicity.MULTI, mgmt.getEdgeLabel("viewed").multiplicity());
+        assertTrue(mgmt.getEdgeLabel("viewed").isUnidirected());
+    }
+
+    private void assertIndices(SchemaStatus status){
+        assertTrue(ManagementUtil.isIndexHasStatus(mgmt.getGraphIndex("nameCompositeIndex"), status));
+        assertTrue(ManagementUtil.isIndexHasStatus(mgmt.getGraphIndex("timeForOrganizationsOnlyCompositeIndex"), status));
+        assertTrue(ManagementUtil.isIndexHasStatus(mgmt.getGraphIndex("connectsOnlyEdgeCompositeIndex"), status));
+        assertTrue(ManagementUtil.isIndexHasStatus(mgmt.getGraphIndex("uniqueCompositeIndexWithLocking"), status));
+        assertTrue(ManagementUtil.isIndexHasStatus(mgmt.getGraphIndex("multiKeysCompositeIndex"), status));
+        assertTrue(ManagementUtil.isIndexHasStatus(mgmt.getGraphIndex("nameMixedIndex"), status));
+
+        assertTrue(ManagementUtil.isIndexHasStatus(mgmt.getRelationIndex(mgmt.getRelationType("connects"), "connectsTimeVertexCentricIndex"), status));
+        assertTrue(ManagementUtil.isIndexHasStatus(mgmt.getRelationIndex(mgmt.getRelationType("viewed"), "vertexCentricUnidirectedEdgeIndexWithTwoProps"), status));
+        assertTrue(ManagementUtil.isIndexHasStatus(mgmt.getRelationIndex(mgmt.getRelationType("longPropCardinalityList"), "longPropCardinalityListMetaPropertyVertexCentricIndexForTime"), status));
+    }
+
+    private String createJsonFileAndReturnPath() {
+        return createJsonFileAndReturnPath("test_schema_example.json");
+    }
+
+    private String createJsonFileAndReturnPath(String resourcePath) {
+        try{
+            ClassLoader loader = Thread.currentThread().getContextClassLoader();
+            InputStream resourceStream = loader.getResourceAsStream(resourcePath);
+            String jsonSchemaExample = IOUtils.toString(resourceStream, StandardCharsets.UTF_8);
+            File file = File.createTempFile( "janusgraph", "_"+resourcePath);
+            file.deleteOnExit();
+            FileUtils.writeStringToFile(file, jsonSchemaExample, StandardCharsets.UTF_8);
+            return file.getAbsolutePath();
+        } catch (IOException e){
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void createData(){
+        GraphTraversalSource g = graph.traversal();
+
+        Vertex vertex1 = g.addV("organization").property("time", 12345L)
+            .property("name", "test_org1")
+            .property("longPropCardinalityList", 123L, "time", 321L)
+            .property("longPropCardinalityList", 123L, "time", 213L)
+            .property("longPropCardinalityList", 123L, "time", 231L).next();
+
+        Vertex vertex2 = g.addV("organization").property("time", 54321L)
+            .property("name", "test_org2")
+            .property("longPropCardinalityList", 123L, "time", 321L)
+            .property("longPropCardinalityList", 123L, "time", 213L)
+            .property("longPropCardinalityList", 123L, "time", 231L).next();
+
+        Vertex vertex3 = g.addV("device").property("time", 1L)
+            .property("name", "test_org3")
+            .property("longPropCardinalityList", 123L, "time", 321L)
+            .property("longPropCardinalityList", 123L, "time", 213L)
+            .property("longPropCardinalityList", 123L, "time", 231L).next();
+
+        g.addE("connects").from(vertex1).to(vertex2).property("name", "connectsEdge1").property("time", 123L).next();
+        g.addE("connects").from(vertex1).to(vertex3).property("name", "connectsEdge2").property("time", 124L).next();
+        g.addE("connects").from(vertex3).to(vertex2).property("name", "connectsEdge3").property("time", 125L).next();
+        g.addE("viewed").from(vertex2).to(vertex3).property("name", "connectsEdge4").property("time", 100L).next();
+
+        g.tx().commit();
+    }
 }

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/CustomJsonStringParameterParser.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/CustomJsonStringParameterParser.java
@@ -1,0 +1,27 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.es;
+
+import org.janusgraph.core.schema.Parameter;
+import org.janusgraph.core.schema.json.parser.JsonParameterParser;
+
+public class CustomJsonStringParameterParser implements JsonParameterParser {
+
+    @Override
+    public Parameter parse(String key, String value) {
+        return Parameter.of(key, value);
+    }
+
+}

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/CustomTestSchemaInitStrategy.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/CustomTestSchemaInitStrategy.java
@@ -1,0 +1,30 @@
+// Copyright 2024 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.es;
+
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.schema.SchemaInitStrategy;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+
+public class CustomTestSchemaInitStrategy implements SchemaInitStrategy {
+
+    public static volatile boolean initialized = false;
+
+    @Override
+    public JanusGraph initializeSchemaAndStart(GraphDatabaseConfiguration graphDatabaseConfiguration) {
+        initialized = true;
+        return null;
+    }
+}

--- a/janusgraph-es/src/test/resources/test_schema_example.json
+++ b/janusgraph-es/src/test/resources/test_schema_example.json
@@ -1,0 +1,232 @@
+{
+    "vertexLabels": [
+        {
+            "label": "organization"
+        },
+        {
+            "label": "device",
+            "staticVertex": false,
+            "partition": false
+        },
+        {
+            "label": "unmodifiableVertex",
+            "staticVertex": true
+        },
+        {
+            "label": "temporaryVertexForTwoHours",
+            "staticVertex": true,
+            "ttl": 7200000
+        }
+    ],
+    "edgeLabels": [
+        {
+            "label": "connects",
+            "multiplicity": "SIMPLE",
+            "unidirected": false
+        },
+        {
+            "label": "viewed",
+            "multiplicity": "MULTI",
+            "unidirected": true
+        },
+        {
+            "label": "temporaryEdgeForOneHour",
+            "ttl": 3600000
+        },
+        {
+            "label": "edgeWhichUsesLocksInEventualConsistentDBs",
+            "consistency": "LOCK"
+        },
+        {
+            "label": "edgeWhichUsesForkingInEventualConsistentDBs",
+            "consistency": "FORK"
+        }
+    ],
+    "propertyKeys": [
+        {
+            "key": "time",
+            "className": "java.lang.Long"
+        },
+        {
+            "key": "doubleProp",
+            "className": "java.lang.Double"
+        },
+        {
+            "key": "integerProp",
+            "className": "java.lang.Integer"
+        },
+        {
+            "key": "longPropCardinalityList",
+            "className": "java.lang.Long",
+            "cardinality": "LIST"
+        },
+        {
+            "key": "name",
+            "className": "java.lang.String",
+            "cardinality": "SINGLE"
+        },
+        {
+            "key": "geoshape",
+            "className": "org.janusgraph.core.attribute.Geoshape"
+        },
+        {
+            "key": "type",
+            "className": "java.lang.String",
+            "cardinality": "SET"
+        },
+        {
+            "key": "propertyWhichUsesLocksInEventualConsistentDBs",
+            "className": "java.lang.Long",
+            "cardinality": "SET",
+            "consistency": "LOCK"
+        },
+        {
+            "key": "temporaryPropertyForOneHour",
+            "className": "java.lang.Long",
+            "ttl": 3600000
+        },
+        {
+            "key": "anotherName",
+            "className": "java.lang.String"
+        }
+    ],
+    "compositeIndexes": [
+        {
+            "name": "nameCompositeIndex",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "keys": [
+                {
+                    "propertyKey": "name"
+                }
+            ]
+        },
+        {
+            "name": "timeForOrganizationsOnlyCompositeIndex",
+            "indexOnly": "organization",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "keys": [
+                {
+                    "propertyKey": "time"
+                }
+            ]
+        },
+        {
+            "name": "connectsOnlyEdgeCompositeIndex",
+            "indexOnly": "connects",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Edge",
+            "keys": [
+                {
+                    "propertyKey": "name"
+                }
+            ]
+        },
+        {
+            "name": "uniqueCompositeIndexWithLocking",
+            "indexOnly": "unmodifiableVertex",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "unique": true,
+            "consistency": "LOCK",
+            "keys": [
+                {
+                    "propertyKey": "integerProp"
+                }
+            ]
+        },
+        {
+            "name": "multiKeysCompositeIndex",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "unique": true,
+            "consistency": "LOCK",
+            "keys": [
+                {
+                    "propertyKey": "doubleProp"
+                },
+                {
+                    "propertyKey": "integerProp"
+                }
+            ]
+        }
+    ],
+    "vertexCentricEdgeIndexes": [
+        {
+            "name": "connectsTimeVertexCentricIndex",
+            "indexedEdgeLabel": "connects",
+            "direction": "BOTH",
+            "propertyKeys": [
+                "time"
+            ],
+            "order": "asc"
+        },
+        {
+            "name": "vertexCentricUnidirectedEdgeIndexWithTwoProps",
+            "indexedEdgeLabel": "viewed",
+            "direction": "OUT",
+            "propertyKeys": [
+                "time",
+                "integerProp"
+            ],
+            "order": "asc"
+        }
+    ],
+    "vertexCentricPropertyIndexes": [
+        {
+            "name": "longPropCardinalityListMetaPropertyVertexCentricIndexForTime",
+            "indexedPropertyKey": "longPropCardinalityList",
+            "propertyKeys": [
+                "time"
+            ],
+            "order": "desc"
+        }
+    ],
+    "mixedIndexes": [
+        {
+            "name": "nameMixedIndex",
+            "indexOnly": "organization",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "indexBackend": "search",
+            "keys": [
+                {
+                    "propertyKey": "name",
+                    "parameters": [
+                        {
+                            "key": "string-analyzer",
+                            "value": "standard",
+                            "parser": "string"
+                        },
+                        {
+                            "key": "mapping",
+                            "value": "org.janusgraph.core.schema.Mapping.STRING",
+                            "parser": "enum"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "typeAndAnotherNameMixedIndex",
+            "indexOnly": "unmodifiableVertex",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "indexBackend": "search",
+            "keys": [
+                {
+                    "propertyKey": "type"
+                },
+                {
+                    "propertyKey": "anotherName",
+                    "parameters": [
+                        {
+                            "key": "string-analyzer",
+                            "value": "standard",
+                            "parser": "org.janusgraph.diskstorage.es.CustomJsonStringParameterParser"
+                        },
+                        {
+                            "key": "mapping",
+                            "value": "org.janusgraph.core.schema.Mapping.STRING",
+                            "parser": "enum"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/janusgraph-es/src/test/resources/test_schema_from_doc.json
+++ b/janusgraph-es/src/test/resources/test_schema_from_doc.json
@@ -1,0 +1,240 @@
+{
+    "vertexLabels": [
+        {
+            "label": "normalVertex"
+        },
+        {
+            "label": "partitionedVertex",
+            "partition": true
+        },
+        {
+            "label": "unmodifiableVertex",
+            "staticVertex": true
+        },
+        {
+            "label": "temporaryVertexForTwoHours",
+            "staticVertex": true,
+            "ttl": 7200000
+        }
+    ],
+    "edgeLabels": [
+        {
+            "label": "normalSimpleEdge",
+            "multiplicity": "SIMPLE",
+            "unidirected": false
+        },
+        {
+            "label": "unidirectedMultiEdge",
+            "multiplicity": "MULTI",
+            "unidirected": true
+        },
+        {
+            "label": "temporaryEdgeForOneHour",
+            "ttl": 3600000
+        },
+        {
+            "label": "edgeWhichUsesLocksInEventualConsistentDBs",
+            "consistency": "LOCK"
+        },
+        {
+            "label": "edgeWhichUsesForkingInEventualConsistentDBs",
+            "consistency": "FORK"
+        }
+    ],
+    "propertyKeys": [
+        {
+            "key": "normalProperty",
+            "className": "java.lang.Long"
+        },
+        {
+            "key": "stringProperty",
+            "className": "java.lang.String",
+            "cardinality": "SINGLE"
+        },
+        {
+            "key": "anotherStringProperty",
+            "className": "java.lang.String",
+            "cardinality": "SINGLE"
+        },
+        {
+            "key": "listProperty",
+            "className": "java.lang.Long",
+            "cardinality": "LIST"
+        },
+        {
+            "key": "geoshapeProperty",
+            "className": "org.janusgraph.core.attribute.Geoshape"
+        },
+        {
+            "key": "setProperty",
+            "className": "java.lang.String",
+            "cardinality": "SET"
+        },
+        {
+            "key": "propertyWhichUsesLocksInEventualConsistentDBs",
+            "className": "java.lang.Long",
+            "cardinality": "SET",
+            "consistency": "LOCK"
+        },
+        {
+            "key": "temporaryPropertyForOneHour",
+            "className": "java.lang.Long",
+            "ttl": 3600000
+        }
+    ],
+    "compositeIndexes": [
+        {
+            "name": "simpleCompositeIndex",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "keys": [
+                {
+                    "propertyKey": "normalProperty"
+                }
+            ]
+        },
+        {
+            "name": "indexOnlyForNormalVerticesOnListProperty",
+            "indexOnly": "normalVertex",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "keys": [
+                {
+                    "propertyKey": "listProperty"
+                }
+            ]
+        },
+        {
+            "name": "compositeIndexOnEdge",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Edge",
+            "keys": [
+                {
+                    "propertyKey": "normalProperty"
+                }
+            ]
+        },
+        {
+            "name": "uniqueCompositeIndexWithLocking",
+            "indexOnly": "unmodifiableVertex",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "unique": true,
+            "consistency": "LOCK",
+            "keys": [
+                {
+                    "propertyKey": "stringProperty"
+                }
+            ]
+        },
+        {
+            "name": "multiKeysCompositeIndex",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "keys": [
+                {
+                    "propertyKey": "normalProperty"
+                },
+                {
+                    "propertyKey": "anotherStringProperty"
+                }
+            ]
+        },
+        {
+            "name": "compositeIndexWithInlinedProperties",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "keys": [
+                {
+                    "propertyKey": "setProperty"
+                }
+            ],
+            "inlinePropertyKeys": ["normalProperty", "stringProperty", "anotherStringProperty"]
+        }
+    ],
+    "vertexCentricEdgeIndexes": [
+        {
+            "name": "vertexCentricBothDirectionsEdgeIndex",
+            "indexedEdgeLabel": "normalSimpleEdge",
+            "direction": "BOTH",
+            "propertyKeys": [
+                "normalProperty"
+            ],
+            "order": "asc"
+        },
+        {
+            "name": "vertexCentricUnidirectedEdgeIndexOnMultipleProperties",
+            "indexedEdgeLabel": "unidirectedMultiEdge",
+            "direction": "OUT",
+            "propertyKeys": [
+                "stringProperty",
+                "anotherStringProperty"
+            ],
+            "order": "desc"
+        }
+    ],
+    "vertexCentricPropertyIndexes": [
+        {
+            "name": "normalVertexCentricPropertyKey",
+            "indexedPropertyKey": "listProperty",
+            "propertyKeys": [
+                "normalProperty"
+            ],
+            "order": "asc"
+        }
+    ],
+    "mixedIndexes": [
+        {
+            "name": "simpleMixedIndexOnMultipleProperties",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "indexBackend": "search",
+            "keys": [
+                {
+                    "propertyKey": "normalProperty"
+                },
+                {
+                    "propertyKey": "geoshapeProperty"
+                }
+            ]
+        },
+        {
+            "name": "mixedIndexWithParametersOnProperties",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Vertex",
+            "indexBackend": "search",
+            "keys": [
+                {
+                    "propertyKey": "stringProperty",
+                    "parameters": [
+                        {
+                            "key": "string-analyzer",
+                            "value": "standard",
+                            "parser": "string"
+                        },
+                        {
+                            "key": "mapping",
+                            "value": "org.janusgraph.core.schema.Mapping.STRING",
+                            "parser": "enum"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "mixedIndexWithCustomParameterKeyAndParserFullClassPath",
+            "indexOnly": "unidirectedMultiEdge",
+            "typeClass": "org.apache.tinkerpop.gremlin.structure.Edge",
+            "indexBackend": "search",
+            "keys": [
+                {
+                    "propertyKey": "anotherStringProperty",
+                    "parameters": [
+                        {
+                            "key": "%`custom%`similarity",
+                            "value": "boolean",
+                            "parser": "string"
+                        },
+                        {
+                            "key": "mapping",
+                            "value": "org.janusgraph.core.schema.Mapping.TEXTSTRING",
+                            "parser": "org.janusgraph.core.schema.json.parser.EnumJsonParameterParser"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ plugins:
         interactions/connecting/dotnet.md: basics/connecting/dotnet.md
         advanced-topics/bulk-loading.md: operations/bulk-loading.md
         advanced-topics/advschema.md: schema/advschema.md
+        advanced-topics/schema-init-strategies.md: schema/schema-init-strategies.md
         advanced-topics/monitoring.md: operations/monitoring.md
         advanced-topics/migrating-titan.md: operations/migrating-titan.md
         advanced-topics/migrating-thrift.md: operations/migrating-thrift.md
@@ -138,6 +139,7 @@ nav:
       - Index Lifecycle: schema/index-management/index-lifecycle.md
       - Reindexing: schema/index-management/index-reindexing.md
       - Removal: schema/index-management/index-removal.md
+    - Schema Initialization: schema/schema-init-strategies.md
   - Operations:
     - JanusGraph Server: operations/server.md
     - Deployment Scenarios: operations/deployment.md


### PR DESCRIPTION
Add ability to import schema defined in JSON format via file path or directly via JSON string. 
This implementation doesn't migrate or update already defined schema elements. Neither it removes existing defined elements. 
`SchemaInitStrategy` is defined in mind to be able to implement migration and more advance schema management, even so current JSON schema importer implementation is fairly simple. This work is made in hopes to simplify schema definition for beginners, speed-up prototypes development based on JanusGraph, and simplify testing.

#### Notes to reviewers
Best way to understand how this schema importer work is to read added documentation page `docs/schema/schema-init-strategies.md`.
By default none of the functionality is affected. New functionality can be activated only by providing non-default values to `schema.init.strategy` configuration option.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
