### PR TITLE
fix: docs update broken permissions CTR

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -87,9 +87,16 @@ jobs:
             --menu.js-url="https://raw.githubusercontent.com/JanusGraph/janusgraph/master/docs/theme/structor-menu.js.gotmpl"
             --exp-branch=master --debug
       - run: sudo chown -R $(id -u):$(id -g) .
+      - uses: actions/create-github-app-token@v3
+        id: docs-update-app-token
+        with:
+          client-id: ${{ vars.DOCS_UPDATE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.DOCS_UPDATE_APP_CERT }}
+          owner: ${{ github.repository_owner }}
+          repositories: docs.janusgraph.org
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
-          token: ${{ secrets.ACCESS_TOKEN }}
+          token: ${{ steps.docs-update-app-token.outputs.token }}
           repository-name: JanusGraph/docs.janusgraph.org
           branch: master
           folder: site


### PR DESCRIPTION
Current docs update stopped working. I suspect PAT that was used is either removed or broken. This switches from using someone else's PAT to short lived generated access tokens using JanusGraph's own GitHub App that serves as a service account. 

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
