### PR TITLE
[v1.1] Fix maven central publishing CTR

### DIFF
--- a/.github/workflows/ci-publish-commit.yml
+++ b/.github/workflows/ci-publish-commit.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           mkdir -p ~/.m2/
           echo "<settingsSecurity><master>$MASTER_PASSWORD</master></settingsSecurity>" > ~/.m2/settings-security.xml
-          echo "<settings><servers><server><id>ossrh</id><username>$OSSRH_USERNAME</username><password>$OSSRH_PASSWORD</password></server></servers></settings>" > ~/.m2/settings.xml
+          echo "<settings><servers><server><id>central</id><username>$OSSRH_USERNAME</username><password>$OSSRH_PASSWORD</password></server></servers></settings>" > ~/.m2/settings.xml
         env:
           MASTER_PASSWORD: ${{ secrets.MASTER_PASSWORD }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
@@ -83,4 +83,4 @@ jobs:
       - name: Make JanusGraph JAR artifacts
         run: mvn clean install -Pjanusgraph-release -DskipTests=true
       - name: Deploy JanusGraph JAR artifacts into staging repository
-        run: mvn deploy -Pjanusgraph-release,janusgraph-commit-release -DskipTests=true -DautoReleaseAfterClose=true -Ddescription="$JG_DESCRIPTION" -DstagingDescription="$JG_DESCRIPTION"
+        run: mvn deploy -Pjanusgraph-release -DskipTests=true -DwaitUntil=published -DautoPublish=true -Ddescription="$JG_DESCRIPTION" -DstagingDescription="$JG_DESCRIPTION"

--- a/.github/workflows/ci-publish-official.yml
+++ b/.github/workflows/ci-publish-official.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           mkdir -p ~/.m2/
           echo "<settingsSecurity><master>$MASTER_PASSWORD</master></settingsSecurity>" > ~/.m2/settings-security.xml
-          echo "<settings><servers><server><id>ossrh</id><username>$OSSRH_USERNAME</username><password>$OSSRH_PASSWORD</password></server></servers></settings>" > ~/.m2/settings.xml
+          echo "<settings><servers><server><id>central</id><username>$OSSRH_USERNAME</username><password>$OSSRH_PASSWORD</password></server></servers></settings>" > ~/.m2/settings.xml
         env:
           MASTER_PASSWORD: ${{ secrets.MASTER_PASSWORD }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
@@ -87,7 +87,7 @@ jobs:
       - name: Print content of the generated target directory for debugging purposes
         run: echo $(ls janusgraph-dist/target/)
       - name: Deploy JanusGraph JAR artifacts into staging repository
-        run: mvn deploy -Pjanusgraph-release -DskipTests=true
+        run: mvn deploy -Pjanusgraph-release -DskipTests=true -DwaitUntil=validated -DautoPublish=false
       - name: Sign JanusGraph full distribution artifact
         run: gpg --armor --detach-sign --yes janusgraph-dist/target/${JG_FULL_DIST_NAME}.zip
       - name: Install requirements to build documentation

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,7 +23,7 @@ See the relevant issue [here.](https://issues.sonatype.org/browse/OSSRH-28274)
 * [ ] **For Manual release flow only** Run Deploy to create [Sonatype](https://oss.sonatype.org/#welcome) staging repository and Generate artifacts for release page
 * [ ] **For Manual release flow only** Create a draft release and upload artifacts to it
 * [ ] Update release description of draft release
-* [ ] Close the staging repository in [Sonatype](https://oss.sonatype.org/#stagingRepositories)
+* [ ] Close the staging repository in [Sonatype](https://central.sonatype.com/publishing)
 * [ ] Convert draft release to a public pre-release
 * [ ] Create `[VOTE]` [janusgraph-dev](https://lists.lfaidata.foundation/g/janusgraph-dev) vote thread and [get required votes of 3 TSC members](https://www.apache.org/foundation/voting.html)
 * [ ] Release the staging repository in Sonatype
@@ -101,7 +101,7 @@ Steps below were taken from [this guide.](https://maven.apache.org/guides/mini/g
 <settings>
   <servers>
     <server>
-      <id>ossrh</id>
+      <id>central</id>
       <username>{sonatype username}</username>
       <password>{encrypted sonatype password}</password>
     </server>
@@ -120,7 +120,7 @@ Otherwise, you will have to type in your gpg passphrase many times when prompted
 <settings>
    <servers>
     <server>
-      <id>ossrh</id>
+      <id>central</id>
         <username>{sonatype username}</username>
         <password>{encrypted sonatype password}</password>
     </server>
@@ -249,7 +249,7 @@ git clean -fdx
 * Deploy all jars (including javadoc and sources) and all signatures for jars to a staging repository on Sonatype. Notice, this step includes 2 separate commands. The first command will clean repository before generating artifacts and the second command will deploy those generated artifacts. You should not change anything in the repository or run `clean` between the first and the second commands.
 ```Shell
 mvn clean install -Pjanusgraph-release -DskipTests=true
-mvn deploy -Pjanusgraph-release -DskipTests=true
+mvn deploy -Pjanusgraph-release -DskipTests=true -DwaitUntil=validated -DautoPublish=false
 ```
 
 * Install MkDocs if not installed. It is needed to build documentation.
@@ -339,7 +339,7 @@ can't be canceled.
 ### Release the staging repository
 
 When the vote is complete and successful, it is time to finalize the release.  
-Log into Sonatype and select the [staging repository](https://oss.sonatype.org/#stagingRepositories) that was closed previously.  
+Log into Sonatype and select the [staging repository](https://central.sonatype.com/publishing) that was closed previously.  
 Once the release is selected click `Release`.  
 The staging directory should be automatically deleted after the release is completed.  
 The release artifacts will be synched over to Maven Central in about 2 hours.  

--- a/pom.xml
+++ b/pom.xml
@@ -47,12 +47,8 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
     </distributionManagement>
     <properties>
         <titan.compatible-versions>1.0.0,1.1.0-SNAPSHOT</titan.compatible-versions>
@@ -120,6 +116,8 @@
         <caffeine.version>2.9.3</caffeine.version>
         <checker-qual.version>3.46.0</checker-qual.version>
         <curator.version>5.7.0</curator.version>
+        <autoPublish>false</autoPublish>
+        <waitUntil>validated</waitUntil>
     </properties>
     <modules>
         <module>janusgraph-grpc</module>
@@ -1550,24 +1548,17 @@
                             </execution>
                         </executions>
                     </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>janusgraph-commit-release</id>
-            <build>
-                <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.7.0</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <!-- The Base URL of Nexus instance where we want to stage -->
-                            <nexusUrl>https://oss.sonatype.org</nexusUrl>
                             <!-- The server "id" element from settings to use authentication from -->
-                            <serverId>ossrh</serverId>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>${autoPublish}</autoPublish>
+                            <waitUntil>${waitUntil}</waitUntil>
+                            <waitMaxTime>3600</waitMaxTime>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.1`:
 - [Fix maven central publishing CTR](https://github.com/JanusGraph/janusgraph/pull/4830)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)