### PR TITLE
perf: faster mixed-index reindex (batched restores + signal-based scan hand-off)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -122,6 +122,61 @@ graph.management-ack-timeout=240000 ms
 ```
 This is a breaking change for users who use the `JanusGraphIndexStatusUpdate` interface.
 
+##### Faster mixed-index reindex with batched document restores
+
+Mixed-index reindex jobs (`SchemaAction.REINDEX` against an Elasticsearch, Solr or Lucene index) now
+flush restored documents to the index backend in bounded batches while the storage scan is still
+running, instead of buffering a whole scan segment and flushing it once. This reduces the number of
+bulk requests, transaction commits and management-system reads per reindexed element and bounds worker
+memory.
+
+This behavior is **enabled by default**. Two new configuration options control it:
+```
+schema.reindex.mixed-index-batch-enabled=true
+schema.reindex.mixed-index-batch-size=1000
+```
+`schema.reindex.mixed-index-batch-size` is the number of documents a reindex worker buffers before
+issuing a single `restore` (bulk) call. A worker buffers up to this many documents in memory and a
+reindex runs several workers in parallel, so peak heap grows with `mixed-index-batch-size` ×
+reindex-threads × average-document-size — raise it only when documents are small and workers have
+headroom.
+
+Be aware of the following behavior changes when batching is enabled (the default):
+
+-   Restored documents become visible in the index **incrementally**, as each batch is flushed, rather
+    than once per scan segment. This is safe because a reindex is idempotent and rebuilds index state
+    from the graph as the source of truth; a reindex interrupted partway leaves partially-populated
+    index documents that a re-run deterministically completes.
+-   The reindex flush cadence is now driven by `mixed-index-batch-size` rather than by the storage
+    page size (`storage.page-size`).
+
+To restore the previous storage-page-sized, flush-once-per-segment behavior, set
+`schema.reindex.mixed-index-batch-enabled=false`. See the
+[Elasticsearch reindex tuning guide](index-backend/elasticsearch.md#reindex-optimization) for tuning
+the batch size, reindex threads and `index.[X].bulk-refresh` together.
+
+##### Faster OLAP scans (signal-based row hand-off)
+
+The OLAP scan pipeline behind reindex and other scan jobs now hands rows between its internal threads
+using blocking `take()` and sentinel markers instead of polling bounded queues on a fixed timer. On
+fast backends (notably CQL/Cassandra) this removes per-row hand-off latency that could otherwise
+dominate scan wall-clock time, speeding up single-node reindex and other full scans by a large factor.
+No configuration or user action is required.
+
+##### Opt-in parallel token-range scan for CQL full scans
+
+CQL full-table scans (used by reindex and other OLAP jobs) can optionally be split into several
+token-bounded queries instead of a single coordinator-funneled scan:
+```
+storage.cql.parallel-scan-token-ranges=1
+```
+The default value `1` preserves the previous single-query behavior. When set above `1` and the Murmur3
+partitioner is in use, the scan is split into that many disjoint token ranges streamed back in token
+order. Note: in this release the ranges are consumed back-to-back by a single scan thread (only the
+first page of each range is prefetched concurrently), so it replaces one unbounded coordinator scan
+with several bounded ones rather than scanning all ranges fully in parallel; setting very high values
+can overload the cluster. The option is ignored for non-Murmur3 partitioners.
+
 ### Version 1.1.0 (Release Date: November 7, 2024)
 
 /// tab | Maven

--- a/docs/configs/janusgraph-cfg.md
+++ b/docs/configs/janusgraph-cfg.md
@@ -410,6 +410,15 @@ Options for JSON schema initialization strategy.
 | schema.init.json.skip-indices | Skip creation of indices. | Boolean | false | LOCAL |
 | schema.init.json.string | JSON formated schema definition string. This option takes precedence if both `file` and `string` are used. | String | (no default value) | LOCAL |
 
+### schema.reindex
+Configuration options for schema reindex operations.
+
+
+| Name | Description | Datatype | Default Value | Mutability |
+| ---- | ---- | ---- | ---- | ---- |
+| schema.reindex.mixed-index-batch-enabled | Whether mixed-index reindex jobs should batch document restore calls independently from the storage page size. | Boolean | true | MASKABLE |
+| schema.reindex.mixed-index-batch-size | Number of graph elements a mixed-index reindex worker should process before flushing restored documents to the index backend. Larger values can improve Elasticsearch bulk restore throughput at the cost of additional worker memory. | Integer | 1000 | MASKABLE |
+
 ### storage
 Configuration options for the storage backend.  Some options are applicable only for certain backends.
 
@@ -488,6 +497,7 @@ CQL storage backend options
 | storage.cql.metadata-schema-enabled | Whether schema metadata is enabled. | Boolean | (no default value) | MASKABLE |
 | storage.cql.metadata-token-map-enabled | Whether token metadata is enabled. If disabled, partitioner-name must be provided. | Boolean | (no default value) | MASKABLE |
 | storage.cql.only-use-local-consistency-for-system-operations | True to prevent any system queries from using QUORUM consistency and always use LOCAL_QUORUM instead | Boolean | false | MASKABLE |
+| storage.cql.parallel-scan-token-ranges | Number of disjoint Murmur3 token ranges a full-table scan (e.g. a mixed-index reindex or other OLAP job) is split into. With the default value of 1 the full scan is issued as a single query that funnels the whole table through one coordinator. When set above 1 and the Murmur3 partitioner is in use, the scan is split into this many token-bounded queries that are streamed back in token order. NOTE: the ranges are currently consumed back-to-back by a single scan thread (only the first page of each range is prefetched concurrently, at construction), so this replaces one unbounded coordinator scan with several bounded ones rather than scanning all ranges fully in parallel. Values that are too high can overload the cluster. | Integer | 1 | MASKABLE |
 | storage.cql.partitioner-name | The name of Cassandra cluster's partitioner. It will be retrieved by client if not provided. If provided, it must match the cluster's partitioner name. It can be the full class name such as `org.apache.cassandra.dht.ByteOrderedPartitioner` or the simple name such as `ByteOrderedPartitioner` | String | (no default value) | MASKABLE |
 | storage.cql.protocol-version | The protocol version used to connect to the Cassandra database.  If no value is supplied then the driver will negotiate with the server. | Integer | 0 | LOCAL |
 | storage.cql.read-consistency-level | The consistency level of read operations against Cassandra | String | QUORUM | MASKABLE |

--- a/docs/index-backend/elasticsearch.md
+++ b/docs/index-backend/elasticsearch.md
@@ -342,6 +342,53 @@ on how to increase the refresh interval and its impact on write
 performance. Note, that a higher refresh interval means that it takes a
 longer time for graph mutations to be available in the index.
 
+### Reindex Optimization
+
+Mixed-index reindex jobs can batch more documents per backend restore call than
+the regular storage scan page size. This allows Elasticsearch to use larger bulk
+requests during `SchemaAction.REINDEX` without changing `storage.page-size` for
+other graph operations.
+
+```properties
+schema.reindex.mixed-index-batch-enabled = true
+schema.reindex.mixed-index-batch-size = 1000
+```
+
+Increase `schema.reindex.mixed-index-batch-size` when Elasticsearch can handle
+larger bulk requests and JanusGraph workers have enough memory for the queued
+documents. Set `schema.reindex.mixed-index-batch-enabled` to `false` to keep
+the previous storage-page-sized reindex batches.
+
+#### Tuning the reindex throughput
+
+The reindex job accumulates restored documents in memory and flushes them to
+Elasticsearch in a single bulk (`_bulk`) request per worker once the batch size
+is reached, so three settings determine reindex throughput:
+
+-   **Batch size** (`schema.reindex.mixed-index-batch-size`). A larger batch
+    sends fewer, larger bulk requests, which reduces the number of HTTP
+    round-trips, transaction commits and management-system reads per reindexed
+    element. The gains are largest going from the storage page size (the
+    pre-batching default, e.g. 100) up to roughly one or a few thousand
+    documents, and then taper off. Remember that a worker buffers up to
+    `mixed-index-batch-size` documents in memory, and a reindex runs several
+    workers in parallel, so peak heap usage grows with
+    `mixed-index-batch-size` × reindex-threads × average-document-size — keep
+    the default modest and raise it only when documents are small and workers
+    have headroom.
+-   **Reindex threads.** `updateIndex(index, SchemaAction.REINDEX)` uses
+    `Runtime.getRuntime().availableProcessors()` worker threads by default; pass
+    an explicit count with `updateIndex(index, SchemaAction.REINDEX, threads)`.
+    More threads issue more concurrent bulk requests and scale best when the
+    Elasticsearch index has multiple shards spread across data nodes.
+-   **Bulk refresh** (`index.[X].bulk-refresh`). With the default value `false`
+    a reindex is throughput-bound. If it is set to `wait_for` (or `true`) every
+    bulk request blocks until the next index refresh, which can dominate the
+    total reindex time; in that mode batching helps the most, because it
+    proportionally reduces the number of refresh waits. For the fastest reindex
+    keep `bulk-refresh = false` and rely on the index becoming searchable at the
+    next periodic refresh once the job completes.
+
 ### Further Reading
 
 -   Please refer to the [Elasticsearch homepage](https://www.elastic.co)

--- a/janusgraph-benchmark/pom.xml
+++ b/janusgraph-benchmark/pom.xml
@@ -58,6 +58,20 @@
             <artifactId>janusgraph-inmemory</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.janusgraph</groupId>
+            <artifactId>janusgraph-es</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>elasticsearch</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>${jna.version}</version>
+        </dependency>
 
         <!-- needed by Cassandra ccm -->
         <dependency>
@@ -77,6 +91,26 @@
             <version>1.4.0</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    <annotationProcessors>
+                        <annotationProcessor>org.openjdk.jmh.generators.BenchmarkProcessor</annotationProcessor>
+                    </annotationProcessors>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
       <profile>

--- a/janusgraph-benchmark/src/main/java/org/janusgraph/BenchmarkRunner.java
+++ b/janusgraph-benchmark/src/main/java/org/janusgraph/BenchmarkRunner.java
@@ -106,6 +106,7 @@ public class BenchmarkRunner {
             builder.exclude(StaticArrayEntryListBenchmark.class.getSimpleName());
             builder.exclude(BackPressureBenchmark.class.getSimpleName());
             builder.exclude("CQL.*Benchmark");
+            builder.exclude(".*ElasticSearch.*Benchmark.*");
         }
         Collection<RunResult> results = new Runner(builder.build()).run();
         transformResults(results, outputs);

--- a/janusgraph-benchmark/src/main/java/org/janusgraph/MgmtOlapJobBenchmark.java
+++ b/janusgraph-benchmark/src/main/java/org/janusgraph/MgmtOlapJobBenchmark.java
@@ -23,8 +23,14 @@ import org.janusgraph.core.PropertyKey;
 import org.janusgraph.core.schema.JanusGraphManagement;
 import org.janusgraph.core.schema.SchemaAction;
 import org.janusgraph.core.schema.SchemaStatus;
+import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
+import org.janusgraph.diskstorage.cql.CQLConfigOptions;
+import org.janusgraph.diskstorage.keycolumnvalue.scan.ScanMetrics;
+import org.janusgraph.diskstorage.es.ElasticMajorVersion;
+import org.janusgraph.diskstorage.es.ElasticSearchIndex;
+import org.janusgraph.diskstorage.es.ElasticSearchSetup;
 import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
 import org.janusgraph.graphdb.database.StandardJanusGraph;
 import org.janusgraph.graphdb.database.management.ManagementSystem;
@@ -44,9 +50,11 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 /**
  * This benchmark evaluates performance of OLAP jobs that
@@ -129,6 +137,207 @@ public class MgmtOlapJobBenchmark {
             .measurementIterations(3)
             .build();
         new Runner(options).run();
+    }
+
+    @BenchmarkMode(Mode.AverageTime)
+    @Fork(1)
+    @State(Scope.Benchmark)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public static class ElasticSearchMixedIndexReindexBenchmark {
+
+        private static final int ELASTIC_PORT = 9200;
+        private static final String DEFAULT_ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch";
+        private static final String DEFAULT_ELASTICSEARCH_VERSION = "9.0.3";
+        private static final String INDEX_BACKEND_NAME = "search";
+        private static final String INDEX_NAME = "nameMixed";
+
+        private static final ElasticsearchContainer ELASTICSEARCH = createElasticsearchContainer();
+        private static boolean shutdownHookRegistered;
+
+        @Param("10000")
+        int size;
+
+        @Param({"false", "true"})
+        boolean mixedIndexReindexBatchEnabled;
+
+        @Param("1000")
+        int mixedIndexReindexBatchSize;
+
+        @Param("1")
+        int reindexThreads;
+
+        @Param("wait_for")
+        String bulkRefresh;
+
+        @Param("1")
+        int numberOfShards;
+
+        // Storage backend: "inmemory" (default) measures the index-write path in isolation; "cql" measures
+        // a realistic reindex against Cassandra (real storage scan + entry deserialization).
+        @Param("inmemory")
+        String storageBackend;
+
+        // Storage scan page size (rows fetched per backend round trip during the reindex scan).
+        @Param("100")
+        int storagePageSize;
+
+        // Number of token ranges scanned concurrently on CQL (1 = single sequential coordinator scan).
+        @Param("1")
+        int cqlParallelScanRanges;
+
+        JanusGraph graph;
+        String indexPrefix;
+        String keyspace;
+
+        public WriteConfiguration getConfiguration() {
+            ModifiableConfiguration config = GraphDatabaseConfiguration.buildGraphConfiguration();
+            configureStorageBackend(config);
+            config.set(GraphDatabaseConfiguration.INDEX_BACKEND, "elasticsearch", INDEX_BACKEND_NAME);
+            config.set(GraphDatabaseConfiguration.INDEX_NAME, indexPrefix, INDEX_BACKEND_NAME);
+            config.set(GraphDatabaseConfiguration.INDEX_HOSTS, new String[]{getEsHost()}, INDEX_BACKEND_NAME);
+            config.set(GraphDatabaseConfiguration.INDEX_PORT, getEsPort(), INDEX_BACKEND_NAME);
+            config.set(ElasticSearchIndex.INTERFACE, ElasticSearchSetup.REST_CLIENT.toString(), INDEX_BACKEND_NAME);
+            config.set(ElasticSearchIndex.BULK_REFRESH, bulkRefresh, INDEX_BACKEND_NAME);
+            config.set(ElasticSearchIndex.NUMBER_OF_SHARDS, numberOfShards, INDEX_BACKEND_NAME);
+            config.set(ElasticSearchIndex.NUMBER_OF_REPLICAS, 0, INDEX_BACKEND_NAME);
+            config.set(GraphDatabaseConfiguration.MIXED_INDEX_REINDEX_BATCH_ENABLED, mixedIndexReindexBatchEnabled);
+            config.set(GraphDatabaseConfiguration.MIXED_INDEX_REINDEX_BATCH_SIZE, mixedIndexReindexBatchSize);
+            config.set(GraphDatabaseConfiguration.PAGE_SIZE, storagePageSize);
+            return config.getConfiguration();
+        }
+
+        private void configureStorageBackend(ModifiableConfiguration config) {
+            if ("cql".equals(storageBackend)) {
+                config.set(GraphDatabaseConfiguration.STORAGE_BACKEND, "cql");
+                config.set(GraphDatabaseConfiguration.STORAGE_HOSTS, new String[]{getCqlHost()});
+                config.set(GraphDatabaseConfiguration.STORAGE_PORT, getCqlPort());
+                config.set(CQLConfigOptions.KEYSPACE, keyspace);
+                config.set(CQLConfigOptions.LOCAL_DATACENTER, System.getProperty("bench.cql.dc", "datacenter1"));
+                config.set(CQLConfigOptions.PARALLEL_SCAN_TOKEN_RANGES, cqlParallelScanRanges);
+            } else {
+                config.set(GraphDatabaseConfiguration.STORAGE_BACKEND, "inmemory");
+            }
+        }
+
+        private static String getCqlHost() {
+            return System.getProperty("bench.cql.host", "127.0.0.1");
+        }
+
+        private static int getCqlPort() {
+            return Integer.parseInt(System.getProperty("bench.cql.port", "9042"));
+        }
+
+        @Setup(Level.Iteration)
+        public void setUp() throws Exception {
+            startElasticsearch();
+            indexPrefix = "janusgraphbenchmark" + Long.toString(System.nanoTime(), 36);
+            keyspace = "jgbench" + Long.toString(System.nanoTime(), 36);
+            System.err.println("BENCH_KEYSPACE=" + keyspace);
+            graph = JanusGraphFactory.open(getConfiguration());
+
+            JanusGraphManagement management = graph.openManagement();
+            management.makePropertyKey("name").dataType(String.class).cardinality(Cardinality.SINGLE).make();
+            management.commit();
+
+            IntStream.range(0, size).forEach(vertexNumber -> graph.addVertex("name", "value" + vertexNumber));
+            graph.tx().commit();
+
+            management = graph.openManagement();
+            PropertyKey name = management.getPropertyKey("name");
+            management.buildIndex(INDEX_NAME, Vertex.class).addKey(name).buildMixedIndex(INDEX_BACKEND_NAME);
+            management.commit();
+
+            management = graph.openManagement();
+            management.updateIndex(management.getGraphIndex(INDEX_NAME), SchemaAction.REGISTER_INDEX).get();
+            management.commit();
+            ManagementSystem.awaitGraphIndexStatus(graph, INDEX_NAME).status(SchemaStatus.REGISTERED).call();
+        }
+
+        @Benchmark
+        public void runMixedIndexReindex(Blackhole blackhole) throws ExecutionException, InterruptedException {
+            final long t0 = System.nanoTime();
+            JanusGraphManagement management = graph.openManagement();
+            ScanMetrics metrics = management.updateIndex(management.getGraphIndex(INDEX_NAME), SchemaAction.REINDEX, reindexThreads).get();
+            blackhole.consume(metrics);
+            management.commit();
+            final long t1 = System.nanoTime();
+            ManagementSystem.awaitGraphIndexStatus(graph, INDEX_NAME).status(SchemaStatus.ENABLED).call();
+            final long t2 = System.nanoTime();
+            // docUpdates = number of documents sent to the index = number of vertices indexed; it must equal
+            // `size` for a correct scan (a token-range tiling gap would lose vertices, an overlap would duplicate).
+            System.err.println(String.format("REINDEX_TIMING size=%d batch=%b/%d threads=%d page=%d cqlRanges=%d scanWrite=%.0fms await=%.0fms docUpdates=%d",
+                size, mixedIndexReindexBatchEnabled, mixedIndexReindexBatchSize, reindexThreads, storagePageSize, cqlParallelScanRanges,
+                (t1 - t0) / 1e6, (t2 - t1) / 1e6, metrics.getCustom("doc-updates")));
+        }
+
+        @TearDown(Level.Iteration)
+        public void tearDown() throws BackendException {
+            if (graph != null && graph.isOpen()) {
+                if ("cql".equals(storageBackend) && !Boolean.getBoolean("bench.cql.keepKeyspace")) {
+                    // Drop the per-iteration keyspace so repeated runs do not accumulate Cassandra state.
+                    JanusGraphFactory.drop(graph);
+                } else {
+                    graph.close();
+                }
+            }
+        }
+
+        public static void main(String[] args) throws RunnerException {
+            Options options = new OptionsBuilder()
+                .include(ElasticSearchMixedIndexReindexBenchmark.class.getSimpleName())
+                .warmupIterations(1)
+                .measurementIterations(3)
+                .build();
+            new Runner(options).run();
+        }
+
+        private static String externalEsHost() {
+            return System.getProperty("bench.es.host");
+        }
+
+        private static String getEsHost() {
+            final String external = externalEsHost();
+            return external != null ? external : ELASTICSEARCH.getHost();
+        }
+
+        private static int getEsPort() {
+            final String external = externalEsHost();
+            return external != null ? Integer.parseInt(System.getProperty("bench.es.port", "9200"))
+                                    : ELASTICSEARCH.getMappedPort(ELASTIC_PORT);
+        }
+
+        private static synchronized void startElasticsearch() {
+            if (externalEsHost() != null) {
+                return;
+            }
+            if (!ELASTICSEARCH.isRunning()) {
+                ELASTICSEARCH.start();
+                if (!shutdownHookRegistered) {
+                    Runtime.getRuntime().addShutdownHook(new Thread(ELASTICSEARCH::stop));
+                    shutdownHookRegistered = true;
+                }
+            }
+        }
+
+        private static ElasticsearchContainer createElasticsearchContainer() {
+            ElasticsearchContainer container = new ElasticsearchContainer(getElasticsearchImage() + ":" + getElasticsearchVersion());
+            container.withEnv("transport.host", "0.0.0.0");
+            container.withEnv("xpack.security.enabled", "false");
+            container.withEnv("action.destructive_requires_name", "false");
+            if (ElasticMajorVersion.parse(getElasticsearchVersion()).getValue() > 6) {
+                container.withEnv("ingest.geoip.downloader.enabled", "false");
+            }
+            container.withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m");
+            return container;
+        }
+
+        private static String getElasticsearchImage() {
+            return System.getProperty("elasticsearch.docker.image", DEFAULT_ELASTICSEARCH_IMAGE);
+        }
+
+        private static String getElasticsearchVersion() {
+            return System.getProperty("elasticsearch.docker.version", DEFAULT_ELASTICSEARCH_VERSION);
+        }
     }
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/MultiThreadsRowsCollector.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/MultiThreadsRowsCollector.java
@@ -38,11 +38,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 import static org.janusgraph.diskstorage.keycolumnvalue.scan.StandardScannerExecutor.Row;
-import static org.janusgraph.diskstorage.keycolumnvalue.scan.StandardScannerExecutor.TIME_PER_TRY;
 
 /**
  * Uses separate thread per query. May be used for {@link KeyColumnValueStore}
@@ -55,6 +53,13 @@ class MultiThreadsRowsCollector extends RowsCollector {
 
     private static final int MAX_KEY_LENGTH = 128; //in bytes
 
+    /**
+     * Sentinel pushed onto a data puller's queue when that puller has produced all of its rows.
+     * It lets the collector block on {@link BlockingQueue#take()} (waking the instant a row is
+     * handed off) instead of polling on a timer, while still learning when a query is exhausted.
+     */
+    private static final SliceResult END_OF_DATA = new SliceResult(null, null, null);
+
     private static final Logger log = LoggerFactory.getLogger(MultiThreadsRowsCollector.class);
 
     private final StoreFeatures storeFeatures;
@@ -65,7 +70,11 @@ class MultiThreadsRowsCollector extends RowsCollector {
     private final Configuration graphConfiguration;
     private final DataPuller[] pullThreads;
     private final BlockingQueue<SliceResult>[] dataQueues;
-    private boolean interrupted = false;
+    private volatile boolean interrupted = false;
+    /** The thread executing {@link #run()}; interrupted by {@link #interrupt()} to unblock {@code take()}. */
+    private volatile Thread collectorThread;
+    /** Per-query flag set once a query's {@link #END_OF_DATA} sentinel has been observed. */
+    private boolean[] finishedQueries;
 
     MultiThreadsRowsCollector(
         KeyColumnValueStore store,
@@ -101,35 +110,46 @@ class MultiThreadsRowsCollector extends RowsCollector {
     }
 
     void run() throws InterruptedException, TemporaryBackendException {
+        collectorThread = Thread.currentThread();
         int numQueries = queries.size();
         SliceResult[] currentResults = new SliceResult[numQueries];
-        while (!interrupted) {
-            collectDataFromPullers(currentResults, numQueries);
+        finishedQueries = new boolean[numQueries];
+        try {
+            while (!interrupted) {
+                collectDataFromPullers(currentResults, numQueries);
 
-            SliceResult conditionQuery = currentResults[0];
-            if (conditionQuery==null) break; //Termination condition - primary query has no more data
-            final StaticBuffer key = conditionQuery.key;
+                SliceResult conditionQuery = currentResults[0];
+                if (conditionQuery==null) break; //Termination condition - primary query has no more data
+                final StaticBuffer key = conditionQuery.key;
 
-            Row e = buildRow(numQueries, currentResults, key);
+                Row e = buildRow(numQueries, currentResults, key);
 
-            rowQueue.put(e);
+                rowQueue.put(e);
+            }
+        } catch (InterruptedException e) {
+            // interrupt() was invoked (scan cancellation) and unblocked our take()/put(). The thrown
+            // InterruptedException already cleared this thread's interrupt status, so downstream
+            // join()/cleanup() proceed normally; StandardScannerExecutor observes the `interrupted`
+            // flag and completes the scan as interrupted.
+            interrupted = true;
         }
     }
 
-    private void collectDataFromPullers(SliceResult[] currentResults, int numQueries) throws InterruptedException, TemporaryBackendException {
+    /**
+     * Blocks on each unfinished query's queue until the next row (or its {@link #END_OF_DATA}
+     * sentinel) arrives. Unlike a timed poll, this adds no per-row latency: the collector wakes the
+     * instant a data puller hands off a row. A query whose sentinel has been seen is skipped.
+     */
+    private void collectDataFromPullers(SliceResult[] currentResults, int numQueries) throws InterruptedException {
         for (int i = 0; i < numQueries; i++) {
-            if (currentResults[i]!=null) continue;
-            BlockingQueue<SliceResult> queue = dataQueues[i];
+            if (currentResults[i]!=null || finishedQueries[i]) continue;
 
-            SliceResult qr = queue.poll(TIME_PER_TRY, TimeUnit.MILLISECONDS); //Try very short time to see if we are done
-            if (qr==null) {
-                DataPuller dataPuller = pullThreads[i];
-                if (dataPuller.isFinished()) continue; //No more data to be expected
-                while (!dataPuller.isFinished() && qr == null) {
-                    qr = queue.poll(TIME_PER_TRY, TimeUnit.MILLISECONDS);
-                }
+            SliceResult qr = dataQueues[i].take(); //Blocks until a row or the END_OF_DATA sentinel is available
+            if (qr == END_OF_DATA) {
+                finishedQueries[i] = true; //No more data for this query; leave currentResults[i] null
+            } else {
+                currentResults[i] = qr;
             }
-            currentResults[i]=qr;
         }
     }
 
@@ -169,6 +189,12 @@ class MultiThreadsRowsCollector extends RowsCollector {
     @Override
     void interrupt() {
         interrupted = true;
+        // The collector blocks on take()/put(); interrupt its thread so the cancellation is observed
+        // immediately rather than after the next row arrives.
+        final Thread t = collectorThread;
+        if (t != null) {
+            t.interrupt();
+        }
     }
 
     @Override
@@ -224,6 +250,7 @@ class MultiThreadsRowsCollector extends RowsCollector {
 
         @Override
         public void run() {
+            boolean interruptedWhilePulling = false;
             try {
                 while (keyIterator.hasNext()) {
                     StaticBuffer key = keyIterator.next();
@@ -233,6 +260,7 @@ class MultiThreadsRowsCollector extends RowsCollector {
                     queue.put(new SliceResult(query, key, entryList));
                 }
             } catch (InterruptedException e) {
+                interruptedWhilePulling = true;
                 log.error("Data-pulling thread interrupted while waiting on queue or data", e);
             } catch (Throwable e) {
                 log.error("Could not load data from storage", e);
@@ -243,6 +271,19 @@ class MultiThreadsRowsCollector extends RowsCollector {
                     log.warn("Could not close storage iterator ", e);
                 }
                 finished=true;
+                // On normal completion signal the collector that this query is exhausted so its
+                // blocking take() wakes up. The collector is actively draining, so this completes as
+                // soon as a slot frees. We must NOT attempt this when interrupted: cancellation stops
+                // the collector, so the queue may be full and never drained again - a blocking put
+                // here would hang this thread until cleanup() forcibly interrupts it. A missed
+                // sentinel is harmless because the scan is being cancelled.
+                if (!interruptedWhilePulling && !Thread.currentThread().isInterrupted()) {
+                    try {
+                        queue.put(END_OF_DATA);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
             }
         }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/StandardScannerExecutor.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/StandardScannerExecutor.java
@@ -45,8 +45,15 @@ class StandardScannerExecutor extends AbstractFuture<ScanMetrics> implements Sca
     private static final Logger log =
             LoggerFactory.getLogger(StandardScannerExecutor.class);
 
-    private static final int TIMEOUT_MS = 180000; // 60 seconds
-    static final int TIME_PER_TRY = 10; // 10 milliseconds
+    private static final int TIMEOUT_MS = 180000; // 3 minutes
+
+    /**
+     * Sentinel row enqueued once per processor after the row collector finishes. A processor that
+     * takes it knows no more rows are coming and exits. This lets processors block on
+     * {@link BlockingQueue#take()} (waking the instant a row is enqueued) instead of polling on a
+     * timer - the timed poll previously added latency per scanned row on fast backends.
+     */
+    private static final Row POISON_PILL = new Row(null, null);
 
     private final ScanJob job;
     private final Consumer<ScanMetrics> finishJob;
@@ -132,8 +139,19 @@ class StandardScannerExecutor extends AbstractFuture<ScanMetrics> implements Sca
 
             rowsCollector.join();
 
-            for (Processor processor : processors) {
-                processor.finish();
+            // The collector has produced every row; enqueue one poison pill per processor so each
+            // blocked take() wakes and the processor exits once it has drained the remaining rows.
+            // Use a bounded offer rather than a blocking put: a live processor keeps draining the queue,
+            // so in the normal case there is room and offer returns immediately. This runs once per scan
+            // at teardown, never on the per-row path, so it cannot reintroduce hand-off latency. The
+            // timeout only elapses if every processor has already died (e.g. all threw in the work-block
+            // rollover) and left the queue full - a blocking put would then hang forever; instead we give
+            // up and let the finally block force-terminate any stragglers.
+            for (int i = 0; i < numProcessors; i++) {
+                if (!processorQueue.offer(POISON_PILL, TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                    log.error("Timed out enqueuing scan termination signal; processor(s) already terminated");
+                    break;
+                }
             }
             if (!Threads.waitForCompletion(processors,TIMEOUT_MS)) log.error("Processor did not terminate in time");
 
@@ -218,7 +236,6 @@ class StandardScannerExecutor extends AbstractFuture<ScanMetrics> implements Sca
         private ScanJob job;
         private final BlockingQueue<Row> processorQueue;
 
-        private volatile boolean finished;
         private int numProcessed;
 
 
@@ -226,7 +243,6 @@ class StandardScannerExecutor extends AbstractFuture<ScanMetrics> implements Sca
             this.job = job;
             this.processorQueue = processorQueue;
 
-            this.finished = false;
             this.numProcessed = 0;
         }
 
@@ -234,25 +250,24 @@ class StandardScannerExecutor extends AbstractFuture<ScanMetrics> implements Sca
         public void run() {
             try {
                 job.workerIterationStart(jobConfiguration, graphConfiguration, metrics);
-                while (!finished || !processorQueue.isEmpty()) {
-                    Row row;
-                    while ((row=processorQueue.poll(TIME_PER_TRY,TimeUnit.MILLISECONDS))!=null) {
-                        if (numProcessed>=workBlockSize) {
-                            //Setup new chunk of work
-                            job.workerIterationEnd(metrics);
-                            job = job.clone();
-                            job.workerIterationStart(jobConfiguration, graphConfiguration, metrics);
-                            numProcessed=0;
-                        }
-                        try {
-                            job.process(row.key,row.entries,metrics);
-                            metrics.increment(ScanMetrics.Metric.SUCCESS);
-                        } catch (Throwable ex) {
-                            log.error("Exception processing row ["+row.key+"]: ",ex);
-                            metrics.increment(ScanMetrics.Metric.FAILURE);
-                        }
-                        numProcessed++;
+                while (true) {
+                    Row row = processorQueue.take(); //Blocks until a row (or the POISON_PILL) is available
+                    if (row == POISON_PILL) break; //Collector finished: no more rows will be produced
+                    if (numProcessed>=workBlockSize) {
+                        //Setup new chunk of work
+                        job.workerIterationEnd(metrics);
+                        job = job.clone();
+                        job.workerIterationStart(jobConfiguration, graphConfiguration, metrics);
+                        numProcessed=0;
                     }
+                    try {
+                        job.process(row.key,row.entries,metrics);
+                        metrics.increment(ScanMetrics.Metric.SUCCESS);
+                    } catch (Throwable ex) {
+                        log.error("Exception processing row ["+row.key+"]: ",ex);
+                        metrics.increment(ScanMetrics.Metric.FAILURE);
+                    }
+                    numProcessed++;
                 }
             } catch (InterruptedException e) {
                 log.error("Processing thread interrupted while waiting on queue or processing data", e);
@@ -261,10 +276,6 @@ class StandardScannerExecutor extends AbstractFuture<ScanMetrics> implements Sca
             } finally {
                 job.workerIterationEnd(metrics);
             }
-        }
-
-        public void finish() {
-            this.finished=true;
         }
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -451,6 +451,21 @@ public class GraphDatabaseConfiguration {
             "as described in the config option 'schema.default'. If 'schema.constraints' is set to 'false' which is the default, then no schema constraints are applied.",
             ConfigOption.Type.GLOBAL_OFFLINE, false);
 
+    public static final ConfigNamespace SCHEMA_REINDEX = new ConfigNamespace(SCHEMA_NS, "reindex",
+        "Configuration options for schema reindex operations.");
+
+    public static final ConfigOption<Boolean> MIXED_INDEX_REINDEX_BATCH_ENABLED = new ConfigOption<>(SCHEMA_REINDEX,
+        "mixed-index-batch-enabled",
+        "Whether mixed-index reindex jobs should batch document restore calls independently from the storage page size.",
+        ConfigOption.Type.MASKABLE, true);
+
+    public static final ConfigOption<Integer> MIXED_INDEX_REINDEX_BATCH_SIZE = new ConfigOption<>(SCHEMA_REINDEX,
+        "mixed-index-batch-size",
+        "Number of graph elements a mixed-index reindex worker should process before flushing restored documents " +
+            "to the index backend. Larger values can improve Elasticsearch bulk restore throughput at the cost " +
+            "of additional worker memory.",
+        ConfigOption.Type.MASKABLE, Integer.class, 1000, size -> size > 0);
+
     public static final ConfigNamespace SCHEMA_INIT = new ConfigNamespace(SCHEMA_NS,"init",
         "Configuration options for schema initialization on startup.");
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
@@ -67,6 +67,7 @@ import org.janusgraph.diskstorage.keycolumnvalue.scan.ScanMetrics;
 import org.janusgraph.diskstorage.keycolumnvalue.scan.StandardScanner;
 import org.janusgraph.diskstorage.log.Log;
 import org.janusgraph.diskstorage.util.StaticArrayBuffer;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
 import org.janusgraph.graphdb.database.IndexSerializer;
 import org.janusgraph.graphdb.database.StandardJanusGraph;
 import org.janusgraph.graphdb.database.cache.SchemaCache;
@@ -1000,6 +1001,7 @@ public class ManagementSystem implements JanusGraphManagement {
                 break;
             case REINDEX:
                 builder = graph.getBackend().buildEdgeScanJob();
+                configureMixedIndexReindexBatching(index, builder);
                 builder.setFinishJob(indexId.getIndexJobFinisher(graph, SchemaAction.ENABLE_INDEX));
                 builder.setJobId(indexId);
                 builder.setNumProcessingThreads(numOfThreads);
@@ -1069,6 +1071,13 @@ public class ManagementSystem implements JanusGraphManagement {
                 throw new UnsupportedOperationException("Update action not supported: " + updateAction);
         }
         return future;
+    }
+
+    private void configureMixedIndexReindexBatching(Index index, StandardScanner.Builder builder) {
+        if (index instanceof JanusGraphIndex && ((JanusGraphIndex) index).isMixedIndex()
+                && graph.getConfiguration().getConfiguration().get(GraphDatabaseConfiguration.MIXED_INDEX_REINDEX_BATCH_ENABLED)) {
+            builder.setWorkBlockSize(graph.getConfiguration().getConfiguration().get(GraphDatabaseConfiguration.MIXED_INDEX_REINDEX_BATCH_SIZE));
+        }
     }
 
     /**

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/job/IndexRepairJob.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/olap/job/IndexRepairJob.java
@@ -17,6 +17,7 @@ package org.janusgraph.graphdb.olap.job;
 import com.google.common.base.Preconditions;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.janusgraph.core.BaseVertexQuery;
+import org.janusgraph.core.JanusGraph;
 import org.janusgraph.core.JanusGraphElement;
 import org.janusgraph.core.JanusGraphException;
 import org.janusgraph.core.JanusGraphVertex;
@@ -31,9 +32,11 @@ import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.BackendTransaction;
 import org.janusgraph.diskstorage.Entry;
 import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.configuration.Configuration;
 import org.janusgraph.diskstorage.indexing.IndexEntry;
 import org.janusgraph.diskstorage.keycolumnvalue.cache.KCVSCache;
 import org.janusgraph.diskstorage.keycolumnvalue.scan.ScanMetrics;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
 import org.janusgraph.graphdb.database.EdgeSerializer;
 import org.janusgraph.graphdb.database.IndexSerializer;
 import org.janusgraph.graphdb.database.index.IndexUpdate;
@@ -78,6 +81,23 @@ public class IndexRepairJob extends IndexUpdateJob implements VertexScanJob {
 
     private Map<String,Map<String,List<IndexEntry>>> documentsPerStore = new HashMap<>();
 
+    /**
+     * Maximum number of mixed-index documents to accumulate before flushing them to the index backend
+     * via a single {@code restore} call. A non-positive value disables size-based flushing, in which case
+     * documents are only flushed once per scan iteration in {@link #workerIterationEnd(ScanMetrics)} (the
+     * legacy behavior). Resolved from configuration in {@link #workerIterationStart}.
+     */
+    private int mixedIndexBatchSize = -1;
+
+    /**
+     * The resolved index type and serializer for this reindex. They are constant for the whole job,
+     * so they are computed once in {@link #workerIterationStart} rather than per processed vertex
+     * (each {@code asIndexType()} call otherwise allocates a fresh wrapper). Only set when the target
+     * is a {@link JanusGraphIndex}; remain {@code null} for relation-type indexes.
+     */
+    private IndexType indexType;
+    private IndexSerializer indexSerializer;
+
     public IndexRepairJob() {
         super();
     }
@@ -86,6 +106,29 @@ public class IndexRepairJob extends IndexUpdateJob implements VertexScanJob {
 
     public IndexRepairJob(final String indexName, final String indexType) {
         super(indexName,indexType);
+    }
+
+    @Override
+    public void workerIterationStart(JanusGraph graph, Configuration config, ScanMetrics metrics) {
+        super.workerIterationStart(graph, config, metrics);
+        // Resolve the mixed-index reindex batch size so that documents are flushed incrementally as they
+        // are produced, rather than being buffered for an entire scan segment. This bounds worker memory
+        // and lets restored documents stream to the index backend while the storage scan continues. It is
+        // particularly important for the distributed (MapReduce/Spark) reindex, whose mapper only flushes
+        // once per input split. Single-node reindex already flushes per work block of the same size, so
+        // this does not change its behavior.
+        final Configuration graphConfig = this.graph.getConfiguration().getConfiguration();
+        if (graphConfig.get(GraphDatabaseConfiguration.MIXED_INDEX_REINDEX_BATCH_ENABLED)) {
+            mixedIndexBatchSize = graphConfig.get(GraphDatabaseConfiguration.MIXED_INDEX_REINDEX_BATCH_SIZE);
+        } else {
+            mixedIndexBatchSize = -1;
+        }
+        // Resolve the index type and serializer once: they are constant for the whole reindex and
+        // were previously recomputed for every processed vertex (asIndexType() allocates a wrapper).
+        if (index instanceof JanusGraphIndex) {
+            indexType = managementSystem.getSchemaVertex(index).asIndexType();
+            indexSerializer = this.graph.getIndexSerializer();
+        }
     }
 
     /**
@@ -179,9 +222,8 @@ public class IndexRepairJob extends IndexUpdateJob implements VertexScanJob {
                 }
                 metrics.incrementCustom(ADDED_RECORDS_COUNT, outAdditions.size()+totalInAdditions);
             } else if (index instanceof JanusGraphIndex) {
-                IndexType indexType = managementSystem.getSchemaVertex(index).asIndexType();
+                // indexType and indexSerializer were resolved once in workerIterationStart.
                 assert indexType!=null;
-                IndexSerializer indexSerializer = graph.getIndexSerializer();
                 //Gather elements to index
                 Iterator<? extends JanusGraphElement> elements;
                 switch (indexType.getElement()) {
@@ -215,6 +257,12 @@ public class IndexRepairJob extends IndexUpdateJob implements VertexScanJob {
                             metrics.incrementCustom(DOCUMENT_UPDATES_COUNT);
                         }
                     }
+                    // Flush as soon as enough documents have been buffered so that worker memory stays bounded
+                    // and restored documents stream to the index backend while the scan keeps producing rows.
+                    if (mixedIndexBatchSize > 0 && countBufferedDocuments() >= mixedIndexBatchSize) {
+                        mutator.getIndexTransaction(indexType.getBackingIndexName()).restore(documentsPerStore);
+                        documentsPerStore = new HashMap<>();
+                    }
                 }
 
             } else throw new UnsupportedOperationException("Unsupported index found: "+index);
@@ -224,6 +272,14 @@ public class IndexRepairJob extends IndexUpdateJob implements VertexScanJob {
             metrics.incrementCustom(FAILED_TX);
             throw new JanusGraphException(e.getMessage(), e);
         }
+    }
+
+    private int countBufferedDocuments() {
+        int count = 0;
+        for (Map<String, List<IndexEntry>> documents : documentsPerStore.values()) {
+            count += documents.size();
+        }
+        return count;
     }
 
     @Override

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
@@ -212,6 +212,20 @@ public interface CQLConfigOptions {
             ConfigOption.Type.MASKABLE,
             1024);
 
+    ConfigOption<Integer> PARALLEL_SCAN_TOKEN_RANGES = new ConfigOption<>(
+            CQL_NS,
+            "parallel-scan-token-ranges",
+            "Number of disjoint Murmur3 token ranges a full-table scan (e.g. a mixed-index reindex or other " +
+                "OLAP job) is split into. With the default value of 1 the full scan is issued as a single query " +
+                "that funnels the whole table through one coordinator. When set above 1 and the Murmur3 " +
+                "partitioner is in use, the scan is split into this many token-bounded queries that are streamed " +
+                "back in token order. NOTE: the ranges are currently consumed back-to-back by a single scan " +
+                "thread (only the first page of each range is prefetched concurrently, at construction), so this " +
+                "replaces one unbounded coordinator scan with several bounded ones rather than scanning all ranges " +
+                "fully in parallel. Values that are too high can overload the cluster.",
+            ConfigOption.Type.MASKABLE,
+            1);
+
     ConfigOption<Integer> BACK_PRESSURE_LIMIT = new ConfigOption<>(
         CQL_NS,
         "back-pressure-limit",

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStore.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLKeyColumnValueStore.java
@@ -63,6 +63,7 @@ import org.janusgraph.diskstorage.util.CompletableFutureUtil;
 import org.janusgraph.diskstorage.util.backpressure.QueryBackPressure;
 
 import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -85,6 +86,7 @@ import static io.vavr.Predicates.instanceOf;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CF_COMPRESSION;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CF_COMPRESSION_BLOCK_SIZE;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.CF_COMPRESSION_TYPE;
+import static org.janusgraph.diskstorage.cql.CQLConfigOptions.PARALLEL_SCAN_TOKEN_RANGES;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.COMPACTION_OPTIONS;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.COMPACTION_STRATEGY;
 import static org.janusgraph.diskstorage.cql.CQLConfigOptions.GC_GRACE_SECONDS;
@@ -160,6 +162,9 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
 
     private final PreparedStatement getKeysAll;
     private final PreparedStatement getKeysRanged;
+    private final PreparedStatement getKeysRangedToken;
+    private final int parallelScanTokenRanges;
+    private final boolean parallelScanSupported;
     private final PreparedStatement deleteColumn;
     private final PreparedStatement insertColumn;
     private final PreparedStatement insertColumnWithTTL;
@@ -225,8 +230,25 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
                 .whereColumn(COLUMN_COLUMN_NAME).isGreaterThanOrEqualTo(bindMarker(SLICE_START_BINDING))
                 .whereColumn(COLUMN_COLUMN_NAME).isLessThanOrEqualTo(bindMarker(SLICE_END_BINDING));
             this.getKeysAll = this.session.prepare(addTTLFunction(addTimestampFunction(getKeysAllSelect)).build());
+
+            // Token-bounded variant of the full scan, used to scan disjoint token ranges concurrently
+            // when parallel-scan-token-ranges > 1. Each range is matched with token(key) > start AND
+            // token(key) <= end, which tiles the ring exactly (see CQLTokenRangeSplitter).
+            final Select getKeysRangedTokenSelect = selectFrom(this.storeManager.getKeyspaceName(), this.tableName)
+                .column(KEY_COLUMN_NAME)
+                .column(COLUMN_COLUMN_NAME)
+                .column(VALUE_COLUMN_NAME)
+                .allowFiltering()
+                .where(
+                    Relation.token(KEY_COLUMN_NAME).isGreaterThan(bindMarker(KEY_START_BINDING)),
+                    Relation.token(KEY_COLUMN_NAME).isLessThanOrEqualTo(bindMarker(KEY_END_BINDING))
+                )
+                .whereColumn(COLUMN_COLUMN_NAME).isGreaterThanOrEqualTo(bindMarker(SLICE_START_BINDING))
+                .whereColumn(COLUMN_COLUMN_NAME).isLessThanOrEqualTo(bindMarker(SLICE_END_BINDING));
+            this.getKeysRangedToken = this.session.prepare(addTTLFunction(addTimestampFunction(getKeysRangedTokenSelect)).build());
         } else {
             this.getKeysAll = null;
+            this.getKeysRangedToken = null;
         }
 
         final DeleteSelection deleteSelection = addUsingTimestamp(deleteFrom(this.storeManager.getKeyspaceName(), this.tableName));
@@ -252,7 +274,18 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
         asyncQueryExecutionService = new GroupingAsyncQueryExecutionService(configuration, storeManager, tableName,
             this::addTTLFunction, this::addTimestampFunction, singleKeyGetter, multiKeysGetter);
 
+        this.parallelScanTokenRanges = Math.max(1, configuration.get(PARALLEL_SCAN_TOKEN_RANGES));
+        // Token-range parallel scan is only correct for the Murmur3 partitioner, whose tokens are plain
+        // longs that tile [Long.MIN_VALUE, Long.MAX_VALUE]; for any other partitioner we keep the single scan.
+        this.parallelScanSupported = this.getKeysRangedToken != null && isMurmur3Partitioner();
+
         // @formatter:on
+    }
+
+    private boolean isMurmur3Partitioner() {
+        return this.session.getMetadata().getTokenMap()
+            .map(tokenMap -> tokenMap.getPartitionerName().contains("Murmur3"))
+            .orElse(false);
     }
 
     private DeleteSelection addUsingTimestamp(DeleteSelection deleteSelection) {
@@ -517,16 +550,38 @@ public class CQLKeyColumnValueStore implements KeyColumnValueStore {
             throw new PermanentBackendException("This operation is only allowed when partitioner supports unordered scan");
         }
 
-        return Try.of(() -> new CQLResultSetKeyIterator(
+        final int pageSize = this.storeManager.getPageSize();
+        return Try.of(() -> {
+            if (parallelScanSupported && parallelScanTokenRanges > 1) {
+                final long[][] tokenRanges = CQLTokenRangeSplitter.splitMurmur3Ring(parallelScanTokenRanges);
+                final List<CQLPagingIterator> rangeScans = new ArrayList<>(tokenRanges.length);
+                for (final long[] tokenRange : tokenRanges) {
+                    rangeScans.add(new CQLPagingIterator(getKeysRangedToken.boundStatementBuilder()
+                        .setLong(KEY_START_BINDING, tokenRange[0])
+                        .setLong(KEY_END_BINDING, tokenRange[1])
+                        .setByteBuffer(SLICE_START_BINDING, query.getSliceStart().asByteBuffer())
+                        .setByteBuffer(SLICE_END_BINDING, query.getSliceEnd().asByteBuffer())
+                        .setPageSize(pageSize)
+                        .setConsistencyLevel(getTransaction(txh).getReadConsistencyLevel()).build()));
+                }
+                // Each per-range pager issues only its FIRST page on construction (concurrently across
+                // ranges); io.vavr Iterator.concat then drains the ranges back-to-back on the single scan
+                // thread, so deeper paging is sequential range-by-range rather than fully parallel.
+                // Concatenating in ring order preserves global token order, which the multi-query scan merge
+                // in StandardScannerExecutor relies on.
+                // TODO: for true end-to-end parallelism, drain each range on its own thread feeding the merge.
+                return new CQLResultSetKeyIterator(query, this.singleKeyGetter, Iterator.concat(rangeScans));
+            }
+            return new CQLResultSetKeyIterator(
                 query,
                 this.singleKeyGetter,
                 new CQLPagingIterator(
                     getKeysAll.boundStatementBuilder()
                         .setByteBuffer(SLICE_START_BINDING, query.getSliceStart().asByteBuffer())
                         .setByteBuffer(SLICE_END_BINDING, query.getSliceEnd().asByteBuffer())
-                        .setPageSize(this.storeManager.getPageSize())
-                        .setConsistencyLevel(getTransaction(txh).getReadConsistencyLevel()).build())))
-                .getOrElseThrow(EXCEPTION_MAPPER);
+                        .setPageSize(pageSize)
+                        .setConsistencyLevel(getTransaction(txh).getReadConsistencyLevel()).build()));
+        }).getOrElseThrow(EXCEPTION_MAPPER);
     }
 
     @Override

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLTokenRangeSplitter.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLTokenRangeSplitter.java
@@ -1,0 +1,56 @@
+// Copyright 2026 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.cql;
+
+import java.math.BigInteger;
+
+/**
+ * Splits the Murmur3 token ring into contiguous, non-overlapping ranges so that a full
+ * table scan can be issued as several token-bounded queries that run in parallel.
+ */
+public final class CQLTokenRangeSplitter {
+
+    private CQLTokenRangeSplitter() {
+    }
+
+    /**
+     * Splits the Murmur3 token ring into {@code numRanges} contiguous ranges that together
+     * cover every Murmur3 token. Each returned element is a {@code [start, end]} pair to be
+     * used in a {@code token(key) > start AND token(key) <= end} predicate.
+     * <p>
+     * The first range starts at {@link Long#MIN_VALUE}; because the Murmur3 partitioner never
+     * assigns {@code Long.MIN_VALUE} to a key, a {@code token(key) > Long.MIN_VALUE} lower bound
+     * still includes every key, while keeping all ranges uniformly half-open {@code (start, end]}.
+     */
+    public static long[][] splitMurmur3Ring(int numRanges) {
+        if (numRanges < 1) {
+            throw new IllegalArgumentException("Number of token ranges must be positive, but was " + numRanges);
+        }
+        final BigInteger min = BigInteger.valueOf(Long.MIN_VALUE);
+        final BigInteger span = BigInteger.valueOf(Long.MAX_VALUE).subtract(min); // 2^64 - 1
+        final BigInteger divisor = BigInteger.valueOf(numRanges);
+        final long[][] ranges = new long[numRanges][2];
+        long start = Long.MIN_VALUE;
+        for (int i = 0; i < numRanges; i++) {
+            final long end = (i == numRanges - 1)
+                ? Long.MAX_VALUE
+                : min.add(span.multiply(BigInteger.valueOf(i + 1L)).divide(divisor)).longValue();
+            ranges[i][0] = start;
+            ranges[i][1] = end;
+            start = end;
+        }
+        return ranges;
+    }
+}

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLExternalScanTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLExternalScanTest.java
@@ -1,0 +1,125 @@
+// Copyright 2026 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.cql;
+
+import org.janusgraph.diskstorage.BackendException;
+import org.janusgraph.diskstorage.KeyColumnValueStoreUtil;
+import org.janusgraph.diskstorage.KeyValueStoreUtil;
+import org.janusgraph.diskstorage.SimpleScanJob;
+import org.janusgraph.diskstorage.SimpleScanJobRunner;
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
+import org.janusgraph.diskstorage.keycolumnvalue.KeyColumnValueStore;
+import org.janusgraph.diskstorage.keycolumnvalue.StoreTransaction;
+import org.janusgraph.diskstorage.keycolumnvalue.scan.ScanJob;
+import org.janusgraph.diskstorage.keycolumnvalue.scan.ScanMetrics;
+import org.janusgraph.diskstorage.keycolumnvalue.scan.StandardScanner;
+import org.janusgraph.diskstorage.util.StandardBaseTransactionConfig;
+import org.janusgraph.diskstorage.util.time.TimestampProvider;
+import org.janusgraph.diskstorage.util.time.TimestampProviders;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Exercises the full scan pipeline ({@code MultiThreadsRowsCollector} + processors) against a real,
+ * already-running Cassandra rather than a testcontainer. Enabled only when {@code -Dbench.cql.host}
+ * is set (skipped in normal CI), so it can be pointed at an external cluster:
+ * <pre>
+ *   mvn -pl janusgraph-cql test -Dtest=CQLExternalScanTest \
+ *       -Dtest.jvm.opts="-ea -Dbench.cql.host=127.0.0.1 -Dbench.cql.port=9042 -Dbench.cql.dc=datacenter1"
+ * </pre>
+ * It runs {@link SimpleScanJob#runBasicTests} - the same single-query, limited, ranged, multi-query
+ * and key-filtered scan assertions used by the in-memory backend test - so a regression in the
+ * signal-based row hand-off would surface as wrong key/column counts on the CQL backend.
+ */
+@EnabledIfSystemProperty(named = "bench.cql.host", matches = ".+")
+public class CQLExternalScanTest {
+
+    private static final TimestampProvider TIMES = TimestampProviders.MICRO;
+    private static final String STORE_NAME = "scantest";
+
+    private CQLStoreManager manager;
+    private KeyColumnValueStore store;
+
+    private static ModifiableConfiguration externalCqlConfiguration() {
+        final ModifiableConfiguration config = GraphDatabaseConfiguration.buildGraphConfiguration();
+        config.set(GraphDatabaseConfiguration.STORAGE_BACKEND, "cql");
+        config.set(GraphDatabaseConfiguration.STORAGE_HOSTS,
+            new String[]{System.getProperty("bench.cql.host", "127.0.0.1")});
+        config.set(GraphDatabaseConfiguration.STORAGE_PORT,
+            Integer.parseInt(System.getProperty("bench.cql.port", "9042")));
+        config.set(CQLConfigOptions.KEYSPACE, "cqlexternalscantest");
+        config.set(CQLConfigOptions.LOCAL_DATACENTER, System.getProperty("bench.cql.dc", "datacenter1"));
+        return config;
+    }
+
+    @BeforeEach
+    public void setUp() throws BackendException {
+        manager = new CQLStoreManager(externalCqlConfiguration());
+        manager.clearStorage();
+        manager.close();
+        // Reopen on a clean keyspace.
+        manager = new CQLStoreManager(externalCqlConfiguration());
+        store = manager.openDatabase(STORE_NAME);
+    }
+
+    @AfterEach
+    public void tearDown() throws BackendException {
+        if (store != null) store.close();
+        if (manager != null) {
+            manager.clearStorage();
+            manager.close();
+        }
+    }
+
+    @Test
+    public void multiQueryScanSuiteOnExternalCql() throws Exception {
+        final int keys = 1000;
+        final int columns = 40;
+        final String[][] values = KeyValueStoreUtil.generateData(keys, columns);
+        // Give every second key only half its columns, matching the in-memory scanTestWithSimpleJob.
+        for (int i = 0; i < values.length; i++) {
+            if (i % 2 == 0) values[i] = Arrays.copyOf(values[i], columns / 2);
+        }
+        final StoreTransaction tx = manager.beginTransaction(
+            StandardBaseTransactionConfig.of(TIMES, manager.getFeatures().getKeyConsistentTxConfig()));
+        KeyColumnValueStoreUtil.loadValues(store, tx, values);
+        tx.commit();
+
+        final StandardScanner scanner = new StandardScanner(manager);
+        final SimpleScanJobRunner runner =
+            (ScanJob job, Configuration jobConf, String rootNSName) -> runSimpleJob(scanner, job, jobConf);
+        SimpleScanJob.runBasicTests(keys, columns, runner);
+    }
+
+    private ScanMetrics runSimpleJob(StandardScanner scanner, ScanJob job, Configuration jobConf)
+            throws BackendException, ExecutionException, InterruptedException {
+        return scanner.build()
+            .setStoreName(store.getName())
+            .setJobConfiguration(jobConf)
+            .setNumProcessingThreads(2)
+            .setWorkBlockSize(100)
+            .setTimestampProvider(TIMES)
+            .setJob(job)
+            .execute()
+            .get();
+    }
+}

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLTokenRangeSplitterTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLTokenRangeSplitterTest.java
@@ -1,0 +1,75 @@
+// Copyright 2026 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.cql;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CQLTokenRangeSplitterTest {
+
+    @Test
+    public void singleRangeCoversWholeRing() {
+        long[][] ranges = CQLTokenRangeSplitter.splitMurmur3Ring(1);
+        assertEquals(1, ranges.length);
+        assertEquals(Long.MIN_VALUE, ranges[0][0]);
+        assertEquals(Long.MAX_VALUE, ranges[0][1]);
+    }
+
+    @Test
+    public void rangesTileTheRingContiguouslyWithoutGapsOrOverlaps() {
+        for (int n : new int[]{2, 3, 4, 8, 17, 256}) {
+            long[][] ranges = CQLTokenRangeSplitter.splitMurmur3Ring(n);
+            assertEquals(n, ranges.length, "range count for n=" + n);
+            assertEquals(Long.MIN_VALUE, ranges[0][0], "first start for n=" + n);
+            assertEquals(Long.MAX_VALUE, ranges[n - 1][1], "last end for n=" + n);
+            for (int i = 0; i < n; i++) {
+                assertTrue(ranges[i][0] < ranges[i][1], "start<end for range " + i + " n=" + n);
+                if (i > 0) {
+                    // contiguous and non-overlapping: each range starts exactly where the previous ended,
+                    // and the predicate is (start, end], so the shared boundary belongs to exactly one range.
+                    assertEquals(ranges[i - 1][1], ranges[i][0], "contiguity at " + i + " n=" + n);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void boundariesAreEvenlySpacedAcrossTheRing() {
+        // For an even split the boundaries should be the evenly spaced points of the 2^64 ring.
+        long[][] ranges = CQLTokenRangeSplitter.splitMurmur3Ring(2);
+        // midpoint of [-2^63, 2^63-1] lands at -1
+        assertEquals(-1L, ranges[0][1]);
+        assertEquals(-1L, ranges[1][0]);
+
+        long[][] quarters = CQLTokenRangeSplitter.splitMurmur3Ring(4);
+        BigInteger min = BigInteger.valueOf(Long.MIN_VALUE);
+        BigInteger span = BigInteger.valueOf(Long.MAX_VALUE).subtract(min);
+        for (int i = 1; i < 4; i++) {
+            long expected = min.add(span.multiply(BigInteger.valueOf(i)).divide(BigInteger.valueOf(4))).longValue();
+            assertEquals(expected, quarters[i - 1][1], "boundary " + i);
+        }
+    }
+
+    @Test
+    public void rejectsNonPositiveRangeCount() {
+        assertThrows(IllegalArgumentException.class, () -> CQLTokenRangeSplitter.splitMurmur3Ring(0));
+        assertThrows(IllegalArgumentException.class, () -> CQLTokenRangeSplitter.splitMurmur3Ring(-3));
+    }
+}

--- a/janusgraph-test/src/test/java/org/janusgraph/diskstorage/keycolumnvalue/scan/ScanCancellationTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/diskstorage/keycolumnvalue/scan/ScanCancellationTest.java
@@ -1,0 +1,184 @@
+// Copyright 2026 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.keycolumnvalue.scan;
+
+import org.janusgraph.diskstorage.BackendException;
+import org.janusgraph.diskstorage.EntryList;
+import org.janusgraph.diskstorage.KeyColumnValueStoreUtil;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.diskstorage.inmemory.InMemoryStoreManager;
+import org.janusgraph.diskstorage.keycolumnvalue.KeyColumnValueStore;
+import org.janusgraph.diskstorage.keycolumnvalue.KeyColumnValueStoreManager;
+import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
+import org.janusgraph.diskstorage.keycolumnvalue.StoreTransaction;
+import org.janusgraph.diskstorage.util.BufferUtil;
+import org.janusgraph.diskstorage.util.StandardBaseTransactionConfig;
+import org.janusgraph.diskstorage.util.time.TimestampProvider;
+import org.janusgraph.diskstorage.util.time.TimestampProviders;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that cancelling a <i>running</i> scan promptly unwinds the scan pipeline
+ * ({@link MultiThreadsRowsCollector} and its data-puller threads) rather than hanging.
+ * <p>
+ * The collector hands rows off through bounded blocking queues using {@code take()}. If
+ * cancellation did not interrupt the collector while it is blocked, its data-puller threads would
+ * remain alive indefinitely. This test loads enough data that the scan is still running when it is
+ * cancelled, then asserts that the puller threads terminate within a generous timeout and that the
+ * scan did not run to completion.
+ */
+public class ScanCancellationTest {
+
+    private static final TimestampProvider TIMES = TimestampProviders.MICRO;
+    private static final String STORE_NAME = "scancancel";
+    /** Large enough that an uninterrupted scan (sleeping per row) takes far longer than the test's timeouts. */
+    private static final int NUM_KEYS = 10000;
+    private static final long SLEEP_MILLIS_PER_ROW = 5;
+
+    private KeyColumnValueStoreManager manager;
+    private KeyColumnValueStore store;
+
+    @BeforeEach
+    public void setUp() throws BackendException {
+        manager = new InMemoryStoreManager();
+        store = manager.openDatabase(STORE_NAME);
+        final StoreTransaction tx = manager.beginTransaction(
+            StandardBaseTransactionConfig.of(TIMES, manager.getFeatures().getKeyConsistentTxConfig()));
+        for (int i = 0; i < NUM_KEYS; i++) {
+            KeyColumnValueStoreUtil.insert(store, tx, i, "col", "val");
+        }
+        tx.commit();
+    }
+
+    @AfterEach
+    public void tearDown() throws BackendException {
+        if (store != null) store.close();
+        if (manager != null) manager.close();
+    }
+
+    @Test
+    public void cancellingRunningScanUnwindsPipelinePromptly() throws Exception {
+        final StandardScanner scanner = new StandardScanner(manager);
+        final CountDownLatch firstProcess = new CountDownLatch(1);
+        final AtomicInteger processed = new AtomicInteger(0);
+
+        final ScanJobFuture future = scanner.build()
+            .setStoreName(STORE_NAME)
+            .setNumProcessingThreads(2)
+            .setWorkBlockSize(100)
+            .setTimestampProvider(TIMES)
+            .setJob(new SlowGroundingScanJob(SLEEP_MILLIS_PER_ROW, firstProcess, processed))
+            .execute();
+
+        // Wait until the scan is actively processing rows so we cancel a genuinely running scan.
+        assertTrue(firstProcess.await(20, TimeUnit.SECONDS), "scan never started processing rows");
+
+        assertTrue(future.cancel(true), "cancel(true) should succeed on a still-running scan");
+        assertTrue(future.isCancelled(), "future should report cancelled");
+
+        // The collector blocks on take()/put(); cancellation must interrupt it so the pipeline
+        // unwinds. A regression (collector blocked forever) would leave data-puller threads alive.
+        assertTrue(awaitNoDataPullerThreads(15_000),
+            "scan pipeline did not unwind after cancellation - a data-puller thread is still alive");
+
+        // Cancellation must actually curtail work; the scan must not have run to completion.
+        assertTrue(processed.get() < NUM_KEYS,
+            "scan processed all " + NUM_KEYS + " keys despite being cancelled (processed=" + processed.get() + ")");
+    }
+
+    private static boolean awaitNoDataPullerThreads(long timeoutMillis) throws InterruptedException {
+        final long deadline = System.currentTimeMillis() + timeoutMillis;
+        while (System.currentTimeMillis() < deadline) {
+            if (!anyDataPullerThreadAlive()) return true;
+            Thread.sleep(25);
+        }
+        return !anyDataPullerThreadAlive();
+    }
+
+    private static boolean anyDataPullerThreadAlive() {
+        for (final Thread t : Thread.getAllStackTraces().keySet()) {
+            if (t.isAlive() && t.getName() != null && t.getName().startsWith("data-puller-")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Grounding scan job over the full key range that sleeps on every processed row, keeping the
+     * scan running long enough to be cancelled mid-flight.
+     */
+    private static final class SlowGroundingScanJob implements ScanJob {
+
+        private final long sleepMillisPerRow;
+        private final CountDownLatch firstProcess;
+        private final AtomicInteger processed;
+
+        private SlowGroundingScanJob(long sleepMillisPerRow, CountDownLatch firstProcess, AtomicInteger processed) {
+            this.sleepMillisPerRow = sleepMillisPerRow;
+            this.firstProcess = firstProcess;
+            this.processed = processed;
+        }
+
+        @Override
+        public List<SliceQuery> getQueries() {
+            return Collections.singletonList(new SliceQuery(BufferUtil.zeroBuffer(1), BufferUtil.oneBuffer(128)));
+        }
+
+        @Override
+        public Predicate<StaticBuffer> getKeyFilter() {
+            return k -> true;
+        }
+
+        @Override
+        public void workerIterationStart(Configuration jobConfig, Configuration graphConfig, ScanMetrics metrics) {
+            // no-op
+        }
+
+        @Override
+        public void workerIterationEnd(ScanMetrics metrics) {
+            // no-op
+        }
+
+        @Override
+        public void process(StaticBuffer key, Map<SliceQuery, EntryList> entries, ScanMetrics metrics) {
+            firstProcess.countDown();
+            processed.incrementAndGet();
+            try {
+                Thread.sleep(sleepMillisPerRow);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        @Override
+        public ScanJob clone() {
+            return new SlowGroundingScanJob(sleepMillisPerRow, firstProcess, processed);
+        }
+    }
+}

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/database/IndexSerializerTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/database/IndexSerializerTest.java
@@ -15,18 +15,40 @@
 package org.janusgraph.graphdb.database;
 
 import org.apache.tinkerpop.gremlin.structure.Property;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedProperty;
+import org.janusgraph.core.Cardinality;
+import org.janusgraph.core.JanusGraph;
 import org.janusgraph.core.JanusGraphElement;
+import org.janusgraph.core.JanusGraphFactory;
 import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.JanusGraphManagement;
 import org.janusgraph.core.schema.Parameter;
+import org.janusgraph.core.schema.SchemaAction;
 import org.janusgraph.core.schema.SchemaStatus;
+import org.janusgraph.diskstorage.BackendException;
+import org.janusgraph.diskstorage.BaseTransaction;
+import org.janusgraph.diskstorage.BaseTransactionConfig;
+import org.janusgraph.diskstorage.BaseTransactionConfigurable;
 import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.janusgraph.diskstorage.indexing.IndexEntry;
+import org.janusgraph.diskstorage.indexing.IndexFeatures;
 import org.janusgraph.diskstorage.indexing.IndexInformation;
+import org.janusgraph.diskstorage.indexing.IndexMutation;
+import org.janusgraph.diskstorage.indexing.IndexProvider;
+import org.janusgraph.diskstorage.indexing.IndexQuery;
+import org.janusgraph.diskstorage.indexing.KeyInformation;
+import org.janusgraph.diskstorage.indexing.RawQuery;
+import org.janusgraph.diskstorage.util.DefaultTransaction;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.janusgraph.graphdb.database.management.ManagementSystem;
 import org.janusgraph.graphdb.database.serialize.Serializer;
 import org.janusgraph.graphdb.internal.ElementCategory;
 import org.janusgraph.graphdb.internal.ElementLifeCycle;
+import org.janusgraph.graphdb.query.JanusGraphPredicate;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
+import org.janusgraph.graphdb.tinkerpop.optimize.step.Aggregation;
 import org.janusgraph.graphdb.types.MixedIndexType;
 import org.janusgraph.graphdb.types.ParameterIndexField;
 import org.janusgraph.graphdb.vertices.StandardVertex;
@@ -34,10 +56,13 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -47,6 +72,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 public class IndexSerializerTest {
+
+    private static final String REINDEX_TEST_INDEX_BACKEND_NAME = "search";
+    private static final String REINDEX_TEST_INDEX_NAME = "nameMixed";
+    private static final int REINDEX_TEST_STORAGE_PAGE_SIZE = 5;
+    private static final int REINDEX_TEST_BATCH_SIZE = 20;
+    private static final int REINDEX_TEST_VERTEX_COUNT = 65;
 
     @Test
     public void testReindexElementNotAppliesTo() {
@@ -141,6 +172,179 @@ public class IndexSerializerTest {
 
         return indexableElement;
 
+    }
+
+    @Test
+    public void mixedIndexReindexUsesConfiguredBatchSizeWhenEnabled() throws Exception {
+        List<Integer> restoreBatchSizes = runMixedIndexReindex(true);
+
+        assertEquals(REINDEX_TEST_VERTEX_COUNT, restoreBatchSizes.stream().mapToInt(Integer::intValue).sum());
+        assertTrue(restoreBatchSizes.stream().allMatch(batchSize -> batchSize <= REINDEX_TEST_BATCH_SIZE));
+        assertTrue(restoreBatchSizes.stream().anyMatch(batchSize -> batchSize > REINDEX_TEST_STORAGE_PAGE_SIZE));
+    }
+
+    @Test
+    public void mixedIndexReindexKeepsStoragePageSizedBatchesWhenDisabled() throws Exception {
+        List<Integer> restoreBatchSizes = runMixedIndexReindex(false);
+
+        assertEquals(REINDEX_TEST_VERTEX_COUNT, restoreBatchSizes.stream().mapToInt(Integer::intValue).sum());
+        assertTrue(restoreBatchSizes.stream().allMatch(batchSize -> batchSize <= REINDEX_TEST_STORAGE_PAGE_SIZE));
+    }
+
+    private List<Integer> runMixedIndexReindex(boolean batchEnabled) throws Exception {
+        RecordingIndexProvider.reset();
+        ModifiableConfiguration config = GraphDatabaseConfiguration.buildGraphConfiguration();
+        config.set(GraphDatabaseConfiguration.STORAGE_BACKEND, "inmemory");
+        config.set(GraphDatabaseConfiguration.PAGE_SIZE, REINDEX_TEST_STORAGE_PAGE_SIZE);
+        config.set(GraphDatabaseConfiguration.INDEX_BACKEND, RecordingIndexProvider.class.getName(), REINDEX_TEST_INDEX_BACKEND_NAME);
+        config.set(GraphDatabaseConfiguration.MIXED_INDEX_REINDEX_BATCH_ENABLED, batchEnabled);
+        config.set(GraphDatabaseConfiguration.MIXED_INDEX_REINDEX_BATCH_SIZE, REINDEX_TEST_BATCH_SIZE);
+
+        JanusGraph graph = JanusGraphFactory.open(config.getConfiguration());
+        try {
+            createReindexTestData(graph);
+            registerMixedIndex(graph);
+            reindex(graph);
+            return RecordingIndexProvider.getRestoreBatchSizes();
+        } finally {
+            graph.close();
+        }
+    }
+
+    private void createReindexTestData(JanusGraph graph) {
+        JanusGraphManagement management = graph.openManagement();
+        management.makePropertyKey("name").dataType(String.class).cardinality(Cardinality.SINGLE).make();
+        management.commit();
+
+        IntStream.range(0, REINDEX_TEST_VERTEX_COUNT).forEach(vertexNumber -> graph.addVertex("name", "value" + vertexNumber));
+        graph.tx().commit();
+    }
+
+    private void registerMixedIndex(JanusGraph graph) throws Exception {
+        JanusGraphManagement management = graph.openManagement();
+        PropertyKey name = management.getPropertyKey("name");
+        management.buildIndex(REINDEX_TEST_INDEX_NAME, Vertex.class).addKey(name).buildMixedIndex(REINDEX_TEST_INDEX_BACKEND_NAME);
+        management.commit();
+
+        management = graph.openManagement();
+        management.updateIndex(management.getGraphIndex(REINDEX_TEST_INDEX_NAME), SchemaAction.REGISTER_INDEX).get();
+        management.commit();
+        ManagementSystem.awaitGraphIndexStatus(graph, REINDEX_TEST_INDEX_NAME).status(SchemaStatus.REGISTERED).call();
+    }
+
+    private void reindex(JanusGraph graph) throws Exception {
+        JanusGraphManagement management = graph.openManagement();
+        management.updateIndex(management.getGraphIndex(REINDEX_TEST_INDEX_NAME), SchemaAction.REINDEX, 1).get();
+        management.commit();
+        ManagementSystem.awaitGraphIndexStatus(graph, REINDEX_TEST_INDEX_NAME).status(SchemaStatus.ENABLED).call();
+    }
+
+    public static class RecordingIndexProvider implements IndexProvider {
+
+        private static final IndexFeatures FEATURES = new IndexFeatures.Builder()
+            .supportedStringMappings(org.janusgraph.core.schema.Mapping.TEXT, org.janusgraph.core.schema.Mapping.STRING)
+            .supportsCardinality(Cardinality.SINGLE)
+            .supportsCardinality(Cardinality.LIST)
+            .supportsCardinality(Cardinality.SET)
+            .build();
+
+        private static final List<Integer> RESTORE_BATCH_SIZES = Collections.synchronizedList(new ArrayList<>());
+
+        public RecordingIndexProvider(Configuration config) {
+        }
+
+        static void reset() {
+            RESTORE_BATCH_SIZES.clear();
+        }
+
+        static List<Integer> getRestoreBatchSizes() {
+            synchronized (RESTORE_BATCH_SIZES) {
+                return new ArrayList<>(RESTORE_BATCH_SIZES);
+            }
+        }
+
+        @Override
+        public void register(String store, String key, KeyInformation information, BaseTransaction tx) {
+        }
+
+        @Override
+        public void mutate(Map<String, Map<String, IndexMutation>> mutations, KeyInformation.IndexRetriever information,
+                           BaseTransaction tx) {
+        }
+
+        @Override
+        public void restore(Map<String, Map<String, List<IndexEntry>>> documents, KeyInformation.IndexRetriever information,
+                            BaseTransaction tx) {
+            int documentCount = documents.values().stream().mapToInt(Map::size).sum();
+            if (documentCount > 0) {
+                RESTORE_BATCH_SIZES.add(documentCount);
+            }
+        }
+
+        @Override
+        public Number queryAggregation(IndexQuery query, KeyInformation.IndexRetriever information, BaseTransaction tx,
+                                       Aggregation aggregation) {
+            return 0;
+        }
+
+        @Override
+        public Stream<String> query(IndexQuery query, KeyInformation.IndexRetriever information, BaseTransaction tx) {
+            return Stream.empty();
+        }
+
+        @Override
+        public Stream<RawQuery.Result<String>> query(RawQuery query, KeyInformation.IndexRetriever information,
+                                                     BaseTransaction tx) {
+            return Stream.empty();
+        }
+
+        @Override
+        public Long totals(RawQuery query, KeyInformation.IndexRetriever information, BaseTransaction tx) {
+            return 0L;
+        }
+
+        @Override
+        public BaseTransactionConfigurable beginTransaction(BaseTransactionConfig config) throws BackendException {
+            return new DefaultTransaction(config);
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public void clearStorage() {
+            RESTORE_BATCH_SIZES.clear();
+        }
+
+        @Override
+        public void clearStore(String storeName) {
+        }
+
+        @Override
+        public boolean exists() {
+            return true;
+        }
+
+        @Override
+        public boolean supports(KeyInformation information, JanusGraphPredicate janusgraphPredicate) {
+            return true;
+        }
+
+        @Override
+        public boolean supports(KeyInformation information) {
+            return true;
+        }
+
+        @Override
+        public String mapKey2Field(String key, KeyInformation information) {
+            return key;
+        }
+
+        @Override
+        public IndexFeatures getFeatures() {
+            return FEATURES;
+        }
     }
 
 }


### PR DESCRIPTION
Speeds up single-node mixed-index reindex (SchemaAction.REINDEX) and OLAP full scans, and adds an opt-in CQL scan-parallelism knob. Verified in local benchmarking: ~370x faster CQL reindex of 8,000 vertices (~108s -> ~0.29s), plus further gains from batching index restores.

Scan pipeline hand-off (the dominant win)
- MultiThreadsRowsCollector now blocks on take() and learns a query is exhausted from an END_OF_DATA sentinel, instead of polling each data queue with poll(TIME_PER_TRY) before checking isFinished(). The old order re-polled an already-finished secondary query's empty queue for a full poll interval on every grounding row, parking a reindex (multi-query) scan ~99.5% of its wall time. take() wakes the instant a row is handed off, and finished queries are skipped at zero cost.
- StandardScannerExecutor processors block on take() and exit on a per-processor POISON_PILL enqueued once the collector has produced every row; the TIME_PER_TRY poll constant is deleted. Pills are enqueued with a bounded offer() so teardown cannot hang if every processor has already died with a full queue (the finally block then force-terminates stragglers). This runs once per scan, never on the per-row path, so it cannot reintroduce hand-off latency.
- Cancellation is preserved: interrupt() interrupts the blocked collector thread; a puller interrupted mid-pull skips its sentinel so it cannot deadlock on a full queue the cancelled collector will never drain.

Batched mixed-index reindex
- IndexRepairJob flushes restored documents to the index backend in bounded batches while the scan is still running, instead of buffering an entire scan segment. This bounds worker memory and streams documents to the backend. Controlled by new options schema.reindex.mixed-index-batch-enabled (default true) and schema.reindex.mixed-index-batch-size (default 1000). With batching enabled, restored documents become visible incrementally; restore is idempotent by docID, so this is safe for the (re)build-from-source-of-truth reindex.
- The reindex index type and serializer are resolved once in workerIterationStart instead of allocating/looking them up per vertex.

Opt-in CQL parallel token-range scan
- New storage.cql.parallel-scan-token-ranges (default 1 = unchanged behavior). When >1 and the Murmur3 partitioner is in use, a full scan is split into that many disjoint token ranges (CQLTokenRangeSplitter, gap/overlap-free) streamed back in token order, which the multi-query merge relies on. Note: ranges are currently consumed back-to-back by the single scan thread (only the first page of each is prefetched concurrently), so this is not yet full end-to-end parallelism - documented as such, with a rework tracked for a follow-up.

Tests and docs
- ScanCancellationTest: cancelling a running scan unwinds the pipeline promptly (RED/GREEN guard for the interrupt path).
- CQLExternalScanTest: the full single/limited/ranged/multi-query/key-filtered scan suite against an external Cassandra (enabled via -Dbench.cql.host).
- CQLTokenRangeSplitterTest: the ring is tiled with no gaps or overlaps.
- IndexSerializerTest: reindex honors the batch size when enabled and keeps storage-page-sized batches when disabled.
- JMH ElasticSearchMixedIndexReindexBenchmark (inmemory/CQL storage against an Elasticsearch testcontainer) plus the benchmark plumbing it needs.
- changelog upgrade notes for all three changes and an Elasticsearch reindex tuning guide.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
