### PR TITLE
Fix url for [JG_TEMPLATES]

### DIFF
--- a/docs/operations/container.md
+++ b/docs/operations/container.md
@@ -303,7 +303,7 @@ Here's the policy we follow for tagging our container images:
 
 
 [JG]: https://janusgraph.org/
-[JG_TEMPLATES]: https://github.com/search?q=org:JanusGraph+repo:janusgraph+filename:janusgraph.properties%20path:janusgraph-dist/src/assembly/static/conf/gremlin-server
+[JG_TEMPLATES]: https://github.com/search?q=repo:janusgraph/janusgraph+%20path:janusgraph-dist/docker/conf/janusgraph-*-server.properties
 [GS_CONFIG]: http://tinkerpop.apache.org/docs/current/reference/#_configuring_2
 [YQ_GITHUB]: https://github.com/mikefarah/yq
 [YQ_DOC]: https://mikefarah.gitbook.io/yq


### PR DESCRIPTION
Hello JanusGraph Team,
This pull request contains a correction of the link to the JanusGraph configuration file templates. The current version of the link no longer matches how search works on GitHub, nor the structure of the janusgraph-dist/ directory.

Regards
-----

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
