### PR TITLE
Fix benchmark CI failure caused by missing pkg_resources module

### DIFF
--- a/.github/workflows/ci-benchmark.yml
+++ b/.github/workflows/ci-benchmark.yml
@@ -58,7 +58,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - run: pip install setuptools
+      # ccm requires the pkg_resources module which was removed in setuptools 82,
+      # so setuptools needs to stay below version 82 (see #4905)
+      - run: pip install 'setuptools<82'
       - run: pip install git+https://github.com/li-boxuan/ccm.git
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
Our benchmark CI installs the latest setuptools before installing ccm. Starting from setuptools 82.0.0 the pkg_resources module is no longer included, but the ccm script imports it on startup. As a result, every CQL benchmark fails with "No module named 'pkg_resources'" as soon as CcmBridge tries to create the cluster. Pin setuptools below version 82 so that pkg_resources remains available for ccm.

Fixes #4905

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
