### PR TITLE
fix: scan merge no longer loses data on writes concurrent with the scan

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -225,6 +225,24 @@ returning a partial result, and it fails fast: the error surfaces as soon as the
 end-of-data marker is observed rather than after the remaining key space has been streamed and
 discarded.
 
+##### Scan merge no longer loses data on writes concurrent with the scan
+
+The multi-query scan merge matches each secondary slice query's rows against the grounding
+(key-existence) stream. A key written while the scan runs can appear only in a secondary stream —
+the grounding puller had already passed its position — and such a row can never match. Previously
+it permanently occupied the merge's single pending slot for that query, so every later key was
+silently merged with empty results for the query: a reindex on a live graph produced documents
+missing that query's data for the rest of the scan. On backends whose scans iterate keys in their
+natural order the merge now classifies every row directly against the grounding key (a merge join),
+so stale rows are dropped outright; on token-ordered backends (such as CQL with the Murmur3
+partitioner), where that order is not computable client-side, a bounded per-query buffer of
+unmatched rows recovers by dropping the rows the grounding stream has provably passed. Keys written
+during the scan are unaffected either way: they are indexed by normal live-write index maintenance,
+never by the scan itself. Because the merge join is only sound on a scan that really iterates keys
+in their natural order, a multi-query scan now also verifies that promise against the stream as it
+is consumed and fails the scan if the store violates its declared key order, instead of silently
+dropping rows.
+
 ##### Scan progress logging
 
 `StandardScannerExecutor` now logs a start line (job, query count, processor count, collector type,

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/MultiThreadsRowsCollector.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/MultiThreadsRowsCollector.java
@@ -33,6 +33,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,6 +85,45 @@ class MultiThreadsRowsCollector extends RowsCollector {
     private volatile Thread collectorThread;
     /** Per-query flag set once a query's {@link #END_OF_DATA} sentinel has been observed. */
     private boolean[] finishedQueries;
+    /**
+     * Per-secondary-query buffer of rows taken from the data queue but not yet matched to a
+     * grounding key, oldest first; see {@link #secondaryEntries(int, StaticBuffer)}. Index 0
+     * (the grounding query) is unused - its rows are consumed one per merge iteration. On a
+     * key-ordered scan the buffer holds at most one row (the merge-join look-ahead).
+     */
+    private Deque<SliceResult>[] pendingRows;
+
+    /**
+     * Whether this scan iterates keys in their natural {@link StaticBuffer} order for every query,
+     * which lets the merge classify any row against the current grounding key by comparison. Token-
+     * ordered scans (e.g. CQL/Murmur3) iterate in a backend-internal order the merge cannot compute,
+     * so they use the bounded-buffer recovery in {@link #bufferedSecondaryEntries(int, StaticBuffer)}
+     * instead. Targeted scans (keysToScan) and supplier-provided iterators (token-range splits) make
+     * no natural-order promise either.
+     */
+    private final boolean scanKeysNaturallyOrdered;
+
+    /**
+     * Upper bound of {@link #pendingRows} per query on scans without a computable key order. Large
+     * enough that a row whose key was written during the scan (and therefore never appears in the
+     * grounding stream) is evicted by a later match long before the buffer fills, small enough that
+     * buffered rows stay negligible next to the per-query hand-off queues. When the buffer does fill
+     * without a match, the current key yields no entries for that query - the historical single-slot
+     * behavior - instead of blocking.
+     */
+    private static final int MAX_PENDING_ROWS_PER_QUERY = 32;
+
+    /**
+     * Upper bound of BLOCKING waits for new secondary rows per grounding key on the buffered path
+     * (wait-free polls of already-produced rows are not budgeted). Large enough to unconditionally
+     * recover the current key's row behind realistic bursts of stale rows even when rows trickle in
+     * one at a time, small enough that a grounding key never stalls the merge for long behind a
+     * secondary puller that must scan far between rows.
+     */
+    private static final int MAX_BLOCKING_TAKES_PER_KEY = 8;
+
+    /** Preceding grounding key of a natural-order multi-query scan; see {@link #verifyNaturalKeyOrder}. */
+    private StaticBuffer previousGroundingKey;
 
     MultiThreadsRowsCollector(
         KeyColumnValueStore store,
@@ -123,6 +164,8 @@ class MultiThreadsRowsCollector extends RowsCollector {
         this.graphConfiguration = graphConfiguration;
         this.keyIteratorSupplier = keyIteratorSupplier;
         this.threadNameSuffix = threadNameSuffix;
+        this.scanKeysNaturallyOrdered =
+            storeFeatures.isKeyOrdered() && keysToScan == null && keyIteratorSupplier == null;
 
         this.dataQueues = new BlockingQueue[queries.size()];
         this.pullThreads = new DataPuller[queries.size()];
@@ -177,20 +220,30 @@ class MultiThreadsRowsCollector extends RowsCollector {
 
     void run() throws InterruptedException, TemporaryBackendException {
         collectorThread = Thread.currentThread();
-        int numQueries = queries.size();
-        SliceResult[] currentResults = new SliceResult[numQueries];
+        final int numQueries = queries.size();
         finishedQueries = new boolean[numQueries];
+        @SuppressWarnings("unchecked")
+        final Deque<SliceResult>[] buffers = new ArrayDeque[numQueries];
+        pendingRows = buffers;
+        for (int i = 1; i < numQueries; i++) {
+            pendingRows[i] = new ArrayDeque<>();
+        }
         try {
             while (!interrupted) {
-                collectDataFromPullers(currentResults, numQueries);
+                final SliceResult primary = nextPrimaryRow();
+                if (primary == null) break; //Termination condition - primary query has no more data
+                final StaticBuffer key = primary.key;
+                if (scanKeysNaturallyOrdered && numQueries > 1) {
+                    verifyNaturalKeyOrder(key);
+                }
 
-                SliceResult conditionQuery = currentResults[0];
-                if (conditionQuery==null) break; //Termination condition - primary query has no more data
-                final StaticBuffer key = conditionQuery.key;
-
-                Row e = buildRow(numQueries, currentResults, key);
-
-                putRow(e);
+                final Map<SliceQuery, EntryList> queryResults = new HashMap<>(numQueries);
+                assert queries.get(0).equals(primary.query);
+                queryResults.put(queries.get(0), primary.entries);
+                for (int i = 1; i < numQueries; i++) {
+                    queryResults.put(queries.get(i), secondaryEntries(i, key));
+                }
+                putRow(new Row(key, queryResults));
             }
         } catch (InterruptedException e) {
             // interrupt() was invoked (scan cancellation) and unblocked our take()/put(). The thrown
@@ -205,13 +258,197 @@ class MultiThreadsRowsCollector extends RowsCollector {
     }
 
     /**
-     * Zero-delay backstop for pullers whose sentinel the merge loop never consumed: a query can end
-     * the scan with a pending, never-matching row (e.g. a key written between the grounding query's
-     * pass and this query's) that permanently occupies its slot, so its later sentinel is never
-     * taken. The rows already merged are complete either way, but a failure recorded by such a
-     * puller still marks the scan as incomplete-by-error. Deliberately does NOT join or wait: a
-     * still-running straggler puller is normal here (see above) and is interrupted by
-     * {@link #join()}/{@link #cleanup()}.
+     * Next row of the grounding (primary) query, or null once it is exhausted. The grounding query
+     * matches at least one cell of every key, so its stream defines the key set of the scan.
+     * <p>
+     * A puller that dies on a storage error still enqueues its END_OF_DATA sentinel, which is
+     * indistinguishable from legitimate exhaustion - so the puller's failure is checked the moment
+     * its sentinel is observed (here and in {@link #secondaryEntries(int, StaticBuffer)}). Without
+     * that check the scan would stream the entire remaining key space only to be discarded at the
+     * end, or worse, complete "successfully" with silently missing rows (for a reindex: an
+     * incomplete index getting ENABLED). {@link DataPuller#failure} is written before the sentinel
+     * is enqueued, so observing the sentinel guarantees the failure is visible.
+     */
+    private SliceResult nextPrimaryRow() throws InterruptedException, TemporaryBackendException {
+        if (finishedQueries[0]) {
+            return null;
+        }
+        final SliceResult qr = dataQueues[0].take(); //Blocks until a row or the END_OF_DATA sentinel is available
+        if (qr == END_OF_DATA) {
+            throwIfPullerFailed(0);
+            finishedQueries[0] = true;
+            return null;
+        }
+        return qr;
+    }
+
+    /**
+     * The merge join in {@link #orderedSecondaryEntries(int, StaticBuffer)} drops every row comparing
+     * below the current grounding key as provably stale, which is only sound while the scan really
+     * yields keys in their natural order - the promise {@link StoreFeatures#isKeyOrdered()} makes for
+     * whole-key-space scans. A store that broke it would not fail visibly: rows of live keys would be
+     * dropped as stale and the scan would complete "successfully" with silently missing data (for a
+     * reindex: an incomplete index getting ENABLED). So the promise is verified against the grounding
+     * stream as it is consumed - all of one scan's streams share its iteration order - and a violation
+     * fails the scan instead. Single-query scans skip this: nothing is merged, so no row can be dropped.
+     */
+    private void verifyNaturalKeyOrder(final StaticBuffer key) throws TemporaryBackendException {
+        if (previousGroundingKey != null && previousGroundingKey.compareTo(key) >= 0) {
+            throw new TemporaryBackendException("Scan of store [" + store.getName() + "] returned keys out of " +
+                "their natural order although the store declares itself key-ordered (StoreFeatures.isKeyOrdered()); " +
+                "failing the scan because the ordered merge drops out-of-order rows, so its result would silently miss data");
+        }
+        previousGroundingKey = key;
+    }
+
+    /**
+     * Entries of secondary query {@code queryIndex} for the given grounding key.
+     * <p>
+     * All queries iterate keys in the same order, and the grounding stream covers every key a
+     * secondary stream can contain EXCEPT keys whose row set changed while the scan runs: a key
+     * created after the grounding puller passed its position (or deleted before it arrived there)
+     * can appear only in a secondary stream. Such a stale row can never match a grounding key.
+     * Holding a single pending row per query (the historical design) therefore wedged the merge on
+     * live graphs: the stale row occupied the slot forever and every later key silently received
+     * {@link EntryList#EMPTY_LIST} for the query - for a reindex, documents missing that query's
+     * data for the rest of the scan.
+     * <p>
+     * On a key-ordered scan every row is classified directly against the current grounding key
+     * (classic merge join, at most one look-ahead row buffered). Otherwise the shared iteration
+     * order still proves any buffered row OLDER than a matching row stale, so a bounded buffer
+     * recovers from stale rows as later keys match. Dropping a stale row loses nothing: a key
+     * written after the scan passed it is indexed by the normal live-write path, never by the scan.
+     */
+    private EntryList secondaryEntries(final int queryIndex, final StaticBuffer key)
+            throws InterruptedException, TemporaryBackendException {
+        return scanKeysNaturallyOrdered ? orderedSecondaryEntries(queryIndex, key)
+            : bufferedSecondaryEntries(queryIndex, key);
+    }
+
+    /**
+     * Merge-join for key-ordered scans: a strict key comparison classifies every row as stale
+     * (behind the grounding stream - dropped), matching (consumed), or ahead (kept as the single
+     * look-ahead row). Stale rows can never accumulate, no matter how sparse the query.
+     */
+    private EntryList orderedSecondaryEntries(final int queryIndex, final StaticBuffer key)
+            throws InterruptedException, TemporaryBackendException {
+        final Deque<SliceResult> pending = pendingRows[queryIndex];
+        SliceResult next = pending.pollFirst();
+        int dropped = 0; //Logged once per invocation to keep log volume bounded under stale bursts
+        try {
+            while (true) {
+                if (next == null) {
+                    if (finishedQueries[queryIndex]) {
+                        return EntryList.EMPTY_LIST;
+                    }
+                    final SliceResult qr = dataQueues[queryIndex].take(); //Blocks until a row or the END_OF_DATA sentinel is available
+                    if (qr == END_OF_DATA) {
+                        throwIfPullerFailed(queryIndex);
+                        finishedQueries[queryIndex] = true;
+                        return EntryList.EMPTY_LIST;
+                    }
+                    next = qr;
+                }
+                final int order = next.key.compareTo(key);
+                if (order == 0) {
+                    assert queries.get(queryIndex).equals(next.query);
+                    return next.entries;
+                }
+                if (order > 0) {
+                    pending.addFirst(next); //Ahead of the grounding stream; the look-ahead row for later keys
+                    return EntryList.EMPTY_LIST;
+                }
+                dropped++; //Behind the grounding stream: proven stale
+                next = null;
+            }
+        } finally {
+            logDroppedStaleRows(dropped, queryIndex);
+        }
+    }
+
+    /**
+     * Bounded-buffer recovery for scans without a computable key order (e.g. token-ordered CQL
+     * scans): unmatched rows are buffered up to {@link #MAX_PENDING_ROWS_PER_QUERY}; every buffered
+     * row older than a matching row is proven stale and dropped. If the buffer fills without a
+     * match (which takes {@value #MAX_PENDING_ROWS_PER_QUERY} consecutive stale rows between two
+     * matches of this query), the affected keys yield no entries for this query - the historical
+     * per-key behavior - while buffered rows keep matching and evicting as later keys arrive.
+     * <p>
+     * Already-produced rows are always drained (a wait-free {@code poll()}), but BLOCKING waits for
+     * new rows are budgeted per grounding key ({@link #MAX_BLOCKING_TAKES_PER_KEY}): a secondary
+     * query much sparser than the grounding stream produces rows only as fast as its puller scans
+     * the key space, and waiting on it up to the buffer cap would stall the whole merge - in the
+     * extreme, serializing the scan behind the secondary stream instead of overlapping the two.
+     */
+    private EntryList bufferedSecondaryEntries(final int queryIndex, final StaticBuffer key)
+            throws InterruptedException, TemporaryBackendException {
+        final Deque<SliceResult> pending = pendingRows[queryIndex];
+        SliceResult match = null;
+        for (SliceResult buffered : pending) {
+            if (buffered.key.equals(key)) {
+                match = buffered;
+                break;
+            }
+        }
+        int blockingTakes = 0;
+        while (match == null && !finishedQueries[queryIndex] && pending.size() < MAX_PENDING_ROWS_PER_QUERY) {
+            SliceResult qr = dataQueues[queryIndex].poll(); //Wait-free: whatever the puller already produced
+            if (qr == null) {
+                if (blockingTakes >= MAX_BLOCKING_TAKES_PER_KEY) {
+                    break; //Budget spent; do not stall the merge waiting on a sparser secondary stream
+                }
+                blockingTakes++;
+                qr = dataQueues[queryIndex].take(); //Blocks until a row or the END_OF_DATA sentinel is available
+            }
+            if (qr == END_OF_DATA) {
+                throwIfPullerFailed(queryIndex);
+                finishedQueries[queryIndex] = true; //Buffered rows may still match later grounding keys
+                break;
+            }
+            if (qr.key.equals(key)) {
+                match = qr;
+                break;
+            }
+            pending.addLast(qr); //Ahead of the grounding stream (or stale); kept for later keys
+        }
+        if (match == null) {
+            return EntryList.EMPTY_LIST;
+        }
+        dropStaleRowsBefore(match, pending, queryIndex);
+        assert queries.get(queryIndex).equals(match.query);
+        return match.entries;
+    }
+
+    /**
+     * Drops every buffered row preceding {@code match} as proven stale and removes {@code match}
+     * itself as consumed. A match taken straight from the data queue is not buffered, in which case
+     * every buffered row precedes it in stream order and all of them are dropped.
+     */
+    private void dropStaleRowsBefore(final SliceResult match, final Deque<SliceResult> pending, final int queryIndex) {
+        int dropped = 0;
+        while (!pending.isEmpty()) {
+            if (pending.pollFirst() == match) {
+                break;
+            }
+            dropped++;
+        }
+        logDroppedStaleRows(dropped, queryIndex);
+    }
+
+    private void logDroppedStaleRows(final int dropped, final int queryIndex) {
+        if (dropped > 0 && log.isDebugEnabled()) {
+            log.debug("Dropped {} row(s) of query [{}{}] whose key(s) changed during the scan and are " +
+                "absent from the grounding stream; such keys are indexed by the live-write path instead",
+                dropped, queryIndex, threadNameSuffix);
+        }
+    }
+
+    /**
+     * Zero-delay backstop for pullers whose sentinel the merge loop never consumed (a query can end
+     * the scan with buffered rows and rows still queued behind them). The rows already merged are
+     * complete either way, but a failure recorded by such a puller still marks the scan as
+     * incomplete-by-error. Deliberately does NOT join or wait: a still-running straggler puller is
+     * normal here and is interrupted by {@link #join()}/{@link #cleanup()}.
      */
     private void throwIfAnyPullerFailed() throws TemporaryBackendException {
         for (int i = 0; i < pullThreads.length; i++) {
@@ -225,49 +462,6 @@ class MultiThreadsRowsCollector extends RowsCollector {
             throw new TemporaryBackendException(
                 "Data puller [" + queryIndex + threadNameSuffix + "] failed; failing the scan because its result would be incomplete", failure);
         }
-    }
-
-    /**
-     * Blocks on each unfinished query's queue until the next row (or its {@link #END_OF_DATA}
-     * sentinel) arrives. Unlike a timed poll, this adds no per-row latency: the collector wakes the
-     * instant a data puller hands off a row. A query whose sentinel has been seen is skipped.
-     * <p>
-     * A puller that dies on a storage error still enqueues its END_OF_DATA sentinel, which is
-     * indistinguishable from legitimate query exhaustion - so the puller's failure is checked the
-     * moment its sentinel is observed. Without that check the scan would stream the entire remaining
-     * key space only to be discarded at the end, or worse, complete "successfully" with silently
-     * missing rows (for a reindex: an incomplete index getting ENABLED). {@link DataPuller#failure}
-     * is written before the sentinel is enqueued, so observing the sentinel guarantees the failure
-     * is visible.
-     */
-    private void collectDataFromPullers(SliceResult[] currentResults, int numQueries)
-            throws InterruptedException, TemporaryBackendException {
-        for (int i = 0; i < numQueries; i++) {
-            if (currentResults[i]!=null || finishedQueries[i]) continue;
-
-            SliceResult qr = dataQueues[i].take(); //Blocks until a row or the END_OF_DATA sentinel is available
-            if (qr == END_OF_DATA) {
-                throwIfPullerFailed(i);
-                finishedQueries[i] = true; //No more data for this query; leave currentResults[i] null
-            } else {
-                currentResults[i] = qr;
-            }
-        }
-    }
-
-    private Row buildRow(int numQueries, SliceResult[] currentResults, StaticBuffer key) {
-        Map<SliceQuery,EntryList> queryResults = new HashMap<>(numQueries);
-        for (int i = 0; i< currentResults.length; i++) {
-            SliceQuery query = queries.get(i);
-            EntryList entries = EntryList.EMPTY_LIST;
-            if (currentResults[i]!=null && currentResults[i].key.equals(key)) {
-                assert query.equals(currentResults[i].query);
-                entries = currentResults[i].entries;
-                currentResults[i]=null;
-            }
-            queryResults.put(query,entries);
-        }
-        return new Row(key, queryResults);
     }
 
     @Override

--- a/janusgraph-test/src/test/java/org/janusgraph/diskstorage/keycolumnvalue/scan/ScanStaleSecondaryRowTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/diskstorage/keycolumnvalue/scan/ScanStaleSecondaryRowTest.java
@@ -1,0 +1,462 @@
+// Copyright 2026 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.keycolumnvalue.scan;
+
+import org.janusgraph.diskstorage.BackendException;
+import org.janusgraph.diskstorage.Entry;
+import org.janusgraph.diskstorage.EntryList;
+import org.janusgraph.diskstorage.KeyColumnValueStoreUtil;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.StoreMetaData;
+import org.janusgraph.diskstorage.TemporaryBackendException;
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.diskstorage.inmemory.InMemoryStoreManager;
+import org.janusgraph.diskstorage.keycolumnvalue.KCVSManagerProxy;
+import org.janusgraph.diskstorage.keycolumnvalue.KCVSProxy;
+import org.janusgraph.diskstorage.keycolumnvalue.KeyColumnValueStore;
+import org.janusgraph.diskstorage.keycolumnvalue.KeyColumnValueStoreManager;
+import org.janusgraph.diskstorage.keycolumnvalue.KeyIterator;
+import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
+import org.janusgraph.diskstorage.keycolumnvalue.StandardStoreFeatures;
+import org.janusgraph.diskstorage.keycolumnvalue.StoreFeatures;
+import org.janusgraph.diskstorage.keycolumnvalue.StoreTransaction;
+import org.janusgraph.diskstorage.util.BufferUtil;
+import org.janusgraph.diskstorage.util.RecordIterator;
+import org.janusgraph.diskstorage.util.StandardBaseTransactionConfig;
+import org.janusgraph.diskstorage.util.StaticArrayBuffer;
+import org.janusgraph.diskstorage.util.StaticArrayEntry;
+import org.janusgraph.diskstorage.util.time.TimestampProvider;
+import org.janusgraph.diskstorage.util.time.TimestampProviders;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The multi-query scan merge must not lose data when a key's rows change while the scan runs. Such
+ * a key can appear in a secondary slice query's stream but not in the grounding (key-existence)
+ * stream, whose puller already passed the key's position. Historically that stale row permanently
+ * occupied the merge's single pending slot for the query, so every later key was silently merged
+ * with empty results for it - for a reindex, documents missing that query's data for the rest of
+ * the scan.
+ * <p>
+ * These tests inject stale keys into the secondary stream only, at their correct sort positions,
+ * and assert every real key still carries its secondary data (and that the stale keys do not
+ * surface as scan rows). Both merge strategies are exercised: the merge join used when the scan
+ * iterates keys in natural order, and the bounded-buffer recovery used when the key order is not
+ * computable (simulated by masking {@code keyOrdered} off the in-memory store's features, as on
+ * token-ordered backends like CQL). Secondary queries with data on only a subset of keys (the
+ * common case - a slice query only returns keys with matching columns) are covered explicitly.
+ */
+public class ScanStaleSecondaryRowTest {
+
+    private static final TimestampProvider TIMES = TimestampProviders.MICRO;
+    private static final String STORE_NAME = "stalerowscan";
+    private static final int NUM_KEYS = 500;
+    /** Every SPARSE_STRIDE-th key carries the secondary column in the sparse scenarios. */
+    private static final int SPARSE_STRIDE = 10;
+
+    private static final SliceQuery GROUNDING_QUERY =
+        new SliceQuery(BufferUtil.zeroBuffer(1), BufferUtil.oneBuffer(128)).setLimit(1);
+    /** Covers only the "s" column, so keys without it are absent from this query's stream. */
+    private static final SliceQuery SECONDARY_QUERY = new SliceQuery(
+        KeyColumnValueStoreUtil.stringToByteBuffer("s"), KeyColumnValueStoreUtil.stringToByteBuffer("t"));
+
+    private static final String PROCESSED_ROWS = "processed-rows";
+    private static final String ROWS_WITH_SECONDARY = "rows-with-secondary";
+
+    private KeyColumnValueStoreManager manager;
+    private KeyColumnValueStore store;
+
+    @BeforeEach
+    public void setUp() throws BackendException {
+        manager = new InMemoryStoreManager();
+        store = manager.openDatabase(STORE_NAME);
+    }
+
+    @AfterEach
+    public void tearDown() throws BackendException {
+        if (store != null) store.close();
+        if (manager != null) manager.close();
+    }
+
+    /** Every key has secondary data; stale bursts of one and two rows; bounded-buffer merge path. */
+    @Test
+    public void staleRowsMustNotWedgeADenseQueryOnTheBufferedPath() throws Exception {
+        loadData(1);
+        final Map<Integer, Integer> staleBursts = new HashMap<>();
+        staleBursts.put(100, 1);
+        staleBursts.put(250, 2);
+        staleBursts.put(400, 1);
+
+        runScanAndAssert(withoutNaturalKeyOrder(manager), staleBursts, NUM_KEYS);
+    }
+
+    /**
+     * Only every tenth key has secondary data and a burst of 45 consecutive stale rows (more than
+     * the merge's pending buffer would hold) arrives between two matches: the natural-key-order
+     * merge join classifies each stale row directly and must lose nothing, no matter the burst size.
+     */
+    @Test
+    public void manyConsecutiveStaleRowsMustNotStarveASparseQueryOnTheOrderedPath() throws Exception {
+        loadData(SPARSE_STRIDE);
+        final Map<Integer, Integer> staleBursts = new HashMap<>();
+        staleBursts.put(20, 45);
+
+        runScanAndAssert(manager, staleBursts, NUM_KEYS / SPARSE_STRIDE);
+    }
+
+    /** Sparse secondary data with small stale bursts on the bounded-buffer merge path. */
+    @Test
+    public void staleRowsMustNotStarveASparseQueryOnTheBufferedPath() throws Exception {
+        loadData(SPARSE_STRIDE);
+        final Map<Integer, Integer> staleBursts = new HashMap<>();
+        staleBursts.put(10, 2);
+        staleBursts.put(30, 3);
+
+        runScanAndAssert(withoutNaturalKeyOrder(manager), staleBursts, NUM_KEYS / SPARSE_STRIDE);
+    }
+
+    /**
+     * Characterizes the bounded-buffer path's documented limit: a burst of stale rows LARGER than
+     * the pending buffer (45 > 32) between two matches cannot be resolved without a computable key
+     * order - staleness is only ever proven by a later match, and none of the buffered stale rows
+     * will ever match. The merge then degrades exactly like the historical behavior for the keys
+     * after the burst (empty results for this query), but the scan must still complete: every key
+     * surfaces with its grounding data, nothing hangs and nothing fails. Keys with secondary data
+     * before the burst keep it. The same burst on the ordered path loses nothing (see
+     * {@link #manyConsecutiveStaleRowsMustNotStarveASparseQueryOnTheOrderedPath()}), which is why
+     * backends should expose a key order where they can.
+     */
+    @Test
+    public void staleBurstBeyondTheBufferDegradesButNeverHangsTheBufferedPath() throws Exception {
+        loadData(SPARSE_STRIDE);
+        final int burstAfterMatch = 20;
+        final Map<Integer, Integer> staleBursts = new HashMap<>();
+        staleBursts.put(burstAfterMatch, 45);
+
+        // Matches 1..20 keep their data; the rows of matches 21..50 sit behind the unresolvable
+        // stale rows and are never reached - the documented degradation, bounded to this query.
+        runScanAndAssert(withoutNaturalKeyOrder(manager), staleBursts, burstAfterMatch);
+    }
+
+    /**
+     * The natural-order merge join drops every row comparing below the current grounding key, which
+     * is only sound while the store's scan really yields keys in their natural order - the promise
+     * {@code StoreFeatures.isKeyOrdered()} makes. A store that breaks the promise must fail the scan
+     * loudly: completing it would silently drop live keys' rows as "stale", the very data loss this
+     * class guards against. (Backends without a natural scan order, e.g. token-ordered CQL, declare
+     * {@code keyOrdered=false} and use the buffered strategy instead - see the tests above.)
+     */
+    @Test
+    public void keyOrderViolationOnTheOrderedPathMustFailTheScanInsteadOfDroppingRows() throws Exception {
+        loadData(1);
+
+        final ExecutionException failure = assertThrows(ExecutionException.class,
+            () -> runScan(misorderedGroundingManager(manager)));
+
+        final Throwable cause = failure.getCause();
+        assertTrue(cause instanceof TemporaryBackendException,
+            "an order-contract violation must surface as a backend failure but was: " + cause);
+        assertTrue(cause.getMessage().contains("natural order"), cause.getMessage());
+    }
+
+    /**
+     * @param secondaryStride every how-many-th key receives the secondary "s" column (1 = every key)
+     */
+    private void loadData(int secondaryStride) throws BackendException {
+        final StoreTransaction tx = manager.beginTransaction(
+            StandardBaseTransactionConfig.of(TIMES, manager.getFeatures().getKeyConsistentTxConfig()));
+        for (int i = 0; i < NUM_KEYS; i++) {
+            KeyColumnValueStoreUtil.insert(store, tx, i, "a", "ground" + i);
+            if (i % secondaryStride == 0) {
+                KeyColumnValueStoreUtil.insert(store, tx, i, "s", "sec" + i);
+            }
+        }
+        tx.commit();
+    }
+
+    private void runScanAndAssert(KeyColumnValueStoreManager scanManager, Map<Integer, Integer> staleBursts,
+                                  int expectedRowsWithSecondary) throws Exception {
+        final ScanMetrics metrics = runScan(staleRowInjectingManager(scanManager, staleBursts));
+
+        assertEquals(NUM_KEYS, metrics.getCustom(PROCESSED_ROWS),
+            "every real key must surface exactly once; stale keys must not surface at all");
+        assertEquals(expectedRowsWithSecondary, metrics.getCustom(ROWS_WITH_SECONDARY),
+            "every key with secondary data must keep it; a wedged or starved merge blanks keys after a stale row");
+        assertEquals(NUM_KEYS, metrics.get(ScanMetrics.Metric.SUCCESS));
+        assertEquals(0, metrics.get(ScanMetrics.Metric.FAILURE));
+    }
+
+    private ScanMetrics runScan(KeyColumnValueStoreManager scanManager) throws Exception {
+        return new StandardScanner(scanManager).build()
+            .setStoreName(STORE_NAME)
+            .setNumProcessingThreads(2)
+            .setWorkBlockSize(100)
+            .setTimestampProvider(TIMES)
+            .setJob(new SecondaryDataCountingJob())
+            .execute()
+            .get(60, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Masks {@code keyOrdered} off the store's features, making the merge treat the scan like a
+     * token-ordered backend (no computable key order) and use its bounded-buffer strategy.
+     */
+    private static KeyColumnValueStoreManager withoutNaturalKeyOrder(KeyColumnValueStoreManager real) {
+        return new KCVSManagerProxy(real) {
+            @Override
+            public StoreFeatures getFeatures() {
+                return new StandardStoreFeatures.Builder(real.getFeatures()).keyOrdered(false).build();
+            }
+        };
+    }
+
+    /**
+     * Wraps the store manager so the SECONDARY query's key stream contains extra keys the grounding
+     * stream does not have, at their correct sort positions - exactly what a key written mid-scan
+     * between the two pullers' passes looks like.
+     *
+     * @param staleBursts number of consecutive stale keys to inject (value) after the n-th key
+     *                    returned by the secondary stream (n = map key, 1-based)
+     */
+    private static KeyColumnValueStoreManager staleRowInjectingManager(KeyColumnValueStoreManager real,
+                                                                       Map<Integer, Integer> staleBursts) {
+        return new KCVSManagerProxy(real) {
+            @Override
+            public KeyColumnValueStore openDatabase(String name, StoreMetaData.Container metaData) throws BackendException {
+                return staleRowInjectingStore(real.openDatabase(name, metaData), staleBursts);
+            }
+        };
+    }
+
+    private static KeyColumnValueStore staleRowInjectingStore(KeyColumnValueStore real,
+                                                              Map<Integer, Integer> staleBursts) {
+        return new KCVSProxy(real) {
+            @Override
+            public KeyIterator getKeys(SliceQuery columnQuery, StoreTransaction txh) throws BackendException {
+                final KeyIterator keys = real.getKeys(columnQuery, unwrapTx(txh));
+                // Only the secondary stream sees the stale keys (the grounding puller "passed their
+                // position before they were written"). Match the queries exactly so a change to the
+                // scan's query shapes fails loudly instead of silently injecting into the wrong stream.
+                if (columnQuery.equals(GROUNDING_QUERY)) {
+                    return keys;
+                }
+                if (columnQuery.equals(SECONDARY_QUERY)) {
+                    return injectStaleKeys(keys, staleBursts);
+                }
+                throw new IllegalStateException("Unexpected scan query: " + columnQuery);
+            }
+        };
+    }
+
+    /**
+     * Serves the grounding stream with one key out of natural order - what the scan of a store that
+     * (wrongly) declares {@code keyOrdered} while iterating in some other consistent order looks
+     * like. The scan must die on the grounding stream's order violation, so the secondary stream
+     * needs no doctoring.
+     */
+    private static KeyColumnValueStoreManager misorderedGroundingManager(KeyColumnValueStoreManager real) {
+        return new KCVSManagerProxy(real) {
+            @Override
+            public KeyColumnValueStore openDatabase(String name, StoreMetaData.Container metaData) throws BackendException {
+                final KeyColumnValueStore store = real.openDatabase(name, metaData);
+                return new KCVSProxy(store) {
+                    @Override
+                    public KeyIterator getKeys(SliceQuery columnQuery, StoreTransaction txh) throws BackendException {
+                        final KeyIterator keys = store.getKeys(columnQuery, unwrapTx(txh));
+                        return columnQuery.equals(GROUNDING_QUERY) ? injectMisorderedKey(keys, 10) : keys;
+                    }
+                };
+            }
+        };
+    }
+
+    /** Inserts, after the n-th real key, a key sorting BEFORE it: its strict prefix (one byte shorter). */
+    private static KeyIterator injectMisorderedKey(KeyIterator delegate, int afterNthKey) {
+        return new KeyIterator() {
+            private int realKeysReturned = 0;
+            private StaticBuffer lastRealKey = null;
+            private boolean injectNow = false;
+            private boolean currentIsInjected = false;
+
+            @Override
+            public boolean hasNext() {
+                return injectNow || delegate.hasNext();
+            }
+
+            @Override
+            public StaticBuffer next() {
+                if (injectNow) {
+                    injectNow = false;
+                    currentIsInjected = true;
+                    final byte[] prefix = new byte[lastRealKey.length() - 1];
+                    for (int i = 0; i < prefix.length; i++) {
+                        prefix[i] = lastRealKey.getByte(i);
+                    }
+                    return StaticArrayBuffer.of(prefix);
+                }
+                final StaticBuffer key = delegate.next();
+                currentIsInjected = false;
+                lastRealKey = key;
+                injectNow = ++realKeysReturned == afterNthKey;
+                return key;
+            }
+
+            @Override
+            public RecordIterator<Entry> getEntries() {
+                return currentIsInjected ? staleEntries() : delegate.getEntries();
+            }
+
+            @Override
+            public void close() throws IOException {
+                delegate.close();
+            }
+        };
+    }
+
+    private static KeyIterator injectStaleKeys(KeyIterator delegate, Map<Integer, Integer> staleBursts) {
+        return new KeyIterator() {
+            private int realKeysReturned = 0;
+            private int staleToInject = 0;
+            private int staleSequence = 0;
+            private StaticBuffer lastRealKey = null;
+            private boolean currentIsStale = false;
+
+            @Override
+            public boolean hasNext() {
+                return staleToInject > 0 || delegate.hasNext();
+            }
+
+            @Override
+            public StaticBuffer next() {
+                if (staleToInject > 0) {
+                    staleToInject--;
+                    currentIsStale = true;
+                    return staleKeyAfter(lastRealKey, staleSequence++);
+                }
+                final StaticBuffer key = delegate.next();
+                currentIsStale = false;
+                lastRealKey = key;
+                realKeysReturned++;
+                final Integer burst = staleBursts.get(realKeysReturned);
+                if (burst != null) {
+                    staleSequence = 0;
+                    staleToInject = burst;
+                }
+                return key;
+            }
+
+            @Override
+            public RecordIterator<Entry> getEntries() {
+                return currentIsStale ? staleEntries() : delegate.getEntries();
+            }
+
+            @Override
+            public void close() throws IOException {
+                delegate.close();
+            }
+        };
+    }
+
+    /**
+     * A key sorting directly after {@code realKey} and before the next real key: appending a suffix
+     * byte places the stale key right after {@code realKey} in unsigned byte order but before any
+     * following distinct key ({@code KeyColumnValueStoreUtil} writes fixed-length keys, so no real
+     * key is a prefix of another), and ascending suffix bytes keep multiple stale keys ordered
+     * among themselves.
+     */
+    private static StaticBuffer staleKeyAfter(StaticBuffer realKey, int sequence) {
+        final byte[] bytes = new byte[realKey.length() + 1];
+        for (int i = 0; i < realKey.length(); i++) {
+            bytes[i] = realKey.getByte(i);
+        }
+        bytes[realKey.length()] = (byte) sequence;
+        return StaticArrayBuffer.of(bytes);
+    }
+
+    private static RecordIterator<Entry> staleEntries() {
+        final Iterator<Entry> single = Collections.singletonList(
+            StaticArrayEntry.of(KeyColumnValueStoreUtil.stringToByteBuffer("s"),
+                KeyColumnValueStoreUtil.stringToByteBuffer("stale"))).iterator();
+        return new RecordIterator<Entry>() {
+            @Override
+            public boolean hasNext() {
+                return single.hasNext();
+            }
+
+            @Override
+            public Entry next() {
+                return single.next();
+            }
+
+            @Override
+            public void close() {
+                // NOP
+            }
+        };
+    }
+
+    private static final class SecondaryDataCountingJob implements ScanJob {
+
+        @Override
+        public List<SliceQuery> getQueries() {
+            return Arrays.asList(GROUNDING_QUERY, SECONDARY_QUERY);
+        }
+
+        @Override
+        public Predicate<StaticBuffer> getKeyFilter() {
+            return k -> true;
+        }
+
+        @Override
+        public void workerIterationStart(Configuration jobConfig, Configuration graphConfig, ScanMetrics metrics) {
+            // no-op
+        }
+
+        @Override
+        public void workerIterationEnd(ScanMetrics metrics) {
+            // no-op
+        }
+
+        @Override
+        public void process(StaticBuffer key, Map<SliceQuery, EntryList> entries, ScanMetrics metrics) {
+            metrics.incrementCustom(PROCESSED_ROWS);
+            final EntryList secondary = entries.get(SECONDARY_QUERY);
+            if (secondary != null && !secondary.isEmpty()) {
+                metrics.incrementCustom(ROWS_WITH_SECONDARY);
+            }
+        }
+
+        @Override
+        public ScanJob clone() {
+            return new SecondaryDataCountingJob();
+        }
+    }
+}


### PR DESCRIPTION
Fixes a silent data-loss mode in the multi-query scan merge on live graphs, discovered while reviewing #4918 (the mechanism predates that PR).

**The bug.** `MultiThreadsRowsCollector` matches each secondary slice query's rows against the grounding (key-existence) stream and held at most **one** pending row per secondary query. A key written while the scan runs can appear only in a secondary stream — the grounding puller had already passed its position — and such a row can never match a grounding key. It permanently occupied the query's pending slot, so the merge never consumed that queue again and every later key was silently merged with `EntryList.EMPTY_LIST` for that query. Concretely: a reindex on a live graph produced documents missing that query's data for the rest of the scan, with no error.

**The fix.** Two merge strategies replace the single slot:

- On scans that iterate keys in their **natural order** (`StoreFeatures#isKeyOrdered`, whole-key-space scans), every row is classified against the current grounding key by comparison — a classic merge join with a single look-ahead row. Stale rows are dropped outright and can never accumulate, no matter how sparse the secondary query.
- On **token-ordered** scans (e.g. CQL/Murmur3), where the iteration order is not computable client-side, unmatched rows are buffered (bounded, 32 per query). All streams of one scan share one key order, so every buffered row older than the row matching the current grounding key is *provably* stale — the grounding stream has passed its position — and is dropped (logged at DEBUG). Already-produced rows are drained wait-free; blocking waits for new rows are budgeted per grounding key so a much sparser secondary stream cannot stall the merge.

Dropping loses nothing: a key written after the scan passed its position is indexed by normal live-write index maintenance, never by the scan.

**Regression tests.** `ScanStaleSecondaryRowTest` injects stale keys into the secondary stream at their correct sort positions and asserts every real key keeps its secondary data on **both** merge paths (the token-ordered path is simulated by masking `keyOrdered` off the in-memory store's features), including a sparse secondary query (data on every tenth key only) hit by 45 consecutive stale rows. Stale keys never surface as scan rows. On the previous merge the dense scenario fails with 400 of 500 keys blanked.

Independent of #4920 (disjoint files); both apply cleanly in either order.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
