### PR TITLE
[v1.1] fix: LF crowdfunding sponsorship link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -14,4 +14,4 @@
 
 # These are supported funding model platforms
 
-custom: ['https://crowdfunding.lfx.linuxfoundation.org/projects/janusgraph']
+custom: ['https://crowdfunding.linuxfoundation.org/initiatives/janusgraph']


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.1`:
 - [fix: LF crowdfunding sponsorship link](https://github.com/JanusGraph/janusgraph/pull/4916)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)