### PR TITLE
Improve readability of testReadMarkerCompatibility

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/diskstorage/log/LogTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/diskstorage/log/LogTest.java
@@ -14,6 +14,20 @@
 
 package org.janusgraph.diskstorage.log;
 
+import com.google.common.base.Preconditions;
+import io.github.artsok.RepeatedIfExceptionsTest;
+import org.janusgraph.diskstorage.BackendException;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.util.BufferUtil;
+import org.janusgraph.diskstorage.util.StaticArrayBuffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,25 +37,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.janusgraph.diskstorage.BackendException;
-import org.janusgraph.diskstorage.StaticBuffer;
-import org.janusgraph.diskstorage.util.BufferUtil;
-import org.janusgraph.diskstorage.util.StaticArrayBuffer;
-import static org.junit.Assert.assertThrows;
-import org.junit.jupiter.api.AfterEach;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Preconditions;
-
-import io.github.artsok.RepeatedIfExceptionsTest;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests general log implementations

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/diskstorage/log/LogTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/diskstorage/log/LogTest.java
@@ -14,20 +14,6 @@
 
 package org.janusgraph.diskstorage.log;
 
-import com.google.common.base.Preconditions;
-import io.github.artsok.RepeatedIfExceptionsTest;
-import org.janusgraph.diskstorage.BackendException;
-import org.janusgraph.diskstorage.StaticBuffer;
-import org.janusgraph.diskstorage.util.BufferUtil;
-import org.janusgraph.diskstorage.util.StaticArrayBuffer;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,10 +23,25 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.janusgraph.diskstorage.BackendException;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.util.BufferUtil;
+import org.janusgraph.diskstorage.util.StaticArrayBuffer;
+import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.AfterEach;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 
 /**
  * Tests general log implementations
@@ -226,7 +227,7 @@ public abstract class LogTest {
     }
 
     @Test
-    public void testReadMarkerCompatibility() {
+    public void testReadMarkerCompatibility() throws Exception {
         Log l1 = manager.openLog("testx");
         l1.registerReader(ReadMarker.fromIdentifierOrNow("mark"), new StoringReader(0));
         l1.registerReader(ReadMarker.fromIdentifierOrTime("mark", Instant.now().minusMillis(100)), new StoringReader(1));

--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/diskstorage/log/LogTest.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/diskstorage/log/LogTest.java
@@ -226,18 +226,14 @@ public abstract class LogTest {
     }
 
     @Test
-    public void testReadMarkerCompatibility() throws Exception {
+    public void testReadMarkerCompatibility() {
         Log l1 = manager.openLog("testx");
-        l1.registerReader(ReadMarker.fromIdentifierOrNow("mark"),new StoringReader(0));
-        l1.registerReader(ReadMarker.fromIdentifierOrTime("mark", Instant.now().minusMillis(100)),new StoringReader(1));
-        try {
-            l1.registerReader(ReadMarker.fromIdentifierOrNow("other"));
-            fail();
-        } catch (IllegalArgumentException ignored) {}
-        try {
-            l1.registerReader(ReadMarker.fromTime(Instant.now().minusMillis(100)));
-            fail();
-        } catch (IllegalArgumentException ignored) {}
+        l1.registerReader(ReadMarker.fromIdentifierOrNow("mark"), new StoringReader(0));
+        l1.registerReader(ReadMarker.fromIdentifierOrTime("mark", Instant.now().minusMillis(100)), new StoringReader(1));
+    
+        assertThrows(IllegalArgumentException.class, () -> l1.registerReader(ReadMarker.fromIdentifierOrNow("other")));
+        assertThrows(IllegalArgumentException.class, () -> l1.registerReader(ReadMarker.fromTime(Instant.now().minusMillis(100))));
+        
         l1.registerReader(ReadMarker.fromNow(), new StoringReader(2));
     }
 


### PR DESCRIPTION
Improves the readability of the test. Replaces manual exception handling with the testing framework's built-in features (e.g., assertThrows), improving readability, maintainability, and debugging efficiency.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?
