### PR TITLE
fix: harden scan cancellation and cleanup against pre-existing races

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/StandardScannerExecutor.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/StandardScannerExecutor.java
@@ -70,10 +70,17 @@ class StandardScannerExecutor extends AbstractFuture<ScanMetrics> implements Sca
     /** How often the running scan logs a one-line progress summary. */
     private static final long PROGRESS_LOG_PERIOD_MS = 30_000;
 
-    private boolean hasCompleted = false;
-    private boolean interrupted = false;
+    private boolean collectorCleanedUp = false;
+    private boolean storeTxRolledBack = false;
+    /**
+     * Written by the cancelling thread ({@link #interruptTask()}), read by the scan thread; volatile
+     * together with {@link #rowsCollector} so that - whichever way the cancel/setup race goes - either
+     * the canceller observes the collector and interrupts it, or the scan thread observes the flag.
+     */
+    private volatile boolean interrupted = false;
 
-    private RowsCollector rowsCollector;
+    /** Written by the scan thread during setup, read by the cancelling thread; see {@link #interrupted}. */
+    private volatile RowsCollector rowsCollector;
     private volatile BlockingQueue<Row> processorQueue;
     private volatile int processorQueueCapacity;
 
@@ -134,8 +141,19 @@ class StandardScannerExecutor extends AbstractFuture<ScanMetrics> implements Sca
         }  catch (Throwable e) {
             log.error("Exception trying to setup the job:", e);
             cleanupSilent();
-            job.workerIterationEnd(metrics);
+            endJobIterationSilently();
             setException(e);
+            return;
+        }
+
+        if (interrupted) {
+            // The scan was cancelled before the collector existed, so interruptTask() had nothing to
+            // interrupt: stop here instead of running a whole scan whose result would be discarded.
+            // (Both `interrupted` and `rowsCollector` are volatile, so a cancel concurrent with the
+            // setup above either sees the collector and interrupts it, or is seen by this check.)
+            cleanupSilent();
+            endJobIterationSilently();
+            setException(new InterruptedException("Scanner got interrupted"));
             return;
         }
 
@@ -196,7 +214,7 @@ class StandardScannerExecutor extends AbstractFuture<ScanMetrics> implements Sca
             } else {
                 log.error("Exception occurred during job execution:", e);
             }
-            job.workerIterationEnd(metrics);
+            endJobIterationSilently();
             setException(e);
         } finally {
             if (progressLogger != null) {
@@ -283,24 +301,82 @@ class StandardScannerExecutor extends AbstractFuture<ScanMetrics> implements Sca
     @Override
     protected void interruptTask() {
         interrupted = true;
-        rowsCollector.interrupt();
-    }
-
-    private void cleanup() throws BackendException {
-        if (!hasCompleted) {
-            hasCompleted = true;
-            if(rowsCollector != null){
-                rowsCollector.cleanup();
-            }
-            storeTx.rollback();
+        // Cancellation can arrive before run() has built the collector; the interrupted flag alone
+        // is enough then - run() completes the future as interrupted once it gets going.
+        final RowsCollector collector = rowsCollector;
+        if (collector != null) {
+            collector.interrupt();
         }
     }
 
+    /**
+     * Idempotent teardown, called once on the regular completion path and once more from the
+     * final cleanup-on-failure path. Collector cleanup and the transaction rollback are tracked
+     * separately: the rollback must run even when the collector cleanup throws, a rollback
+     * failure must not mask the collector failure (it is attached as suppressed), and a failed
+     * rollback stays retryable by the later cleanup attempt instead of being skipped forever.
+     */
+    private void cleanup() throws BackendException {
+        Throwable collectorFailure = null;
+        try {
+            if (!collectorCleanedUp) {
+                if(rowsCollector != null){
+                    rowsCollector.cleanup();
+                }
+                // Marked only on success so a failed cleanup (e.g. an iterator close error) stays
+                // retryable by the later cleanup attempt, exactly like the rollback below.
+                collectorCleanedUp = true;
+            }
+        } catch (Throwable t) {
+            collectorFailure = t;
+            throw t;
+        } finally {
+            if (!storeTxRolledBack) {
+                try {
+                    storeTx.rollback();
+                    storeTxRolledBack = true;
+                } catch (BackendException | RuntimeException | Error rollbackFailure) {
+                    if (collectorFailure == null) {
+                        throw rollbackFailure;
+                    }
+                    if (rollbackFailure instanceof Error) {
+                        // A JVM-level Error outranks the collector failure - propagate it as primary
+                        // and keep the collector failure visible as suppressed.
+                        rollbackFailure.addSuppressed(collectorFailure);
+                        throw rollbackFailure;
+                    }
+                    // Keep the collector failure primary; losing it to a rollback failure would hide
+                    // the root cause of the cleanup problem.
+                    collectorFailure.addSuppressed(rollbackFailure);
+                }
+            }
+        }
+    }
+
+    /**
+     * Truly silent variant of {@link #cleanup()} for teardown paths: cleanup() can also propagate
+     * RuntimeException/Error (e.g. from the transaction rollback), and letting anything escape here
+     * would skip the subsequent future completion - callers of get() would block forever - or kill
+     * the scan thread from a finally block.
+     */
     private void cleanupSilent() {
         try {
             cleanup();
-        } catch (BackendException ex) {
+        } catch (Throwable ex) {
             log.error("Encountered exception when trying to clean up after failure",ex);
+        }
+    }
+
+    /**
+     * {@code workerIterationEnd} runs user job code; on teardown paths a failure in it must neither
+     * prevent the future from completing (a throw before {@code setException} would leave callers of
+     * {@code get()} blocked forever) nor mask the primary failure being reported.
+     */
+    private void endJobIterationSilently() {
+        try {
+            job.workerIterationEnd(metrics);
+        } catch (Throwable e) {
+            log.warn("Exception occurred while ending the job iteration during scan teardown", e);
         }
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/util/system/Threads.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/util/system/Threads.java
@@ -50,7 +50,10 @@ public class Threads {
             try {
                 Thread.sleep(Math.min(sleepPeriodMillis,endTime-currentTime));
             } catch (InterruptedException e) {
-                System.err.println("Interrupted while waiting for completion of threads!");
+                // The caller was interrupted (e.g. scan cancellation): stop waiting and preserve the
+                // interrupt status instead of silently swallowing it and sitting out the full timeout.
+                Thread.currentThread().interrupt();
+                return !oneAlive(threads);
             }
         }
         return true;

--- a/janusgraph-test/src/test/java/org/janusgraph/diskstorage/keycolumnvalue/scan/ScanCancellationTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/diskstorage/keycolumnvalue/scan/ScanCancellationTest.java
@@ -35,11 +35,16 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -111,9 +116,60 @@ public class ScanCancellationTest {
             "scan processed all " + NUM_KEYS + " keys despite being cancelled (processed=" + processed.get() + ")");
     }
 
+    /**
+     * Cancels the scan while the scan thread is still inside job setup (before the row collector
+     * exists). Historically this threw NullPointerException out of {@code cancel(true)}; with the
+     * fix the cancel is a clean no-op on the missing collector, and the scan thread observes the
+     * volatile {@code interrupted} flag right after setup, tears the pipeline down and never
+     * processes a row nor invokes the finish-job callback.
+     */
+    @Test
+    public void cancelBeforeSetupCompletesMustNotRunTheScan() throws Exception {
+        final StandardScanner scanner = new StandardScanner(manager);
+        final CountDownLatch setupEntered = new CountDownLatch(1);
+        final CountDownLatch cancelIssued = new CountDownLatch(1);
+        final CountDownLatch iterationEnded = new CountDownLatch(1);
+        final AtomicBoolean finishJobCalled = new AtomicBoolean(false);
+        final AtomicInteger processed = new AtomicInteger(0);
+
+        final ScanJobFuture future = scanner.build()
+            .setStoreName(STORE_NAME)
+            // A single worker keeps the workerIterationEnd signal unambiguous on a regressed path.
+            .setNumProcessingThreads(1)
+            .setWorkBlockSize(100)
+            .setTimestampProvider(TIMES)
+            .setFinishJob(m -> finishJobCalled.set(true))
+            .setJob(new SetupBlockingScanJob(setupEntered, cancelIssued, iterationEnded, processed))
+            .execute();
+
+        assertTrue(setupEntered.await(20, TimeUnit.SECONDS), "scan never entered job setup");
+
+        // The collector does not exist yet; cancel(true) used to NPE out of this call.
+        assertTrue(future.cancel(true), "cancel(true) should succeed on a scan still in setup");
+        assertTrue(future.isCancelled(), "future should report cancelled");
+
+        cancelIssued.countDown(); // let the scan thread finish setup and observe the cancellation
+
+        assertThrows(CancellationException.class, () -> future.get(20, TimeUnit.SECONDS));
+        assertTrue(iterationEnded.await(20, TimeUnit.SECONDS), "scan thread never wound down the job");
+        assertTrue(awaitNoDataPullerThreads(15_000),
+            "scan pipeline did not unwind after a pre-setup cancellation");
+
+        // Bounded absence-check rather than a single fixed sleep: on the fixed path nothing can
+        // invoke finishJob or process rows anymore, while a regressed path (scan running despite
+        // the cancel) trips the assertions the moment it does either.
+        final long absenceDeadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(500);
+        while (System.nanoTime() - absenceDeadline < 0) {
+            assertFalse(finishJobCalled.get(), "finishJob must not run for a cancelled scan");
+            assertEquals(0, processed.get(), "a scan cancelled before setup completed must process no rows");
+            Thread.sleep(25);
+        }
+    }
+
     private static boolean awaitNoDataPullerThreads(long timeoutMillis) throws InterruptedException {
-        final long deadline = System.currentTimeMillis() + timeoutMillis;
-        while (System.currentTimeMillis() < deadline) {
+        // nanoTime is monotonic; a wall-clock jump must not shorten or extend the wait.
+        final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+        while (System.nanoTime() - deadline < 0) {
             if (!anyDataPullerThreadAlive()) return true;
             Thread.sleep(25);
         }
@@ -127,6 +183,61 @@ public class ScanCancellationTest {
             }
         }
         return false;
+    }
+
+    /**
+     * Scan job whose setup ({@code workerIterationStart}) blocks until the test has issued the
+     * cancellation, guaranteeing the cancel lands while the row collector does not exist yet.
+     */
+    private static final class SetupBlockingScanJob implements ScanJob {
+
+        private final CountDownLatch setupEntered;
+        private final CountDownLatch cancelIssued;
+        private final CountDownLatch iterationEnded;
+        private final AtomicInteger processed;
+
+        private SetupBlockingScanJob(CountDownLatch setupEntered, CountDownLatch cancelIssued,
+                                     CountDownLatch iterationEnded, AtomicInteger processed) {
+            this.setupEntered = setupEntered;
+            this.cancelIssued = cancelIssued;
+            this.iterationEnded = iterationEnded;
+            this.processed = processed;
+        }
+
+        @Override
+        public List<SliceQuery> getQueries() {
+            return Collections.singletonList(new SliceQuery(BufferUtil.zeroBuffer(1), BufferUtil.oneBuffer(128)));
+        }
+
+        @Override
+        public Predicate<StaticBuffer> getKeyFilter() {
+            return k -> true;
+        }
+
+        @Override
+        public void workerIterationStart(Configuration jobConfig, Configuration graphConfig, ScanMetrics metrics) {
+            setupEntered.countDown();
+            try {
+                cancelIssued.await(30, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        @Override
+        public void workerIterationEnd(ScanMetrics metrics) {
+            iterationEnded.countDown();
+        }
+
+        @Override
+        public void process(StaticBuffer key, Map<SliceQuery, EntryList> entries, ScanMetrics metrics) {
+            processed.incrementAndGet();
+        }
+
+        @Override
+        public ScanJob clone() {
+            return new SetupBlockingScanJob(setupEntered, cancelIssued, iterationEnded, processed);
+        }
     }
 
     /**


### PR DESCRIPTION
Four long-standing issues in the scan-job framework, independent of any particular backend:

- StandardScannerExecutor.interruptTask() dereferenced rowsCollector unconditionally, so a cancel(true) arriving before run() built the collector threw NullPointerException from the future's cancellation path.

- `interrupted` and `rowsCollector` crossed the cancelling-thread/scan-thread boundary as plain fields with no happens-before, so a cancel could be lost entirely: interruptTask() might miss the initialized collector while run() missed `interrupted=true`, letting a cancelled scan run to completion and still invoke `finishJob`. Both fields are now volatile (whichever way the cancel/setup race goes, one side observes the other) and run() short-circuits after setup when the cancel arrived before the collector existed.

- StandardScannerExecutor.cleanup() set hasCompleted before running the collector cleanup and the transaction rollback; a cleanup failure therefore skipped storeTx.rollback() permanently (subsequent cleanup calls no-op on hasCompleted), leaking the scan's store transaction. Collector cleanup and rollback completion are now tracked separately: the rollback always runs (in a finally block), a rollback failure does not mask the original collector-cleanup failure (attached as suppressed), and a failed rollback stays retryable by the later cleanup attempt instead of being skipped forever.

- Threads.waitForCompletion() swallowed InterruptedException, discarded the caller's interrupt status and kept waiting out the full timeout, so a cancelled scan could not shorten the up-to-3-minute processor wait. It now restores the interrupt flag and returns the current completion state immediately (single caller: StandardScannerExecutor, which logs and proceeds to forced termination).

`ScanCancellationTest` now also covers cancelling while the scan is still in job setup: `cancel(true)` must not throw, the future completes as cancelled, the pipeline unwinds, no row is processed and `finishJob` is never invoked.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
