### PR TITLE
Cover the element ids accepted by IndexSerializer.removeElement (#4928)

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/IndexSerializer.java
@@ -332,7 +332,10 @@ public class IndexSerializer {
     }
 
     public void removeElement(Object elementId, MixedIndexType index, Map<String,Map<String,List<IndexEntry>>> documentsPerStore) {
-        Preconditions.checkArgument((index.getElement()==ElementCategory.VERTEX && elementId instanceof Long) ||
+        //A String id is valid for a vertex when the graph allows custom vertex id types, and element2String below
+        //encodes it, so accept the same ids that method does
+        Preconditions.checkArgument((index.getElement()==ElementCategory.VERTEX
+                && (elementId instanceof Long || elementId instanceof String)) ||
             (index.getElement().isRelation() && elementId instanceof RelationIdentifier),"Invalid element id [%s] provided for index: %s",elementId,index);
         getDocuments(documentsPerStore,index).put(element2String(elementId),new ArrayList<>());
     }

--- a/janusgraph-core/src/test/java/org/janusgraph/graphdb/database/IndexSerializerRemoveElementTest.java
+++ b/janusgraph-core/src/test/java/org/janusgraph/graphdb/database/IndexSerializerRemoveElementTest.java
@@ -1,0 +1,95 @@
+// Copyright 2026 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.database;
+
+import org.janusgraph.diskstorage.indexing.IndexEntry;
+import org.janusgraph.graphdb.database.util.IndexRecordUtil;
+import org.janusgraph.graphdb.internal.ElementCategory;
+import org.janusgraph.graphdb.relations.RelationIdentifier;
+import org.janusgraph.graphdb.types.MixedIndexType;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+//removeElement is called by the transaction log recovery of StandardTransactionLogProcessor when the element of a
+//restored transaction no longer exists, to remove its stale mixed index document. Rejecting a valid element id aborts
+//that recovery, which is the mechanism that exists to repair a diverged index.
+public class IndexSerializerRemoveElementTest {
+
+    private static final String STORE_NAME = "vertexByName";
+
+    private static IndexSerializer indexSerializer() {
+        //removeElement reads neither the configuration nor the serializers
+        return new IndexSerializer(null, null, null, null, false);
+    }
+
+    private static MixedIndexType index(ElementCategory elementCategory) {
+        final MixedIndexType index = mock(MixedIndexType.class);
+        when(index.getElement()).thenReturn(elementCategory);
+        when(index.getStoreName()).thenReturn(STORE_NAME);
+        return index;
+    }
+
+    private static List<IndexEntry> removeElement(Object elementId, ElementCategory elementCategory) {
+        final Map<String, Map<String, List<IndexEntry>>> documentsPerStore = new HashMap<>();
+        indexSerializer().removeElement(elementId, index(elementCategory), documentsPerStore);
+        final Map<String, List<IndexEntry>> documents = documentsPerStore.get(STORE_NAME);
+        assertEquals(1, documents.size());
+        final String documentId = documents.keySet().iterator().next();
+        //The document id must identify the element that was removed
+        assertEquals(elementId, IndexRecordUtil.string2ElementId(documentId));
+        return documents.get(documentId);
+    }
+
+    @Test
+    public void shouldRemoveVertexWithCustomStringId() {
+        //A graph configured with graph.allow-custom-vid-types assigns String vertex ids. An empty entry list is how a
+        //document removal is expressed
+        assertTrue(removeElement("customVertexId", ElementCategory.VERTEX).isEmpty());
+    }
+
+    @Test
+    public void shouldRemoveVertexWithLongId() {
+        assertTrue(removeElement(42L, ElementCategory.VERTEX).isEmpty());
+    }
+
+    @Test
+    public void shouldRemoveRelation() {
+        assertTrue(removeElement(new RelationIdentifier(4L, 2L, 8L, 6L), ElementCategory.EDGE).isEmpty());
+    }
+
+    @Test
+    public void shouldRejectIdOfWrongTypeForElementCategory() {
+        final IndexSerializer indexSerializer = indexSerializer();
+        final MixedIndexType vertexIndex = index(ElementCategory.VERTEX);
+        final MixedIndexType edgeIndex = index(ElementCategory.EDGE);
+        final Map<String, Map<String, List<IndexEntry>>> documents = new HashMap<>();
+
+        //A relation id is not a vertex id, and a vertex id is not a relation id
+        assertThrows(IllegalArgumentException.class, () -> indexSerializer.removeElement(
+            new RelationIdentifier(4L, 2L, 8L, 6L), vertexIndex, documents));
+        assertThrows(IllegalArgumentException.class,
+            () -> indexSerializer.removeElement("customVertexId", edgeIndex, documents));
+        assertThrows(IllegalArgumentException.class, () -> indexSerializer.removeElement(1.5, vertexIndex, documents));
+    }
+}


### PR DESCRIPTION
Fixes #4928.

`IndexSerializer.removeElement` rejected every vertex id which is not a `Long`, but the very next line calls `element2String`, which accepts a `Long`, a `RelationIdentifier` **or** a `String`. The two methods disagreed about what a valid element id is, and the stricter of them ran first.

A graph configured with `graph.allow-custom-vid-types` assigns String vertex ids. The only caller is `StandardTransactionLogProcessor`, which calls `removeElement` when the element of a restored transaction no longer exists. So recovering a transaction that deleted an indexed vertex threw `IllegalArgumentException`, the stale index document was never removed, and the recovery mechanism that exists to repair a diverged index could not complete.

This applies the fix suggested in the issue: accept the same vertex ids `element2String` accepts. A relation index still requires a `RelationIdentifier`.

### Testing

`IndexSerializerRemoveElementTest` covers a String vertex id, a Long vertex id, a relation id, and the ids that must still be rejected. I confirmed the String case reproduces the reported failure without the fix:

```
IllegalArgument Invalid element id [customVertexId] provided for index: Mock for MixedIndexType
```

Each test also asserts the resulting document id round-trips back to the original element id through `string2ElementId`, so the document that gets removed is the right one, and that the entry list is empty, which is how a document removal is expressed.

-----

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)? — no new dependencies
- [x] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository? — not applicable
- [x] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository? — not applicable
