### PR TITLE
Make trivy scan tentative to overcome rate limits

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -108,14 +108,23 @@ jobs:
           export JG_VER="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$(git rev-parse --short HEAD)"
           echo "JG_VER=${JG_VER}" >> $GITHUB_ENV
       - name: Run Trivy vulnerability scanner
+        id: trivy_scan_step
         if: github.repository == 'janusgraph/janusgraph'
-        uses: aquasecurity/trivy-action@0.24.0
+        # TODO: currently this step is tentative because of the rate-limiting issue.
+        # Thus, we add `continue-on-error: true` here, but we should remove it
+        # when either the issue is fixed (see: https://github.com/aquasecurity/trivy-action/issues/389)
+        # or we self-host trivy database.
+        uses: aquasecurity/trivy-action@0.28.0
+        continue-on-error: true
         with:
           image-ref: 'ghcr.io/janusgraph/janusgraph:${{ env.JG_VER }}${{ matrix.tag_suffix }}'
           format: 'sarif'
           output: 'trivy-results.sarif'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Trivy scan results to GitHub Security tab
-        if: github.repository == 'janusgraph/janusgraph'
+        if: github.repository == 'janusgraph/janusgraph' && success() && steps.trivy_scan_step.outcome == 'success'
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Currently trivy scan jobs started to failing in all commits (see [here](https://github.com/JanusGraph/janusgraph/actions/runs/11663626552/job/32532820274) for example). 
This is due to rate limits and the root issue is the following:  https://github.com/aquasecurity/trivy-action/issues/389
Thus, this PR makes trivy scan job tentative for now.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
