### PR TITLE
feat(cql): lossless scan merge under Murmur3 via client-computed token order

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -243,6 +243,21 @@ in their natural order, a multi-query scan now also verifies that promise agains
 is consumed and fails the scan if the store violates its declared key order, instead of silently
 dropping rows.
 
+##### CQL scans under the Murmur3 partitioner use the lossless merge join
+
+Cassandra's Murmur3 ring order — token first, key bytes among equal tokens — is now computed
+client-side through the driver's token factory (the same code token-aware routing relies on) and
+declared to the scan framework via the new `StoreFeatures#getScanKeyOrder()` hook. Multi-query CQL
+scans, including the split-parallel pipelines of `storage.cql.parallel-scan-token-ranges`, therefore
+merge with the lossless merge-join strategy instead of the bounded-buffer strategy, whose recovery
+from keys written concurrently with the scan is capped (a burst of more than 32 such keys between
+two matches of one query blanked that query's data for the keys behind the burst). The declared
+order is verified against every scan as it is consumed — the same tripwire that guards natural-order
+backends — so a client/server order mismatch fails the scan instead of silently dropping rows.
+Disabling the driver's token metadata (`storage.cql.metadata-token-map-enabled = false`) removes the
+declaration and restores the previous bounded-buffer merge; partitioners whose order the driver
+cannot compute (RandomPartitioner, Amazon Keyspaces' DefaultPartitioner) keep using it automatically.
+
 ##### Scan progress logging
 
 `StandardScannerExecutor` now logs a start line (job, query count, processor count, collector type,

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/StandardStoreFeatures.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/StandardStoreFeatures.java
@@ -14,8 +14,11 @@
 
 package org.janusgraph.diskstorage.keycolumnvalue;
 
+import org.janusgraph.diskstorage.StaticBuffer;
 import org.janusgraph.diskstorage.configuration.Configuration;
 import org.janusgraph.diskstorage.util.time.TimestampProviders;
+
+import java.util.Comparator;
 
 /**
  * Immutable, {@link Builder}-customizable implementation of StoreFeatures.
@@ -30,6 +33,7 @@ public class StandardStoreFeatures implements StoreFeatures {
     private final boolean batchMutation;
     private final boolean localKeyPartition;
     private final boolean keyOrdered;
+    private final Comparator<StaticBuffer> scanKeyOrder;
     private final boolean distributed;
     private final boolean transactional;
     private final boolean keyConsistent;
@@ -84,6 +88,11 @@ public class StandardStoreFeatures implements StoreFeatures {
     @Override
     public boolean isKeyOrdered() {
         return keyOrdered;
+    }
+
+    @Override
+    public Comparator<StaticBuffer> getScanKeyOrder() {
+        return scanKeyOrder;
     }
 
     @Override
@@ -178,6 +187,7 @@ public class StandardStoreFeatures implements StoreFeatures {
         private boolean batchMutation;
         private boolean localKeyPartition;
         private boolean keyOrdered;
+        private Comparator<StaticBuffer> scanKeyOrder;
         private boolean distributed;
         private boolean transactional;
         private boolean timestamps;
@@ -212,6 +222,7 @@ public class StandardStoreFeatures implements StoreFeatures {
             batchMutation(template.hasBatchMutation());
             localKeyPartition(template.hasLocalKeyPartition());
             keyOrdered(template.isKeyOrdered());
+            scanKeyOrder(template.getScanKeyOrder());
             distributed(template.isDistributed());
             transactional(template.hasTxIsolation());
             timestamps(template.hasTimestamps());
@@ -276,6 +287,12 @@ public class StandardStoreFeatures implements StoreFeatures {
 
         public Builder keyOrdered(boolean b) {
             keyOrdered = b;
+            return this;
+        }
+
+        /** See {@link StoreFeatures#getScanKeyOrder()}; null (the default) means not computable. */
+        public Builder scanKeyOrder(Comparator<StaticBuffer> order) {
+            scanKeyOrder = order;
             return this;
         }
 
@@ -352,7 +369,7 @@ public class StandardStoreFeatures implements StoreFeatures {
         public StandardStoreFeatures build() {
             return new StandardStoreFeatures(consistentScan, unorderedScan, orderedScan,
                     multiQuery, locking, batchMutation, localKeyPartition,
-                    keyOrdered, distributed, transactional, keyConsistent,
+                    keyOrdered, scanKeyOrder, distributed, transactional, keyConsistent,
                     timestamps, preferredTimestamps, cellLevelTTL,
                     storeLevelTTL, visibility, supportsPersist,
                     keyConsistentTxConfig,
@@ -363,7 +380,8 @@ public class StandardStoreFeatures implements StoreFeatures {
 
     private StandardStoreFeatures(boolean consistentScan, boolean unorderedScan, boolean orderedScan,
                                   boolean multiQuery, boolean locking, boolean batchMutation,
-                                  boolean localKeyPartition, boolean keyOrdered, boolean distributed,
+                                  boolean localKeyPartition, boolean keyOrdered,
+                                  Comparator<StaticBuffer> scanKeyOrder, boolean distributed,
                                   boolean transactional, boolean keyConsistent,
                                   boolean timestamps, TimestampProviders preferredTimestamps,
                                   boolean cellLevelTTL, boolean storeLevelTTL,
@@ -380,6 +398,7 @@ public class StandardStoreFeatures implements StoreFeatures {
         this.batchMutation = batchMutation;
         this.localKeyPartition = localKeyPartition;
         this.keyOrdered = keyOrdered;
+        this.scanKeyOrder = scanKeyOrder;
         this.distributed = distributed;
         this.transactional = transactional;
         this.keyConsistent = keyConsistent;

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/StoreFeatures.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/StoreFeatures.java
@@ -14,9 +14,12 @@
 
 package org.janusgraph.diskstorage.keycolumnvalue;
 
+import org.janusgraph.diskstorage.StaticBuffer;
 import org.janusgraph.diskstorage.configuration.Configuration;
 import org.janusgraph.diskstorage.keycolumnvalue.scan.ScanJob;
 import org.janusgraph.diskstorage.util.time.TimestampProviders;
+
+import java.util.Comparator;
 
 /**
  * Describes features supported by a storage backend.
@@ -80,6 +83,26 @@ public interface StoreFeatures {
      *
      */
     boolean isKeyOrdered();
+
+    /**
+     * A total order over keys consistent with the iteration order of this backend's key scans, or
+     * null when that order is not computable client-side (the default). When non-null, every
+     * whole-key-space scan of a store of this backend - {@link KeyColumnValueStore#getKeys(SliceQuery,
+     * StoreTransaction)}, {@link KeyColumnValueStore#getKeys(KeyRangeQuery, StoreTransaction)} and
+     * every split iterator of a {@link SplittableScanStore} - MUST yield keys strictly increasing
+     * under this comparator. Scan-order violations fail multi-query scans (the scan framework
+     * verifies the promise as it consumes rows).
+     * <p>
+     * Backends whose scans iterate in the natural {@link StaticBuffer} order need not implement
+     * this; declaring {@link #isKeyOrdered()} already lets the scan framework merge with the natural
+     * order. This hook is for backends with a deterministic but non-natural scan order that a client
+     * can compute - e.g. Cassandra's token order under the Murmur3 partitioner - and enables the
+     * lossless merge-join strategy of multi-query scans in place of the bounded-buffer strategy
+     * (whose recovery from keys written concurrently with the scan is capped).
+     */
+    default Comparator<StaticBuffer> getScanKeyOrder() {
+        return null;
+    }
 
     /**
      * Whether this storage backend writes and reads data from more than one

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/MultiThreadsRowsCollector.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/keycolumnvalue/scan/MultiThreadsRowsCollector.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
@@ -88,20 +89,23 @@ class MultiThreadsRowsCollector extends RowsCollector {
     /**
      * Per-secondary-query buffer of rows taken from the data queue but not yet matched to a
      * grounding key, oldest first; see {@link #secondaryEntries(int, StaticBuffer)}. Index 0
-     * (the grounding query) is unused - its rows are consumed one per merge iteration. On a
-     * key-ordered scan the buffer holds at most one row (the merge-join look-ahead).
+     * (the grounding query) is unused - its rows are consumed one per merge iteration. When the
+     * scan order is known the buffer holds at most one row (the merge-join look-ahead).
      */
     private Deque<SliceResult>[] pendingRows;
 
     /**
-     * Whether this scan iterates keys in their natural {@link StaticBuffer} order for every query,
-     * which lets the merge classify any row against the current grounding key by comparison. Token-
-     * ordered scans (e.g. CQL/Murmur3) iterate in a backend-internal order the merge cannot compute,
-     * so they use the bounded-buffer recovery in {@link #bufferedSecondaryEntries(int, StaticBuffer)}
-     * instead. Targeted scans (keysToScan) and supplier-provided iterators (token-range splits) make
-     * no natural-order promise either.
+     * The order in which this scan's streams iterate keys, when it is computable client-side; null
+     * otherwise. A known order lets the merge classify any row against the current grounding key by
+     * comparison (the lossless merge join). It is either the store-provided order
+     * ({@link StoreFeatures#getScanKeyOrder()}, e.g. CQL/Murmur3 token order - which split iterators
+     * of one token range follow too) or, on key-ordered whole-key-space scans
+     * ({@link StoreFeatures#isKeyOrdered()}), the natural {@link StaticBuffer} order. Scans with no
+     * computable order use the bounded-buffer recovery in
+     * {@link #bufferedSecondaryEntries(int, StaticBuffer)} instead. Targeted scans (keysToScan)
+     * iterate in the caller's list order and make neither promise.
      */
-    private final boolean scanKeysNaturallyOrdered;
+    private final Comparator<StaticBuffer> scanKeyOrder;
 
     /**
      * Upper bound of {@link #pendingRows} per query on scans without a computable key order. Large
@@ -122,8 +126,16 @@ class MultiThreadsRowsCollector extends RowsCollector {
      */
     private static final int MAX_BLOCKING_TAKES_PER_KEY = 8;
 
-    /** Preceding grounding key of a natural-order multi-query scan; see {@link #verifyNaturalKeyOrder}. */
+    /** Preceding grounding key of a known-order multi-query scan; see {@link #verifyScanKeyOrder}. */
     private StaticBuffer previousGroundingKey;
+
+    /**
+     * Whether {@link #scanKeyOrder} came from {@link StoreFeatures#getScanKeyOrder()} rather than
+     * being the natural order implied by {@link StoreFeatures#isKeyOrdered()}. Order violations
+     * name the promise that was actually relied on, and a store may legally provide the natural
+     * comparator, so comparator identity cannot tell the two apart.
+     */
+    private final boolean scanKeyOrderIsStoreProvided;
 
     MultiThreadsRowsCollector(
         KeyColumnValueStore store,
@@ -164,8 +176,17 @@ class MultiThreadsRowsCollector extends RowsCollector {
         this.graphConfiguration = graphConfiguration;
         this.keyIteratorSupplier = keyIteratorSupplier;
         this.threadNameSuffix = threadNameSuffix;
-        this.scanKeysNaturallyOrdered =
-            storeFeatures.isKeyOrdered() && keysToScan == null && keyIteratorSupplier == null;
+        Comparator<StaticBuffer> order = null;
+        boolean storeProvided = false;
+        if (keysToScan == null) {
+            order = storeFeatures.getScanKeyOrder();
+            storeProvided = order != null;
+            if (order == null && keyIteratorSupplier == null && storeFeatures.isKeyOrdered()) {
+                order = Comparator.naturalOrder();
+            }
+        }
+        this.scanKeyOrder = order;
+        this.scanKeyOrderIsStoreProvided = storeProvided;
 
         this.dataQueues = new BlockingQueue[queries.size()];
         this.pullThreads = new DataPuller[queries.size()];
@@ -233,8 +254,8 @@ class MultiThreadsRowsCollector extends RowsCollector {
                 final SliceResult primary = nextPrimaryRow();
                 if (primary == null) break; //Termination condition - primary query has no more data
                 final StaticBuffer key = primary.key;
-                if (scanKeysNaturallyOrdered && numQueries > 1) {
-                    verifyNaturalKeyOrder(key);
+                if (scanKeyOrder != null && numQueries > 1) {
+                    verifyScanKeyOrder(key);
                 }
 
                 final Map<SliceQuery, EntryList> queryResults = new HashMap<>(numQueries);
@@ -285,18 +306,22 @@ class MultiThreadsRowsCollector extends RowsCollector {
     /**
      * The merge join in {@link #orderedSecondaryEntries(int, StaticBuffer)} drops every row comparing
      * below the current grounding key as provably stale, which is only sound while the scan really
-     * yields keys in their natural order - the promise {@link StoreFeatures#isKeyOrdered()} makes for
-     * whole-key-space scans. A store that broke it would not fail visibly: rows of live keys would be
-     * dropped as stale and the scan would complete "successfully" with silently missing data (for a
-     * reindex: an incomplete index getting ENABLED). So the promise is verified against the grounding
-     * stream as it is consumed - all of one scan's streams share its iteration order - and a violation
-     * fails the scan instead. Single-query scans skip this: nothing is merged, so no row can be dropped.
+     * yields keys in the order the store declared - natural order under
+     * {@link StoreFeatures#isKeyOrdered()}, or the store-provided {@link StoreFeatures#getScanKeyOrder()}
+     * (for CQL/Murmur3: a client-side token computation that must match the server's). A store that
+     * broke the promise would not fail visibly: rows of live keys would be dropped as stale and the
+     * scan would complete "successfully" with silently missing data (for a reindex: an incomplete
+     * index getting ENABLED). So the promise is verified against the grounding stream as it is
+     * consumed - all of one scan's streams share its iteration order - and a violation fails the
+     * scan instead. Single-query scans skip this: nothing is merged, so no row can be dropped.
      */
-    private void verifyNaturalKeyOrder(final StaticBuffer key) throws TemporaryBackendException {
-        if (previousGroundingKey != null && previousGroundingKey.compareTo(key) >= 0) {
+    private void verifyScanKeyOrder(final StaticBuffer key) throws TemporaryBackendException {
+        if (previousGroundingKey != null && scanKeyOrder.compare(previousGroundingKey, key) >= 0) {
+            final String declaredOrder = scanKeyOrderIsStoreProvided
+                ? "the store-provided scan order [" + scanKeyOrder + "] it declared (StoreFeatures.getScanKeyOrder())"
+                : "the natural key order it declared (StoreFeatures.isKeyOrdered())";
             throw new TemporaryBackendException("Scan of store [" + store.getName() + "] returned keys out of " +
-                "their natural order although the store declares itself key-ordered (StoreFeatures.isKeyOrdered()); " +
-                "failing the scan because the ordered merge drops out-of-order rows, so its result would silently miss data");
+                declaredOrder + "; failing the scan because the ordered merge drops out-of-order rows, so its result would silently miss data");
         }
         previousGroundingKey = key;
     }
@@ -313,22 +338,24 @@ class MultiThreadsRowsCollector extends RowsCollector {
      * {@link EntryList#EMPTY_LIST} for the query - for a reindex, documents missing that query's
      * data for the rest of the scan.
      * <p>
-     * On a key-ordered scan every row is classified directly against the current grounding key
-     * (classic merge join, at most one look-ahead row buffered). Otherwise the shared iteration
-     * order still proves any buffered row OLDER than a matching row stale, so a bounded buffer
-     * recovers from stale rows as later keys match. Dropping a stale row loses nothing: a key
-     * written after the scan passed it is indexed by the normal live-write path, never by the scan.
+     * When the scan's key order is known ({@link #scanKeyOrder}) every row is classified directly
+     * against the current grounding key (classic merge join, at most one look-ahead row buffered).
+     * Otherwise the shared iteration order still proves any buffered row OLDER than a matching row
+     * stale, so a bounded buffer recovers from stale rows as later keys match. Dropping a stale row
+     * loses nothing: a key written after the scan passed it is indexed by the normal live-write
+     * path, never by the scan.
      */
     private EntryList secondaryEntries(final int queryIndex, final StaticBuffer key)
             throws InterruptedException, TemporaryBackendException {
-        return scanKeysNaturallyOrdered ? orderedSecondaryEntries(queryIndex, key)
+        return scanKeyOrder != null ? orderedSecondaryEntries(queryIndex, key)
             : bufferedSecondaryEntries(queryIndex, key);
     }
 
     /**
-     * Merge-join for key-ordered scans: a strict key comparison classifies every row as stale
-     * (behind the grounding stream - dropped), matching (consumed), or ahead (kept as the single
-     * look-ahead row). Stale rows can never accumulate, no matter how sparse the query.
+     * Merge-join for scans whose key order is known ({@link #scanKeyOrder}): a strict key comparison
+     * classifies every row as stale (behind the grounding stream - dropped), matching (consumed), or
+     * ahead (kept as the single look-ahead row). Stale rows can never accumulate, no matter how
+     * sparse the query.
      */
     private EntryList orderedSecondaryEntries(final int queryIndex, final StaticBuffer key)
             throws InterruptedException, TemporaryBackendException {
@@ -349,7 +376,7 @@ class MultiThreadsRowsCollector extends RowsCollector {
                     }
                     next = qr;
                 }
-                final int order = next.key.compareTo(key);
+                final int order = scanKeyOrder.compare(next.key, key);
                 if (order == 0) {
                     assert queries.get(queryIndex).equals(next.query);
                     return next.entries;

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/TokenOrderKeyComparator.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/TokenOrderKeyComparator.java
@@ -1,0 +1,59 @@
+// Copyright 2026 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.cql;
+
+import com.datastax.oss.driver.api.core.metadata.TokenMap;
+import com.datastax.oss.driver.api.core.metadata.token.Token;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.keycolumnvalue.StoreFeatures;
+
+import java.util.Comparator;
+
+/**
+ * The ring order a CQL range scan iterates partition keys in, computed client-side: by the
+ * partitioner's token first and, among keys with equal tokens (hash collisions), by the unsigned
+ * key bytes - Cassandra's {@code DecoratedKey} order. Token computation is delegated to the
+ * driver's {@link TokenMap} (the same token factory the driver relies on for token-aware routing),
+ * so it matches the connected cluster's partitioner by construction. Only the token FACTORY is
+ * used, which is fixed for the lifetime of a cluster, so holding one {@link TokenMap} instance
+ * across ring topology changes is safe.
+ * <p>
+ * Declared through {@link StoreFeatures#getScanKeyOrder()}, this order puts multi-query scans
+ * (e.g. a reindex) on the lossless merge-join strategy. The scan framework verifies the order
+ * against every scan as it consumes rows and fails the scan on the first violation, so a
+ * client/server order mismatch surfaces as an error instead of silently dropped rows.
+ */
+public class TokenOrderKeyComparator implements Comparator<StaticBuffer> {
+
+    private final TokenMap tokenMap;
+
+    public TokenOrderKeyComparator(final TokenMap tokenMap) {
+        this.tokenMap = tokenMap;
+    }
+
+    @Override
+    public int compare(final StaticBuffer a, final StaticBuffer b) {
+        final Token tokenA = tokenMap.newToken(a.asByteBuffer());
+        final Token tokenB = tokenMap.newToken(b.asByteBuffer());
+        final int byToken = tokenA.compareTo(tokenB);
+        return byToken != 0 ? byToken : a.compareTo(b);
+    }
+
+    /** Identifies this order (and the partitioner it mirrors) in scan-order violation errors. */
+    @Override
+    public String toString() {
+        return "CQL token order (partitioner " + tokenMap.getPartitionerName() + ")";
+    }
+}

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/builder/CQLStoreFeaturesBuilder.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/builder/CQLStoreFeaturesBuilder.java
@@ -18,6 +18,7 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import org.janusgraph.diskstorage.common.DistributedStoreManager;
 import org.janusgraph.diskstorage.configuration.Configuration;
 import org.janusgraph.diskstorage.cql.CQLStoreManager;
+import org.janusgraph.diskstorage.cql.TokenOrderKeyComparator;
 import org.janusgraph.diskstorage.keycolumnvalue.StandardStoreFeatures;
 import org.janusgraph.diskstorage.keycolumnvalue.StoreFeatures;
 import org.janusgraph.util.system.NetworkUtil;
@@ -89,6 +90,18 @@ public class CQLStoreFeaturesBuilder {
             case "RandomPartitioner":
             case "Murmur3Partitioner": {
                 fb.keyOrdered(false).orderedScan(false).unorderedScan(true);
+                // Murmur3 ring order is client-computable through the driver's token factory; declaring it
+                // puts multi-query scans (e.g. a reindex) on the lossless merge-join strategy instead of the
+                // bounded-buffer one, whose recovery from writes concurrent with the scan is capped. The
+                // TokenMap is absent when metadata token-map support is disabled (the escape hatch back to
+                // the buffered merge) or the partitioner is unknown to the driver (e.g. Amazon Keyspaces'
+                // DefaultPartitioner); RandomPartitioner is deliberately not declared - its order would be
+                // computable the same way, but no CI covers it and an undetected deviation would fail every
+                // multi-query scan via the framework's order verification.
+                if ("Murmur3Partitioner".equals(partitioner)) {
+                    session.getMetadata().getTokenMap()
+                        .ifPresent(tokenMap -> fb.scanKeyOrder(new TokenOrderKeyComparator(tokenMap)));
+                }
                 deployment = DistributedStoreManager.Deployment.REMOTE;
                 break;
             }

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLScanKeyOrderTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/CQLScanKeyOrderTest.java
@@ -1,0 +1,295 @@
+// Copyright 2026 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.cql;
+
+import org.janusgraph.JanusGraphCassandraContainer;
+import org.janusgraph.diskstorage.BackendException;
+import org.janusgraph.diskstorage.EntryList;
+import org.janusgraph.diskstorage.KeyColumnValueStoreUtil;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.configuration.Configuration;
+import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
+import org.janusgraph.diskstorage.keycolumnvalue.KeyColumnValueStore;
+import org.janusgraph.diskstorage.keycolumnvalue.KeyIterator;
+import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
+import org.janusgraph.diskstorage.keycolumnvalue.SplittableScanStore;
+import org.janusgraph.diskstorage.keycolumnvalue.StoreTransaction;
+import org.janusgraph.diskstorage.keycolumnvalue.scan.ScanJob;
+import org.janusgraph.diskstorage.keycolumnvalue.scan.ScanMetrics;
+import org.janusgraph.diskstorage.keycolumnvalue.scan.StandardScanner;
+import org.janusgraph.diskstorage.util.BufferUtil;
+import org.janusgraph.diskstorage.util.StandardBaseTransactionConfig;
+import org.janusgraph.diskstorage.util.time.TimestampProvider;
+import org.janusgraph.diskstorage.util.time.TimestampProviders;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Conformance of the client-computed CQL scan order ({@code StoreFeatures.getScanKeyOrder()}) with
+ * the order a real Cassandra actually iterates keys in. Under the Murmur3 partitioner scans stream
+ * in ring order - (token, key bytes) - which the driver can compute client-side; declaring it lets
+ * the multi-query scan merge use its lossless merge-join strategy instead of the bounded-buffer
+ * strategy whose recovery from concurrent writes is capped. The declaration is only safe if it
+ * EXACTLY matches the server (a mismatch makes the merge drop live rows as stale), so this test
+ * checks the promise empirically: every whole-scan and split iteration must be strictly increasing
+ * under the declared comparator, and a multi-query scan must pass the scan framework's order
+ * tripwire, which fails the scan on the first out-of-order key.
+ * <p>
+ * Under the ByteOrderedPartitioner no comparator is declared BY DESIGN - scans iterate in the
+ * natural key order and the merge join engages through {@code StoreFeatures.isKeyOrdered()} - so
+ * the comparator-conformance tests are skipped on key-ordered clusters (the end-to-end merge test
+ * still runs there, exercising the natural-order join against a real backend).
+ */
+@Testcontainers
+public class CQLScanKeyOrderTest {
+
+    private static final TimestampProvider TIMES = TimestampProviders.MICRO;
+    private static final String STORE_NAME = "scanordertest";
+    private static final int NUM_KEYS = 300;
+
+    private static final SliceQuery EVERYTHING =
+        new SliceQuery(BufferUtil.zeroBuffer(1), BufferUtil.oneBuffer(128));
+    private static final SliceQuery GROUNDING_QUERY =
+        new SliceQuery(BufferUtil.zeroBuffer(1), BufferUtil.oneBuffer(128)).setLimit(1);
+
+    private static final String PROCESSED_ROWS = "processed-rows";
+    private static final String ROWS_WITH_SECONDARY = "rows-with-secondary";
+
+    @Container
+    public static final JanusGraphCassandraContainer cqlContainer = new JanusGraphCassandraContainer();
+
+    private CQLStoreManager manager;
+    private KeyColumnValueStore store;
+
+    @BeforeEach
+    public void setUp() throws BackendException {
+        manager = new CQLStoreManager(cqlContainer.getConfiguration(CQLScanKeyOrderTest.class.getSimpleName()));
+        store = manager.openDatabase(STORE_NAME);
+        loadData();
+    }
+
+    @AfterEach
+    public void tearDown() throws BackendException {
+        if (store != null) store.close();
+        if (manager != null) {
+            manager.clearStorage();
+            manager.close();
+        }
+    }
+
+    /**
+     * The comparator-conformance tests only apply to token-ordered clusters: a key-ordered cluster
+     * (ByteOrderedPartitioner) iterates scans in the natural key order and declares that through
+     * {@code StoreFeatures.isKeyOrdered()} instead of providing a comparator.
+     */
+    private void assumeTokenOrderedCluster() {
+        Assumptions.assumeFalse(manager.getFeatures().isKeyOrdered(),
+            "key-ordered (byte-ordered) cluster: scans follow the natural key order and no client-computed comparator is declared");
+    }
+
+    @Test
+    public void murmur3StoreMustDeclareAComputableScanKeyOrder() {
+        assumeTokenOrderedCluster();
+        assertNotNull(manager.getFeatures().getScanKeyOrder(),
+            "CQL with the Murmur3 partitioner must expose its token order for the lossless scan merge");
+    }
+
+    @Test
+    public void wholeScanMustIterateInTheDeclaredOrder() throws Exception {
+        assumeTokenOrderedCluster();
+        final Comparator<StaticBuffer> order = manager.getFeatures().getScanKeyOrder();
+        assertNotNull(order);
+
+        final StoreTransaction tx = beginTx();
+        try {
+            final List<StaticBuffer> keys = drainKeys(store.getKeys(EVERYTHING, tx));
+            assertEquals(NUM_KEYS, keys.size());
+            assertStrictlyIncreasing(keys, order);
+            assertTrue(countNaturalInversions(keys) > 0,
+                "token order coincided with natural key order; the conformance check would be vacuous");
+        } finally {
+            tx.rollback();
+        }
+    }
+
+    /**
+     * With parallel-scan-token-ranges > 1 a whole-key-space getKeys concatenates one pager per
+     * token range; the concatenation must follow ring order for the global iteration to stay
+     * monotonic under the declared comparator.
+     */
+    @Test
+    public void wholeScanWithParallelTokenRangesMustIterateInTheDeclaredOrder() throws Exception {
+        assumeTokenOrderedCluster();
+        store.close();
+        manager.close();
+        final ModifiableConfiguration config =
+            cqlContainer.getConfiguration(CQLScanKeyOrderTest.class.getSimpleName());
+        config.set(CQLConfigOptions.PARALLEL_SCAN_TOKEN_RANGES, 5);
+        manager = new CQLStoreManager(config);
+        store = manager.openDatabase(STORE_NAME);
+
+        wholeScanMustIterateInTheDeclaredOrder();
+    }
+
+    @Test
+    public void splitScansMustIterateInTheDeclaredOrder() throws Exception {
+        assumeTokenOrderedCluster();
+        final Comparator<StaticBuffer> order = manager.getFeatures().getScanKeyOrder();
+        assertNotNull(order);
+        final int splitCount = 4;
+
+        final StoreTransaction tx = beginTx();
+        try {
+            final SplittableScanStore splittable = assertInstanceOf(SplittableScanStore.class, store,
+                "the CQL store must expose split scans for the split-order conformance check");
+            final Set<StaticBuffer> union = new HashSet<>();
+            for (int split = 0; split < splitCount; split++) {
+                final List<StaticBuffer> keys = drainKeys(splittable.getKeysForSplit(EVERYTHING, tx, split, splitCount));
+                assertStrictlyIncreasing(keys, order);
+                union.addAll(keys);
+            }
+            assertEquals(NUM_KEYS, union.size(), "splits must tile the key space exactly");
+        } finally {
+            tx.rollback();
+        }
+    }
+
+    /**
+     * End to end: a multi-query scan on the real backend runs the merge join under the declared
+     * order with the framework's order tripwire active, so any client/server order mismatch fails
+     * the scan, and every key must keep its secondary data (an out-of-order comparator would blank
+     * keys by dropping their rows as stale before tripping).
+     */
+    @Test
+    public void multiQueryScanMustMergeLosslesslyUnderTheDeclaredOrder() throws Exception {
+        final ScanMetrics metrics = new StandardScanner(manager).build()
+            .setStoreName(STORE_NAME)
+            .setNumProcessingThreads(2)
+            .setWorkBlockSize(100)
+            .setTimestampProvider(TIMES)
+            .setJob(new SecondaryDataCountingJob())
+            .execute()
+            .get(120, TimeUnit.SECONDS);
+
+        assertEquals(NUM_KEYS, metrics.getCustom(PROCESSED_ROWS));
+        assertEquals(NUM_KEYS, metrics.getCustom(ROWS_WITH_SECONDARY),
+            "every key must keep its secondary data under the merge join");
+        assertEquals(NUM_KEYS, metrics.get(ScanMetrics.Metric.SUCCESS));
+        assertEquals(0, metrics.get(ScanMetrics.Metric.FAILURE));
+    }
+
+    private void loadData() throws BackendException {
+        final StoreTransaction tx = beginTx();
+        try {
+            for (int i = 0; i < NUM_KEYS; i++) {
+                KeyColumnValueStoreUtil.insert(store, tx, i, "a", "value" + i);
+            }
+        } catch (BackendException | RuntimeException e) {
+            tx.rollback();
+            throw e;
+        }
+        tx.commit();
+    }
+
+    private StoreTransaction beginTx() throws BackendException {
+        return manager.beginTransaction(
+            StandardBaseTransactionConfig.of(TIMES, manager.getFeatures().getKeyConsistentTxConfig()));
+    }
+
+    private static List<StaticBuffer> drainKeys(KeyIterator iterator) throws Exception {
+        final List<StaticBuffer> keys = new ArrayList<>();
+        try {
+            while (iterator.hasNext()) {
+                keys.add(iterator.next());
+            }
+        } finally {
+            iterator.close();
+        }
+        return keys;
+    }
+
+    private static void assertStrictlyIncreasing(List<StaticBuffer> keys, Comparator<StaticBuffer> order) {
+        for (int i = 1; i < keys.size(); i++) {
+            final int cmp = order.compare(keys.get(i - 1), keys.get(i));
+            assertTrue(cmp < 0, "scan iteration violated the declared order at position " + i + " (compare=" + cmp + ")");
+        }
+    }
+
+    private static int countNaturalInversions(List<StaticBuffer> keys) {
+        int inversions = 0;
+        for (int i = 1; i < keys.size(); i++) {
+            if (keys.get(i - 1).compareTo(keys.get(i)) > 0) {
+                inversions++;
+            }
+        }
+        return inversions;
+    }
+
+    private static final class SecondaryDataCountingJob implements ScanJob {
+
+        @Override
+        public List<SliceQuery> getQueries() {
+            return Arrays.asList(GROUNDING_QUERY, EVERYTHING);
+        }
+
+        @Override
+        public Predicate<StaticBuffer> getKeyFilter() {
+            return k -> true;
+        }
+
+        @Override
+        public void workerIterationStart(Configuration jobConfig, Configuration graphConfig, ScanMetrics metrics) {
+            // no-op
+        }
+
+        @Override
+        public void workerIterationEnd(ScanMetrics metrics) {
+            // no-op
+        }
+
+        @Override
+        public void process(StaticBuffer key, Map<SliceQuery, EntryList> entries, ScanMetrics metrics) {
+            metrics.incrementCustom(PROCESSED_ROWS);
+            final EntryList secondary = entries.get(EVERYTHING);
+            if (secondary != null && !secondary.isEmpty()) {
+                metrics.incrementCustom(ROWS_WITH_SECONDARY);
+            }
+        }
+
+        @Override
+        public ScanJob clone() {
+            return new SecondaryDataCountingJob();
+        }
+    }
+}

--- a/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/TokenOrderKeyComparatorTest.java
+++ b/janusgraph-cql/src/test/java/org/janusgraph/diskstorage/cql/TokenOrderKeyComparatorTest.java
@@ -1,0 +1,116 @@
+// Copyright 2026 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.cql;
+
+import com.datastax.oss.driver.api.core.metadata.TokenMap;
+import com.datastax.oss.driver.api.core.metadata.token.Token;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.util.StaticArrayBuffer;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins the two layers of {@link TokenOrderKeyComparator} in isolation, with a stubbed
+ * {@link TokenMap}: keys order by token first, and keys with EQUAL tokens (hash collisions, which
+ * real Murmur3 data will essentially never produce in a test, so the integration tests cannot
+ * exercise this path) tie-break by the UNSIGNED key bytes - Cassandra's {@code DecoratedKey}
+ * order. A signed tie-break would misclassify rows as stale in the scan merge join whenever a
+ * collision straddled the 0x80 byte boundary.
+ */
+public class TokenOrderKeyComparatorTest {
+
+    private static final StaticBuffer KEY_01 = StaticArrayBuffer.of(new byte[]{0x01});
+    private static final StaticBuffer KEY_01_00 = StaticArrayBuffer.of(new byte[]{0x01, 0x00});
+    private static final StaticBuffer KEY_FF = StaticArrayBuffer.of(new byte[]{(byte) 0xFF});
+
+    /** Compares like the driver's Murmur3 token: by a single long. */
+    private static final class StubToken implements Token {
+        private final long value;
+
+        StubToken(long value) {
+            this.value = value;
+        }
+
+        @Override
+        public int compareTo(Token other) {
+            return Long.compare(value, ((StubToken) other).value);
+        }
+    }
+
+    private static TokenOrderKeyComparator comparatorWithTokens(Map<StaticBuffer, Long> tokens) {
+        final TokenMap tokenMap = mock(TokenMap.class);
+        when(tokenMap.newToken(any())).thenAnswer(invocation -> {
+            final ByteBuffer keyBuffer = (ByteBuffer) invocation.getArguments()[0];
+            final Long token = tokens.get(StaticArrayBuffer.of(keyBuffer.duplicate()));
+            assertNotNull(token, "token requested for an unexpected key");
+            return new StubToken(token);
+        });
+        return new TokenOrderKeyComparator(tokenMap);
+    }
+
+    @Test
+    public void keysOrderByTokenBeforeKeyBytes() {
+        final Map<StaticBuffer, Long> tokens = new HashMap<>();
+        tokens.put(KEY_FF, 10L);
+        tokens.put(KEY_01, 20L);
+        final TokenOrderKeyComparator comparator = comparatorWithTokens(tokens);
+
+        // 0xFF > 0x01 as key bytes, but its token is smaller, and the token must dominate.
+        assertTrue(comparator.compare(KEY_FF, KEY_01) < 0);
+        assertTrue(comparator.compare(KEY_01, KEY_FF) > 0);
+    }
+
+    @Test
+    public void equalTokensTieBreakByUnsignedKeyBytes() {
+        final Map<StaticBuffer, Long> tokens = new HashMap<>();
+        tokens.put(KEY_01, 7L);
+        tokens.put(KEY_FF, 7L);
+        final TokenOrderKeyComparator comparator = comparatorWithTokens(tokens);
+
+        // A SIGNED byte comparison would put 0xFF (-1) before 0x01; DecoratedKey order is unsigned.
+        assertTrue(comparator.compare(KEY_01, KEY_FF) < 0);
+        assertTrue(comparator.compare(KEY_FF, KEY_01) > 0);
+    }
+
+    @Test
+    public void equalTokensPrefixKeySortsBeforeItsExtension() {
+        final Map<StaticBuffer, Long> tokens = new HashMap<>();
+        tokens.put(KEY_01, 7L);
+        tokens.put(KEY_01_00, 7L);
+        final TokenOrderKeyComparator comparator = comparatorWithTokens(tokens);
+
+        assertTrue(comparator.compare(KEY_01, KEY_01_00) < 0);
+        assertTrue(comparator.compare(KEY_01_00, KEY_01) > 0);
+    }
+
+    @Test
+    public void sameKeyComparesEqual() {
+        final Map<StaticBuffer, Long> tokens = new HashMap<>();
+        tokens.put(KEY_01, 7L);
+        final TokenOrderKeyComparator comparator = comparatorWithTokens(tokens);
+
+        assertEquals(0, comparator.compare(KEY_01, KEY_01));
+    }
+}

--- a/janusgraph-test/src/test/java/org/janusgraph/diskstorage/keycolumnvalue/scan/ScanStaleSecondaryRowTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/diskstorage/keycolumnvalue/scan/ScanStaleSecondaryRowTest.java
@@ -18,6 +18,7 @@ import org.janusgraph.diskstorage.BackendException;
 import org.janusgraph.diskstorage.Entry;
 import org.janusgraph.diskstorage.EntryList;
 import org.janusgraph.diskstorage.KeyColumnValueStoreUtil;
+import org.janusgraph.diskstorage.PermanentBackendException;
 import org.janusgraph.diskstorage.StaticBuffer;
 import org.janusgraph.diskstorage.StoreMetaData;
 import org.janusgraph.diskstorage.TemporaryBackendException;
@@ -33,6 +34,7 @@ import org.janusgraph.diskstorage.keycolumnvalue.StandardStoreFeatures;
 import org.janusgraph.diskstorage.keycolumnvalue.StoreFeatures;
 import org.janusgraph.diskstorage.keycolumnvalue.StoreTransaction;
 import org.janusgraph.diskstorage.util.BufferUtil;
+import org.janusgraph.diskstorage.util.EntryArrayList;
 import org.janusgraph.diskstorage.util.RecordIterator;
 import org.janusgraph.diskstorage.util.StandardBaseTransactionConfig;
 import org.janusgraph.diskstorage.util.StaticArrayBuffer;
@@ -44,8 +46,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -184,7 +188,60 @@ public class ScanStaleSecondaryRowTest {
         final Throwable cause = failure.getCause();
         assertTrue(cause instanceof TemporaryBackendException,
             "an order-contract violation must surface as a backend failure but was: " + cause);
-        assertTrue(cause.getMessage().contains("natural order"), cause.getMessage());
+        assertTrue(cause.getMessage().contains("out of the natural key order"), cause.getMessage());
+    }
+
+    /**
+     * A store-provided scan-order comparator ({@code StoreFeatures.getScanKeyOrder()}) must put the
+     * merge on the lossless merge-join strategy even though the scan is not naturally ordered
+     * ({@code keyOrdered=false}, as token-ordered backends declare). The 45-row stale burst exceeds
+     * the buffered strategy's pending buffer, so only the merge join keeps every key's data - this
+     * fails with 20 of 50 keys blanked if the comparator is ignored.
+     */
+    @Test
+    public void storeProvidedScanOrderMustDriveTheLosslessMergeJoin() throws Exception {
+        loadData(SPARSE_STRIDE);
+        final Map<Integer, Integer> staleBursts = new HashMap<>();
+        staleBursts.put(20, 45);
+
+        runScanAndAssert(withScanKeyOrder(withoutNaturalKeyOrder(manager), Comparator.naturalOrder()),
+            staleBursts, NUM_KEYS / SPARSE_STRIDE);
+    }
+
+    /**
+     * Same protection as the natural-order tripwire, for a store-PROVIDED order: when the scan's
+     * streams do not actually iterate in the order the comparator declares (here: the comparator
+     * says reversed, the store iterates naturally - what a wrong client-side token computation
+     * would look like on a real backend), the scan must fail instead of silently dropping rows
+     * that the merge join misclassifies as stale.
+     */
+    @Test
+    public void misdeclaredStoreProvidedScanOrderMustFailTheScan() throws Exception {
+        loadData(1);
+
+        final ExecutionException failure = assertThrows(ExecutionException.class,
+            () -> runScan(withScanKeyOrder(withoutNaturalKeyOrder(manager), Comparator.reverseOrder())));
+
+        final Throwable cause = failure.getCause();
+        assertTrue(cause instanceof TemporaryBackendException,
+            "an order-contract violation must surface as a backend failure but was: " + cause);
+        assertTrue(cause.getMessage().contains("out of the store-provided scan order"), cause.getMessage());
+    }
+
+    /**
+     * End-to-end shape of a token-ordered backend with a client-computable order (CQL/Murmur3 with
+     * a token comparator): every stream iterates in a consistent order that is NOT the natural one
+     * (simulated by serving all streams in reverse), the store declares the matching comparator,
+     * and a stale burst larger than the buffered strategy's pending buffer arrives. The merge join
+     * under the provided order must keep every key's data and drop every stale row.
+     */
+    @Test
+    public void staleBurstsUnderAStoreProvidedNonNaturalOrderMustBeLossless() throws Exception {
+        loadData(SPARSE_STRIDE);
+        final Map<Integer, Integer> staleBursts = new HashMap<>();
+        staleBursts.put(20, 45);
+
+        assertScanKeepsSecondaryData(runScan(reversedOrderManager(manager, staleBursts)), NUM_KEYS / SPARSE_STRIDE);
     }
 
     /**
@@ -204,8 +261,10 @@ public class ScanStaleSecondaryRowTest {
 
     private void runScanAndAssert(KeyColumnValueStoreManager scanManager, Map<Integer, Integer> staleBursts,
                                   int expectedRowsWithSecondary) throws Exception {
-        final ScanMetrics metrics = runScan(staleRowInjectingManager(scanManager, staleBursts));
+        assertScanKeepsSecondaryData(runScan(staleRowInjectingManager(scanManager, staleBursts)), expectedRowsWithSecondary);
+    }
 
+    private static void assertScanKeepsSecondaryData(ScanMetrics metrics, int expectedRowsWithSecondary) {
         assertEquals(NUM_KEYS, metrics.getCustom(PROCESSED_ROWS),
             "every real key must surface exactly once; stale keys must not surface at all");
         assertEquals(expectedRowsWithSecondary, metrics.getCustom(ROWS_WITH_SECONDARY),
@@ -234,6 +293,150 @@ public class ScanStaleSecondaryRowTest {
             @Override
             public StoreFeatures getFeatures() {
                 return new StandardStoreFeatures.Builder(real.getFeatures()).keyOrdered(false).build();
+            }
+        };
+    }
+
+    /** Declares a store-provided scan order ({@code StoreFeatures.getScanKeyOrder()}) on top of {@code real}. */
+    private static KeyColumnValueStoreManager withScanKeyOrder(KeyColumnValueStoreManager real,
+                                                               Comparator<StaticBuffer> scanKeyOrder) {
+        return new KCVSManagerProxy(real) {
+            @Override
+            public StoreFeatures getFeatures() {
+                return new StandardStoreFeatures.Builder(real.getFeatures()).scanKeyOrder(scanKeyOrder).build();
+            }
+        };
+    }
+
+    /**
+     * Serves every query's stream in REVERSE natural order - a consistent, deterministic iteration
+     * order that is not the natural one, the shape of a token-ordered backend - and declares the
+     * matching comparator via {@code StoreFeatures.getScanKeyOrder()} (with {@code keyOrdered}
+     * masked off). Stale keys are injected into the secondary stream at their correct positions in
+     * the SERVED (reversed) order: after the n-th served secondary row, keys sorting between it and
+     * the next served row.
+     */
+    private static KeyColumnValueStoreManager reversedOrderManager(KeyColumnValueStoreManager real,
+                                                                   Map<Integer, Integer> staleBursts) {
+        return new KCVSManagerProxy(real) {
+            @Override
+            public StoreFeatures getFeatures() {
+                return new StandardStoreFeatures.Builder(real.getFeatures())
+                    .keyOrdered(false)
+                    .scanKeyOrder(Comparator.reverseOrder())
+                    .build();
+            }
+
+            @Override
+            public KeyColumnValueStore openDatabase(String name, StoreMetaData.Container metaData) throws BackendException {
+                final KeyColumnValueStore store = real.openDatabase(name, metaData);
+                return new KCVSProxy(store) {
+                    @Override
+                    public KeyIterator getKeys(SliceQuery columnQuery, StoreTransaction txh) throws BackendException {
+                        final List<KeyRow> rows = materialize(store.getKeys(columnQuery, unwrapTx(txh)));
+                        Collections.reverse(rows);
+                        if (columnQuery.equals(SECONDARY_QUERY)) {
+                            injectStaleRowsReversed(rows, staleBursts);
+                        } else if (!columnQuery.equals(GROUNDING_QUERY)) {
+                            throw new IllegalStateException("Unexpected scan query: " + columnQuery);
+                        }
+                        return keyIteratorOver(rows);
+                    }
+                };
+            }
+        };
+    }
+
+    /** A fully materialized scan row: the key plus the entries of one slice query. */
+    private static final class KeyRow {
+        final StaticBuffer key;
+        final EntryList entries;
+
+        KeyRow(StaticBuffer key, EntryList entries) {
+            this.key = key;
+            this.entries = entries;
+        }
+    }
+
+    private static List<KeyRow> materialize(KeyIterator keys) throws BackendException {
+        final List<KeyRow> rows = new ArrayList<>();
+        try (KeyIterator iterator = keys) {
+            while (iterator.hasNext()) {
+                final StaticBuffer key = iterator.next();
+                rows.add(new KeyRow(key, EntryArrayList.of(iterator.getEntries())));
+            }
+        } catch (IOException e) {
+            throw new PermanentBackendException(e);
+        }
+        return rows;
+    }
+
+    /**
+     * Inserts, after the n-th row (n = map key, 1-based, counted over the rows already in the
+     * list), a burst of stale rows sorting strictly between that row and the following one in the
+     * list's (reversed) order: suffixed copies of the FOLLOWING key sort naturally just above it,
+     * i.e. just below the n-th row under the reversed comparator, and descending suffixes keep the
+     * burst itself ordered in the served (reversed) direction.
+     */
+    private static void injectStaleRowsReversed(List<KeyRow> rows, Map<Integer, Integer> staleBursts) {
+        final List<KeyRow> result = new ArrayList<>(rows.size());
+        for (int i = 0; i < rows.size(); i++) {
+            result.add(rows.get(i));
+            final Integer burst = staleBursts.get(i + 1);
+            if (burst != null) {
+                if (i + 1 >= rows.size()) {
+                    throw new IllegalStateException("Stale burst after the last row is not representable");
+                }
+                final StaticBuffer nextRealKey = rows.get(i + 1).key;
+                for (int sequence = burst - 1; sequence >= 0; sequence--) {
+                    result.add(new KeyRow(staleKeyAfter(nextRealKey, sequence), EntryArrayList.of(staleEntries())));
+                }
+            }
+        }
+        rows.clear();
+        rows.addAll(result);
+    }
+
+    private static KeyIterator keyIteratorOver(List<KeyRow> rows) {
+        final Iterator<KeyRow> it = rows.iterator();
+        return new KeyIterator() {
+            private KeyRow current;
+
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public StaticBuffer next() {
+                current = it.next();
+                return current.key;
+            }
+
+            @Override
+            public RecordIterator<Entry> getEntries() {
+                final Iterator<Entry> entries = current.entries.iterator();
+                return new RecordIterator<Entry>() {
+                    @Override
+                    public boolean hasNext() {
+                        return entries.hasNext();
+                    }
+
+                    @Override
+                    public Entry next() {
+                        return entries.next();
+                    }
+
+                    @Override
+                    public void close() {
+                        // NOP
+                    }
+                };
+            }
+
+            @Override
+            public void close() {
+                // NOP: fully materialized
             }
         };
     }


### PR DESCRIPTION
Follow-up to #4921. That fix left the bounded-buffer merge strategy on token-ordered backends with a documented residual: recovery from keys written concurrently with the scan is capped, so a burst of more than 32 such keys between two matches of one secondary query (or 8, when the secondary puller trickles rows one at a time) still blanked that query's data for the keys behind the burst. This PR removes that residual for the main production backend by removing its premise — that Murmur3 iteration order is not computable client-side.

**The idea.** Cassandra's Murmur3 ring order *is* computable client-side: token first, unsigned key bytes among keys with equal tokens (exactly `DecoratedKey` order). The new `TokenOrderKeyComparator` computes tokens through the driver's public `TokenMap.newToken(...)` — the same token factory the driver uses for token-aware routing, so it matches the connected cluster's partitioner by construction rather than by reimplementation.

**The plumbing.** A new `StoreFeatures#getScanKeyOrder()` hook (default `null`, so no other backend or third-party adapter is affected) lets a store declare its scan iteration order. `MultiThreadsRowsCollector` generalizes its merge-join path from "natural order when `isKeyOrdered`" to "whichever order is known": store-provided order first — it also covers the split-parallel pipelines of `storage.cql.parallel-scan-token-ranges`, since each split is a sub-range of the same global token order — then natural order for key-ordered whole-key-space scans as before, and the bounded-buffer strategy only when no order is known (targeted `keysToScan` scans, or no declaration).

**Safety.** A wrong declared order would make the merge join drop live keys' rows as "stale" — the silent data loss #4921 exists to prevent — so the grounding-stream order tripwire from #4921 is generalized to verify whichever order was declared and fails the scan on the first violation. Deliberately conservative scoping on top of that:

- `RandomPartitioner` and Amazon Keyspaces' `DefaultPartitioner` keep the buffered strategy (the former has no CI coverage here, the latter's order is unknown to the driver).
- Disabling `storage.cql.metadata-token-map-enabled` removes the declaration and restores the previous buffered merge — a config escape hatch if a CQL-compatible server ever deviates.

**Verification.**

- New `ScanStaleSecondaryRowTest` scenarios (in-memory, no container): a store-provided order drives the merge join losslessly through a 45-row stale burst that blanks 20 of 50 keys on the buffered path, also when the served order is not the natural one; a misdeclared order fails the scan instead of dropping rows. All written red-first against the unmodified collector.
- New `CQLScanKeyOrderTest` (testcontainers) checks conformance against a real Cassandra 5.0.8/Murmur3: whole scans, multi-token-range scans and every split iterate strictly increasing under the declared comparator (with a sanity assertion that the order genuinely differs from natural key order), and an end-to-end multi-query scan merges every key losslessly with the tripwire active.
- Full `CQLStoreTest` suite on Cassandra 5/Murmur3 passes (the only error, `testGetKeysWithoutOrderedScan`, is the pre-existing `Field.modifiers` reflection hack that fails on any JDK 12+ test JVM and is unrelated); core scan suites, `InMemoryOLAPTest`, `BerkeleyOLAPTest` and the BerkeleyJE reindex test stay green; checkstyle/rat clean.

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
