### PR TITLE
Derive the Elasticsearch index name of a store in one place (#4929)

### DIFF
--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchClient.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchClient.java
@@ -52,7 +52,9 @@ public interface ElasticSearchClient extends Closeable {
 
     void deleteIndex(String indexName) throws IOException;
 
-    void clearStore(String indexName, String storeName) throws IOException;
+    //Takes the Elasticsearch index name of the store, already derived by the caller, so that the mapping from a
+    //JanusGraph store name to an Elasticsearch index name exists in exactly one place
+    void clearStore(String indexStoreName) throws IOException;
 
     void bulkRequest(List<ElasticSearchMutation> requests, String ingestPipeline) throws IOException;
 

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/ElasticSearchIndex.java
@@ -1482,10 +1482,13 @@ public class ElasticSearchIndex implements IndexProvider {
 
     @Override
     public void clearStore(String storeName) throws BackendException {
+        //Derive the name the same way every read and write path does, so that a store name which is not already
+        //lowercase still resolves to the Elasticsearch index which actually holds its documents
+        final String indexStoreName = getIndexStoreName(storeName);
         try {
-            client.clearStore(indexName, storeName);
+            client.clearStore(indexStoreName);
         } catch (final Exception e) {
-            throw new PermanentBackendException("Could not clear store " + indexName + "_" + storeName, e);
+            throw new PermanentBackendException("Could not clear store " + indexStoreName, e);
         }
     }
 

--- a/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestElasticSearchClient.java
+++ b/janusgraph-es/src/main/java/org/janusgraph/diskstorage/es/rest/RestElasticSearchClient.java
@@ -387,10 +387,9 @@ public RestElasticSearchClient(RestClient delegate, int scrollKeepAlive, boolean
     }
 
     @Override
-    public void clearStore(String indexName, String storeName) throws IOException {
-        String name = indexName + "_" + storeName;
-        if (indexExists(name)) {
-            performRequest(REQUEST_TYPE_DELETE, REQUEST_SEPARATOR + indexName + "_" + storeName, null);
+    public void clearStore(String indexStoreName) throws IOException {
+        if (indexExists(indexStoreName)) {
+            performRequest(REQUEST_TYPE_DELETE, REQUEST_SEPARATOR + indexStoreName, null);
         }
     }
 

--- a/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/rest/RestClientClearStoreTest.java
+++ b/janusgraph-es/src/test/java/org/janusgraph/diskstorage/es/rest/RestClientClearStoreTest.java
@@ -1,0 +1,118 @@
+// Copyright 2026 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.diskstorage.es.rest;
+
+import org.apache.http.StatusLine;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+//clearStore deletes the Elasticsearch index which backs a store, and is reached through
+//SchemaAction.DISCARD_INDEX. It must use the index name it is given verbatim, because the caller has already mapped
+//the JanusGraph store name to it. Deriving the name a second time here is what let a store name containing an
+//uppercase character target an index which cannot exist, since Elasticsearch index names are always lowercase.
+@ExtendWith(MockitoExtension.class)
+public class RestClientClearStoreTest {
+
+    private static final String INDEX_STORE_NAME = "janusgraph_vertexbyname";
+
+    @Mock
+    private RestClient restClientMock;
+
+    @Mock
+    private StatusLine statusLine;
+
+    @Captor
+    private ArgumentCaptor<Request> requestCaptor;
+
+    private RestElasticSearchClient createClient() throws IOException {
+        //The version lookup during instantiation is not under test
+        when(restClientMock.performRequest(any())).thenThrow(new IOException());
+        final RestElasticSearchClient clientUnderTest = new RestElasticSearchClient(restClientMock, 0, false,
+            0, Collections.emptySet(), 0, 0, 100_000_000);
+        Mockito.reset(restClientMock);
+        return clientUnderTest;
+    }
+
+    private Response response(int statusCode) {
+        when(statusLine.getStatusCode()).thenReturn(statusCode);
+        final Response response = Mockito.mock(Response.class);
+        when(response.getStatusLine()).thenReturn(statusLine);
+        return response;
+    }
+
+    @Test
+    public void shouldDeleteTheIndexItIsGiven() throws IOException {
+        try (RestElasticSearchClient clientUnderTest = createClient()) {
+            final Response found = response(200);
+            when(restClientMock.performRequest(any())).thenReturn(found);
+            clientUnderTest.clearStore(INDEX_STORE_NAME);
+
+            //The existence check, then the deletion, both against the given name
+            verify(restClientMock, Mockito.times(2)).performRequest(requestCaptor.capture());
+            final List<Request> requests = requestCaptor.getAllValues();
+            assertEquals("HEAD", requests.get(0).getMethod());
+            assertEquals("/" + INDEX_STORE_NAME, requests.get(0).getEndpoint());
+            assertEquals("DELETE", requests.get(1).getMethod());
+            assertEquals("/" + INDEX_STORE_NAME, requests.get(1).getEndpoint());
+        }
+    }
+
+    @Test
+    public void shouldNotDeleteAnIndexWhichDoesNotExist() throws IOException {
+        try (RestElasticSearchClient clientUnderTest = createClient()) {
+            final Response notFound = response(404);
+            when(restClientMock.performRequest(any())).thenReturn(notFound);
+            clientUnderTest.clearStore(INDEX_STORE_NAME);
+
+            //Only the existence check is issued, so no deletion followed it
+            verify(restClientMock, Mockito.times(1)).performRequest(requestCaptor.capture());
+            assertEquals("HEAD", requestCaptor.getValue().getMethod());
+        }
+    }
+
+    @Test
+    public void shouldNotLowercaseTheNameItIsGiven() throws IOException {
+        //Deriving the name is the caller's job. If this method lowercased as well, a store whose Elasticsearch index
+        //genuinely differs in case could not be addressed at all
+        final String mixedCase = "Janusgraph_MixedCase";
+        try (RestElasticSearchClient clientUnderTest = createClient()) {
+            final Response found = response(200);
+            when(restClientMock.performRequest(any())).thenReturn(found);
+            clientUnderTest.clearStore(mixedCase);
+
+            verify(restClientMock, Mockito.times(2)).performRequest(requestCaptor.capture());
+            assertTrue(requestCaptor.getAllValues().stream()
+                .allMatch(request -> request.getEndpoint().equals("/" + mixedCase)));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4929.

Every read and write path maps a JanusGraph store name to an Elasticsearch index name through `generateIndexStoreName`, which lowercases the store. `RestElasticSearchClient.clearStore` composed the same name by hand and did not lowercase it.

A mixed index stores its JanusGraph index name as the store name verbatim, and JanusGraph index names are case-sensitive. So for an index named `vertexByName`:

| | |
|---|---|
| written and queried as | `<indexName>_vertexbyname` |
| `clearStore` targeted | `<indexName>_vertexByName` |

An Elasticsearch index name is always lowercase, so the second cannot exist. Either the existence check returned false and the call silently did nothing, or Elasticsearch rejected the name and `ManagementSystem` reported the misleading *"Index removal is not supported for this Backend"*. Either way the documents remained while the schema was marked `DISCARDED`, so JanusGraph believed the data was gone.

### Approach

I took the second option from the issue — removing the duplicated derivation rather than correcting it. `ElasticSearchIndex.clearStore` now derives the name through `getIndexStoreName`, the same call every other path uses, and passes it down. So the mapping exists in exactly one place and cannot drift again.

**This changes an interface signature:** `ElasticSearchClient.clearStore(String indexName, String storeName)` becomes `clearStore(String indexStoreName)`. `RestElasticSearchClient` is the only implementation and `ElasticSearchIndex` the only caller, both in this module, so nothing else in the tree is affected. `IndexProvider.clearStore(String storeName)` is a different interface and is untouched.

If you would rather not change the signature, the one-line alternative from the issue — lowercasing inside `clearStore` — also fixes the reported bug, and I am happy to switch to it. I preferred this version because the duplication is the root cause.

### Testing

Docker was not available to me, so I could not run the container-backed `ElasticsearchIndexTest` locally and did not want to add an integration test I could not verify. `RestClientClearStoreTest` unit-tests the client contract with a mocked `RestClient`: the existence check and the delete both address the exact name given, no delete is issued when the index is absent, and the method does not lowercase what it receives — which is what makes passing the pre-derived name correct.

The lowercasing itself stays covered by the existing paths, since `getIndexStoreName` is now the only derivation and every read and write already depends on it.

### Also worth a look, not fixed here

Two things I noticed next to this code, both from your issue and both left alone deliberately:

- Because `generateIndexStoreName` lowercases, two mixed indexes differing only in case (`byName` and `byname`) map to the same Elasticsearch index and silently share documents. `ManagementSystem.checkIndexName` only enforces uniqueness on the JanusGraph side. That is a validation change, not a rename, so it belongs in its own PR.
- `RestElasticSearchClient.deleteIndex` does nothing at all when the name is not an alias, which looks unintended but is a separate concern.

-----

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)? — no new dependencies
- [x] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository? — not applicable
- [x] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository? — not applicable
