### PR TITLE
#4871 support recurring transaction recovery and extend recovery stat…

### DIFF
--- a/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/TestMockLog.java
+++ b/janusgraph-backend-testutils/src/main/java/org/janusgraph/graphdb/TestMockLog.java
@@ -132,6 +132,11 @@ public class TestMockLog implements LogManager {
         }
 
         @Override
+        public synchronized boolean unregisterReaderAndStopReadingProcess(MessageReader reader) {
+            return readers.remove(reader);
+        }
+
+        @Override
         public String getName() {
             return name;
         }

--- a/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphFactory.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/JanusGraphFactory.java
@@ -303,6 +303,18 @@ public class JanusGraphFactory {
         return new StandardTransactionLogProcessor((StandardJanusGraph)graph, start);
     }
 
+    /**
+     * Returns a {@link TransactionRecovery} process for recovering partially failed transactions. The recovery process
+     * will start processing the write-ahead transaction log at the specified transaction time.
+     * Once stopped, this method can be used to start the recovery process again from a specified transaction time.
+     * @param graph
+     * @param start
+     * @return
+     */
+    public static TransactionRecovery startRecurringTransactionRecovery(JanusGraph graph, Instant start) {
+        return new StandardTransactionLogProcessor((StandardJanusGraph) graph, start, true);
+    }
+
     //###################################
     //          HELPER METHODS
     //###################################

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/log/Log.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/log/Log.java
@@ -83,6 +83,17 @@ public interface Log {
     boolean unregisterReader(MessageReader reader);
 
     /**
+     * Removes the given reader from the list of registered readers, terminates the reader thread pool and returns
+     * whether this reader was registered in the first place.
+     * Note, that removing the reader by this method also stops the reading process.
+     *
+     * @param reader
+     * @return true if this MessageReader was registered before and was successfully
+     *         unregistered, else false
+     */
+    boolean unregisterReaderAndStopReadingProcess(MessageReader reader);
+
+    /**
      * Returns the name of this log
      * @return
      */


### PR DESCRIPTION
Related feature request is #4871.

### For all changes:
- [ yes ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ yes ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ yes ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ yes ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ yes ] Have you written and/or updated unit tests to verify your changes?
- [ not applicable ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ not applicable ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ not applicable ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ yes ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Implementation notes

In this PR, two changes are done:

1. providing a `startRecurringTransactionRecovery()` method to be able to run the recovery process multiple times without closing the graph.
   1. the heart of this change is to extend `ReadMarker` class with a recurring mode. A `ReadMarker` with recurring mode is very similar to a `ReadMarker` without identifier, the main difference is that two recurring mode `ReadMarker` is always compatible with each other so a reader can be registered for the same KCVSLog instance multiple times.
   2. other important difference compared to `startTransactionRecovery()` method is that when `shutdown()` is called, the reader is unregistered and the reading process is stopped so resources are not occupied while the log processor is not actively running
2. extending `getStatistics()` method by returning a third counter that expresses how many transaction could not be fixed from those that initially failed (and was attempted to be fixed during recovery)
