### PR TITLE
[v1.1] Bump aquasecurity/trivy-action from 0.28.0 to 0.31.0

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -114,7 +114,7 @@ jobs:
         # Thus, we add `continue-on-error: true` here, but we should remove it
         # when either the issue is fixed (see: https://github.com/aquasecurity/trivy-action/issues/389)
         # or we self-host trivy database.
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.31.0
         continue-on-error: true
         with:
           image-ref: 'ghcr.io/janusgraph/janusgraph:${{ env.JG_VER }}${{ matrix.tag_suffix }}'


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.1`:
 - [Bump aquasecurity/trivy-action from 0.28.0 to 0.31.0](https://github.com/JanusGraph/janusgraph/pull/4796)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)