### PR TITLE
[v1.1] Bump com.nimbusds:nimbus-jose-jwt from 9.37.3 to 10.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1191,7 +1191,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
-                <version>9.37.3</version>
+                <version>10.0.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.1`:
 - [Bump com.nimbusds:nimbus-jose-jwt from 9.37.3 to 10.0.2](https://github.com/JanusGraph/janusgraph/pull/4810)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)