### PR TITLE
[v1.1] Fix benchmark CI failure caused by missing pkg_resources module

### DIFF
--- a/.github/workflows/ci-benchmark.yml
+++ b/.github/workflows/ci-benchmark.yml
@@ -58,7 +58,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - run: pip install setuptools
+      # ccm requires the pkg_resources module which was removed in setuptools 82,
+      # so setuptools needs to stay below version 82 (see #4905)
+      - run: pip install 'setuptools<82'
       - run: pip install git+https://github.com/li-boxuan/ccm.git
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.1`:
 - [Fix benchmark CI failure caused by missing pkg_resources module](https://github.com/JanusGraph/janusgraph/pull/4909)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)