### PR TITLE
Publish the lazily initialised index type caches safely (#4927)

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/indextype/CompositeIndexTypeWrapper.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/indextype/CompositeIndexTypeWrapper.java
@@ -35,9 +35,9 @@ import java.util.List;
  */
 public class CompositeIndexTypeWrapper extends IndexTypeWrapper implements CompositeIndexType {
 
-    private IndexField[] fields = null;
+    private volatile IndexField[] fields = null;
 
-    private String[] inlineKeys = null;
+    private volatile String[] inlineKeys = null;
 
     public CompositeIndexTypeWrapper(SchemaSource base) {
         super(base);

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/indextype/MixedIndexTypeWrapper.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/indextype/MixedIndexTypeWrapper.java
@@ -30,7 +30,7 @@ import java.util.List;
 public class MixedIndexTypeWrapper extends IndexTypeWrapper implements MixedIndexType {
 
     public static final String NAME_PREFIX = "extindex";
-    private ParameterIndexField[] fields = null;
+    private volatile ParameterIndexField[] fields = null;
 
     public MixedIndexTypeWrapper(SchemaSource base) {
         super(base);

--- a/janusgraph-core/src/test/java/org/janusgraph/graphdb/types/indextype/IndexTypeWrapperPublicationTest.java
+++ b/janusgraph-core/src/test/java/org/janusgraph/graphdb/types/indextype/IndexTypeWrapperPublicationTest.java
@@ -1,0 +1,61 @@
+// Copyright 2026 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.types.indextype;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Modifier;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+//These fields cache a value which is built on first read rather than in the constructor. Nothing orders the writes
+//which populate that value before the write which publishes the reference to it, so without volatile another thread
+//can observe the reference while the value it points at is still half built.
+//
+//RelationTypeVertex.getKeyIndexes caches the IndexType instances of a property key, so every caller on that vertex is
+//handed the same wrapper. Several threads reach one wrapper when they share a transaction, which a transaction that is
+//not thread bound supports: the vertexCache of StandardJanusGraphTx is concurrent for exactly that reason.
+//
+//The race cannot be reproduced reliably in a test. It needs a reordering which a given JVM and processor may never
+//perform, so a thread based test would pass whether or not the field is volatile. This asserts the property itself
+//instead. A field which is final is accepted too, so that moving the cache behind an immutable holder does not fail
+//here.
+public class IndexTypeWrapperPublicationTest {
+
+    @Test
+    public void mixedIndexFieldsShouldBePublishedSafely() throws Exception {
+        assertSafelyPublished(MixedIndexTypeWrapper.class, "fields");
+    }
+
+    @Test
+    public void compositeIndexCachesShouldBePublishedSafely() throws Exception {
+        assertSafelyPublished(CompositeIndexTypeWrapper.class, "fields");
+        assertSafelyPublished(CompositeIndexTypeWrapper.class, "inlineKeys");
+    }
+
+    @Test
+    public void sharedIndexTypeCachesShouldBePublishedSafely() throws Exception {
+        assertSafelyPublished(IndexTypeWrapper.class, "fieldMap");
+        assertSafelyPublished(IndexTypeWrapper.class, "cachedTypeConstraint");
+        assertSafelyPublished(IndexTypeWrapper.class, "schemaTypeConstraint");
+    }
+
+    private static void assertSafelyPublished(Class<?> declaringClass, String fieldName) throws NoSuchFieldException {
+        final int modifiers = declaringClass.getDeclaredField(fieldName).getModifiers();
+        assertTrue(Modifier.isVolatile(modifiers) || Modifier.isFinal(modifiers),
+            declaringClass.getSimpleName() + "." + fieldName + " can be read by one thread while another writes it, "
+                + "so it must be volatile or final to be published safely");
+    }
+}


### PR DESCRIPTION
Fixes #4927.

`MixedIndexTypeWrapper.getFieldKeys` builds its `ParameterIndexField[]` on first read and caches it in a field which is not `volatile`. Nothing orders the writes which fill the array before the write which publishes the reference, so another thread can read a non-null reference to an array whose elements are still null.

An array is the case where the racy lazy-initialisation idiom cannot be rescued. Final-field semantics give safe publication to immutable objects, but array elements are never final, so the array needs a barrier.

### How one wrapper is reached by two threads

`JanusGraphSchemaVertex.asIndexType()` builds a new wrapper on every call, so the sharing does not come from there. It comes from `RelationTypeVertex.getKeyIndexes()`, which caches the `IndexType` instances of a property key, so every caller on that vertex is handed the same wrapper.

Several threads reach one wrapper when they share a transaction. A transaction which is not thread bound supports that, and `StandardJanusGraphTx` uses a `CaffeineVertexCache` so that concurrent threads resolve the same vertex instances. So this needs a multi-threaded transaction rather than ordinary concurrent querying — a supported mode, but not the default one.

The readers are hot paths: `IndexSerializer.reindexElement` walks the fields on every mutation and immediately calls `field.getFieldKey()`, and the query planner reaches them through `TypeUtil`. The array length is always correct, so the symptom is a `NullPointerException` from a null element — an exception the source makes look impossible, because the array is fully built before it is stored.

Rarely observed because x86 does not reorder store-store in hardware and the window is one call wide. ARM does permit that reordering, so this is more likely on Graviton or Apple Silicon.

### The fix

Make the field `volatile`, which is what the three equivalent lazy fields in the superclass `IndexTypeWrapper` already do (`fieldMap`, `cachedTypeConstraint`, `schemaTypeConstraint`) using the identical read-into-a-local idiom. No lock is added, so the read stays lock-free and the harmless duplicate construction is preserved.

### Scope beyond the issue

`CompositeIndexTypeWrapper` caches `fields` and `inlineKeys` with exactly the same pattern, so this PR makes those `volatile` as well. Same defect in the sibling class, one word each. Happy to split it out if you would rather.

### On the test

The race needs a reordering which a given JVM and processor may never perform, so a thread-based test would pass whether or not the field is `volatile`, which is worse than no test. `IndexTypeWrapperPublicationTest` asserts the property of the fields directly. It accepts `final` as well as `volatile`, so moving a cache behind an immutable holder later does not fail it for the wrong reason.

I recognise a reflection assertion on a field modifier is unusual. I chose it over a stress test that cannot fail, but I am happy to drop the test entirely if you would rather not carry it.

### Related, not fixed here

`RelationTypeVertex.indexes` and `indexesReferences` — the very fields that make these wrappers shared — use the identical pattern, holding a `Collections.unmodifiableList` over an `ArrayList` whose `size` and element array are not final. That one may be worse, because a partially visible list yields *fewer indexes than exist* rather than a null that throws: an index update could be skipped, or the planner could decide no index covers a query, with nothing reported. It is outside this issue, so I left it alone and am glad to open a separate issue for it.

-----

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)? — no new dependencies
- [x] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository? — not applicable
- [x] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository? — not applicable
