### PR TITLE
Fix HBase Docker build failures due to outdated buster repositories

### DIFF
--- a/janusgraph-dist/docker/Dockerfile
+++ b/janusgraph-dist/docker/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG BASE_IMAGE=eclipse-temurin:11-jre
 
-FROM debian:buster-slim as builder
+FROM debian:bullseye-slim as builder
 
 ARG TARGETARCH
 ARG JANUS_VERSION=1.0.0-SNAPSHOT

--- a/janusgraph-hbase/docker/Dockerfile
+++ b/janusgraph-hbase/docker/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM debian:bookworm-20240211 as builder
 
-ARG HBASE_VERSION=2.5.0
+ARG HBASE_VERSION=2.6.0
 ARG HBASE_DIST="https://archive.apache.org/dist/hbase"
 
 RUN apt-get update && \
@@ -27,7 +27,7 @@ RUN rm -rf ./docs ./LEGAL ./*.txt ./*/*.cmd
 COPY ./hbase-site.xml /opt/hbase/conf/hbase-site.xml
 COPY ./hbase-policy.xml /opt/hbase/conf/hbase-policy.xml
 
-FROM openjdk:8-jre-buster
+FROM openjdk:8-jre-bullseye
 
 ARG HBASE_UID=1000
 ARG HBASE_GID=1000


### PR DESCRIPTION
## Description

This PR fixes HBase test failures caused by Docker build issues where the `apt-get update` command was failing with exit code 100.

## Problem

The HBase tests were failing with the following error:
```
org.testcontainers.containers.ContainerFetchException: Can't get Docker image
...
Caused by: com.github.dockerjava.api.exception.DockerClientException: Could not build image: The command '/bin/sh -c apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y socat' returned a non-zero code: 100
```

## Root Cause

The issue was caused by using outdated base images:
- `openjdk:8-jre-buster` in the HBase Dockerfile
- `debian:buster-slim` in the dist Dockerfile

Debian Buster reached end-of-life and its repositories are no longer accessible via standard URLs, causing `apt-get update` to fail.

## Solution

- Updated HBase Dockerfile base image from `openjdk:8-jre-buster` to `openjdk:8-jre-bullseye`
- Updated dist Dockerfile builder stage from `debian:buster-slim` to `debian:bullseye-slim`
- Updated default HBase version from 2.5.0 to 2.6.0 to match the version used in `HBaseContainer.java`

These changes maintain JDK8 compatibility while using more recent and supported Debian repositories.