### PR TITLE
Bump Cassandra and Elasticsearch images & add persistent volumes

### DIFF
--- a/janusgraph-dist/docker/examples/docker-compose-cql-es.yml
+++ b/janusgraph-dist/docker/examples/docker-compose-cql-es.yml
@@ -36,8 +36,10 @@ services:
       retries: 3
 
   cassandra:
-    image: cassandra:4.0.18
+    image: cassandra:4.0.20
     container_name: jce-cassandra
+    volumes:
+      - ${JCE_CASSANDRA_DATA:-janusgraph-cassandra-data}:/var/lib/cassandra
     ports:
       - "9042:9042"
       - "9160:9160"
@@ -47,11 +49,13 @@ services:
       test: ["CMD", "nodetool", "status"]
       interval: 10s
       timeout: 30s
-      retries: 6
+      retries: 10
 
   elasticsearch:
-    image: elasticsearch:8.18.4
+    image: elasticsearch:8.19.15
     container_name: jce-elastic
+    volumes:
+      - ${JCE_ELASTICSEARCH_DATA:-janusgraph-elasticsearch-data}:/usr/share/elasticsearch/data/
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - "http.host=0.0.0.0"
@@ -92,3 +96,5 @@ networks:
   jce-network:
 volumes:
   janusgraph-default-data:
+  janusgraph-cassandra-data:
+  janusgraph-elasticsearch-data:


### PR DESCRIPTION
Hello JanusGraph Team,

This pull request contains some enhancements for the example of compose file. 
* An update Cassandra image to 4.0.20
* An update Elasticsearch image to 8.19.15
* Increase Cassandra health‑check retries. On slow disks, Cassandra could incorrectly be marked unhealthy with the previous settings
* Add JCE_ELASTICSEARCH_DATA and JCE_CASSANDRA_DATA compose environment variables. Use docker volumes janusgraph-cassandra-data and janusgraph-elasticsearch-data by default

Regards
-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
