### PR TITLE
Fix NPE in GraphTransaction.doClose() on concurrent graph close (#4899)

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphBlueprintsGraph.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphBlueprintsGraph.java
@@ -344,9 +344,13 @@ public abstract class JanusGraphBlueprintsGraph implements JanusGraph {
 
         @Override
         protected void doClose() {
+            // Snapshot the shared txs reference first: close() may null it out concurrently on another
+            // thread. Capturing it before the calls below keeps the race window minimal so this thread
+            // still removes its own ThreadLocal entry rather than relying on delayed GC-based cleanup.
+            ThreadLocal<JanusGraphBlueprintsTransaction> localTxs = txs;
             super.doClose();
             transactionListeners.remove();
-            txs.remove();
+            if (localTxs != null) localTxs.remove();
         }
 
         @Override

--- a/janusgraph-test/src/test/java/org/janusgraph/core/ThreadLocalTxLeakTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/core/ThreadLocalTxLeakTest.java
@@ -108,6 +108,56 @@ class ThreadLocalTxLeakTest {
         assertThreadLocalClosed();
     }
 
+    /**
+     * Reproduces https://github.com/JanusGraph/janusgraph/issues/4899: when the graph is closed on another
+     * thread (nulling the shared {@code txs} field) while a transaction is being closed, {@code doClose()}
+     * used to throw a {@link NullPointerException} in its cleanup block, masking the real commit/rollback
+     * outcome. After the fix, {@code doClose()} snapshots the {@code txs} reference and tolerates a null,
+     * so the cleanup completes without throwing.
+     */
+    @Test
+    void doCloseMustBeNullSafeWhenTxsClearedConcurrently() throws Exception {
+        CompletableFuture.runAsync(() -> {
+            // Simulate a concurrent close() that has already nulled the shared txs field before this
+            // thread reaches the doClose() cleanup that runs in commit()/rollback()'s finally block.
+            ThreadLocal<?> original = getThreadLocalTxs(graph);
+            setThreadLocalTxs(graph, null);
+            try {
+                Assertions.assertDoesNotThrow(() -> invokeDoClose(graph),
+                    "doClose() must not throw when txs has been nulled concurrently");
+            } finally {
+                // Restore the field so the @AfterEach close() does not trip over the artificially nulled txs.
+                setThreadLocalTxs(graph, original);
+            }
+        }, executorService).get();
+    }
+
+    private void invokeDoClose(JanusGraph graph) {
+        try {
+            Field container = JanusGraphBlueprintsGraph.class.getDeclaredField("tinkerpopTxContainer");
+            container.setAccessible(true);
+            Object graphTransaction = container.get(graph);
+            java.lang.reflect.Method doClose = graphTransaction.getClass().getDeclaredMethod("doClose");
+            doClose.setAccessible(true);
+            doClose.invoke(graphTransaction);
+        } catch (ReflectiveOperationException e) {
+            if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            }
+            throw new JanusGraphException(e);
+        }
+    }
+
+    private void setThreadLocalTxs(JanusGraph graph, ThreadLocal<?> value) {
+        try {
+            Field txs = JanusGraphBlueprintsGraph.class.getDeclaredField("txs");
+            txs.setAccessible(true);
+            txs.set(graph, value);
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            throw new JanusGraphException(e);
+        }
+    }
+
     private void assertThreadLocalClosed() {
         Assertions.assertDoesNotThrow(() -> {
             CompletableFuture.runAsync(


### PR DESCRIPTION
Fixes #4899.

## Problem

There is a race between `JanusGraphBlueprintsGraph.close()` and `GraphTransaction.doClose()`. `close()` sets the shared `txs` ThreadLocal field to `null`, but `doClose()` called `txs.remove()` without a null check. If a graph is closed on one thread while another thread is finishing a `commit()`/`rollback()`, the committing thread throws an NPE in its `finally` cleanup block — *after* the storage commit has already been attempted, masking the real outcome.

This commonly surfaces during application shutdown / container termination, where in-flight Gremlin requests overlap with graph close. Note that `getAutoStartTx()` and `GraphTransaction.isOpen()` already guard against `txs == null`, but `doClose()` did not — the null-handling was inconsistent.

## Fix

Snapshot the shared `txs` reference to a local and null-check it before calling `remove()`:

```java
protected void doClose() {
    super.doClose();
    transactionListeners.remove();
    ThreadLocal<JanusGraphBlueprintsTransaction> localTxs = txs;
    if (localTxs != null) localTxs.remove();
}
```

This preserves the `txs = null` behavior from #1653 (which intentionally drops the strong reference to allow ThreadLocal cleanup, see #1341) while making cleanup null-safe.

## Testing

Added a regression test `ThreadLocalTxLeakTest#doCloseMustBeNullSafeWhenTxsClearedConcurrently` that simulates a concurrent `close()` nulling the field and asserts `doClose()` does not throw. Verified it **fails with an NPE** without the fix and **passes** with it. All tests in the class pass.

---

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)? (N/A — no new dependencies)
- [x] If applicable, have you updated the LICENSE.txt file? (N/A)
- [x] If applicable, have you updated the NOTICE.txt file? (N/A)
