### PR TITLE
[v1.1] Bump org.apache.commons:commons-lang3 from 3.16.0 to 3.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -697,7 +697,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.16.0</version>
+                <version>3.18.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-configuration</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.1`:
 - [Bump org.apache.commons:commons-lang3 from 3.16.0 to 3.18.0](https://github.com/JanusGraph/janusgraph/pull/4811)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)