### PR TITLE
[v1.1] Bump io.netty:netty-common from 4.1.112.Final to 4.1.115.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <zookeeper.version>3.9.2</zookeeper.version>
-        <netty4.version>4.1.112.Final</netty4.version>
+        <netty4.version>4.1.115.Final</netty4.version>
         <jna.version>5.14.0</jna.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.1`:
 - [Bump io.netty:netty-common from 4.1.112.Final to 4.1.115.Final](https://github.com/JanusGraph/janusgraph/pull/4725)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)