### PR TITLE
Returning Composite index structure and field values for hex string

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/CompositeIndexInfo.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/CompositeIndexInfo.java
@@ -1,0 +1,52 @@
+// Copyright 2025 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core.schema;
+
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.graphdb.types.CompositeIndexType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CompositeIndexInfo {
+    final CompositeIndexType compositeIndexType;
+    final Object[] indexFieldValues;
+
+    final Map<PropertyKey, Object> indexValues;
+
+    public CompositeIndexInfo(CompositeIndexType compositeIndexType, Object[] indexFieldValues) {
+        this.compositeIndexType = compositeIndexType;
+        this.indexFieldValues = indexFieldValues;
+
+        this.indexValues = new HashMap<>();
+        for (int i = 0; i < compositeIndexType.getFieldKeys().length; i++) {
+            PropertyKey p = compositeIndexType.getFieldKeys()[i].getFieldKey();
+            Object v = indexFieldValues[i];
+            this.indexValues.put(p, v);
+        }
+    }
+
+    public CompositeIndexType getCompositeIndexType() {
+        return compositeIndexType;
+    }
+
+    public String getIndexName() {
+        return compositeIndexType.getName();
+    }
+
+    public Map<PropertyKey, Object> getValues() {
+        return indexValues;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/JanusGraphManagement.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/JanusGraphManagement.java
@@ -24,7 +24,6 @@ import org.janusgraph.core.PropertyKey;
 import org.janusgraph.core.RelationType;
 import org.janusgraph.core.VertexLabel;
 import org.janusgraph.diskstorage.keycolumnvalue.scan.ScanJobFuture;
-import org.janusgraph.graphdb.types.CompositeIndexType;
 
 import java.time.Duration;
 import java.util.List;
@@ -500,5 +499,5 @@ public interface JanusGraphManagement extends JanusGraphConfiguration, SchemaMan
      * @param hexString
      * @return composite index info
      */
-    CompositeIndexType getIndexInfo(String hexString) throws DecoderException;
+    CompositeIndexInfo getIndexInfo(String hexString) throws DecoderException;
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
@@ -26,6 +26,7 @@ import org.janusgraph.core.JanusGraphVertexProperty;
 import org.janusgraph.core.PropertyKey;
 import org.janusgraph.core.SchemaViolationException;
 import org.janusgraph.core.attribute.Geoshape;
+import org.janusgraph.core.schema.CompositeIndexInfo;
 import org.janusgraph.core.schema.Parameter;
 import org.janusgraph.core.schema.SchemaStatus;
 import org.janusgraph.diskstorage.BackendException;
@@ -523,6 +524,10 @@ public class IndexSerializer {
 
     public long getIndexIdFromKey(StaticBuffer key) {
         return IndexRecordUtil.getIndexIdFromKey(key, hashKeys, hashLength);
+    }
+
+    public CompositeIndexInfo getIndexInfoFromKey(StaticBuffer key, Function<Long, CompositeIndexType> compositeIndexTypeFunction) {
+        return IndexRecordUtil.getIndexInfoFromKey(serializer, compositeIndexTypeFunction, key, hashKeys, hashLength);
     }
 
     public StaticBuffer getIndexKey(CompositeIndexType index, Map<String, Object> fieldValues) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
@@ -37,6 +37,7 @@ import org.janusgraph.core.Multiplicity;
 import org.janusgraph.core.PropertyKey;
 import org.janusgraph.core.RelationType;
 import org.janusgraph.core.VertexLabel;
+import org.janusgraph.core.schema.CompositeIndexInfo;
 import org.janusgraph.core.schema.ConsistencyModifier;
 import org.janusgraph.core.schema.EdgeLabelMaker;
 import org.janusgraph.core.schema.Index;
@@ -566,7 +567,7 @@ public class ManagementSystem implements JanusGraphManagement {
     }
 
     @Override
-    public CompositeIndexType getIndexInfo(String hexString) throws DecoderException {
+    public CompositeIndexInfo getIndexInfo(String hexString) throws DecoderException {
         StaticArrayBuffer indexKey = StaticArrayBuffer.of(Hex.decodeHex(hexString));
         return transaction.getCompositeIndexInfo(indexKey);
     }


### PR DESCRIPTION
Enhancements for this API, introduced in the [PR](https://github.com/JanusGraph/janusgraph/pull/4754)
to return not only index structure but also corresponding field values:

```
getIndexInfo(String hexString)

Purpose: Decodes a hex string to retrieve composite index information.
Parameters:
hexString: A hexadecimal string representing the index key.
Returns:
CompositeIndexType: The composite index details.
```
