### PR TITLE
Introducing JanusGraph Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ can support thousands of concurrent users, complex traversals, and analytic grap
 [![Mentioned in Awesome Bigtable][awesome-shield]][awesome-link]
 [![CII Best Practices][bestpractices-shield]][bestpractices-link]
 [![Codacy Badge][codacy-shield]][codacy-link]
+[![Gurubase][gurubase-shield]][gurubase-link]
 
 [actions-shield]: https://img.shields.io/github/actions/workflow/status/JanusGraph/janusgraph/ci-core.yml?branch=master
 [actions-link]: https://github.com/JanusGraph/janusgraph/actions
@@ -32,6 +33,8 @@ can support thousands of concurrent users, complex traversals, and analytic grap
 [codecov-shield]:https://codecov.io/gh/JanusGraph/janusgraph/branch/master/graph/badge.svg
 [codecov-link]:https://codecov.io/gh/JanusGraph/janusgraph
 [docker-pulls-img]: https://img.shields.io/docker/pulls/janusgraph/janusgraph.svg
+[gurubase-shield]: https://img.shields.io/badge/Gurubase-Ask%20JanusGraph%20Guru-006BFF
+[gurubase-link]: https://gurubase.io/g/janusgraph
 [docker-hub-url]: https://hub.docker.com/r/janusgraph/janusgraph
 
 ## Learn More


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [JanusGraph Guru](https://gurubase.io/g/janusgraph) to Gurubase. JanusGraph Guru uses the data from this repo and data from the [docs](https://janusgraph.org) to answer questions by leveraging the LLM.

In this PR, I showcased the "JanusGraph Guru", which highlights that JanusGraph now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable JanusGraph Guru in Gurubase, just let me know that's totally fine.
