### PR TITLE
[v1.1] Bump codecov/codecov-action from 4 to 5

### DIFF
--- a/.github/workflows/ci-backend-cql.yml
+++ b/.github/workflows/ci-backend-cql.yml
@@ -247,7 +247,7 @@ jobs:
         with:
           name: jacoco-reports-${{ matrix.module }}-${{ matrix.name }}
           path: target/jacoco-combined.exec
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/ci-backend-hbase.yml
+++ b/.github/workflows/ci-backend-hbase.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           name: jacoco-reports-${{ matrix.module }}-${{ matrix.name }}
           path: target/jacoco-combined.exec
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/ci-backend-scylla.yml
+++ b/.github/workflows/ci-backend-scylla.yml
@@ -143,7 +143,7 @@ jobs:
         with:
           name: jacoco-reports-${{ matrix.module }}-${{ matrix.name }}
           path: target/jacoco-combined.exec
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -139,7 +139,7 @@ jobs:
         with:
           name: jacoco-reports-${{ matrix.module }}-java-${{ matrix.java }}
           path: target/jacoco-combined.exec
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/ci-index-es.yml
+++ b/.github/workflows/ci-index-es.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           name: jacoco-reports-${{ matrix.module }}-${{ matrix.name }}
           path: target/jacoco-combined.exec
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/ci-index-solr.yml
+++ b/.github/workflows/ci-index-solr.yml
@@ -95,7 +95,7 @@ jobs:
         with:
           name: jacoco-reports-${{ matrix.module }}-${{ matrix.name }}
           path: target/jacoco-combined.exec
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.1`:
 - [Bump codecov/codecov-action from 4 to 5](https://github.com/JanusGraph/janusgraph/pull/4728)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)