### PR TITLE
Schema Management APIs for Enhanced Debugging in JanusGraph

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphCustomIdTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/JanusGraphCustomIdTest.java
@@ -16,6 +16,7 @@ package org.janusgraph.graphdb;
 
 import com.google.common.base.Preconditions;
 import io.github.artsok.RepeatedIfExceptionsTest;
+import org.apache.commons.codec.DecoderException;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.T;
@@ -580,6 +581,38 @@ public abstract class JanusGraphCustomIdTest extends JanusGraphBaseTest {
         open(true, true);
         final Path file = tempDir.resolve("testgraph_" + this.getClass().getCanonicalName() + ".json");
         testWritingAndReading(file.toFile());
+    }
+
+    @Test
+    public void testGetVertexId() throws DecoderException {
+
+        open(true, true);
+
+        mgmt.makeVertexLabel("cat").make();
+        makeKey("id", Integer.class);
+        makeKey("name", String.class);
+
+        mgmt.commit();
+
+        Vertex v1 = tx.addVertex(T.id, 1000L, T.label, "cat");
+        v1.property("id", 1);
+        v1.property("name", "cat_1");
+        Object vertexId1 = v1.id();
+
+        Vertex v2 = tx.addVertex(T.id, "id_cat2", T.label, "cat");
+        v2.property("id", 2);
+        v2.property("name", "cat_2");
+        Object vertexId2 = v2.id();
+
+        tx.commit();
+
+        mgmt = graph.openManagement();
+
+        String hex1 = mgmt.getVertexKey(vertexId1);
+        String hex2 = mgmt.getVertexKey(vertexId2);
+
+        assertEquals(vertexId1, mgmt.getVertexId(hex1));
+        assertEquals(vertexId2, mgmt.getVertexId(hex2));
     }
 
     private void testWritingAndReading(File f) {

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/JanusGraphManagement.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/JanusGraphManagement.java
@@ -14,6 +14,7 @@
 
 package org.janusgraph.core.schema;
 
+import org.apache.commons.codec.DecoderException;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Element;
@@ -23,9 +24,11 @@ import org.janusgraph.core.PropertyKey;
 import org.janusgraph.core.RelationType;
 import org.janusgraph.core.VertexLabel;
 import org.janusgraph.diskstorage.keycolumnvalue.scan.ScanJobFuture;
+import org.janusgraph.graphdb.types.CompositeIndexType;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -469,4 +472,33 @@ public interface JanusGraphManagement extends JanusGraphConfiguration, SchemaMan
      */
     String printIndexes();
 
+    /**
+     * Get vertexId for the given hex string
+     * @param hexString
+     * @return vertex Id
+     * @throws DecoderException
+     */
+    Object getVertexId(String hexString) throws DecoderException;
+
+    /**
+     * Get a hex string representing vertex id
+     * @param vertexId  vertex id
+     * @return a hex string representing bytes of vertex id
+     */
+    String getVertexKey(Object vertexId);
+
+    /**
+     * Get a hex string representing index key
+     * @param indexName  schema index name
+     * @param fieldValues index fields with values
+     * @return a hex string representing bytes of index key
+     */
+    String getIndexKey(String indexName, Map<String, Object> fieldValues);
+
+    /**
+     * Get index info from given hex string
+     * @param hexString
+     * @return composite index info
+     */
+    CompositeIndexType getIndexInfo(String hexString) throws DecoderException;
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
@@ -525,6 +525,10 @@ public class IndexSerializer {
         return IndexRecordUtil.getIndexIdFromKey(key, hashKeys, hashLength);
     }
 
+    public StaticBuffer getIndexKey(CompositeIndexType index, Map<String, Object> fieldValues) {
+        return IndexRecordUtil.getIndexKey(index, fieldValues, serializer, hashKeys, hashLength);
+    }
+
     public boolean isHashKeys() {
         return hashKeys;
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/util/IndexRecordUtil.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/util/IndexRecordUtil.java
@@ -73,6 +73,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 import static org.janusgraph.util.encoding.LongEncoding.STRING_ENCODING_MARKER;
 
@@ -329,6 +330,19 @@ public class IndexRecordUtil {
 
     public static StaticBuffer getIndexKey(CompositeIndexType index, IndexRecordEntry[] record, Serializer serializer, boolean hashKeys, HashingUtil.HashLength hashLength) {
         return getIndexKey(index, IndexRecordUtil.getValues(record), serializer, hashKeys, hashLength);
+    }
+
+    public static StaticBuffer getIndexKey(CompositeIndexType index, Map<String, Object> fieldValues, Serializer serializer, boolean hashKeys, HashingUtil.HashLength hashLength) {
+        Object[] values = Arrays.stream(index.getFieldKeys()).map(field -> {
+            String fieldName = field.getFieldKey().name();
+            if (fieldValues.containsKey(fieldName)) {
+                return fieldValues.get(fieldName);
+            } else {
+                throw new NoSuchElementException("Value for fieldName=" + fieldName + " is not provided for indexName=" + index.getName());
+            }
+        }).toArray();
+
+        return getIndexKey(index, values, serializer, hashKeys, hashLength);
     }
 
     public static StaticBuffer getIndexKey(CompositeIndexType index, Object[] values, Serializer serializer, boolean hashKeys, HashingUtil.HashLength hashLength) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -49,9 +49,11 @@ import org.janusgraph.core.schema.VertexLabelMaker;
 import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.BackendTransaction;
 import org.janusgraph.diskstorage.EntryList;
+import org.janusgraph.diskstorage.StaticBuffer;
 import org.janusgraph.diskstorage.indexing.IndexTransaction;
 import org.janusgraph.diskstorage.keycolumnvalue.MultiKeysQueryGroups;
 import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
+import org.janusgraph.diskstorage.util.StaticArrayBuffer;
 import org.janusgraph.diskstorage.util.time.TimestampProvider;
 import org.janusgraph.graphdb.database.EdgeSerializer;
 import org.janusgraph.graphdb.database.IndexSerializer;
@@ -1241,6 +1243,34 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
             vertexLabel = config.getAutoSchemaMaker().makeVertexLabel(makeVertexLabel(name));
         }
         return vertexLabel;
+    }
+
+    public StaticBuffer getCompositeIndexKey(String indexName, Map<String, Object> fieldValues) {
+        JanusGraphSchemaVertex schemaVertex = getSchemaVertex(JanusGraphSchemaCategory.GRAPHINDEX.getSchemaName(indexName));
+        Preconditions.checkNotNull(schemaVertex, "Index with name [" + indexName + "] was not found");
+        IndexType indexType = schemaVertex.asIndexType();
+        if (indexType instanceof CompositeIndexType) {
+            CompositeIndexType compositeIndex = (CompositeIndexType) indexType;
+            StaticBuffer indexKey = indexSerializer.getIndexKey(compositeIndex, fieldValues);
+            return indexKey;
+        } else {
+            throw new IllegalArgumentException("Index with name [" + indexName + "] is not a composite index");
+        }
+    }
+
+    public CompositeIndexType getCompositeIndexInfo(StaticArrayBuffer indexKey) {
+        long schemaVertexId = indexSerializer.getIndexIdFromKey(indexKey);
+        InternalVertex typeVertex = vertexCache.get(schemaVertexId, existingVertexRetriever);
+
+        Preconditions.checkNotNull(typeVertex, "Index with key [" + indexKey + "] was not found");
+        JanusGraphSchemaVertex schemaVertex = (JanusGraphSchemaVertex) typeVertex;
+
+        IndexType indexType = schemaVertex.asIndexType();
+        if (indexType instanceof CompositeIndexType) {
+            return (CompositeIndexType) indexType;
+        } else {
+            throw new IllegalArgumentException("Index with key [" + indexKey + "] is not a composite index");
+        }
     }
 
     @Override


### PR DESCRIPTION
This PR introduces new schema management APIs to JanusGraph to enhance debugging capabilities, especially for issues where information is derived from logs. These APIs provide utilities to map between vertex IDs and their hex string representation, retrieve index key hex strings, and obtain index information using hex strings.

The added methods are:

`getVertexId(String hexString)`

```
Purpose: Converts a hex string back to its corresponding vertex ID.
Parameters:
hexString: A hexadecimal string representing the vertex ID.
Returns:
Vertex ID as an object.

```

`getIndexKey(String indexName, Map<String, Object> fieldValues)`

```
Purpose: Generates a hex string representing a schema index's index key bytes for given index name and vertex properties values.
Parameters:
indexName: The name of the schema index.
fieldValues: A map of index fields and their corresponding values.
Returns:
A hex string representing the index key.
```

`getIndexInfo(String hexString)`

```
Purpose: Decodes a hex string to retrieve composite index information.
Parameters:
hexString: A hexadecimal string representing the index key.
Returns:
CompositeIndexType: The composite index details.
```

### Key Benefits
Improved Debugging: Facilitates troubleshooting by enabling a direct relationship between logs and schema elements.
Enhanced Index Management: Allows index information to be decoded for better schema debugging and analysis.

### Usage Example
1. Given a hex string from a log file, use getVertexId() to identify the associated vertex.
2. Decode the hex string with getIndexInfo() to retrieve comprehensive details about the composite index.