### PR TITLE
Update Docker Compose configuration for JanusGraph and dependencies

### DIFF
--- a/janusgraph-dist/docker/examples/docker-compose-cql-es.yml
+++ b/janusgraph-dist/docker/examples/docker-compose-cql-es.yml
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3"
-
 services:
   janusgraph:
-    image: docker.io/janusgraph/janusgraph:latest
+    image: janusgraph/janusgraph:latest
     container_name: jce-janusgraph
     environment:
       JANUS_PROPS_TEMPLATE: cql-es
@@ -33,7 +31,7 @@ services:
       retries: 3
 
   cassandra:
-    image: cassandra:3
+    image: cassandra:3.11.17
     container_name: jce-cassandra
     ports:
       - "9042:9042"
@@ -42,7 +40,7 @@ services:
       - jce-network
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.6.0
+    image: elasticsearch:6.8.23
     container_name: jce-elastic
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
@@ -56,6 +54,23 @@ services:
       - "9200:9200"
     networks:
       - jce-network
+
+  janusgraph-visualizer:
+    image: janusgraph/janusgraph-visualizer:latest
+    container_name: jce-visualizer
+    ports:
+      - "3000:3000"
+      - "3001:3001"
+    networks:
+      - jce-network
+    depends_on:
+      - janusgraph
+    environment:
+      - GRAPH_URL=http://jce-janusgraph:8182
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3001"]
+      interval: 10s
+      retries: 3
 
 networks:
   jce-network:


### PR DESCRIPTION
- Removed `version: "3"` so that docker-compose will use the latest version.
- I bumped up some of the docker image versions. I've tested in my local machine and it works fine. I think I can even go with higher versions, but then I think I have to change some environment parameters, which I am not sure about yet.
- I've also added `janusgraph-visualizer`, which allows visualizing the graph at `http://localhost:3001/`. Note that the value of `host` in the web app has to be set to `jce-janusgraph` instead of `localhost`, which is the default value.