### PR TITLE
added reference to JanusGraph-Python package

### DIFF
--- a/docs/basics/connecting/python.md
+++ b/docs/basics/connecting/python.md
@@ -47,8 +47,38 @@ print(f'Hercules is {hercules_age} years old.')
     `next()` is a terminal step that submits the traversal to the
     Gremlin Server and returns a single result.
 
-## JanusGraph Specific Types and Predicates
+## JanusGraph-Python for JanusGraph Specific Types and Predicates
 
 JanusGraph contains some types and [predicates](../search-predicates.md) that
 are not part of Apache TinkerPop and are therefore also not supported by
 Gremlin-Python.
+[JanusGraph-Python](https://github.com/JanusGraph/janusgraph-python) is a Python
+package that adds support for some of these types and predicates to Gremlin-Python.
+
+After installing the package, a message serializer needs to be configured for
+JanusGraph which can be done like this for GraphSON 3:
+
+```python
+from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
+from janusgraph_python.driver.serializer import JanusGraphSONSerializersV3d0
+
+connection = DriverRemoteConnection(
+  'ws://localhost:8182/gremlin', 'g',
+  message_serializer=JanusGraphSONSerializersV3d0())
+```
+
+or like this for GraphBinary:
+
+```python
+from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
+from janusgraph_python.driver.serializer import JanusGraphBinarySerializersV1
+
+connection = DriverRemoteConnection(
+  'ws://localhost:8182/gremlin', 'g',
+  message_serializer=JanusGraphBinarySerializersV1())
+```
+
+Refer to [the documentation of JanusGraph-Python](https://github.com/JanusGraph/janusgraph-python#janusgraph-python)
+for more information about the package, including its [compatibility with
+different JanusGraph versions](https://github.com/JanusGraph/janusgraph-python#version-compatibility)
+and differences in support between the different [serialization formats](https://github.com/JanusGraph/janusgraph-python#serialization-formats).


### PR DESCRIPTION
I have noticed that in the latest JanusGraph documentation the JanusGraph-Python package is not mentioned on the https://docs.janusgraph.org/basics/connecting/python/ page. With this PR, I have added the missing reference following the format used for JanusGraph.Net.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
