### PR TITLE
Report why an update action does not apply to a mixed index (#4930)

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/ManagementSystem.java
@@ -985,6 +985,14 @@ public class ManagementSystem implements JanusGraphManagement {
                     if (applicableStatus.contains(field.getStatus()))
                         keySubset.add((PropertyKeyVertex) field.getFieldKey());
                 }
+                //A mixed index keeps a status per field instead of one status on the index, so this is the
+                //equivalent of the isApplicableStatus check the composite branch makes above. Without it an action
+                //which matches no field reaches setStatusVertex, whose precondition then fails with a message about
+                //RelationTypeVertex and composite indexes which says nothing about the real problem
+                Preconditions.checkArgument(!keySubset.isEmpty(),
+                    "Update action [%s] cannot be invoked for index [%s] because none of its fields has one of the" +
+                        " applicable statuses %s. The current status of each field is %s", updateAction, index.name(),
+                    applicableStatus, fieldStatuses(mixedIndexType));
 
                 dependentTypes.addAll(keySubset);
             }
@@ -1026,11 +1034,6 @@ public class ManagementSystem implements JanusGraphManagement {
                         " vertex-centric indexes: " + index.name());
                 }
                 if (((JanusGraphIndex) index).isMixedIndex()) {
-                    //Fail fast instead of starting a background job which would only fail inside the worker
-                    Preconditions.checkArgument(!keySubset.isEmpty(),
-                        "Update action [%s] cannot be invoked for index [%s] because none of its fields has" +
-                            " one of the applicable statuses %s", updateAction, index.name(),
-                        updateAction.getApplicableStatus());
                     //Stale document deletions are flushed through the same bulk restore() calls as reindex
                     //document restores, so the reindex batch size option governs both
                     future = MixedIndexStaleEntryRemover.submit(graph, indexId.indexName,
@@ -1278,6 +1281,13 @@ public class ManagementSystem implements JanusGraphManagement {
 
     private void setUpdateTrigger(Callable<Boolean> trigger) {
         updatedTypeTriggers.add(trigger);
+    }
+
+    //Reports the status of every field of a mixed index, so that a rejected update action can say why it was rejected
+    private static String fieldStatuses(MixedIndexType index) {
+        return Arrays.stream(index.getFieldKeys())
+            .map(field -> field.getFieldKey().name() + "=" + field.getStatus())
+            .collect(Collectors.joining(", ", "[", "]"));
     }
 
     private void setStatus(JanusGraphSchemaVertex vertex, SchemaStatus status, Set<PropertyKeyVertex> keys) {

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/database/management/MixedIndexUpdateStatusTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/database/management/MixedIndexUpdateStatusTest.java
@@ -1,0 +1,138 @@
+// Copyright 2026 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.database.management;
+
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.janusgraph.core.Cardinality;
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.JanusGraphFactory;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.core.schema.SchemaAction;
+import org.janusgraph.core.schema.SchemaStatus;
+import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import org.janusgraph.graphdb.database.IndexSerializerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+//A mixed index keeps a SchemaStatus per field rather than one status on the index itself, so updateIndex selects the
+//fields whose status the action applies to. When that selection is empty the action used to reach setStatusVertex,
+//whose precondition is guaranteed to fail for a mixed index and carries no message, so the caller got a bare
+//IllegalArgumentException. Re-running an idempotent schema script is enough to reach it.
+public class MixedIndexUpdateStatusTest {
+
+    private static final String INDEX_BACKEND_NAME = "search";
+    private static final String INDEX_NAME = "nameMixed";
+    private static final String PROPERTY_NAME = "name";
+
+    private JanusGraph graph;
+
+    @BeforeEach
+    public void openGraph() {
+        final ModifiableConfiguration config = GraphDatabaseConfiguration.buildGraphConfiguration();
+        config.set(GraphDatabaseConfiguration.STORAGE_BACKEND, "inmemory");
+        config.set(GraphDatabaseConfiguration.INDEX_BACKEND,
+            IndexSerializerTest.RecordingIndexProvider.class.getName(), INDEX_BACKEND_NAME);
+        graph = JanusGraphFactory.open(config.getConfiguration());
+    }
+
+    @AfterEach
+    public void closeGraph() {
+        if (graph != null) {
+            graph.close();
+        }
+    }
+
+    //A key created in the same management transaction as the index cannot hold data yet, so no reindex is needed and
+    //the index is enabled straight away
+    private void createMixedIndexOnNewKey() {
+        final JanusGraphManagement management = graph.openManagement();
+        final PropertyKey name = management.makePropertyKey(PROPERTY_NAME).dataType(String.class)
+            .cardinality(Cardinality.SINGLE).make();
+        management.buildIndex(INDEX_NAME, Vertex.class).addKey(name).buildMixedIndex(INDEX_BACKEND_NAME);
+        management.commit();
+    }
+
+    //An index over a key which already exists starts as INSTALLED, because the existing data still has to be indexed
+    private void createMixedIndexOnExistingKey() {
+        JanusGraphManagement management = graph.openManagement();
+        management.makePropertyKey(PROPERTY_NAME).dataType(String.class).cardinality(Cardinality.SINGLE).make();
+        management.commit();
+
+        management = graph.openManagement();
+        management.buildIndex(INDEX_NAME, Vertex.class).addKey(management.getPropertyKey(PROPERTY_NAME))
+            .buildMixedIndex(INDEX_BACKEND_NAME);
+        management.commit();
+    }
+
+    private void updateIndex(SchemaAction action) {
+        final JanusGraphManagement management = graph.openManagement();
+        try {
+            management.updateIndex(management.getGraphIndex(INDEX_NAME), action);
+            management.commit();
+        } catch (RuntimeException e) {
+            management.rollback();
+            throw e;
+        }
+    }
+
+    private void awaitStatus(SchemaStatus status) throws Exception {
+        ManagementSystem.awaitGraphIndexStatus(graph, INDEX_NAME).status(status).call();
+    }
+
+    @Test
+    public void shouldRejectAnActionWhichMatchesNoFieldWithADescriptiveError() throws Exception {
+        createMixedIndexOnNewKey();
+        awaitStatus(SchemaStatus.ENABLED);
+
+        //REGISTER_INDEX applies to INSTALLED and DISABLED, so an already enabled index matches no field. This is the
+        //idempotent schema script case from the issue
+        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+            () -> updateIndex(SchemaAction.REGISTER_INDEX));
+
+        //Previously the action reached setStatusVertex, whose Preconditions.checkArgument carries no message at all,
+        //so the caller got a bare IllegalArgumentException with nothing to act on
+        final String message = e.getMessage();
+        assertNotNull(message, "the rejection must say why it was rejected");
+        assertTrue(message.contains("REGISTER_INDEX"), message);
+        assertTrue(message.contains(INDEX_NAME), message);
+        //The status which blocked the action, and the statuses which would have allowed it
+        assertTrue(message.contains(SchemaStatus.ENABLED.name()), message);
+        assertTrue(message.contains(SchemaStatus.INSTALLED.name()), message);
+    }
+
+    @Test
+    public void shouldStillRegisterAnInstalledIndex() throws Exception {
+        //The fields are INSTALLED, which REGISTER_INDEX applies to, so the normal path is unaffected
+        createMixedIndexOnExistingKey();
+        updateIndex(SchemaAction.REGISTER_INDEX);
+        awaitStatus(SchemaStatus.REGISTERED);
+    }
+
+    @Test
+    public void shouldStillDisableAnEnabledIndex() throws Exception {
+        //DISABLE_INDEX applies to ENABLED, so it matches the field and is carried out
+        createMixedIndexOnNewKey();
+        awaitStatus(SchemaStatus.ENABLED);
+        updateIndex(SchemaAction.DISABLE_INDEX);
+        awaitStatus(SchemaStatus.DISABLED);
+    }
+}


### PR DESCRIPTION
Fixes #4930.

A mixed index keeps a `SchemaStatus` per field instead of one status on the index, so `updateIndex` collects the fields whose status the action applies to. When no field matched, that empty set was passed to `setStatus`, which routed to `setStatusVertex`, whose precondition can never hold for a mixed index.

**One correction to the issue:** that precondition is `Preconditions.checkArgument(condition)` with no message argument, so the exception's message is `null`. The caller does not get a confusing message about `RelationTypeVertex` — it gets a bare `IllegalArgumentException` with no message at all. I found this while writing the test, which failed with a `NullPointerException` on `e.getMessage()` before the fix.

Re-running an idempotent schema script is enough to reach it, exactly as the issue describes: `REGISTER_INDEX` applies to `INSTALLED` and `DISABLED`, so it matches no field once the index is enabled. An index built on a property key created in the same management transaction is enabled immediately, so a script that creates an index and then registers it fails the second time it runs.

### Change

The composite branch guards this a few lines earlier via `isApplicableStatus`. Worth noting that method never returns `false` — it throws — so the `return null` after it in the composite branch is unreachable, and the composite behaviour is "throw a descriptive error". This gives the mixed branch the equivalent check, and additionally reports the status of every field so it is clear which one blocked the action:

```
Update action [REGISTER_INDEX] cannot be invoked for index [nameMixed] because none of its fields has one of
the applicable statuses [INSTALLED, DISABLED]. The current status of each field is [name=ENABLED]
```

### Two consequences worth your attention

The guard applies to every action, which is what makes a mixed index behave the way a composite index already does. Two of those are behaviour changes beyond the reported symptom, both of which I believe are improvements — but they are yours to judge:

1. **`DISCARD_INDEX` no longer clears the index backend before failing.** Previously it called `IndexSerializer.clearStore` and *then* threw from `setStatusVertex`, so the documents were already gone while the status change had not happened.
2. **`DROP_INDEX` on a mixed index which is not `DISCARDED` is now rejected.** This is the second problem you flagged in the issue as possibly deserving its own issue — `schemaVertex.remove()` used to run regardless, dropping the schema vertex and orphaning every document in the index backend. A composite index is already gated this way.

I also removed the `!keySubset.isEmpty()` check that `REMOVE_STALE_ENTRIES` made for itself, since the new guard runs earlier and makes it unreachable. If you would rather narrow the guard to only the status-changing actions, that check needs to come back.

### Testing

`MixedIndexUpdateStatusTest` runs against the in-memory backend with the existing `RecordingIndexProvider` as the index backend. It covers the rejected case and asserts the message names the action, the index, the blocking status and the applicable statuses; plus two paths that must keep working, registering an `INSTALLED` index and disabling an `ENABLED` one.

I checked every existing caller of `DISCARD_INDEX` and `DROP_INDEX` in the test tree. The mixed-index sequences in `JanusGraphIndexTest` and `ElasticsearchJanusGraphIndexTest` all discard or mark-discarded before dropping, so they stay compatible; the sequences in `JanusGraphTest` are composite and relation indexes, which this does not touch. `IndexSerializerTest` still passes. Docker was unavailable to me, so I could not run the container-backed suites locally.

-----

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)? — no new dependencies
- [x] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository? — not applicable
- [x] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository? — not applicable
